### PR TITLE
CMS-138 Account - calling codes: Store object does not support countries...

### DIFF
--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/country/CountryResult.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/country/CountryResult.java
@@ -60,6 +60,7 @@ public final class CountryResult
     private JsonNode toJson( final String callingCode, final Country model )
     {
         final ObjectNode json = objectNode();
+        json.put( "callingCodeId", callingCode + "_" + model.getCode() );
         json.put( "callingCode", "+" + callingCode );
         json.put( "englishName", model.getEnglishName() );
         json.put( "localName", model.getLocalName() );

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/model/account/CallingCodeModel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/model/account/CallingCodeModel.js
@@ -1,10 +1,10 @@
 Ext.define('Admin.model.account.CallingCodeModel', {
     extend: 'Ext.data.Model',
 
-    idProperty: 'callingCode',
+    idProperty: 'callingCodeId',
 
     fields: [
-        'countryCode',
+        'callingCodeId',
         'callingCode',
         'englishName',
         'localName'


### PR DESCRIPTION
... that has the same calling code

Since calling code is used as JS property name, it is overwritten by the next country that has the same calling code

In the GUI/mobile: Search for "+47"

Expected:

```
SVALBARD AND JAN MAYEN
NORWAY
```

Actual result:

```
SVALBARD AND JAN MAYEN
```
