### PR TITLE
 CMS-217 Create account graph rpc handler using new API

### DIFF
--- a/modules/wem-api/src/main/java/com/enonic/wem/api/account/selector/AccountKeySelector.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/account/selector/AccountKeySelector.java
@@ -16,4 +16,32 @@ public final class AccountKeySelector
     {
         return this.keys;
     }
+
+    @Override
+    public boolean equals( final Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        final AccountKeySelector that = (AccountKeySelector) o;
+
+        if ( keys != null ? !keys.equals( that.keys ) : that.keys != null )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return keys != null ? keys.hashCode() : 0;
+    }
 }

--- a/modules/wem-api/src/main/java/com/enonic/wem/api/account/selector/AccountQuery.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/account/selector/AccountQuery.java
@@ -130,4 +130,68 @@ public final class AccountQuery
         this.email = email;
         return this;
     }
+
+    @Override
+    public boolean equals( final Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        final AccountQuery that = (AccountQuery) o;
+
+        if ( limit != that.limit )
+        {
+            return false;
+        }
+        if ( offset != that.offset )
+        {
+            return false;
+        }
+        if ( email != null ? !email.equals( that.email ) : that.email != null )
+        {
+            return false;
+        }
+        if ( query != null ? !query.equals( that.query ) : that.query != null )
+        {
+            return false;
+        }
+        if ( sortDirection != that.sortDirection )
+        {
+            return false;
+        }
+        if ( sortField != null ? !sortField.equals( that.sortField ) : that.sortField != null )
+        {
+            return false;
+        }
+        if ( types != null ? !types.equals( that.types ) : that.types != null )
+        {
+            return false;
+        }
+        if ( userStores != null ? !userStores.equals( that.userStores ) : that.userStores != null )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = query != null ? query.hashCode() : 0;
+        result = 31 * result + ( types != null ? types.hashCode() : 0 );
+        result = 31 * result + ( userStores != null ? userStores.hashCode() : 0 );
+        result = 31 * result + limit;
+        result = 31 * result + offset;
+        result = 31 * result + ( sortField != null ? sortField.hashCode() : 0 );
+        result = 31 * result + ( sortDirection != null ? sortDirection.hashCode() : 0 );
+        result = 31 * result + ( email != null ? email.hashCode() : 0 );
+        return result;
+    }
 }

--- a/modules/wem-api/src/main/java/com/enonic/wem/api/command/account/FindAccounts.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/command/account/FindAccounts.java
@@ -49,6 +49,45 @@ public final class FindAccounts
     }
 
     @Override
+    public boolean equals( final Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        final FindAccounts that = (FindAccounts) o;
+
+        if ( includeImage != that.includeImage )
+        {
+            return false;
+        }
+        if ( includeMembers != that.includeMembers )
+        {
+            return false;
+        }
+        if ( selector != null ? !selector.equals( that.selector ) : that.selector != null )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = selector != null ? selector.hashCode() : 0;
+        result = 31 * result + ( includeImage ? 1 : 0 );
+        result = 31 * result + ( includeMembers ? 1 : 0 );
+        return result;
+    }
+
+    @Override
     public void validate()
     {
         Preconditions.checkNotNull( this.selector, "Account selector cannot be null" );

--- a/modules/wem-api/src/main/java/com/enonic/wem/api/command/account/FindMembers.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/command/account/FindMembers.java
@@ -41,4 +41,38 @@ public final class FindMembers
         Preconditions.checkNotNull( this.key, "Account key cannot be null" );
         Preconditions.checkArgument( !this.key.isUser(), "Account must be group or role" );
     }
+
+    @Override
+    public boolean equals( final Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        final FindMembers that = (FindMembers) o;
+
+        if ( includeTransitive != that.includeTransitive )
+        {
+            return false;
+        }
+        if ( key != null ? !key.equals( that.key ) : that.key != null )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = key != null ? key.hashCode() : 0;
+        result = 31 * result + ( includeTransitive ? 1 : 0 );
+        return result;
+    }
 }

--- a/modules/wem-api/src/main/java/com/enonic/wem/api/command/account/FindMemberships.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/command/account/FindMemberships.java
@@ -36,6 +36,40 @@ public final class FindMemberships
     }
 
     @Override
+    public boolean equals( final Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        final FindMemberships that = (FindMemberships) o;
+
+        if ( includeTransitive != that.includeTransitive )
+        {
+            return false;
+        }
+        if ( key != null ? !key.equals( that.key ) : that.key != null )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = key != null ? key.hashCode() : 0;
+        result = 31 * result + ( includeTransitive ? 1 : 0 );
+        return result;
+    }
+
+    @Override
     public void validate()
     {
         Preconditions.checkNotNull( this.key, "Account key cannot be null" );

--- a/modules/wem-web/src/main/java/com/enonic/wem/web/data/account/GetAccountGraphJsonResult.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/data/account/GetAccountGraphJsonResult.java
@@ -1,0 +1,78 @@
+package com.enonic.wem.web.data.account;
+
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.jackson.node.ArrayNode;
+import org.codehaus.jackson.node.ObjectNode;
+
+import com.enonic.wem.api.account.Account;
+import com.enonic.wem.api.account.AccountKey;
+import com.enonic.wem.web.json.result.JsonResult;
+
+public class GetAccountGraphJsonResult
+    extends JsonResult
+{
+
+    private Map<Account, List<Account>> graphData;
+
+    // Nodes ids should be unique, even among different graphs
+    private String timestamp;
+
+    public GetAccountGraphJsonResult( boolean success, Map<Account, List<Account>> graphData )
+    {
+        super( success );
+        this.graphData = graphData;
+        this.timestamp = String.valueOf( System.currentTimeMillis() );
+    }
+
+
+    @Override
+    protected void serialize( final ObjectNode json )
+    {
+        ArrayNode graph = arrayNode();
+        for ( Map.Entry<Account, List<Account>> entry : graphData.entrySet() )
+        {
+            graph.add( createGraphNode( entry.getKey(), entry.getValue() ) );
+        }
+        json.put( "graph", graph );
+    }
+
+    private String getGraphNodeId( Account account )
+    {
+        StringBuffer id = new StringBuffer( timestamp );
+        id.append( "_" );
+        id.append( account.getKey() );
+        return id.toString();
+    }
+
+    private ObjectNode createGraphNodeData( Account account )
+    {
+        AccountKey accountKey = account.getKey();
+        ObjectNode node = objectNode();
+        node.put( "type", accountKey.getType().toString().toLowerCase() );
+        node.put( "key", accountKey.toString() );
+        node.put( "name", accountKey.getLocalName() );
+        return node;
+    }
+
+    private ObjectNode createGraphNode( Account account, List<Account> adjacencies )
+    {
+        ObjectNode node = objectNode();
+        node.put( "id", getGraphNodeId( account ) );
+        node.put( "name", account.getDisplayName() );
+        node.put( "data", createGraphNodeData( account ) );
+        ArrayNode adjacenciesNode = arrayNode();
+        if ( adjacencies != null )
+        {
+            for ( Account adjacency : adjacencies )
+            {
+                ObjectNode nodeTo = objectNode();
+                nodeTo.put( "nodeTo", getGraphNodeId( adjacency ) );
+                adjacenciesNode.add( nodeTo );
+            }
+        }
+        node.put( "adjacencies", adjacenciesNode );
+        return node;
+    }
+}

--- a/modules/wem-web/src/main/java/com/enonic/wem/web/data/account/GetAccountGraphRpcHandler.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/data/account/GetAccountGraphRpcHandler.java
@@ -1,20 +1,26 @@
 package com.enonic.wem.web.data.account;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.stereotype.Component;
 
+import com.enonic.wem.api.account.Account;
+import com.enonic.wem.api.account.AccountKey;
+import com.enonic.wem.api.account.AccountKeySet;
+import com.enonic.wem.api.account.selector.AccountSelectors;
+import com.enonic.wem.api.command.Commands;
 import com.enonic.wem.web.data.AbstractDataRpcHandler;
 import com.enonic.wem.web.json.JsonSerializable;
-import com.enonic.wem.web.rest2.resource.account.graph.GraphResource;
 import com.enonic.wem.web.jsonrpc.JsonRpcContext;
 
 @Component
 public final class GetAccountGraphRpcHandler
     extends AbstractDataRpcHandler
 {
-    @Autowired
-    private GraphResource resource;
-
     public GetAccountGraphRpcHandler()
     {
         super( "account_getGraph" );
@@ -25,8 +31,108 @@ public final class GetAccountGraphRpcHandler
         throws Exception
     {
         final String key = context.param( "key" ).required().asString();
-
-        final JsonSerializable json = this.resource.getInfo( key );
+        final AccountKey accountKey = AccountKey.from( key );
+        Map<Account, List<Account>> result = generateAccountGraph( accountKey );
+        final JsonSerializable json = new GetAccountGraphJsonResult( true, result );
         context.setResult( json );
+    }
+
+    private Map<Account, List<Account>> generateAccountGraph( AccountKey accountKey )
+    {
+        Map<AccountKey, AccountKeySet> nodeMap = new HashMap<AccountKey, AccountKeySet>();
+        // We build full graph currently, this will be changed in future
+        if ( accountKey.isUser() )
+        {
+            generateMembershipsGraph( accountKey, -1, nodeMap );
+        }
+        else if ( accountKey.isGroup() || accountKey.isRole() )
+        {
+            generateMembersGraph( accountKey, -1, nodeMap );
+        }
+        List<Account> accounts =
+            this.client.execute( Commands.account().find().selector( AccountSelectors.keys( nodeMap.keySet() ) ) ).getAll();
+        Map<Account, List<Account>> result = new HashMap<Account, List<Account>>();
+        for ( Map.Entry<AccountKey, AccountKeySet> entry : nodeMap.entrySet() )
+        {
+            Account key = findAccount( entry.getKey(), accounts );
+            List<Account> value = findAccounts( entry.getValue().getSet(), accounts );
+            result.put( key, value );
+        }
+        return result;
+    }
+
+    private List<Account> findAccounts( Collection<AccountKey> accountKeys, Collection<Account> accountList )
+    {
+        List<Account> result = new ArrayList<Account>();
+        for ( Account account : accountList )
+        {
+            if ( accountKeys.contains( account.getKey() ) )
+            {
+                result.add( account );
+            }
+        }
+        return result;
+    }
+
+    private Account findAccount( AccountKey accountKey, Collection<Account> accountList )
+    {
+        for ( Account account : accountList )
+        {
+            if ( accountKey.equals( account.getKey() ) )
+            {
+                return account;
+            }
+        }
+        return null;
+    }
+
+    private void generateMembersGraph( AccountKey accountKey, int level, Map<AccountKey, AccountKeySet> graph )
+    {
+        if ( graph == null )
+        {
+            graph = new HashMap<AccountKey, AccountKeySet>();
+        }
+
+        if ( !graph.containsKey( accountKey ) )
+        {
+            AccountKeySet accountMembers;
+            if ( accountKey.isUser() )
+            {
+                accountMembers = AccountKeySet.empty();
+            }
+            else
+            {
+                accountMembers = this.client.execute( Commands.account().findMembers().key( accountKey ) );
+            }
+            graph.put( accountKey, accountMembers );
+            if ( level != 0 )
+            {
+                for ( AccountKey memberKey : accountMembers )
+                {
+                    generateMembersGraph( memberKey, level - 1, graph );
+                }
+            }
+        }
+    }
+
+    private void generateMembershipsGraph( AccountKey accountKey, int level, Map<AccountKey, AccountKeySet> graph )
+    {
+        if ( graph == null )
+        {
+            graph = new HashMap<AccountKey, AccountKeySet>();
+        }
+        AccountKeySet accountMemberships = this.client.execute( Commands.account().findMemberships().key( accountKey ) );
+        if ( !graph.containsKey( accountKey ) )
+        {
+            graph.put( accountKey, accountMemberships );
+            if ( level != 0 )
+            {
+                for ( AccountKey membershipKey : accountMemberships )
+                {
+                    generateMembershipsGraph( membershipKey, level - 1, graph );
+                }
+            }
+        }
+
     }
 }

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/data/AbstractRpcHandlerTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/data/AbstractRpcHandlerTest.java
@@ -97,6 +97,25 @@ public abstract class AbstractRpcHandlerTest
     }
 
 
+    protected JsonNode getJsonResult( final JsonNode paramsJson )
+    {
+        final JsonRpcRequest req = new JsonRpcRequest();
+        req.setId( "1" );
+        req.setMethod( this.handler.getName() );
+        if ( paramsJson != null )
+        {
+            req.setParams( (ObjectNode) paramsJson );
+        }
+
+        final JsonRpcResponse res = this.processor.process( req );
+        assertNotNull( res );
+        assertFalse( res.hasError() );
+
+        final JsonNode result = res.getResult();
+        assertNotNull( result );
+        return result;
+    }
+
     private void testJson( final JsonNode paramsJson, final JsonNode resultJson )
         throws Exception
     {
@@ -117,7 +136,7 @@ public abstract class AbstractRpcHandlerTest
         assertJson( resultJson, result );
     }
 
-    private JsonNode parseJson( final String fileName )
+    protected JsonNode parseJson( final String fileName )
         throws Exception
     {
         if ( fileName == null )

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/AbstractAccountRpcHandlerTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/AbstractAccountRpcHandlerTest.java
@@ -1,0 +1,68 @@
+package com.enonic.wem.web.data.account;
+
+import java.util.List;
+
+import org.joda.time.DateTime;
+
+import com.google.common.collect.Lists;
+
+import com.enonic.wem.api.account.Account;
+import com.enonic.wem.api.account.AccountKey;
+import com.enonic.wem.api.account.AccountKeySet;
+import com.enonic.wem.api.account.GroupAccount;
+import com.enonic.wem.api.account.RoleAccount;
+import com.enonic.wem.api.account.UserAccount;
+import com.enonic.wem.api.account.result.AccountFacets;
+import com.enonic.wem.api.account.result.AccountResult;
+import com.enonic.wem.web.data.AbstractRpcHandlerTest;
+
+public abstract class AbstractAccountRpcHandlerTest
+    extends AbstractRpcHandlerTest
+{
+    protected AccountResult createAccountResult( final int totalSize, final Account... accounts )
+    {
+        final List<Account> accountList = Lists.newArrayList( accounts );
+        final AccountResult result = new AccountResult( totalSize, accountList );
+        result.setFacets( new AccountFacets() );
+        return result;
+    }
+
+    protected UserAccount createUser( final String qName )
+    {
+        final AccountKey accountKey = AccountKey.user( qName );
+        return createUser( accountKey );
+    }
+
+    protected UserAccount createUser( final AccountKey accountKey )
+    {
+        final UserAccount user = UserAccount.create( accountKey );
+        user.setDisplayName( accountKey.getLocalName().toUpperCase() );
+        user.setEmail( accountKey.getLocalName() + "@" + accountKey.getUserStore() + ".com" );
+        user.setCreatedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
+        user.setModifiedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
+        user.setImage( "image".getBytes() );
+        return user;
+    }
+
+    protected GroupAccount createGroup( final String qName, final AccountKey... members )
+    {
+        final AccountKey accountKey = AccountKey.group( qName );
+        final GroupAccount group = GroupAccount.create( accountKey );
+        group.setDisplayName( accountKey.getLocalName().toUpperCase() );
+        group.setCreatedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
+        group.setModifiedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
+        group.setMembers( AccountKeySet.from( members ) );
+        return group;
+    }
+
+    protected RoleAccount createRole( final String qName, final AccountKey... members )
+    {
+        final AccountKey accountKey = AccountKey.role( qName );
+        final RoleAccount group = RoleAccount.create( accountKey );
+        group.setDisplayName( accountKey.getLocalName().toUpperCase() );
+        group.setCreatedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
+        group.setModifiedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
+        group.setMembers( AccountKeySet.from( members ) );
+        return group;
+    }
+}

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/FindAccountsRpcHandlerTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/FindAccountsRpcHandlerTest.java
@@ -1,35 +1,26 @@
 package com.enonic.wem.web.data.account;
 
-import java.util.List;
-
 import javax.servlet.http.HttpServletRequest;
 
-import org.joda.time.DateTime;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import com.google.common.collect.Lists;
-
 import com.enonic.wem.api.Client;
-import com.enonic.wem.api.account.Account;
 import com.enonic.wem.api.account.AccountKey;
-import com.enonic.wem.api.account.AccountKeySet;
 import com.enonic.wem.api.account.GroupAccount;
 import com.enonic.wem.api.account.RoleAccount;
 import com.enonic.wem.api.account.UserAccount;
 import com.enonic.wem.api.account.result.AccountFacet;
 import com.enonic.wem.api.account.result.AccountFacetEntry;
-import com.enonic.wem.api.account.result.AccountFacets;
 import com.enonic.wem.api.account.result.AccountResult;
 import com.enonic.wem.api.command.account.FindAccounts;
-import com.enonic.wem.web.data.AbstractRpcHandlerTest;
 import com.enonic.wem.web.jsonrpc.JsonRpcHandler;
 
 public class FindAccountsRpcHandlerTest
-    extends AbstractRpcHandlerTest
+    extends AbstractAccountRpcHandlerTest
 {
 
     private Client client;
@@ -84,23 +75,15 @@ public class FindAccountsRpcHandlerTest
         final GroupAccount group1 = createGroup( "enonic:group1", user1.getKey() );
         final RoleAccount role1 = createRole( "system:contributors", user1.getKey() );
 
-        final AccountResult result = createAccountResult( 10, user1, group1, role1);
-        final AccountFacet facet = new AccountFacet("userstore" );
-        facet.addEntry( new AccountFacetEntry( "enonic",2 ) );
-        facet.addEntry( new AccountFacetEntry( "system",1 ) );
+        final AccountResult result = createAccountResult( 10, user1, group1, role1 );
+        final AccountFacet facet = new AccountFacet( "userstore" );
+        facet.addEntry( new AccountFacetEntry( "enonic", 2 ) );
+        facet.addEntry( new AccountFacetEntry( "system", 1 ) );
         result.getFacets().addFacet( facet );
 
         setResult( result );
 
         testSuccess( "findAccounts_param.json", "findAccounts_result_with_facets.json" );
-    }
-
-    private AccountResult createAccountResult( final int totalSize, final Account... accounts )
-    {
-        final List<Account> accountList = Lists.newArrayList( accounts );
-        final AccountResult result = new AccountResult( totalSize, accountList );
-        result.setFacets( new AccountFacets() );
-        return result;
     }
 
     private void setResult( final AccountResult result )
@@ -113,45 +96,6 @@ public class FindAccountsRpcHandlerTest
         final HttpServletRequest req = new MockHttpServletRequest();
         final ServletRequestAttributes attrs = new ServletRequestAttributes( req );
         RequestContextHolder.setRequestAttributes( attrs );
-    }
-
-    private UserAccount createUser( final String qName )
-    {
-        final AccountKey accountKey = AccountKey.user( qName );
-        return createUser( accountKey );
-    }
-
-    private UserAccount createUser( final AccountKey accountKey )
-    {
-        final UserAccount user = UserAccount.create( accountKey );
-        user.setDisplayName( accountKey.getLocalName().toUpperCase() );
-        user.setEmail( accountKey.getLocalName() + "@" + accountKey.getUserStore() + ".com" );
-        user.setCreatedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
-        user.setModifiedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
-        user.setImage( "image".getBytes() );
-        return user;
-    }
-
-    private GroupAccount createGroup( final String qName, final AccountKey... members )
-    {
-        final AccountKey accountKey = AccountKey.group( qName );
-        final GroupAccount group = GroupAccount.create( accountKey );
-        group.setDisplayName( accountKey.getLocalName().toUpperCase() );
-        group.setCreatedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
-        group.setModifiedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
-        group.setMembers( AccountKeySet.from( members ) );
-        return group;
-    }
-
-    private RoleAccount createRole( final String qName, final AccountKey... members )
-    {
-        final AccountKey accountKey = AccountKey.role( qName );
-        final RoleAccount group = RoleAccount.create( accountKey );
-        group.setDisplayName( accountKey.getLocalName().toUpperCase() );
-        group.setCreatedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
-        group.setModifiedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
-        group.setMembers( AccountKeySet.from( members ) );
-        return group;
     }
 
 }

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/GetAccountGraphJsonResultTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/GetAccountGraphJsonResultTest.java
@@ -1,0 +1,196 @@
+package com.enonic.wem.web.data.account;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.node.ArrayNode;
+import org.codehaus.jackson.node.ObjectNode;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.enonic.wem.api.Client;
+import com.enonic.wem.api.account.AccountKey;
+import com.enonic.wem.api.account.AccountKeySet;
+import com.enonic.wem.api.account.selector.AccountSelectors;
+import com.enonic.wem.api.command.Commands;
+import com.enonic.wem.web.jsonrpc.JsonRpcHandler;
+
+import static org.junit.Assert.*;
+
+public class GetAccountGraphJsonResultTest
+    extends AbstractAccountRpcHandlerTest
+{
+
+    private Client client;
+
+    @Override
+    protected JsonRpcHandler createHandler()
+        throws Exception
+    {
+        client = Mockito.mock( Client.class );
+        GetAccountGraphRpcHandler handler = new GetAccountGraphRpcHandler();
+        handler.setClient( client );
+        return handler;
+    }
+
+    @Test
+    public void testGetUserGraph()
+        throws Exception
+    {
+        AccountKey userKey = AccountKey.from( "user:enonic:aro" );
+        AccountKey groupKey = AccountKey.from( "group:enonic:Togservice" );
+        Mockito.when( client.execute( Commands.account().findMemberships().key( userKey ) ) ).thenReturn( AccountKeySet.from( groupKey ) );
+        Mockito.when( client.execute( Commands.account().findMemberships().key( groupKey ) ) ).thenReturn( AccountKeySet.empty() );
+        Mockito.when( client.execute( Commands.account().find().selector( AccountSelectors.keys( userKey, groupKey ) ) ) ).thenReturn(
+            createAccountResult( 1, createUser( "enonic:aro" ), createGroup( "enonic:Togservice" ) ) );
+        testGraphSuccess( "getUserGraph_param.json", "getUserGraph_result.json" );
+    }
+
+
+    @Test
+    public void testGetGroupGraph()
+        throws Exception
+    {
+        AccountKey userKey = AccountKey.from( "user:enonic:aro" );
+        AccountKey groupKey = AccountKey.from( "group:enonic:Togservice" );
+        Mockito.when( client.execute( Commands.account().findMembers().key( groupKey ) ) ).thenReturn( AccountKeySet.from( userKey ) );
+        Mockito.when( client.execute( Commands.account().find().selector( AccountSelectors.keys( userKey, groupKey ) ) ) ).thenReturn(
+            createAccountResult( 1, createUser( "enonic:aro" ), createGroup( "enonic:Togservice" ) ) );
+        testGraphSuccess( "getGroupGraph_param.json", "getGroupGraph_result.json" );
+    }
+
+    @Test
+    public void testGetRoleGraph()
+        throws Exception
+    {
+        AccountKey userKey = AccountKey.from( "user:enonic:aro" );
+        AccountKey groupKey = AccountKey.from( "group:enonic:Togservice" );
+        AccountKey roleKey = AccountKey.from( "role:enonic:admin" );
+        Mockito.when( client.execute( Commands.account().findMembers().key( roleKey ) ) ).thenReturn(
+            AccountKeySet.from( userKey, groupKey ) );
+        Mockito.when( client.execute( Commands.account().findMembers().key( groupKey ) ) ).thenReturn( AccountKeySet.empty() );
+        Mockito.when(
+            client.execute( Commands.account().find().selector( AccountSelectors.keys( userKey, groupKey, roleKey ) ) ) ).thenReturn(
+            createAccountResult( 1, createRole( "enonic:admin" ), createUser( "enonic:aro" ), createGroup( "enonic:Togservice" ) ) );
+        testGraphSuccess( "getRoleGraph_param.json", "getRoleGraph_result.json" );
+    }
+
+    private void assertGraphJson( JsonNode expected, JsonNode actual )
+    {
+        ArrayNode expectedGraph = (ArrayNode) expected.get( "graph" );
+        ArrayNode actualGraph = (ArrayNode) actual.get( "graph" );
+        assertEquals( expectedGraph.size(), actualGraph.size() );
+        assertEquals( createAdjacenciesMap( expectedGraph ), createAdjacenciesMap( actualGraph ) );
+        assertGraphData( expectedGraph, actualGraph );
+    }
+
+    private void assertGraphStructure( JsonNode graphResponse )
+    {
+        assertTrue( "Required field graph is missing", graphResponse.has( "graph" ) );
+        ArrayNode graph = (ArrayNode) graphResponse.get( "graph" );
+        Iterator<JsonNode> graphIterator = graph.iterator();
+        while ( graphIterator.hasNext() )
+        {
+            JsonNode graphNode = graphIterator.next();
+            assertTrue( "Required field id is missing", graphNode.has( "id" ) );
+            assertTrue( "Required field name is missing", graphNode.has( "name" ) );
+            assertTrue( "Required field data is missing", graphNode.has( "data" ) );
+            assertTrue( "Required field adjacencies is missing", graphNode.has( "adjacencies" ) );
+            // Test data node
+            JsonNode dataNode = graphNode.get( "data" );
+            assertTrue( "Required field type in data is missing", dataNode.has( "type" ) );
+            assertTrue( "Required field key in data is missing", dataNode.has( "key" ) );
+            assertTrue( "Required field name in data is missing", dataNode.has( "name" ) );
+            // Test adjacencies node
+            ArrayNode adjacenciesNode = (ArrayNode) graphNode.get( "adjacencies" );
+            Iterator<JsonNode> adjacenciesIterator = adjacenciesNode.iterator();
+            while ( adjacenciesIterator.hasNext() )
+            {
+                assertTrue( "Required field nodeTo in adjacencies is missing", adjacenciesIterator.next().has( "nodeTo" ) );
+            }
+        }
+    }
+
+    private Map<String, Set<String>> createAdjacenciesMap( ArrayNode graph )
+    {
+        Map<String, Set<String>> adjacenciesMap = new HashMap<String, Set<String>>();
+        for ( JsonNode graphNode : graph )
+        {
+            String id = graphNode.get( "id" ).asText();
+            ArrayNode adjacenciesNode = (ArrayNode) graphNode.get( "adjacencies" );
+            Set<String> adjacencies = new HashSet<String>();
+            for ( JsonNode nodeTo : adjacenciesNode )
+            {
+                adjacencies.add( extractKey( nodeTo.get( "nodeTo" ).asText() ) );
+            }
+            adjacenciesMap.put( extractKey( id ), adjacencies );
+        }
+        return adjacenciesMap;
+    }
+
+    private void assertGraphData( ArrayNode expected, ArrayNode actual )
+    {
+        for ( JsonNode node : expected )
+        {
+            String id = extractKey( node.get( "id" ).asText() );
+            JsonNode matchedNode = findGraphNodeById( id, actual );
+            assertNotNull( "Expected graph node with id: " + id + "is not found", matchedNode );
+            assertGraphNode( node, matchedNode );
+        }
+    }
+
+    private void assertGraphNode( JsonNode expected, JsonNode actual )
+    {
+        Iterator<String> fieldIterator = expected.getFieldNames();
+        while ( fieldIterator.hasNext() )
+        {
+            String fieldName = fieldIterator.next();
+            if ( !fieldName.equals( "id" ) && !fieldName.equals( "adjacencies" ) && !fieldName.equals( "data" ) )
+            {
+                assertEquals( "Values of the field '" + fieldName + "' doesn't match", expected.get( fieldName ), actual.get( fieldName ) );
+            }
+            else if ( fieldName.equals( "data" ) )
+            {
+                JsonNode expectedDataNode = expected.get( fieldName );
+                JsonNode actualDataNode = actual.get( fieldName );
+                assertGraphNode( expectedDataNode, actualDataNode );
+            }
+        }
+    }
+
+    private JsonNode findGraphNodeById( String id, ArrayNode graph )
+    {
+        for ( JsonNode node : graph )
+        {
+            String nodeId = extractKey( node.get( "id" ).asText() );
+            if ( id.equals( nodeId ) )
+            {
+                return node;
+            }
+        }
+        return null;
+    }
+
+    private String extractKey( String id )
+    {
+        return id.replaceFirst( "^\\d+_", "" );
+    }
+
+    private void testGraphSuccess( final String paramsFile, final String resultFile )
+        throws Exception
+    {
+        final JsonNode paramsJson = parseJson( paramsFile );
+        final JsonNode resultJson = parseJson( resultFile );
+        assertNotNull( paramsJson );
+        assertTrue( paramsJson instanceof ObjectNode );
+        JsonNode actual = getJsonResult( paramsJson );
+        assertGraphStructure( actual );
+        assertGraphJson( resultJson, actual );
+    }
+
+
+}

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/GetAccountRpcHandlerTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/GetAccountRpcHandlerTest.java
@@ -1,38 +1,25 @@
 package com.enonic.wem.web.data.account;
 
-import java.util.List;
-
 import javax.servlet.http.HttpServletRequest;
 
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.node.ArrayNode;
 import org.codehaus.jackson.node.ObjectNode;
-import org.joda.time.DateTime;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import com.google.common.collect.Lists;
-
 import com.enonic.wem.api.Client;
-import com.enonic.wem.api.account.Account;
-import com.enonic.wem.api.account.AccountKey;
 import com.enonic.wem.api.account.AccountKeySet;
-import com.enonic.wem.api.account.GroupAccount;
-import com.enonic.wem.api.account.RoleAccount;
-import com.enonic.wem.api.account.UserAccount;
-import com.enonic.wem.api.account.result.AccountFacets;
-import com.enonic.wem.api.account.result.AccountResult;
 import com.enonic.wem.api.command.account.FindAccounts;
 import com.enonic.wem.api.command.account.FindMembers;
 import com.enonic.wem.api.command.account.FindMemberships;
-import com.enonic.wem.web.data.AbstractRpcHandlerTest;
 import com.enonic.wem.web.jsonrpc.JsonRpcHandler;
 
 public class GetAccountRpcHandlerTest
-    extends AbstractRpcHandlerTest
+    extends AbstractAccountRpcHandlerTest
 {
 
     private Client client;
@@ -140,14 +127,6 @@ public class GetAccountRpcHandlerTest
         return params;
     }
 
-    private AccountResult createAccountResult( final int totalSize, final Account... accounts )
-    {
-        final List<Account> accountList = Lists.newArrayList( accounts );
-        final AccountResult result = new AccountResult( totalSize, accountList );
-        result.setFacets( new AccountFacets() );
-        return result;
-    }
-
     private AccountKeySet createAccountKeySet( String... keys )
     {
         return AccountKeySet.from( keys );
@@ -158,40 +137,6 @@ public class GetAccountRpcHandlerTest
         final HttpServletRequest req = new MockHttpServletRequest();
         final ServletRequestAttributes attrs = new ServletRequestAttributes( req );
         RequestContextHolder.setRequestAttributes( attrs );
-    }
-
-    private UserAccount createUser( final String qName )
-    {
-        final AccountKey accountKey = AccountKey.user( qName );
-        final UserAccount user = UserAccount.create( accountKey );
-        user.setDisplayName( accountKey.getLocalName().toUpperCase() );
-        user.setEmail( accountKey.getLocalName() + "@" + accountKey.getUserStore() + ".com" );
-        user.setCreatedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
-        user.setModifiedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
-        user.setImage( "image".getBytes() );
-        return user;
-    }
-
-    private GroupAccount createGroup( final String qName, final AccountKey... members )
-    {
-        final AccountKey accountKey = AccountKey.group( qName );
-        final GroupAccount group = GroupAccount.create( accountKey );
-        group.setDisplayName( accountKey.getLocalName().toUpperCase() );
-        group.setCreatedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
-        group.setModifiedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
-        group.setMembers( AccountKeySet.from( members ) );
-        return group;
-    }
-
-    private RoleAccount createRole( final String qName, final AccountKey... members )
-    {
-        final AccountKey accountKey = AccountKey.role( qName );
-        final RoleAccount group = RoleAccount.create( accountKey );
-        group.setDisplayName( accountKey.getLocalName().toUpperCase() );
-        group.setCreatedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
-        group.setModifiedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
-        group.setMembers( AccountKeySet.from( members ) );
-        return group;
     }
 
 }

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getGroupGraph_param.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getGroupGraph_param.json
@@ -1,0 +1,3 @@
+{
+    "key": "group:enonic:Togservice"
+}

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getGroupGraph_result.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getGroupGraph_result.json
@@ -1,0 +1,29 @@
+{
+    "success": true,
+    "graph": [
+        {
+            "id": "1343213539380_user:enonic:aro",
+            "name": "ARO",
+            "data": {
+                "type": "user",
+                "key": "user:enonic:aro",
+                "name": "aro"
+            },
+            "adjacencies": []
+        },
+        {
+            "id": "1343213539380_group:enonic:Togservice",
+            "name": "TOGSERVICE",
+            "data": {
+                "type": "group",
+                "key": "group:enonic:Togservice",
+                "name": "Togservice"
+            },
+            "adjacencies": [
+                {
+                    "nodeTo": "1343213539380_user:enonic:aro"
+                }
+            ]
+        }
+    ]
+}

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getRoleGraph_param.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getRoleGraph_param.json
@@ -1,0 +1,3 @@
+{
+    "key": "role:enonic:admin"
+}

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getRoleGraph_result.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getRoleGraph_result.json
@@ -1,0 +1,42 @@
+{
+    "success": true,
+    "graph": [
+        {
+            "id": "1343213539380_user:enonic:aro",
+            "name": "ARO",
+            "data": {
+                "type": "user",
+                "key": "user:enonic:aro",
+                "name": "aro"
+            },
+            "adjacencies": []
+        },
+        {
+            "id": "1343213539380_group:enonic:Togservice",
+            "name": "TOGSERVICE",
+            "data": {
+                "type": "group",
+                "key": "group:enonic:Togservice",
+                "name": "Togservice"
+            },
+            "adjacencies": []
+        },
+        {
+            "id": "1343213539380_role:enonic:admin",
+            "name": "ADMIN",
+            "data": {
+                "type": "role",
+                "key": "role:enonic:admin",
+                "name": "admin"
+            },
+            "adjacencies": [
+                {
+                    "nodeTo": "1343213539380_group:enonic:Togservice"
+                },
+                {
+                    "nodeTo": "1343213539380_user:enonic:aro"
+                }
+            ]
+        }
+    ]
+}

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getUserGraph_param.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getUserGraph_param.json
@@ -1,0 +1,3 @@
+{
+    "key": "user:enonic:aro"
+}

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getUserGraph_result.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getUserGraph_result.json
@@ -1,0 +1,29 @@
+{
+    "success": true,
+    "graph": [
+        {
+            "id": "1343213539380_user:enonic:aro",
+            "name": "ARO",
+            "data": {
+                "type": "user",
+                "key": "user:enonic:aro",
+                "name": "aro"
+            },
+            "adjacencies": [
+                {
+                    "nodeTo": "1343213539380_group:enonic:Togservice"
+                }
+            ]
+        },
+        {
+            "id": "1343213539380_group:enonic:Togservice",
+            "name": "TOGSERVICE",
+            "data": {
+                "type": "group",
+                "key": "group:enonic:Togservice",
+                "name": "Togservice"
+            },
+            "adjacencies": []
+        }
+    ]
+}


### PR DESCRIPTION
Create account graph rpc handler using new API. Look at FindAccountsRpcHandler for example of using the API. Graph builder can be package protected inside account package. A template is already created at com.enonic.wem.web.data.account.GetAccountGraphRpcHandler.

 Note that this is using the old format. We are now using account keys in the following format <type>:<userstore>:<localname>. Example: user:enonic:aro.
