### PR TITLE
CMS-238 Use new getGraph rpc call in admin

### DIFF
--- a/modules/wem-web/src/main/java/com/enonic/wem/web/data/account/GetAccountGraphJsonResult.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/data/account/GetAccountGraphJsonResult.java
@@ -8,6 +8,7 @@ import org.codehaus.jackson.node.ObjectNode;
 
 import com.enonic.wem.api.account.Account;
 import com.enonic.wem.api.account.AccountKey;
+import com.enonic.wem.web.data.binary.AccountImageUriResolver;
 import com.enonic.wem.web.json.result.JsonResult;
 
 final class GetAccountGraphJsonResult
@@ -51,6 +52,7 @@ final class GetAccountGraphJsonResult
         ObjectNode node = objectNode();
         node.put( "type", accountKey.getType().toString().toLowerCase() );
         node.put( "key", accountKey.toString() );
+        node.put( "image_uri", AccountImageUriResolver.resolve( account ) );
         node.put( "name", accountKey.getLocalName() );
         return node;
     }

--- a/modules/wem-web/src/main/java/com/enonic/wem/web/data/account/GetAccountGraphRpcHandler.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/data/account/GetAccountGraphRpcHandler.java
@@ -50,7 +50,7 @@ public final class GetAccountGraphRpcHandler
             generateMembersGraph( accountKey, -1, nodeMap );
         }
         List<Account> accounts =
-            this.client.execute( Commands.account().find().selector( AccountSelectors.keys( nodeMap.keySet() ) ) ).getAll();
+            this.client.execute( Commands.account().find().selector( AccountSelectors.keys( nodeMap.keySet() ) ).includeImage() ).getAll();
         Map<Account, List<Account>> result = new HashMap<Account, List<Account>>();
         for ( Map.Entry<AccountKey, AccountKeys> entry : nodeMap.entrySet() )
         {

--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/account/group/GroupResult.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/account/group/GroupResult.java
@@ -6,9 +6,9 @@ import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.node.ArrayNode;
 import org.codehaus.jackson.node.ObjectNode;
 
-import com.enonic.wem.api.account.AccountType;
 import com.enonic.wem.web.rest2.common.JsonResult;
 import com.enonic.wem.web.rest2.resource.account.AccountUriHelper;
+import com.enonic.wem.web.rest2.resource.account.NewAccountKeyHelper;
 
 import com.enonic.cms.core.security.group.GroupEntity;
 import com.enonic.cms.core.security.group.GroupType;
@@ -44,6 +44,7 @@ public final class GroupResult
         final String key = String.valueOf( group.getGroupKey() );
 
         json.put( "key", key );
+        json.put( "new_key", NewAccountKeyHelper.composeNewKey( group ) );
         json.put( "type", TYPE_GROUP );
         json.put( "name", group.getName() );
         json.put( "userStore", group.getUserStore() != null ? group.getUserStore().getName() : "null" );

--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/account/user/UserResult.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/account/user/UserResult.java
@@ -7,10 +7,10 @@ import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.node.ArrayNode;
 import org.codehaus.jackson.node.ObjectNode;
 
-import com.enonic.wem.api.account.AccountType;
 import com.enonic.wem.core.search.UserInfoHelper;
 import com.enonic.wem.web.rest2.common.JsonResult;
 import com.enonic.wem.web.rest2.resource.account.AccountUriHelper;
+import com.enonic.wem.web.rest2.resource.account.NewAccountKeyHelper;
 
 import com.enonic.cms.api.client.model.user.Address;
 import com.enonic.cms.api.client.model.user.UserInfo;
@@ -59,6 +59,7 @@ public final class UserResult
 
         json.put( "key", key );
         json.put( "type", TYPE_USER );
+        json.put( "new_key", NewAccountKeyHelper.composeNewKey( user ) );
         json.put( "name", user.getName() );
         json.put( "email", user.getEmail() );
         json.put( "userStore", userstore != null ? userstore.getName() : "null" );

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/AbstractAccountRpcHandlerTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/AbstractAccountRpcHandlerTest.java
@@ -2,7 +2,12 @@ package com.enonic.wem.web.data.account;
 
 import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.joda.time.DateTime;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import com.google.common.collect.Lists;
 
@@ -64,5 +69,12 @@ public abstract class AbstractAccountRpcHandlerTest
         group.setModifiedTime( DateTime.parse( "2012-01-01T10:01:10.101+01:00" ) );
         group.setMembers( AccountKeys.from( members ) );
         return group;
+    }
+
+    protected void mockCurrentContextHttpRequest()
+    {
+        final HttpServletRequest req = new MockHttpServletRequest();
+        final ServletRequestAttributes attrs = new ServletRequestAttributes( req );
+        RequestContextHolder.setRequestAttributes( attrs );
     }
 }

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/FindAccountsRpcHandlerTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/FindAccountsRpcHandlerTest.java
@@ -1,12 +1,7 @@
 package com.enonic.wem.web.data.account;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
 import com.enonic.wem.api.Client;
 import com.enonic.wem.api.account.AccountKey;
@@ -89,13 +84,6 @@ public class FindAccountsRpcHandlerTest
     private void setResult( final AccountResult result )
     {
         Mockito.when( client.execute( Mockito.any( FindAccounts.class ) ) ).thenReturn( result );
-    }
-
-    private void mockCurrentContextHttpRequest()
-    {
-        final HttpServletRequest req = new MockHttpServletRequest();
-        final ServletRequestAttributes attrs = new ServletRequestAttributes( req );
-        RequestContextHolder.setRequestAttributes( attrs );
     }
 
 }

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/GetAccountGraphJsonHandlerTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/GetAccountGraphJsonHandlerTest.java
@@ -21,7 +21,7 @@ import com.enonic.wem.web.jsonrpc.JsonRpcHandler;
 
 import static org.junit.Assert.*;
 
-public class GetAccountGraphJsonResultTest
+public class GetAccountGraphJsonHandlerTest
     extends AbstractAccountRpcHandlerTest
 {
 
@@ -41,11 +41,13 @@ public class GetAccountGraphJsonResultTest
     public void testGetUserGraph()
         throws Exception
     {
+        mockCurrentContextHttpRequest();
         AccountKey userKey = AccountKey.from( "user:enonic:aro" );
         AccountKey groupKey = AccountKey.from( "group:enonic:Togservice" );
         Mockito.when( client.execute( Commands.account().findMemberships().key( userKey ) ) ).thenReturn( AccountKeys.from( groupKey ) );
         Mockito.when( client.execute( Commands.account().findMemberships().key( groupKey ) ) ).thenReturn( AccountKeys.empty() );
-        Mockito.when( client.execute( Commands.account().find().selector( AccountSelectors.keys( userKey, groupKey ) ) ) ).thenReturn(
+        Mockito.when(
+            client.execute( Commands.account().find().selector( AccountSelectors.keys( userKey, groupKey ) ).includeImage() ) ).thenReturn(
             createAccountResult( 1, createUser( "enonic:aro" ), createGroup( "enonic:Togservice" ) ) );
         testGraphSuccess( "getUserGraph_param.json", "getUserGraph_result.json" );
     }
@@ -55,10 +57,12 @@ public class GetAccountGraphJsonResultTest
     public void testGetGroupGraph()
         throws Exception
     {
+        mockCurrentContextHttpRequest();
         AccountKey userKey = AccountKey.from( "user:enonic:aro" );
         AccountKey groupKey = AccountKey.from( "group:enonic:Togservice" );
         Mockito.when( client.execute( Commands.account().findMembers().key( groupKey ) ) ).thenReturn( AccountKeys.from( userKey ) );
-        Mockito.when( client.execute( Commands.account().find().selector( AccountSelectors.keys( userKey, groupKey ) ) ) ).thenReturn(
+        Mockito.when(
+            client.execute( Commands.account().find().selector( AccountSelectors.keys( userKey, groupKey ) ).includeImage() ) ).thenReturn(
             createAccountResult( 1, createUser( "enonic:aro" ), createGroup( "enonic:Togservice" ) ) );
         testGraphSuccess( "getGroupGraph_param.json", "getGroupGraph_result.json" );
     }
@@ -67,14 +71,15 @@ public class GetAccountGraphJsonResultTest
     public void testGetRoleGraph()
         throws Exception
     {
+        mockCurrentContextHttpRequest();
         AccountKey userKey = AccountKey.from( "user:enonic:aro" );
         AccountKey groupKey = AccountKey.from( "group:enonic:Togservice" );
         AccountKey roleKey = AccountKey.from( "role:enonic:admin" );
         Mockito.when( client.execute( Commands.account().findMembers().key( roleKey ) ) ).thenReturn(
             AccountKeys.from( userKey, groupKey ) );
         Mockito.when( client.execute( Commands.account().findMembers().key( groupKey ) ) ).thenReturn( AccountKeys.empty() );
-        Mockito.when(
-            client.execute( Commands.account().find().selector( AccountSelectors.keys( userKey, groupKey, roleKey ) ) ) ).thenReturn(
+        Mockito.when( client.execute(
+            Commands.account().find().selector( AccountSelectors.keys( userKey, groupKey, roleKey ) ).includeImage() ) ).thenReturn(
             createAccountResult( 1, createRole( "enonic:admin" ), createUser( "enonic:aro" ), createGroup( "enonic:Togservice" ) ) );
         testGraphSuccess( "getRoleGraph_param.json", "getRoleGraph_result.json" );
     }
@@ -105,6 +110,7 @@ public class GetAccountGraphJsonResultTest
             assertTrue( "Required field type in data is missing", dataNode.has( "type" ) );
             assertTrue( "Required field key in data is missing", dataNode.has( "key" ) );
             assertTrue( "Required field name in data is missing", dataNode.has( "name" ) );
+            assertTrue( "Required field image_uri in data is missing", dataNode.has( "image_uri" ) );
             // Test adjacencies node
             ArrayNode adjacenciesNode = (ArrayNode) graphNode.get( "adjacencies" );
             Iterator<JsonNode> adjacenciesIterator = adjacenciesNode.iterator();

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/GetAccountRpcHandlerTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/data/account/GetAccountRpcHandlerTest.java
@@ -1,15 +1,10 @@
 package com.enonic.wem.web.data.account;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.node.ArrayNode;
 import org.codehaus.jackson.node.ObjectNode;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
 import com.enonic.wem.api.Client;
 import com.enonic.wem.api.account.AccountKeys;
@@ -130,13 +125,6 @@ public class GetAccountRpcHandlerTest
     private AccountKeys createAccountKeySet( String... keys )
     {
         return AccountKeys.from( keys );
-    }
-
-    private void mockCurrentContextHttpRequest()
-    {
-        final HttpServletRequest req = new MockHttpServletRequest();
-        final ServletRequestAttributes attrs = new ServletRequestAttributes( req );
-        RequestContextHolder.setRequestAttributes( attrs );
     }
 
 }

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getGroupGraph_result.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getGroupGraph_result.json
@@ -7,7 +7,8 @@
             "data": {
                 "type": "user",
                 "key": "user:enonic:aro",
-                "name": "aro"
+                "name": "aro",
+                "image_uri": "http://localhost/admin/rest/binary/account/image/user:enonic:aro"
             },
             "adjacencies": []
         },
@@ -17,7 +18,8 @@
             "data": {
                 "type": "group",
                 "key": "group:enonic:Togservice",
-                "name": "Togservice"
+                "name": "Togservice",
+                "image_uri": "http://localhost/admin/rest/binary/account/image/default/group"
             },
             "adjacencies": [
                 {

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getRoleGraph_result.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getRoleGraph_result.json
@@ -7,7 +7,8 @@
             "data": {
                 "type": "user",
                 "key": "user:enonic:aro",
-                "name": "aro"
+                "name": "aro",
+                "image_uri": "http://localhost/admin/rest/binary/account/image/user:enonic:aro"
             },
             "adjacencies": []
         },
@@ -17,7 +18,8 @@
             "data": {
                 "type": "group",
                 "key": "group:enonic:Togservice",
-                "name": "Togservice"
+                "name": "Togservice",
+                "image_uri": "http://localhost/admin/rest/binary/account/image/default/group"
             },
             "adjacencies": []
         },
@@ -27,7 +29,8 @@
             "data": {
                 "type": "role",
                 "key": "role:enonic:admin",
-                "name": "admin"
+                "name": "admin",
+                "image_uri": "http://localhost/admin/rest/binary/account/image/default/role"
             },
             "adjacencies": [
                 {

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getUserGraph_result.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/data/account/getUserGraph_result.json
@@ -7,7 +7,8 @@
             "data": {
                 "type": "user",
                 "key": "user:enonic:aro",
-                "name": "aro"
+                "name": "aro",
+                "image_uri": "http://localhost/admin/rest/binary/account/image/user:enonic:aro"
             },
             "adjacencies": [
                 {
@@ -21,7 +22,8 @@
             "data": {
                 "type": "group",
                 "key": "group:enonic:Togservice",
-                "name": "Togservice"
+                "name": "Togservice",
+                "image_uri": "http://localhost/admin/rest/binary/account/image/default/group"
             },
             "adjacencies": []
         }

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/rest2/resource/account/group/group_detail.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/rest2/resource/account/group/group_detail.json
@@ -1,5 +1,6 @@
 {
     "key": "BDA046019C23F8A3BCDFB9360E77375BB4BBBEC4",
+    "new_key": "group:enonic:dummygroup",
     "type": "group",
     "name": "dummygroup",
     "userStore": "enonic",

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/rest2/resource/account/user/user_detail.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/rest2/resource/account/user/user_detail.json
@@ -1,6 +1,7 @@
 {
     "key": "ASDD8F7S9F9AFAF7A89F7A87F98A7F9A87FA89F79AS98G7A9",
     "type": "user",
+    "new_key": "user:enonic:dummy",
     "name": "dummy",
     "email": "user@email.com",
     "userStore": "enonic",

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/MembershipsGraphPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/MembershipsGraphPanel.js
@@ -144,7 +144,7 @@ Ext.define('Admin.view.account.MembershipsGraphPanel', {
                         var imageX = (x + leftRightPadding);
                         var imageY = (y + 3);
 
-                        image.src = Admin.lib.UriHelper.getAccountIconUri(data, 16);
+                        image.src = data.image_uri;
                         if (!me.graph._loaded) {
                             image.onload = function () {
                                 context.drawImage(image, imageX, imageY, iconSize, iconSize);

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/preview/group/GroupPreviewPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/preview/group/GroupPreviewPanel.js
@@ -67,14 +67,12 @@ Ext.define('Admin.view.account.preview.group.GroupPreviewPanel', {
                                                 if (me.data) {
                                                     var mask = new Ext.LoadMask(this, {msg: "Please wait..."});
                                                     mask.show();
-                                                    Ext.Ajax.request({
-                                                        url: Admin.lib.UriHelper.getAccountGraphUri(me.data),
-                                                        success: function (response) {
-                                                            var graphData = Ext.JSON.decode(response.responseText).graph;
-                                                            me.graphData = graphData;
-                                                            me.down('membershipsGraphPanel').setGraphData(graphData);
-                                                            mask.hide();
+                                                    Admin.lib.RemoteService.account_getGraph({key: me.data.new_key}, function (r) {
+                                                        if (r.success) {
+                                                            me.graphData = r.graph;
+                                                            me.down('membershipsGraphPanel').setGraphData(me.graphData);
                                                         }
+                                                        mask.hide();
                                                     });
                                                 }
                                             }

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/preview/user/UserPreviewPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/preview/user/UserPreviewPanel.js
@@ -108,16 +108,13 @@ Ext.define('Admin.view.account.preview.user.UserPreviewPanel', {
                                                 if (!me.graphData) {
                                                     var mask = new Ext.LoadMask(this, {msg: "Please wait..."});
                                                     mask.show();
-                                                    Ext.Ajax.request({
-                                                        url: Admin.lib.UriHelper.getAccountGraphUri(me.data),
-                                                        success: function (response) {
-                                                            var graphData = Ext.JSON.decode(response.responseText).graph;
-                                                            me.graphData = graphData;
-                                                            me.down('membershipsGraphPanel').setGraphData(graphData);
-                                                            mask.hide();
+                                                    Admin.lib.RemoteService.account_getGraph({key: me.data.new_key}, function (r) {
+                                                        if (r.success) {
+                                                            me.graphData = r.graph;
+                                                            me.down('membershipsGraphPanel').setGraphData(me.graphData);
                                                         }
+                                                        mask.hide();
                                                     });
-
                                                 }
                                             }
                                         },


### PR DESCRIPTION
Use new account getGraph rpc call in admin. The rpc call does not support only json post (and not form post). To call the method form the UI, you can use the following pattern:

Admin.lib.RemoteService.account_getGraph( { key: "key" }, function(r) { } );

The key is not the old "48294879823FB4892793" format, but the new "user:store:name" format. The search panel still uses the old format, but also sends over the new key format (new_key). Use this to pass in to the new rpc method.
