### PR TITLE
CMS-167 Improve userstore list rest service

### DIFF
--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/userstore/UserStoreResource.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/userstore/UserStoreResource.java
@@ -1,0 +1,41 @@
+package com.enonic.wem.web.rest2.resource.userstore;
+
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.enonic.cms.core.security.userstore.UserStoreEntity;
+import com.enonic.cms.store.dao.UserStoreDao;
+
+@Path("userstore")
+@Produces(MediaType.APPLICATION_JSON)
+@Component
+public class UserStoreResource
+{
+
+    @Autowired
+    private UserStoreDao userStoreDao;
+
+    @GET
+    public UserStoreResults getAll()
+    {
+        final List<UserStoreEntity> userStores = userStoreDao.findAll();
+        return new UserStoreResults( userStores );
+    }
+
+    public UserStoreDao getUserStoreDao()
+    {
+        return userStoreDao;
+    }
+
+    public void setUserStoreDao( final UserStoreDao userStoreDao )
+    {
+        this.userStoreDao = userStoreDao;
+    }
+}

--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/userstore/UserStoreResults.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/userstore/UserStoreResults.java
@@ -1,0 +1,50 @@
+package com.enonic.wem.web.rest2.resource.userstore;
+
+import java.util.Collection;
+
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.node.ArrayNode;
+import org.codehaus.jackson.node.ObjectNode;
+
+import com.enonic.wem.web.rest2.common.JsonResult;
+
+import com.enonic.cms.core.security.userstore.UserStoreEntity;
+
+public class UserStoreResults
+    extends JsonResult
+{
+
+    public static final String KEY = "key";
+
+    public static final String NAME = "name";
+
+    public static final String DEFAULT = "default";
+
+    public static final String CONNECTOR = "connector";
+
+    private Collection<UserStoreEntity> userStores;
+
+    public UserStoreResults( Collection<UserStoreEntity> userStores )
+    {
+        this.userStores = userStores;
+    }
+
+    @Override
+    public JsonNode toJson()
+    {
+        ObjectNode node = objectNode();
+        node.put( "total", userStores.size() );
+        ArrayNode items = arrayNode();
+        for ( UserStoreEntity entity : userStores )
+        {
+            ObjectNode userStoreNode = objectNode();
+            userStoreNode.put( KEY, entity.getKey().toString() );
+            userStoreNode.put( NAME, entity.getName() );
+            userStoreNode.put( DEFAULT, entity.isDefaultUserStore() );
+            userStoreNode.put( CONNECTOR, entity.getConnectorName() );
+            items.add( userStoreNode );
+        }
+        node.put( "userStores", items );
+        return node;
+    }
+}

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/rest2/resource/userstore/UserStoreResourceTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/rest2/resource/userstore/UserStoreResourceTest.java
@@ -1,0 +1,69 @@
+package com.enonic.wem.web.rest2.resource.userstore;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.enonic.wem.web.rest2.resource.AbstractResourceTest;
+
+import com.enonic.cms.core.security.userstore.UserStoreEntity;
+import com.enonic.cms.core.security.userstore.UserStoreKey;
+import com.enonic.cms.store.dao.UserStoreDao;
+
+public class UserStoreResourceTest
+    extends AbstractResourceTest
+{
+
+    private UserStoreResource userStoreResource;
+
+    private UserStoreDao userStoreDao;
+
+    @Before
+    public void setUp()
+    {
+        userStoreDao = Mockito.mock( UserStoreDao.class );
+        userStoreResource = new UserStoreResource();
+        userStoreResource.setUserStoreDao( userStoreDao );
+    }
+
+    @Test
+    public void testGetAll()
+        throws Exception
+    {
+        Mockito.when( userStoreDao.findAll() ).thenReturn( createUserStoreEntityList() );
+        UserStoreResults results = userStoreResource.getAll();
+        assertJsonResult( "all_userstores.json", results );
+    }
+
+    private List<UserStoreEntity> createUserStoreEntityList()
+    {
+        List<UserStoreEntity> userStoreEntityList = new ArrayList<UserStoreEntity>();
+        userStoreEntityList.add( createUserStoreEntity( "1", "default", null, true ) );
+        userStoreEntityList.add( createUserStoreEntity( "2", "Supertest", "enonic" ) );
+        userStoreEntityList.add( createUserStoreEntity( "3", "Example", "enonic" ) );
+        return userStoreEntityList;
+    }
+
+    private UserStoreEntity createUserStoreEntity( String key, String name, String connector, boolean isDefault )
+    {
+        UserStoreEntity entity = new UserStoreEntity();
+        entity.setKey( new UserStoreKey( key ) );
+        entity.setName( name );
+        entity.setConnectorName( connector );
+        entity.setDefaultStore( isDefault );
+        return entity;
+    }
+
+    private UserStoreEntity createUserStoreEntity( String key, String name, String connector )
+    {
+        return createUserStoreEntity( key, name, connector, false );
+    }
+
+    private UserStoreEntity createUserStoreEntity( String key, String name )
+    {
+        return createUserStoreEntity( key, name, null );
+    }
+}

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/rest2/resource/userstore/all_userstores.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/rest2/resource/userstore/all_userstores.json
@@ -1,0 +1,20 @@
+{"total": 3, "userStores": [
+    {
+        "key": "1",
+        "name": "default",
+        "default": true,
+        "connector": null
+    },
+    {
+        "key": "2",
+        "name": "Supertest",
+        "default": false,
+        "connector": "enonic"
+    },
+    {
+        "key": "3",
+        "name": "Example",
+        "default": false,
+        "connector": "enonic"
+    }
+]}


### PR DESCRIPTION
Improve the userstore rest service by moving it into rest2 and use JAX-RS (same as the others). And, the userstore service should list all userstores (without fields, config and administrators). Not even options for fields and config.

The service should live under /admin/rest/userstore. Implement it into com.enonic.wem.web.rest2.resource.userstore.UserStoreResource.
