### PR TITLE
CMS-240 Remove organization from account filter in UI

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/controller/account/FilterPanelController.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/controller/account/FilterPanelController.js
@@ -50,9 +50,6 @@ Ext.define('Admin.controller.account.FilterPanelController', {
         if (!Ext.isEmpty(values.userstore)) {
             query.userstores = Ext.isArray(values.userstore) ? values.userstore.join(',') : values.userstore;
         }
-        if (!Ext.isEmpty(values.organization)) {
-            query.organizations = Ext.isArray(values.organization) ? values.organization.join(',') : values.organization;
-        }
         return query;
     }
 

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/FilterPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/FilterPanel.js
@@ -16,6 +16,7 @@ Ext.define('Admin.view.FilterPanel', {
 
     includeSearch: true,
     includeFacets: undefined,
+    excludeFacets: [],
     includeEmptyFacets: 'all', // all, last, none
 
     statics: {
@@ -173,12 +174,13 @@ Ext.define('Admin.view.FilterPanel', {
                         if (me.includeEmptyFacets === 'all' ||
                             (me.includeEmptyFacets === 'last' && me.lastFacetName === facet.name) ||
                             termCount > 0) {
-
-                            facetItems.push({
-                                name: facet.name,
-                                boxLabel: field + "<span class='count'>(" + facet.terms[field] + ")</span>",
-                                inputValue: field
-                            });
+                            if (!Ext.Array.contains(me.excludeFacets, facet.name)) {
+                                facetItems.push({
+                                    name: facet.name,
+                                    boxLabel: field + "<span class='count'>(" + facet.terms[field] + ")</span>",
+                                    inputValue: field
+                                });
+                            }
                         }
                     }
                 }

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/FilterPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/FilterPanel.js
@@ -3,6 +3,7 @@ Ext.define('Admin.view.account.FilterPanel', {
     alias: 'widget.accountFilter',
 
     includeSearch: true,
-    includeEmptyFacets: 'last'
+    includeEmptyFacets: 'last',
+    excludeFacets: ['organization']
 
 });


### PR DESCRIPTION
Remove organization from account filter in UI. The entire profile will be moved to content so we do not have the option on filtering on organization anymore.
