### PR TITLE
CMS-260 Implement DeleteUserStores handler in API

### DIFF
--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest/rpc/userstore/DeleteUserStoresJsonResult.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest/rpc/userstore/DeleteUserStoresJsonResult.java
@@ -1,0 +1,23 @@
+package com.enonic.wem.web.rest.rpc.userstore;
+
+import org.codehaus.jackson.node.ObjectNode;
+
+import com.enonic.wem.web.json.JsonResult;
+
+final class DeleteUserStoresJsonResult
+    extends JsonResult
+{
+    private final int deletedAccounts;
+
+    public DeleteUserStoresJsonResult( final int deletedAccounts )
+    {
+        this.deletedAccounts = deletedAccounts;
+    }
+
+    @Override
+    protected void serialize( final ObjectNode json )
+    {
+        json.put( "deleted", deletedAccounts );
+    }
+
+}

--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest/rpc/userstore/DeleteUserStoresRpcHandler.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest/rpc/userstore/DeleteUserStoresRpcHandler.java
@@ -1,0 +1,27 @@
+package com.enonic.wem.web.rest.rpc.userstore;
+
+import org.springframework.stereotype.Component;
+
+import com.enonic.wem.api.command.Commands;
+import com.enonic.wem.api.userstore.UserStoreNames;
+import com.enonic.wem.web.json.rpc.JsonRpcContext;
+import com.enonic.wem.web.rest.rpc.AbstractDataRpcHandler;
+
+@Component
+public class DeleteUserStoresRpcHandler
+    extends AbstractDataRpcHandler
+{
+    public DeleteUserStoresRpcHandler()
+    {
+        super( "userstore_delete" );
+    }
+
+    @Override
+    public void handle( final JsonRpcContext context )
+        throws Exception
+    {
+        final String[] names = context.param( "name" ).required().asStringArray();
+        final int userStoresDeleted = this.client.execute( Commands.userStore().delete().names( UserStoreNames.from( names ) ) );
+        context.setResult( new DeleteUserStoresJsonResult( userStoresDeleted ) );
+    }
+}

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/rest/rpc/userstore/DeleteUserStoresRpcHadlerTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/rest/rpc/userstore/DeleteUserStoresRpcHadlerTest.java
@@ -1,0 +1,49 @@
+package com.enonic.wem.web.rest.rpc.userstore;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.enonic.wem.api.Client;
+import com.enonic.wem.api.command.userstore.DeleteUserStores;
+import com.enonic.wem.web.json.rpc.JsonRpcHandler;
+import com.enonic.wem.web.rest.rpc.AbstractRpcHandlerTest;
+
+public class DeleteUserStoresRpcHadlerTest
+    extends AbstractRpcHandlerTest
+{
+
+    private Client client;
+
+    @Override
+    protected JsonRpcHandler createHandler()
+        throws Exception
+    {
+        client = Mockito.mock( Client.class );
+        final DeleteUserStoresRpcHandler handler = new DeleteUserStoresRpcHandler();
+        handler.setClient( client );
+        return handler;
+    }
+
+    @Test
+    public void testRequestDeleteSingle()
+        throws Exception
+    {
+        setResult( 1 );
+
+        testSuccess( "deleteUserStores_param_single.json", "deleteUserStores_result.json" );
+    }
+
+    @Test
+    public void testRequestDeleteMultiple()
+        throws Exception
+    {
+        setResult( 1 );
+
+        testSuccess( "deleteUserStores_param_multiple.json", "deleteUserStores_result.json" );
+    }
+
+    private void setResult( final int result )
+    {
+        Mockito.when( client.execute( Mockito.any( DeleteUserStores.class ) ) ).thenReturn( result );
+    }
+}

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/rest/rpc/userstore/deleteUserStores_param_multiple.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/rest/rpc/userstore/deleteUserStores_param_multiple.json
@@ -1,0 +1,6 @@
+{
+    "name": [
+        "default",
+        "enonic"
+    ]
+}

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/rest/rpc/userstore/deleteUserStores_param_single.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/rest/rpc/userstore/deleteUserStores_param_single.json
@@ -1,0 +1,3 @@
+{
+    "name": [ "default" ]
+}

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/rest/rpc/userstore/deleteUserStores_result.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/rest/rpc/userstore/deleteUserStores_result.json
@@ -1,0 +1,4 @@
+{
+    "success": true,
+    "deleted": 1
+}


### PR DESCRIPTION
Implement DeleteUserStores handler in API. The command is com.enonic.wem.api.command.userstore.DeleteUserStores and the handler should be implemented on com.enonic.wem.core.userstore.DeleteUserStoresHandler.
