### PR TITLE
CMS-262 Implement GetUserStoreConnectors handler in API

### DIFF
--- a/modules/wem-api/src/main/java/com/enonic/wem/api/userstore/connector/UserStoreConnector.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/userstore/connector/UserStoreConnector.java
@@ -157,4 +157,38 @@ public final class UserStoreConnector
     {
         this.pluginClass = pluginClass;
     }
+
+    @Override
+    public boolean equals( final Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+
+        final UserStoreConnector that = (UserStoreConnector) o;
+
+        if ( !name.equals( that.name ) )
+        {
+            return false;
+        }
+        if ( !pluginClass.equals( that.pluginClass ) )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = name.hashCode();
+        result = 31 * result + pluginClass.hashCode();
+        return result;
+    }
 }

--- a/modules/wem-api/src/main/java/com/enonic/wem/api/userstore/connector/UserStoreConnectors.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/userstore/connector/UserStoreConnectors.java
@@ -52,11 +52,13 @@ public final class UserStoreConnectors
         return this.list.iterator();
     }
 
+    @Override
     public int hashCode()
     {
         return this.list.hashCode();
     }
 
+    @Override
     public boolean equals( final Object o )
     {
         return ( o instanceof UserStoreConnectors ) && this.list.equals( ( (UserStoreConnectors) o ).list );

--- a/modules/wem-core/src/main/java/com/enonic/wem/core/userstore/GetUserStoreConnectorsHandler.java
+++ b/modules/wem-core/src/main/java/com/enonic/wem/core/userstore/GetUserStoreConnectorsHandler.java
@@ -1,0 +1,68 @@
+package com.enonic.wem.core.userstore;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.enonic.wem.api.command.userstore.GetUserStoreConnectors;
+import com.enonic.wem.api.userstore.connector.UserStoreConnector;
+import com.enonic.wem.api.userstore.connector.UserStoreConnectors;
+import com.enonic.wem.core.command.CommandContext;
+import com.enonic.wem.core.command.CommandHandler;
+
+import com.enonic.cms.core.security.userstore.UserStoreConnectorManager;
+import com.enonic.cms.core.security.userstore.connector.config.UserStoreConnectorConfig;
+
+@Component
+public class GetUserStoreConnectorsHandler
+    extends CommandHandler<GetUserStoreConnectors>
+{
+
+    private UserStoreConnectorManager userStoreConnectorManager;
+
+    public GetUserStoreConnectorsHandler()
+    {
+        super( GetUserStoreConnectors.class );
+    }
+
+    @Override
+    public void handle( final CommandContext context, final GetUserStoreConnectors command )
+        throws Exception
+    {
+        Map<String, UserStoreConnectorConfig> connectorsConfig = userStoreConnectorManager.getUserStoreConnectorConfigs();
+        List<UserStoreConnector> connectors = new ArrayList<>();
+        for ( UserStoreConnectorConfig connectorConfig : connectorsConfig.values() )
+        {
+            connectors.add( buildUserStoreConnector( connectorConfig ) );
+        }
+        command.setResult( UserStoreConnectors.from( connectors ) );
+    }
+
+
+    private UserStoreConnector buildUserStoreConnector( UserStoreConnectorConfig connectorConfig )
+    {
+        UserStoreConnector connector = new UserStoreConnector( connectorConfig.getName() );
+        connector.setCreateGroup( connectorConfig.canCreateGroup() );
+        connector.setCreateUser( connectorConfig.canCreateUser() );
+        connector.setDeleteGroup( connectorConfig.canDeleteGroup() );
+        connector.setDeleteUser( connectorConfig.canDeleteUser() );
+        connector.setGroupsStoredRemote( connectorConfig.groupsStoredRemote() );
+        connector.setPluginClass( connectorConfig.getPluginType() );
+        connector.setReadGroup( connectorConfig.canReadGroup() );
+        connector.setResurrectDeletedGroups( connectorConfig.resurrectDeletedGroups() );
+        connector.setResurrectDeletedUsers( connectorConfig.resurrectDeletedUsers() );
+        connector.setUpdateGroup( connectorConfig.canUpdateGroup() );
+        connector.setUpdatePassword( connectorConfig.canUpdateUserPassword() );
+        connector.setUpdateUser( connectorConfig.canUpdateUser() );
+        return connector;
+    }
+
+    @Autowired
+    public void setUserStoreConnectorManager( final UserStoreConnectorManager userStoreConnectorManager )
+    {
+        this.userStoreConnectorManager = userStoreConnectorManager;
+    }
+}

--- a/modules/wem-core/src/test/java/com/enonic/wem/core/userstore/GetUserStoreConnectorsHandlerTest.java
+++ b/modules/wem-core/src/test/java/com/enonic/wem/core/userstore/GetUserStoreConnectorsHandlerTest.java
@@ -1,0 +1,74 @@
+package com.enonic.wem.core.userstore;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.enonic.wem.api.Client;
+import com.enonic.wem.api.command.Commands;
+import com.enonic.wem.api.userstore.connector.UserStoreConnector;
+import com.enonic.wem.api.userstore.connector.UserStoreConnectors;
+import com.enonic.wem.core.client.StandardClient;
+import com.enonic.wem.core.command.CommandInvokerImpl;
+
+import com.enonic.cms.core.security.userstore.UserStoreConnectorManager;
+import com.enonic.cms.core.security.userstore.connector.config.GroupPolicyConfig;
+import com.enonic.cms.core.security.userstore.connector.config.UserPolicyConfig;
+import com.enonic.cms.core.security.userstore.connector.config.UserStoreConnectorConfig;
+
+public class GetUserStoreConnectorsHandlerTest
+{
+
+    private Client client;
+
+    private UserStoreConnectorManager userStoreConnectorManager;
+
+    @Before
+    public void setUp()
+    {
+        userStoreConnectorManager = Mockito.mock( UserStoreConnectorManager.class );
+
+        final GetUserStoreConnectorsHandler handler = new GetUserStoreConnectorsHandler();
+        handler.setUserStoreConnectorManager( userStoreConnectorManager );
+
+        final StandardClient standardClient = new StandardClient();
+        final CommandInvokerImpl commandInvoker = new CommandInvokerImpl();
+        commandInvoker.setHandlers( handler );
+        standardClient.setInvoker( commandInvoker );
+
+        client = standardClient;
+    }
+
+    @Test
+    public void testGetUserStoreConnectors()
+    {
+        Map<String, UserStoreConnectorConfig> userStoreConnectorConfigs = new HashMap<>();
+        userStoreConnectorConfigs.put( "ad", createUserStoreConnectorConfig( "ad" ) );
+        userStoreConnectorConfigs.put( "enonic", createUserStoreConnectorConfig( "enonic" ) );
+        UserStoreConnectors expectedResult =
+            UserStoreConnectors.from( Arrays.asList( createUserStoreConnector( "ad" ), createUserStoreConnector( "enonic" ) ) );
+        Mockito.when( userStoreConnectorManager.getUserStoreConnectorConfigs() ).thenReturn( userStoreConnectorConfigs );
+        UserStoreConnectors actualResult = client.execute( Commands.userStore().getConnectors() );
+
+        assert ( expectedResult.getList().containsAll( actualResult.getList() ) );
+
+    }
+
+
+    private UserStoreConnectorConfig createUserStoreConnectorConfig( String name )
+    {
+        return new UserStoreConnectorConfig( name, "ldap", UserPolicyConfig.ALL_FALSE, GroupPolicyConfig.ALL_FALSE );
+    }
+
+    private UserStoreConnector createUserStoreConnector( String name )
+    {
+        UserStoreConnector userStoreConnector = new UserStoreConnector( name );
+        userStoreConnector.setPluginClass( "ldap" );
+        userStoreConnector.setGroupsStoredRemote( true );
+        return userStoreConnector;
+    }
+}


### PR DESCRIPTION
Implement GetUserStoreConnectors handler in API. The command is com.enonic.wem.api.command.userstore.GetUserStoreConnectors and the handler should be implemented on com.enonic.wem.core.userstore.GetUserStoreConnectorsHandler.
