### PR TITLE
CMS-257 Use new createOrUpdate rpc call in admin

### DIFF
--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/account/group/GroupResult.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest2/resource/account/group/GroupResult.java
@@ -79,6 +79,7 @@ public final class GroupResult
                 json.put( "displayName", user.getDisplayName() );
                 json.put( "type", TYPE_USER );
                 json.put( "key", user.getKey().toString() );
+                json.put( "new_key", NewAccountKeyHelper.composeNewKey( user ) );
             }
             else
             {
@@ -89,6 +90,7 @@ public final class GroupResult
                 json.put( "displayName", group.getName() );
                 json.put( "type", type );
                 json.put( "key", group.getGroupKey().toString() );
+                json.put( "new_key", NewAccountKeyHelper.composeNewKey( group ) );
             }
 
             jsonArray.add( json );

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/controller/account/GroupController.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/controller/account/GroupController.js
@@ -15,23 +15,12 @@ Ext.define('Admin.controller.account.GroupController', {
 
     saveGroupToDB: function (group, callback) {
         var me = this;
-        Ext.Ajax.request({
-            url: 'data/group/update',
-            method: 'POST',
-            jsonData: group,
-            success: function (response, opts) {
-                var serverResponse = Ext.JSON.decode(response.responseText);
-                if (!serverResponse.success) {
-                    Ext.Msg.alert('Error', serverResponse.error);
-                } else {
-                    callback(serverResponse.groupkey);
-                }
-                var current = me.getAccountGridPanel().store.currentPage;
-                me.getAccountGridPanel().store.loadPage(current);
-            },
-            failure: function (response, opts) {
-                Ext.Msg.alert('Error', 'Unable to update group');
+        Admin.lib.RemoteService.account_createOrUpdate(group, function (r) {
+            if (r && r.success) {
+                callback(group.key);
             }
+            var current = me.getAccountGridPanel().store.currentPage;
+            me.getAccountGridPanel().store.loadPage(current);
         });
     },
 

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/controller/account/UserController.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/controller/account/UserController.js
@@ -15,25 +15,13 @@ Ext.define('Admin.controller.account.UserController', {
 
     saveUserToDB: function (user, callback) {
         var me = this;
-        Ext.Ajax.request({
-            url: Admin.lib.UriHelper.getUserUpdateUri(user),
-            method: 'POST',
-            jsonData: user,
-            success: function (response, opts) {
-                var serverResponse = Ext.JSON.decode(response.responseText);
-                if (!serverResponse.success) {
-                    Ext.Msg.alert('Error', serverResponse.error);
-                } else {
-                    callback(serverResponse.userkey);
-                }
-                var current = me.getAccountGridPanel().store.currentPage;
-                me.getAccountGridPanel().store.loadPage(current);
-            },
-            failure: function (response, opts) {
-                Ext.Msg.alert('Error', 'Unable to update user');
+        Admin.lib.RemoteService.account_createOrUpdate(user, function (r) {
+            if (r && r.success) {
+                callback(user.key);
             }
+            var current = me.getAccountGridPanel().store.currentPage;
+            me.getAccountGridPanel().store.loadPage(current);
         });
-
     },
 
     changePasswordInDB: function (user, callback) {

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/wizard/group/WizardStepMembersPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/wizard/group/WizardStepMembersPanel.js
@@ -105,7 +105,7 @@ Ext.define('Admin.view.account.wizard.group.WizardStepMembersPanel', {
         var values = selectBox.valueModels;
         var groupsSelected = [];
         Ext.Array.each(values, function (group) {
-            var groupMap = {key: group.data.key, name: group.data.name, userStore: group.data.userStore};
+            var groupMap = group.data.new_key;
             groupsSelected.push(groupMap);
         });
         var userData = { members: groupsSelected };

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/wizard/user/UserWizardPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/wizard/user/UserWizardPanel.js
@@ -280,6 +280,9 @@ Ext.define('Admin.view.account.wizard.user.UserWizardPanel', {
 
     getData: function () {
         var wizardData = this.getWizardPanel().getData();
+        if (this.userFields) {
+            wizardData.key = this.userFields.key;
+        }
         var displayNameField = this.el.select('input.admin-display-name').item(0);
         if (displayNameField) {
             var data = {displayName: displayNameField.getValue() };

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/wizard/user/WizardStepMembershipPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/wizard/user/WizardStepMembershipPanel.js
@@ -89,12 +89,7 @@ Ext.define('Admin.view.account.wizard.user.WizardStepMembershipPanel', {
         var values = selectBox.valueModels;
         var groupsSelected = [];
         Ext.Array.each(values, function (group) {
-            var groupMap = {
-                key: group.raw.key,
-                name: group.raw.name,
-                qualifiedName: group.raw.qualifiedName,
-                type: group.raw.type
-            };
+            var groupMap = group.raw.new_key;
             groupsSelected.push(groupMap);
         });
         var userData = { groups: groupsSelected };


### PR DESCRIPTION
Use new createOrUpdate account rpc call in admin for info. To call the method form the UI, you can use the following pattern:

Admin.lib.RemoteService.account_createOrUpdate( { .. }, function(r) { } );

The profile is not yet supported, so the profile can now be ignored.

The key is not the old "48294879823FB4892793" format, but the new "user:store:name" format. The search panel still uses the old format, but also sends over the new key format (new_key). Use this to pass in to the new rpc method.
