### PR TITLE
CMS-135 Content Manager - Add Live mode button in content edit mode as w...

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/controller/contentManager/ContentWizardController.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/controller/contentManager/ContentWizardController.js
@@ -26,11 +26,19 @@ Ext.define('Admin.controller.contentManager.ContentWizardController', {
                 click: function (el, e) {
                     this.deleteContent(this.getContentWizardPanel().data);
                 }
+            },
+            'contentWizardToolbar *[action=toggleLive]': {
+                click: this.toggleLiveEdit
             }
         });
 
         me.application.on({
         });
+    },
+
+    toggleLiveEdit: function (el, e) {
+        el.setIconCls(el.pressed ? 'icon-lightbulb-on-24' : 'icon-lightbulb-24');
+        this.getContentWizardPanel().toggleLiveEdit();
     },
 
     closeWizard: function (el, e) {

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/lib/UriHelper.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/lib/UriHelper.js
@@ -57,6 +57,10 @@ Ext.define('Admin.lib.UriHelper', {
         },
         Userstore: {
             Search: 'admin/rest/userstore/search'
+        },
+        ContentManager: {
+            Search: 'admin/resources/data/contentManagerStub.json',
+            SearchTree: 'admin/resources/data/contentManagerTreeStub.json'
         }
     },
 
@@ -106,6 +110,7 @@ Ext.define('Admin.lib.UriHelper', {
         }
         var targetLocation = this.getLocationFromUri(uri);
         var targetPath = targetLocation.pathname;
+        var targetSearch = targetLocation.search;
 
         var targetHost = currentLocation.protocol + "//" + currentLocation.host;
 
@@ -136,7 +141,7 @@ Ext.define('Admin.lib.UriHelper', {
             Admin.lib.UriHelper.deployPath = deployPath;
         }
 
-        return targetHost + Admin.lib.UriHelper.deployPath + targetPath;
+        return targetHost + Admin.lib.UriHelper.deployPath + targetPath + targetSearch;
     },
 
     getLocationFromUri: function (uri) {

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/store/contentManager/ContentStore.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/store/contentManager/ContentStore.js
@@ -7,7 +7,7 @@ Ext.define('Admin.store.contentManager.ContentStore', {
 
     proxy: {
         type: 'ajax',
-        url: 'resources/data/contentManagerStub.json',
+        url: Admin.lib.UriHelper.getContentManagerSearchUri(),
         simpleSortMode: true,
         reader: {
             type: 'json',

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/store/contentManager/ContentTreeStore.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/store/contentManager/ContentTreeStore.js
@@ -7,7 +7,7 @@ Ext.define('Admin.store.contentManager.ContentTreeStore', {
 
     proxy: {
         type: 'ajax',
-        url: 'resources/data/contentManagerTreeStub.json',
+        url: Admin.lib.UriHelper.getContentManagerSearchTreeUri(),
         reader: {
             type: 'json',
             totalProperty: 'total'

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/LivePreview.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/LivePreview.js
@@ -13,10 +13,11 @@ Ext.define('Admin.view.contentManager.LivePreview', {
 
     },
 
-    load: function (url) {
+    load: function (url, isEdit) {
         var iframe = this.getTargetEl().down('iframe');
+        isEdit = isEdit || false;
         if (!Ext.isEmpty(url)) {
-            iframe.dom.src = Admin.lib.UriHelper.getAbsoluteUri(url);
+            iframe.dom.src = Admin.lib.UriHelper.getAbsoluteUri(url + "?edit=" + isEdit);
         } else {
             iframe.update("<h2 class='message'>Page can't be found.</h2>");
         }

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/wizard/ContentWizardPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/wizard/ContentWizardPanel.js
@@ -6,10 +6,12 @@ Ext.define('Admin.view.contentManager.wizard.ContentWizardPanel', {
         'Admin.view.contentManager.wizard.ContentWizardToolbar'
     ],
 
-    layout: 'column',
+    layout: 'card',
 
     border: 0,
     autoScroll: true,
+
+    isLiveMode: false,
 
     defaults: {
         border: false
@@ -44,48 +46,64 @@ Ext.define('Admin.view.contentManager.wizard.ContentWizardPanel', {
             xtype: 'contentWizardToolbar'
         });
 
-        me.items = [
-            {
-                width: 138,
-                padding: 5,
-                border: false,
-                items: [
-                    {
-                        xtype: 'container',
-                        plain: true,
-                        width: 128,
-                        height: 128,
-                        cls: 'icon-content-128',
-                        listeners: {
-                            render: function (cmp) {
-                                Ext.tip.QuickTipManager.register({
-                                    target: cmp.el,
-                                    text: 'Content',
-                                    width: 100,
-                                    dismissDelay: 10000 // Hide after 10 seconds hover
-                                });
+        var wizardPanel = {
+            layout: 'column',
+            itemId: 'wizardPanel',
+            border: 0,
+            autoScroll: true,
+
+            defaults: {
+                border: false
+            },
+            items: [
+                {
+                    width: 138,
+                    padding: 5,
+                    border: false,
+                    items: [
+                        {
+                            xtype: 'container',
+                            plain: true,
+                            width: 128,
+                            height: 128,
+                            cls: 'icon-content-128',
+                            listeners: {
+                                render: function (cmp) {
+                                    Ext.tip.QuickTipManager.register({
+                                        target: cmp.el,
+                                        text: 'Content',
+                                        width: 100,
+                                        dismissDelay: 10000 // Hide after 10 seconds hover
+                                    });
+                                }
                             }
                         }
-                    }
-                ]
-            },
-            {
-                columnWidth: 1,
-                padding: '10 10 10 0',
-                defaults: {
-                    border: false
+                    ]
                 },
-                items: [
-                    contentWizardHeader,
-                    {
-                        xtype: 'wizardPanel',
-                        showControls: true,
-                        items: me.getSteps()
-                    }
-                ]
-            }
-        ];
+                {
+                    columnWidth: 1,
+                    padding: '10 10 10 0',
+                    defaults: {
+                        border: false
+                    },
+                    items: [
+                        contentWizardHeader,
+                        {
+                            xtype: 'wizardPanel',
+                            showControls: true,
+                            items: me.getSteps()
+                        }
+                    ]
+                }
+            ]
+        };
 
+        var liveEdit = {
+            itemId: 'livePreview',
+            xtype: 'contentLive'
+        };
+
+        this.items = [wizardPanel, liveEdit];
         this.callParent(arguments);
 
     },
@@ -143,6 +161,19 @@ Ext.define('Admin.view.contentManager.wizard.ContentWizardPanel', {
             if (value === '' || value === 'Display Name') {
                 displayNameFieldElement.removeCls('admin-edited-field');
             }
+        }
+    },
+
+    toggleLiveEdit: function () {
+        this.isLiveMode = !this.isLiveMode;
+        if (this.isLiveMode) {
+            var url = this.data ? this.data.get('url') : '';
+            var livePreview = this.down('#livePreview');
+            livePreview.load(url, true);
+            this.getLayout().setActiveItem(livePreview);
+        } else {
+            var wizardPanel = this.down('#wizardPanel');
+            this.getLayout().setActiveItem(wizardPanel);
         }
     }
 

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/wizard/ContentWizardToolbar.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/wizard/ContentWizardToolbar.js
@@ -98,6 +98,19 @@ Ext.define('Admin.view.contentManager.wizard.ContentWizardToolbar', {
                 defaults: buttonDefaults,
                 items: [
                     {
+                        text: 'Live Mode',
+                        action: 'toggleLive',
+                        iconCls: 'icon-lightbulb-24',
+                        enableToggle: true
+                    }
+                ]
+            },
+            {
+                xtype: 'buttongroup',
+                columns: 1,
+                defaults: buttonDefaults,
+                items: [
+                    {
                         text: 'Close',
                         action: 'closeWizard',
                         iconCls: 'icon-cancel-24'

--- a/modules/wem-webapp/src/main/webapp/admin/resources/data/contentManagerStub.json
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/data/contentManagerStub.json
@@ -6,7 +6,7 @@
                 "name": "Travel",
                 "type": "site",
                 "owner": "system",
-                "url": "/dev/live-edit/page/page.jsp?edit=false",
+                "url": "/dev/live-edit/page/page.jsp",
                 "lastModified": "2010-10-10 10:10:00"
             },
             {
@@ -14,6 +14,7 @@
                 "name": "News",
                 "type": "contentType",
                 "owner": "system",
+                "url": "/dev/live-edit/page/page.jsp",
                 "lastModified": "2010-10-10 10:10:00"
             },
             {
@@ -21,7 +22,7 @@
                 "name": "Blueman",
                 "type": "site",
                 "owner": "system",
-                "url": "/dev/live-edit/page/plug-ins.jsp?edit=false",
+                "url": "/dev/live-edit/page/plug-ins.jsp",
                 "lastModified": "2010-10-10 10:10:00"
             },
             {
@@ -29,13 +30,14 @@
                 "name": "Cityscape",
                 "type": "site",
                 "owner": "system",
-                "url": "/dev/live-edit/page/page.jsp?edit=false",
+                "url": "/dev/live-edit/page/page.jsp",
                 "lastModified": "2010-10-10 10:10:00"
             },
             {
                 "key": 5,
                 "name": "Article",
                 "type": "contentType",
+                "url": "/dev/live-edit/page/page.jsp",
                 "owner": "system",
                 "lastModified": "2010-10-10 10:10:00"
             }

--- a/modules/wem-webapp/src/main/webapp/admin/resources/data/contentManagerTreeStub.json
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/data/contentManagerTreeStub.json
@@ -15,7 +15,7 @@
                     "name": "Travel",
                     "type": "site",
                     "owner": "system",
-                    "url": "/dev/live-edit/page/page.jsp?edit=false",
+                    "url": "/dev/live-edit/page/page.jsp",
                     "lastModified": "2010-10-10 10:10:00",
                     "leaf": true
                 },
@@ -24,7 +24,7 @@
                     "name": "Blueman",
                     "type": "site",
                     "owner": "system",
-                    "url": "/dev/live-edit/page/plug-ins.jsp?edit=false",
+                    "url": "/dev/live-edit/page/plug-ins.jsp",
                     "lastModified": "2010-10-10 10:10:00",
                     "leaf": true
                 },
@@ -33,7 +33,7 @@
                     "name": "Cityscape",
                     "type": "site",
                     "owner": "system",
-                    "url": "/dev/live-edit/page/page.jsp?edit=false",
+                    "url": "/dev/live-edit/page/page.jsp",
                     "lastModified": "2010-10-10 10:10:00",
                     "leaf": true
                 }
@@ -51,6 +51,7 @@
                     "key": 2,
                     "name": "News",
                     "type": "contentType",
+                    "url": "/dev/live-edit/page/page.jsp",
                     "owner": "system",
                     "lastModified": "2010-10-10 10:10:00",
                     "leaf": true
@@ -59,6 +60,7 @@
                     "key": 5,
                     "name": "Article",
                     "type": "contentType",
+                    "url": "/dev/live-edit/page/page.jsp",
                     "owner": "system",
                     "lastModified": "2010-10-10 10:10:00",
                     "leaf": true


### PR DESCRIPTION
...ell

When in content edit mode, the live edit toggle button must available (like for view mode)
But the difference is that now - we load the "edit" version of the test-pages.

The edit test-pages are the following:
/dev/live-edit/page/page.jsp
/dev/live-edit/page/plug-ins.jsp

NB! The pages must be loaded within iframe (just like for the view version)
