### PR TITLE
CMS-178 UriHelper.js - use static get methods

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/lib/UriHelper.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/lib/UriHelper.js
@@ -2,87 +2,60 @@ Ext.define('Admin.lib.UriHelper', {
 
     singleton: true,
 
-    // UriHelper generates getters from the uris object
-    // in the following format: get + <Module> + <Entity> + Uri()
-    // if Entity is a string it is returned, if it is a function - called with arguments of getter,
-    // if an object - the 'selector' function will be called with arguments of getter
-
-    uris: {
-        Account: {
-            Search: 'admin/rest/account',
-            Country: 'admin/rest/misc/country',
-            Timezone: 'admin/rest/misc/timezone',
-            Locale: 'admin/rest/misc/locale',
-            Delete: 'admin/rest/account/delete',
-            SuggestUserName: 'admin/rest/account/user/suggest-name',
-            Info: function (account) {
-                return 'admin/rest/' + account.info_uri;
-            },
-            Graph: function (account) {
-                return 'admin/rest/' + account.graph_uri;
-            },
-            Icon: function (account) {
-                return 'admin/rest/' + account.image_uri;
-            },
-            VerifyEmail: 'admin/rest/account/user/verify-unique-email'
-        },
-        Userstore: {
-            Search: 'admin/rest/userstore/search'
-        },
-        ContentManager: {
-            Search: 'admin/resources/data/contentManagerStub.json',
-            SearchTree: 'admin/resources/data/contentManagerTreeStub.json'
-        }
+    getAccountSearchUri: function () {
+        return this.getAbsoluteUri('admin/rest/account');
     },
 
-    constructor: function () {
-        var module, moduleName, entity, entityName;
-        for (moduleName in this.uris) {
-            if (this.uris.hasOwnProperty(moduleName)) {
-                module = this.uris[moduleName];
-                for (entityName in module) {
-                    if (module.hasOwnProperty(entityName)) {
-                        entity = module[entityName];
-                        this.addMethod(this, 'get' + moduleName + entityName + "Uri", this.getUri(module, entity));
-                    }
-                }
-            }
-        }
+    getAccountCountryUri: function () {
+        return this.getAbsoluteUri('admin/rest/misc/country');
     },
 
-    getUri: function (module, entity) {
-        var me = this;
-        return function () {
-            var uri;
-            if (Ext.isString(entity)) {
-                uri = entity;
-            } else if (Ext.isFunction(entity)) {
-                uri = entity.apply(this, arguments);
-            } else if (Ext.isObject(entity) && Ext.isFunction(entity.selector)) {
-                uri = entity.selector.apply(this, arguments);
-            }
-            return me.getAbsoluteUri(uri);
-        };
+    getAccountTimezoneUri: function () {
+        return this.getAbsoluteUri('admin/rest/misc/timezone');
+    },
+
+    getAccountLocaleUri: function () {
+        return this.getAbsoluteUri('admin/rest/misc/locale');
+    },
+
+    getAccountDeleteUri: function () {
+        return this.getAbsoluteUri('admin/rest/account/delete');
+    },
+
+    getAccountSuggestUserNameUri: function () {
+        this.getAbsoluteUri('admin/rest/account/user/suggest-name');
+    },
+
+    getAccountInfoUri: function (account) {
+        return this.getAbsoluteUri('admin/rest/' + account.info_uri);
+    },
+
+    getAccountGraphUri: function (account) {
+        return this.getAbsoluteUri('admin/rest/' + account.graph_uri);
+    },
+
+    getAccountIconUri: function (account) {
+        return this.getAbsoluteUri('admin/rest/' + account.image_uri);
+    },
+
+    getAccountVerifyEmailUri: function () {
+        return this.getAbsoluteUri('admin/rest/account/user/verify-unique-email');
+    },
+
+    getUserstoreSearchUri: function () {
+        return this.getAbsoluteUri('admin/rest/userstore/search');
+    },
+
+    getContentManagerSearchUri: function () {
+        return this.getAbsoluteUri('admin/resources/data/contentManagerStub.json');
+    },
+
+    getContentManagerSearchTreeUri: function () {
+        return this.getAbsoluteUri('admin/resources/data/contentManagerTreeStub.json');
     },
 
     getAbsoluteUri: function (uri) {
         return window.CONFIG.baseUrl + '/' + uri;
-    },
-
-    // addMethod - By John Resig (MIT Licensed)
-    addMethod: function (object, name, fn) {
-        var old = object[name];
-        if (old) {
-            object[name] = function () {
-                if (fn.length === arguments.length) {
-                    return fn.apply(this, arguments);
-                } else if (typeof old === 'function') {
-                    return old.apply(this, arguments);
-                }
-            };
-        } else {
-            object[name] = fn;
-        }
     }
 
 });


### PR DESCRIPTION
We want to have the UriHelper.js a bit more simpler with no magic (see original outline here CMS-85)
In general we do avoid as much magic JavaScript as it is possible.
