### PR TITLE
CMS-92 Grid: loader mask is missing

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/app-userstore.html
+++ b/modules/wem-webapp/src/main/webapp/admin/app-userstore.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8"/>
     <title>Enonic WEM Admin</title>
     <link rel="stylesheet" type="text/css" href="resources/lib/ext/resources/css/ext-all.css">
     <link rel="stylesheet" type="text/css" href="resources/css/main.css">
@@ -34,7 +34,8 @@
             ],
 
             requires: [
-                'Admin.view.TabPanel'
+                'Admin.view.TabPanel',
+                'Admin.lib.UriHelper'
             ],
 
             launch: function () {

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/TreeGridPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/TreeGridPanel.js
@@ -31,12 +31,14 @@ Ext.define('Admin.view.TreeGridPanel', {
             xtype: 'treepanel',
             cls: 'admin-tree-panel',
             itemId: 'tree',
-            collapsible: true,
             useArrows: true,
             rootVisible: false,
 
             viewConfig: {
-                stripeRows: true
+                stripeRows: true,
+                loadMask: {
+                    store: me.treeStore
+                }
             },
             store: this.treeStore,
             columns: treeColumns
@@ -55,7 +57,9 @@ Ext.define('Admin.view.TreeGridPanel', {
             viewConfig: {
                 trackOver: true,
                 stripeRows: true,
-                loadMask: true
+                loadMask: {
+                    store: me.store
+                }
             },
             store: this.store,
             columns: this.columns

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/GridPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/GridPanel.js
@@ -14,7 +14,8 @@ Ext.define('Admin.view.account.GridPanel', {
     store: 'Admin.store.account.AccountStore',
 
     initComponent: function () {
-        this.columns = [
+        var me = this;
+        me.columns = [
             {
                 text: 'Display Name',
                 dataIndex: 'displayName',
@@ -66,23 +67,25 @@ Ext.define('Admin.view.account.GridPanel', {
             }
         ];
 
-        this.tbar = {
+        me.tbar = {
             xtype: 'pagingtoolbar',
-            store: this.store,
+            store: me.store,
             plugins: ['slidingPagerPlugin']
         };
 
-        this.viewConfig = {
+        me.viewConfig = {
             trackOver: true,
             stripeRows: true,
-            loadMask: true
+            loadMask: {
+                store: me.store
+            }
         };
 
-        this.selModel = Ext.create('Ext.selection.CheckboxModel', {
+        me.selModel = Ext.create('Ext.selection.CheckboxModel', {
             //checkOnly: true
         });
 
-        this.callParent(arguments);
+        me.callParent(arguments);
     },
 
     nameRenderer: function (value, p, record) {


### PR DESCRIPTION
When the grid is updated there should be a loader mask (a spinning Enonic logo)
This loader mask was present before.

This affects both the Accounts grid and Content Manager grid.
