### PR TITLE
CMS-6 Improve rest service for account export

### DIFF
--- a/modules/wem-core/src/main/java/com/enonic/wem/core/search/Facets.java
+++ b/modules/wem-core/src/main/java/com/enonic/wem/core/search/Facets.java
@@ -29,6 +29,34 @@ public final class Facets
         return this.facets.iterator();
     }
 
+    @Override
+    public boolean equals( final Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        final Facets facets1 = (Facets) o;
+
+        if ( facets != null ? !facets.equals( facets1.facets ) : facets1.facets != null )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return facets != null ? facets.hashCode() : 0;
+    }
+
     public void consolidate()
     {
         for ( Facet facet : facets )

--- a/modules/wem-core/src/main/java/com/enonic/wem/core/search/account/AccountSearchHit.java
+++ b/modules/wem-core/src/main/java/com/enonic/wem/core/search/account/AccountSearchHit.java
@@ -3,7 +3,9 @@ package com.enonic.wem.core.search.account;
 public final class AccountSearchHit
 {
     private final AccountKey key;
+
     private final AccountType accountType;
+
     private final float score;
 
     public AccountSearchHit( AccountKey key, AccountType accountType, float score )
@@ -21,6 +23,45 @@ public final class AccountSearchHit
     public float getScore()
     {
         return this.score;
+    }
+
+    @Override
+    public boolean equals( final Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        final AccountSearchHit that = (AccountSearchHit) o;
+
+        if ( Float.compare( that.score, score ) != 0 )
+        {
+            return false;
+        }
+        if ( accountType != that.accountType )
+        {
+            return false;
+        }
+        if ( key != null ? !key.equals( that.key ) : that.key != null )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = key != null ? key.hashCode() : 0;
+        result = 31 * result + ( accountType != null ? accountType.hashCode() : 0 );
+        result = 31 * result + ( score != +0.0f ? Float.floatToIntBits( score ) : 0 );
+        return result;
     }
 
     public AccountType getAccountType()

--- a/modules/wem-core/src/main/java/com/enonic/wem/core/search/account/AccountSearchResults.java
+++ b/modules/wem-core/src/main/java/com/enonic/wem/core/search/account/AccountSearchResults.java
@@ -11,8 +11,11 @@ public final class AccountSearchResults
     implements Iterable<AccountSearchHit>
 {
     private final int from;
+
     private final int total;
+
     private final List<AccountSearchHit> hits;
+
     private final Facets facets;
 
     public AccountSearchResults( int from, int total )
@@ -38,10 +41,11 @@ public final class AccountSearchResults
         return this.from;
     }
 
-    public void add(AccountSearchHit hit)
+    public void add( AccountSearchHit hit )
     {
-        if (hit != null) {
-            this.hits.add(hit);
+        if ( hit != null )
+        {
+            this.hits.add( hit );
         }
     }
 
@@ -58,5 +62,49 @@ public final class AccountSearchResults
     public Facets getFacets()
     {
         return facets;
+    }
+
+    @Override
+    public boolean equals( final Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        final AccountSearchResults that = (AccountSearchResults) o;
+
+        if ( from != that.from )
+        {
+            return false;
+        }
+        if ( total != that.total )
+        {
+            return false;
+        }
+        if ( facets != null ? !facets.equals( that.facets ) : that.facets != null )
+        {
+            return false;
+        }
+        if ( hits != null ? !hits.equals( that.hits ) : that.hits != null )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = from;
+        result = 31 * result + total;
+        result = 31 * result + ( hits != null ? hits.hashCode() : 0 );
+        result = 31 * result + ( facets != null ? facets.hashCode() : 0 );
+        return result;
     }
 }

--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest/account/CsvBuilder.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest/account/CsvBuilder.java
@@ -1,6 +1,6 @@
 package com.enonic.wem.web.rest.account;
 
-class CsvBuilder
+public class CsvBuilder
 {
     private final static String DEFAULT_SEPARATOR = ",";
 

--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/account/AccountResource.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/account/AccountResource.java
@@ -1,6 +1,8 @@
 package com.enonic.wem.web.rest2.resource.account;
 
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import javax.ws.rs.DefaultValue;
@@ -17,10 +19,13 @@ import org.springframework.stereotype.Component;
 import com.enonic.wem.core.search.Facets;
 import com.enonic.wem.core.search.SearchSortOrder;
 import com.enonic.wem.core.search.account.AccountIndexField;
+import com.enonic.wem.core.search.account.AccountKey;
 import com.enonic.wem.core.search.account.AccountSearchHit;
 import com.enonic.wem.core.search.account.AccountSearchQuery;
 import com.enonic.wem.core.search.account.AccountSearchResults;
 import com.enonic.wem.core.search.account.AccountSearchService;
+import com.enonic.wem.core.search.account.AccountType;
+import com.enonic.wem.web.rest2.service.account.AccountCsvExportService;
 
 import com.enonic.cms.core.security.group.GroupEntity;
 import com.enonic.cms.core.security.group.GroupKey;
@@ -41,6 +46,7 @@ public final class AccountResource
 
     private AccountSearchService accountSearchService;
 
+    private AccountCsvExportService accountCsvExportService;
 
     @GET
     public AccountsResult search( @QueryParam("start") @DefaultValue("0") int start, @QueryParam("limit") @DefaultValue("10") int limit,
@@ -66,22 +72,56 @@ public final class AccountResource
                                  @QueryParam("userstores") @DefaultValue("") String userStores,
                                  @QueryParam("organizations") @DefaultValue("") String organizations,
                                  @QueryParam("encoding") @DefaultValue("ISO-8859-1") String characterEncoding,
-                                 @QueryParam("separator") @DefaultValue("t") String separator )
+                                 @QueryParam("separator") @DefaultValue("\t") String separator )
+        throws UnsupportedEncodingException
     {
-        // TODO: Fill inn implementation code here.
-        return null;
+        final int accountsExportLimit = 5000;
+        final AccountSearchQuery searchQuery =
+            buildSearchQuery( query, types, userStores, organizations, 0, accountsExportLimit, sort, sortDir );
+        final AccountSearchResults searchResults = accountSearchService.search( searchQuery );
+
+        return createCsvExportResponse( searchResults, separator, characterEncoding );
     }
 
     @GET
     @Path("export-keys")
     public Response exportKeys( @QueryParam("key") List<String> keys,
                                 @QueryParam("encoding") @DefaultValue("ISO-8859-1") String characterEncoding,
-                                @QueryParam("separator") @DefaultValue("t") String separator )
+                                @QueryParam("separator") @DefaultValue("\t") String separator )
+        throws UnsupportedEncodingException
     {
-        // TODO: Fill inn implementation code here.
-        return null;
+        AccountSearchResults searchResults = getAccountListForKeys( keys );
+
+        return createCsvExportResponse( searchResults, separator, characterEncoding );
     }
 
+    private Response createCsvExportResponse( AccountSearchResults results, String separator, String encoding )
+        throws UnsupportedEncodingException
+    {
+        String content = accountCsvExportService.generateCsv( results, separator );
+        String attachmentHeader = "attachment; filename=" + accountCsvExportService.getExportFileName( new Date() );
+        return Response.ok( content.getBytes( encoding ) ).type( "text/csv" ).
+            header( "Content-Encoding", encoding ).
+            header( "Content-Disposition", attachmentHeader ).build();
+    }
+
+    AccountSearchResults getAccountListForKeys( final List<String> keys )
+    {
+        // TODO: refactor this when accounts API and model classes are in place
+        final AccountSearchResults accounts = new AccountSearchResults( 0, keys.size() );
+        for ( final String key : keys )
+        {
+            final AccountType type = findAccountType( key );
+            final AccountSearchHit account = new AccountSearchHit( new AccountKey( key ), type, 0 );
+            accounts.add( account );
+        }
+        return accounts;
+    }
+
+    private AccountType findAccountType( final String accountKey )
+    {
+        return userDao.findByKey( accountKey ) == null ? AccountType.GROUP : AccountType.USER;
+    }
 
     AccountSearchQuery buildSearchQuery( String query, String types, String userstores, String organizations, int start, int limit,
                                          String sort, String dir )
@@ -157,4 +197,17 @@ public final class AccountResource
     {
         this.accountSearchService = accountSearchService;
     }
+
+    @Autowired
+    public void setAccountCsvExportService( AccountCsvExportService accountCsvExportService )
+    {
+        this.accountCsvExportService = accountCsvExportService;
+    }
+
+    @Autowired
+    public AccountCsvExportService getAccountCsvExportService()
+    {
+        return this.accountCsvExportService;
+    }
+
 }

--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/service/account/AccountCsvExportService.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/service/account/AccountCsvExportService.java
@@ -1,0 +1,246 @@
+package com.enonic.wem.web.rest2.service.account;
+
+import java.util.Date;
+
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.enonic.wem.core.search.UserInfoHelper;
+import com.enonic.wem.core.search.account.AccountSearchHit;
+import com.enonic.wem.core.search.account.AccountSearchResults;
+import com.enonic.wem.web.rest.account.CsvBuilder;
+
+import com.enonic.cms.api.client.model.user.Address;
+import com.enonic.cms.api.client.model.user.UserInfo;
+import com.enonic.cms.core.security.group.GroupEntity;
+import com.enonic.cms.core.security.group.GroupKey;
+import com.enonic.cms.core.security.user.UserEntity;
+import com.enonic.cms.store.dao.GroupDao;
+import com.enonic.cms.store.dao.UserDao;
+
+@Component
+public class AccountCsvExportService
+{
+    private static final DateTimeFormatter csvTimestampFormatter = DateTimeFormat.forPattern( "yyyy-MM-dd HH:mm ZZ" );
+
+    private static final DateTimeFormatter csvDateFormatter = DateTimeFormat.forPattern( "yyyy-MM-dd" );
+
+    private static final DateTimeFormatter filenameFormatter = DateTimeFormat.forPattern( "yyyyMMdd'T'HHmmss" );
+
+    static final String GLOBAL_USERSTORE = "System";
+
+    static final String ACCOUNT_TYPE_GROUP = "Group";
+
+    static final String ACCOUNT_TYPE_ROLE = "Role";
+
+    static final String ACCOUNT_TYPE_USER = "User";
+
+    static final String DEFAULT_SEPARATOR = ",";
+
+
+    @Autowired
+    private GroupDao groupDao;
+
+    @Autowired
+    private UserDao userDao;
+
+    public String getExportFileName( Date timestamp )
+    {
+        final String dateFormatted = filenameFormatter.print( new DateTime( timestamp ) );
+        return String.format( "Accounts-%s.csv", dateFormatted );
+    }
+
+    public String generateCsv( AccountSearchResults accounts )
+    {
+        return generateCsv( accounts, DEFAULT_SEPARATOR );
+    }
+
+    public String generateCsv( AccountSearchResults accounts, String separator )
+    {
+        final CsvBuilder csvBuilder = new CsvBuilder().setSeparator( separator );
+        addCsvHeader( csvBuilder );
+
+        for ( AccountSearchHit accountHit : accounts )
+        {
+            switch ( accountHit.getAccountType() )
+            {
+                case ROLE:
+                case GROUP:
+                    final GroupEntity groupEntity = this.groupDao.findByKey( new GroupKey( accountHit.getKey().toString() ) );
+                    if ( groupEntity != null )
+                    {
+                        addGroupToCsv( csvBuilder, groupEntity );
+                    }
+                    break;
+
+                case USER:
+                    final UserEntity userEntity = this.userDao.findByKey( accountHit.getKey().toString() );
+                    if ( userEntity != null )
+                    {
+                        addUserToCsv( csvBuilder, userEntity );
+                    }
+                    break;
+            }
+            csvBuilder.endOfLine();
+        }
+
+        return csvBuilder.build();
+    }
+
+    private void addCsvHeader( CsvBuilder csvBuilder )
+    {
+        csvBuilder.addValue( "Type" );
+        csvBuilder.addValue( "Display Name" );
+        csvBuilder.addValue( "Local Name" );
+        csvBuilder.addValue( "User Store" );
+        csvBuilder.addValue( "Last Modified" );
+        csvBuilder.addValue( "Description" );
+        csvBuilder.addValue( "Email" );
+        csvBuilder.addValue( "First Name" );
+        csvBuilder.addValue( "Middle Name" );
+        csvBuilder.addValue( "Last Name" );
+        csvBuilder.addValue( "Initials" );
+        csvBuilder.addValue( "Title" );
+        csvBuilder.addValue( "Prefix" );
+        csvBuilder.addValue( "Suffix" );
+        csvBuilder.addValue( "Nickname" );
+        csvBuilder.addValue( "Gender" );
+
+        csvBuilder.addValue( "Birthdate" );
+        csvBuilder.addValue( "Organization" );
+        csvBuilder.addValue( "Country" );
+        csvBuilder.addValue( "Global Position" );
+        csvBuilder.addValue( "Home Page" );
+        csvBuilder.addValue( "Locale" );
+        csvBuilder.addValue( "Member Id" );
+        csvBuilder.addValue( "Personal Id" );
+        csvBuilder.addValue( "Phone" );
+        csvBuilder.addValue( "Mobile" );
+        csvBuilder.addValue( "Fax" );
+        csvBuilder.addValue( "Time Zone" );
+
+        csvBuilder.addValue( "Address Label" );
+        csvBuilder.addValue( "Address Street" );
+        csvBuilder.addValue( "Address Postal Address" );
+        csvBuilder.addValue( "Address Postal Code" );
+        csvBuilder.addValue( "Address Region" );
+        csvBuilder.addValue( "Address ISO Region" );
+        csvBuilder.addValue( "Address Country" );
+        csvBuilder.addValue( "Address ISO Country" );
+
+        csvBuilder.endOfLine();
+    }
+
+    private void addUserToCsv( CsvBuilder csvBuilder, UserEntity user )
+    {
+        csvBuilder.addValue( ACCOUNT_TYPE_USER );
+        csvBuilder.addValue( user.getDisplayName() );
+        csvBuilder.addValue( user.getQualifiedName().getUsername() );
+        if ( user.getUserStore() != null )
+        {
+            csvBuilder.addValue( user.getUserStore().getName() );
+        }
+        else
+        {
+            csvBuilder.addValue( GLOBAL_USERSTORE );
+        }
+
+        // TODO: LastModified is not on UserEntity. Using timestamp instead.
+        // final Date lastModif = user.getLastModified();
+        final Date lastModif = user.getTimestamp().toDate();
+
+        final String lastModifStr = ( lastModif == null ) ? "" : csvTimestampFormatter.print( new DateTime( lastModif ) );
+        csvBuilder.addValue( lastModifStr );
+
+        final UserInfo userInfo = UserInfoHelper.toUserInfo( user );
+        csvBuilder.addValue( userInfo.getDescription() );
+        csvBuilder.addValue( user.getEmail() );
+
+        csvBuilder.addValue( userInfo.getFirstName() );
+        csvBuilder.addValue( userInfo.getMiddleName() );
+        csvBuilder.addValue( userInfo.getLastName() );
+        csvBuilder.addValue( userInfo.getInitials() );
+        csvBuilder.addValue( userInfo.getTitle() );
+        csvBuilder.addValue( userInfo.getPrefix() );
+        csvBuilder.addValue( userInfo.getSuffix() );
+        csvBuilder.addValue( userInfo.getNickName() );
+
+        final String gender = ( userInfo.getGender() == null ) ? "" : userInfo.getGender().toString();
+        csvBuilder.addValue( gender );
+
+        final Date birthday = userInfo.getBirthday();
+        final String birthdayStr = ( birthday == null ) ? "" : csvDateFormatter.print( new DateTime( birthday ) );
+        csvBuilder.addValue( birthdayStr );
+        csvBuilder.addValue( userInfo.getOrganization() );
+        csvBuilder.addValue( userInfo.getCountry() );
+        csvBuilder.addValue( userInfo.getGlobalPosition() );
+        csvBuilder.addValue( userInfo.getHomePage() );
+        final String localeStr = ( userInfo.getLocale() == null ) ? "" : userInfo.getLocale().toString();
+        csvBuilder.addValue( localeStr );
+        csvBuilder.addValue( userInfo.getMemberId() );
+        csvBuilder.addValue( userInfo.getPersonalId() );
+        csvBuilder.addValue( userInfo.getPhone() );
+        csvBuilder.addValue( userInfo.getMobile() );
+        csvBuilder.addValue( userInfo.getFax() );
+        final String timeZoneStr = ( userInfo.getTimeZone() == null ) ? "" : userInfo.getTimeZone().getDisplayName();
+        csvBuilder.addValue( timeZoneStr );
+
+        final Address address = userInfo.getPrimaryAddress();
+        if ( address != null )
+        {
+            csvBuilder.addValue( address.getLabel() );
+            csvBuilder.addValue( address.getStreet() );
+            csvBuilder.addValue( address.getPostalAddress() );
+            csvBuilder.addValue( address.getPostalCode() );
+            csvBuilder.addValue( address.getRegion() );
+            csvBuilder.addValue( address.getIsoRegion() );
+            csvBuilder.addValue( address.getCountry() );
+            csvBuilder.addValue( address.getIsoCountry() );
+        }
+
+    }
+
+    private void addGroupToCsv( CsvBuilder csvBuilder, GroupEntity group )
+    {
+        csvBuilder.addValue( group.isBuiltIn() ? ACCOUNT_TYPE_ROLE : ACCOUNT_TYPE_GROUP );
+
+        // TODO: DisplayName is not on GroupEntity. Using description instead.
+        // csvBuilder.addValue( group.getDisplayName() );
+        csvBuilder.addValue( group.getDescription() );
+
+        csvBuilder.addValue( group.getQualifiedName().getGroupname() );
+        if ( group.getUserStore() != null )
+        {
+            csvBuilder.addValue( group.getUserStore().getName() );
+        }
+        else
+        {
+            csvBuilder.addValue( GLOBAL_USERSTORE );
+        }
+
+        // TODO: LastModified is not on GroupEntity. Using "null" instead.
+        // final Date lastModif = group.getLastModified();
+        final Date lastModif = null;
+
+        final String lastModifStr = ( lastModif == null ) ? "" : csvTimestampFormatter.print( new DateTime( lastModif ) );
+        csvBuilder.addValue( lastModifStr );
+        csvBuilder.addValue( group.getDescription() );
+    }
+
+
+    public void setUserDao( UserDao userDao )
+    {
+        this.userDao = userDao;
+    }
+
+    public void setGroupDao( GroupDao groupDao )
+    {
+        this.groupDao = groupDao;
+    }
+
+}
+
+

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/rest2/service/account/AccountCsvExportServiceTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/rest2/service/account/AccountCsvExportServiceTest.java
@@ -1,0 +1,91 @@
+package com.enonic.wem.web.rest2.service.account;
+
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.enonic.wem.core.search.account.AccountKey;
+import com.enonic.wem.core.search.account.AccountSearchResults;
+import com.enonic.wem.core.search.account.AccountType;
+
+import com.enonic.cms.core.security.group.GroupEntity;
+import com.enonic.cms.core.security.group.GroupKey;
+import com.enonic.cms.core.security.group.GroupType;
+import com.enonic.cms.core.security.user.UserEntity;
+import com.enonic.cms.core.security.userstore.UserStoreEntity;
+import com.enonic.cms.store.dao.GroupDao;
+import com.enonic.cms.store.dao.UserDao;
+
+import static org.junit.Assert.*;
+
+public class AccountCsvExportServiceTest
+{
+
+    private AccountCsvExportService accountCsvExportService;
+
+    @Before
+    public void setUp()
+    {
+        accountCsvExportService = new AccountCsvExportService();
+        UserDao userDao = Mockito.mock( UserDao.class );
+        Mockito.when( userDao.findByKey( "856A22BB46C76B4D8A7787C504E227D2F391D5F0" ) ).thenReturn(
+            createUserEntity( "Test user 1", "tuser1", "tuser1@enonic.com" ) );
+        Mockito.when( userDao.findByKey( "BE9891A338852C102F398CBA65E92626ABD893AC" ) ).thenReturn(
+            createUserEntity( "Test user 2", "tuser2", "tuser2@enonic.com" ) );
+        GroupDao groupDao = Mockito.mock( GroupDao.class );
+        Mockito.when( groupDao.findByKey( new GroupKey( "98D9DCC6E25B94DF499FB233AFD1A2665BE4997C" ) ) ).thenReturn(
+            createGroupEntity( "Test group 1" ) );
+        Mockito.when( groupDao.findByKey( new GroupKey( "0E91A6F5CCCF8464C39CB4D06AA1715B7750B4E6" ) ) ).thenReturn(
+            createGroupEntity( "Test group 2" ) );
+        Mockito.when( groupDao.findByKey( new GroupKey( "A2F5AA36DFE832EDCE705507D537D5083A309666" ) ) ).thenReturn(
+            createGroupEntity( "Test group 3" ) );
+        accountCsvExportService.setUserDao( userDao );
+        accountCsvExportService.setGroupDao( groupDao );
+    }
+
+    @Test
+    public void testGenerateCsv()
+    {
+        AccountSearchResults results = createSearchResults();
+        String csv = accountCsvExportService.generateCsv( results );
+        AccountSearchResults emptyResult = new AccountSearchResults( 0, 0 );
+        String emptyCsv = accountCsvExportService.generateCsv( emptyResult );
+        int end = csv.indexOf( "\n" );
+        assertTrue( "Header is generated right", csv.substring( 0, end + 1 ).compareTo( emptyCsv ) == 0 );
+        assertSame( "There should be 6 line: 1 for header, and 5 for data", csv.split( "\n" ).length, 6 );
+    }
+
+    private AccountSearchResults createSearchResults()
+    {
+        AccountSearchResults results = new AccountSearchResults( 0, 5 );
+        results.add( new AccountKey( "856A22BB46C76B4D8A7787C504E227D2F391D5F0" ), AccountType.USER, 1f );
+        results.add( new AccountKey( "BE9891A338852C102F398CBA65E92626ABD893AC" ), AccountType.USER, 1f );
+        results.add( new AccountKey( "98D9DCC6E25B94DF499FB233AFD1A2665BE4997C" ), AccountType.GROUP, 1f );
+        results.add( new AccountKey( "0E91A6F5CCCF8464C39CB4D06AA1715B7750B4E6" ), AccountType.GROUP, 1f );
+        results.add( new AccountKey( "A2F5AA36DFE832EDCE705507D537D5083A309666" ), AccountType.GROUP, 1f );
+        return results;
+    }
+
+    private UserEntity createUserEntity( String displayName, String name, String email )
+    {
+        UserStoreEntity userStore = new UserStoreEntity();
+        userStore.setName( "default" );
+        UserEntity user = new UserEntity();
+        user.setDisplayName( displayName );
+        user.setName( name );
+        user.setEmail( email );
+        user.setUserStore( userStore );
+        user.setTimestamp( DateTime.now() );
+        return user;
+    }
+
+    private GroupEntity createGroupEntity( String name )
+    {
+        GroupEntity group = new GroupEntity();
+        group.setName( name );
+        group.setType( GroupType.DEVELOPERS );
+        return group;
+    }
+}


### PR DESCRIPTION
We want to improve the rest service for exporing accounts. The export should be implemented in two services:

```
account/export-query (export to csv based on query)
account/export-keys (export to csv based on selected keys - should probably be POST instead of GET)
```

I have created placeholders in code in AccountResource.exportKeys(..) and AccountResource.exportQuery(..). Please also create tests for this. Plenty of examples. Use mocks as dependent services and do not wire it into complex spring stuff.

NOTE! This task only covers the actual rest service. Do not change the JavaScript in Admin Console now. The new rest service lives under /admin/rest/account/export and do not break existing rest services.
