### PR TITLE
CMS-266 Implement userstore config parsing/serializing in API

### DIFF
--- a/modules/wem-api/src/main/java/com/enonic/wem/api/exception/InvalidUserStoreConfigException.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/exception/InvalidUserStoreConfigException.java
@@ -1,0 +1,15 @@
+package com.enonic.wem.api.exception;
+
+public class InvalidUserStoreConfigException
+    extends BaseException
+{
+    public InvalidUserStoreConfigException( final String message, final Object... args )
+    {
+        super( message, args );
+    }
+
+    public InvalidUserStoreConfigException( final Throwable cause, final String message, final Object... args )
+    {
+        super( cause, message, args );
+    }
+}

--- a/modules/wem-api/src/main/java/com/enonic/wem/api/userstore/config/UserStoreConfigParser.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/userstore/config/UserStoreConfigParser.java
@@ -1,12 +1,20 @@
 package com.enonic.wem.api.userstore.config;
 
 import java.io.StringReader;
+import java.util.List;
 
 import org.jdom.Document;
+import org.jdom.Element;
 import org.jdom.input.SAXBuilder;
+
+import com.enonic.wem.api.exception.InvalidUserStoreConfigException;
 
 public final class UserStoreConfigParser
 {
+    private final static String ROOT_ELEMENT_NAME = "config";
+
+    private final static String USER_FIELDS_ELEMENT_NAME = "user-fields";
+
     private final SAXBuilder builder;
 
     public UserStoreConfigParser()
@@ -24,7 +32,43 @@ public final class UserStoreConfigParser
     public UserStoreConfig parseXml( final Document xml )
         throws Exception
     {
-        // TODO: Implement parsing of UserStoreConfig
-        return null;
+        UserStoreConfig userStoreConfig = new UserStoreConfig();
+        Element root = xml.getRootElement();
+        if ( !ROOT_ELEMENT_NAME.equals( root.getName() ) )
+        {
+            throw new InvalidUserStoreConfigException( "Illegal root element:  {0}; must be: {1}", root.getName(), ROOT_ELEMENT_NAME );
+        }
+        Element userFields = root.getChild( USER_FIELDS_ELEMENT_NAME );
+        if ( userFields == null )
+        {
+            throw new InvalidUserStoreConfigException( "Cannot find '{0}' element", USER_FIELDS_ELEMENT_NAME );
+        }
+        List<Element> children = userFields.getChildren();
+        for ( Element child : children )
+        {
+            UserStoreFieldConfig userStoreFieldConfig = parseUserFieldElement( child );
+            userStoreConfig.addField( userStoreFieldConfig );
+        }
+
+        return userStoreConfig;
+    }
+
+    private UserStoreFieldConfig parseUserFieldElement( Element userField )
+    {
+        UserStoreFieldConfig userStoreFieldConfig = new UserStoreFieldConfig( userField.getName() );
+        String iso = userField.getAttributeValue( "iso" );
+        String readOnly = userField.getAttributeValue( "readonly" );
+        String required = userField.getAttributeValue( "required" );
+        String remote = userField.getAttributeValue( "remote" );
+        userStoreFieldConfig.setIso( iso != null ? Boolean.valueOf( iso ) : true );
+        userStoreFieldConfig.setReadOnly( Boolean.valueOf( readOnly ) );
+        userStoreFieldConfig.setRequired( Boolean.valueOf( required ) );
+        userStoreFieldConfig.setRemote( Boolean.valueOf( remote ) );
+        if ( userStoreFieldConfig.isRequired() && userStoreFieldConfig.isReadOnly() )
+        {
+            throw new InvalidUserStoreConfigException(
+                "Illegal field config in {0}: field cannot be required and readonly in the same time", userStoreFieldConfig.getName() );
+        }
+        return userStoreFieldConfig;
     }
 }

--- a/modules/wem-api/src/main/java/com/enonic/wem/api/userstore/config/UserStoreConfigSerializer.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/userstore/config/UserStoreConfigSerializer.java
@@ -1,6 +1,7 @@
 package com.enonic.wem.api.userstore.config;
 
 import org.jdom.Document;
+import org.jdom.Element;
 import org.jdom.output.Format;
 import org.jdom.output.XMLOutputter;
 
@@ -17,8 +18,16 @@ public final class UserStoreConfigSerializer
     public Document toXml( final UserStoreConfig config )
         throws Exception
     {
-        // TODO: Implement serializing of UserStoreConfig
-        return null;
+        Element configEl = new Element( "config" );
+        Element userFields = new Element( "user-fields" );
+        for ( UserStoreFieldConfig field : config.getFields() )
+        {
+            Element userFieldEl = buildUserFieldElement( field );
+
+            userFields.addContent( userFieldEl );
+        }
+        configEl.addContent( userFields );
+        return new Document( configEl );
     }
 
     public String toXmlString( final UserStoreConfig config )
@@ -26,5 +35,27 @@ public final class UserStoreConfigSerializer
     {
         final Document doc = toXml( config );
         return this.out.outputString( doc );
+    }
+
+    private Element buildUserFieldElement( UserStoreFieldConfig field )
+    {
+        Element fieldEl = new Element( field.getName() );
+        if ( field.isReadOnly() )
+        {
+            fieldEl.setAttribute( "readonly", String.valueOf( field.isReadOnly() ) );
+        }
+        if ( field.isRequired() )
+        {
+            fieldEl.setAttribute( "required", String.valueOf( field.isRequired() ) );
+        }
+        if ( field.isRequired() )
+        {
+            fieldEl.setAttribute( "remote", String.valueOf( field.isRemote() ) );
+        }
+        if ( "address".equals( field.getName() ) && !field.isIso() )
+        {
+            fieldEl.setAttribute( "iso", String.valueOf( field.isIso() ) );
+        }
+        return fieldEl;
     }
 }

--- a/modules/wem-api/src/test/java/com/enonic/wem/api/userstore/config/UserStoreConfigParserTest.java
+++ b/modules/wem-api/src/test/java/com/enonic/wem/api/userstore/config/UserStoreConfigParserTest.java
@@ -1,0 +1,91 @@
+package com.enonic.wem.api.userstore.config;
+
+import java.io.IOException;
+
+import org.jdom.Document;
+import org.jdom.JDOMException;
+import org.jdom.input.SAXBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.enonic.wem.api.exception.InvalidUserStoreConfigException;
+
+import static org.junit.Assert.*;
+
+public class UserStoreConfigParserTest
+{
+    private UserStoreConfigParser parser;
+
+    private SAXBuilder builder;
+
+    @Before
+    public void setUp()
+    {
+        parser = new UserStoreConfigParser();
+        builder = new SAXBuilder();
+    }
+
+    @Test(expected = InvalidUserStoreConfigException.class)
+    public void parseInvalidUserStoreConfig()
+        throws Exception
+    {
+        Document doc = buildDocument( "userStoreConfig_invalid.xml" );
+        parser.parseXml( doc );
+    }
+
+    @Test(expected = InvalidUserStoreConfigException.class)
+    public void parseWrongRootUserStoreConfig()
+        throws Exception
+    {
+        Document doc = buildDocument( "userStoreConfig_wrongRoot.xml" );
+        parser.parseXml( doc );
+    }
+
+    @Test(expected = InvalidUserStoreConfigException.class)
+    public void parseWrongStructureUserStoreConfig()
+        throws Exception
+    {
+        Document doc = buildDocument( "userStoreConfig_wrongStructure.xml" );
+        parser.parseXml( doc );
+    }
+
+    @Test
+    public void parseValidUserStoreConfig()
+        throws Exception
+    {
+        Document doc = buildDocument( "userStoreConfig_valid.xml" );
+        UserStoreConfig config = parser.parseXml( doc );
+        assertEquals( 25, config.getFields().size() );
+        assertNotNull( config.getField( "prefix" ) );
+        assertNotNull( config.getField( "first-name" ) );
+        assertNotNull( config.getField( "middle-name" ) );
+        assertNotNull( config.getField( "last-name" ) );
+        assertNotNull( config.getField( "suffix" ) );
+        assertNotNull( config.getField( "initials" ) );
+        assertNotNull( config.getField( "nick-name" ) );
+        assertNotNull( config.getField( "photo" ) );
+        assertNotNull( config.getField( "personal-id" ) );
+        assertNotNull( config.getField( "member-id" ) );
+        assertNotNull( config.getField( "organization" ) );
+        assertNotNull( config.getField( "birthday" ) );
+        assertNotNull( config.getField( "gender" ) );
+        assertNotNull( config.getField( "title" ) );
+        assertNotNull( config.getField( "description" ) );
+        assertNotNull( config.getField( "html-email" ) );
+        assertNotNull( config.getField( "home-page" ) );
+        assertNotNull( config.getField( "time-zone" ) );
+        assertNotNull( config.getField( "locale" ) );
+        assertNotNull( config.getField( "country" ) );
+        assertNotNull( config.getField( "global-position" ) );
+        assertNotNull( config.getField( "phone" ) );
+        assertNotNull( config.getField( "mobile" ) );
+        assertNotNull( config.getField( "fax" ) );
+        assertNotNull( config.getField( "address" ) );
+    }
+
+    private Document buildDocument( String filename )
+        throws IOException, JDOMException
+    {
+        return builder.build( getClass().getResource( filename ).openStream() );
+    }
+}

--- a/modules/wem-api/src/test/java/com/enonic/wem/api/userstore/config/UserStoreConfigSerializerTest.java
+++ b/modules/wem-api/src/test/java/com/enonic/wem/api/userstore/config/UserStoreConfigSerializerTest.java
@@ -1,0 +1,81 @@
+package com.enonic.wem.api.userstore.config;
+
+import java.util.List;
+
+import org.jdom.Attribute;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.input.SAXBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class UserStoreConfigSerializerTest
+{
+
+    private UserStoreConfigSerializer serializer;
+
+    private SAXBuilder builder;
+
+    @Before
+    public void setUp()
+    {
+        serializer = new UserStoreConfigSerializer();
+        builder = new SAXBuilder();
+    }
+
+    @Test
+    public void testUserStoreConfigSerialization()
+        throws Exception
+    {
+        UserStoreConfig config = new UserStoreConfig();
+        config.addField( new UserStoreFieldConfig( "prefix" ) );
+        config.addField( new UserStoreFieldConfig( "first-name" ) );
+        config.addField( new UserStoreFieldConfig( "middle-name" ) );
+        config.addField( new UserStoreFieldConfig( "last-name" ) );
+        config.addField( new UserStoreFieldConfig( "suffix" ) );
+        config.addField( new UserStoreFieldConfig( "initials" ) );
+        config.addField( new UserStoreFieldConfig( "nick-name" ) );
+        config.addField( new UserStoreFieldConfig( "photo" ) );
+        config.addField( new UserStoreFieldConfig( "personal-id" ) );
+        config.addField( new UserStoreFieldConfig( "member-id" ) );
+        config.addField( new UserStoreFieldConfig( "organization" ) );
+        config.addField( new UserStoreFieldConfig( "birthday" ) );
+        config.addField( new UserStoreFieldConfig( "gender" ) );
+        config.addField( new UserStoreFieldConfig( "title" ) );
+        config.addField( new UserStoreFieldConfig( "description" ) );
+        config.addField( new UserStoreFieldConfig( "html-email" ) );
+        config.addField( new UserStoreFieldConfig( "home-page" ) );
+        config.addField( new UserStoreFieldConfig( "time-zone" ) );
+        config.addField( new UserStoreFieldConfig( "locale" ) );
+        config.addField( new UserStoreFieldConfig( "country" ) );
+        config.addField( new UserStoreFieldConfig( "global-position" ) );
+        config.addField( new UserStoreFieldConfig( "phone" ) );
+        config.addField( new UserStoreFieldConfig( "mobile" ) );
+        config.addField( new UserStoreFieldConfig( "fax" ) );
+        config.addField( new UserStoreFieldConfig( "address" ) );
+        Document expectedDoc = builder.build( getClass().getResource( "userStoreConfig_valid.xml" ).openStream() );
+        Document actualDoc = serializer.toXml( config );
+        assertDocs( expectedDoc, actualDoc );
+    }
+
+    private void assertDocs( Document expected, Document actual )
+    {
+        Element root = actual.getRootElement();
+        assertEquals( "config", root.getName() );
+        Element userFields = root.getChild( "user-fields" );
+        assertNotNull( userFields );
+        List<Element> expectedUserFields = expected.getRootElement().getChild( "user-fields" ).getChildren();
+        for ( Element child : expectedUserFields )
+        {
+            Element actualChild = userFields.getChild( child.getName() );
+            assertNotNull( actualChild );
+            List<Attribute> attributes = child.getAttributes();
+            for ( Attribute attribute : attributes )
+            {
+                assertEquals( attribute.getValue(), actualChild.getAttributeValue( attribute.getName() ) );
+            }
+        }
+    }
+}

--- a/modules/wem-api/src/test/resource/com/enonic/wem/api/userstore/config/userStoreConfig_invalid.xml
+++ b/modules/wem-api/src/test/resource/com/enonic/wem/api/userstore/config/userStoreConfig_invalid.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<config>
+  <user-fields>
+
+    <!-- Name -->
+    <prefix required="true" readonly="true"/>
+    <first-name/>
+    <middle-name/>
+    <last-name/>
+    <suffix/>
+    <initials/>
+    <nick-name/>
+
+    <!-- Photo -->
+    <photo/>
+
+    <!-- Personal info -->
+    <personal-id/>
+    <member-id/>
+    <organization/>
+    <birthday/>
+    <gender/>
+    <title/>
+    <description/>
+    <html-email/>
+    <home-page/>
+    <time-zone/>
+    <locale/>
+    <country/>
+    <global-position/>
+    <phone/>
+    <mobile/>
+    <fax/>
+    <address/>
+
+  </user-fields>
+</config>

--- a/modules/wem-api/src/test/resource/com/enonic/wem/api/userstore/config/userStoreConfig_valid.xml
+++ b/modules/wem-api/src/test/resource/com/enonic/wem/api/userstore/config/userStoreConfig_valid.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+  <user-fields>
+
+    <!-- Name -->
+    <prefix/>
+    <first-name/>
+    <middle-name/>
+    <last-name/>
+    <suffix/>
+    <initials/>
+    <nick-name/>
+
+    <!-- Photo -->
+    <photo/>
+
+    <!-- Personal info -->
+    <personal-id/>
+    <member-id/>
+    <organization/>
+    <birthday/>
+    <gender/>
+    <title/>
+    <description/>
+    <html-email/>
+    <home-page/>
+    <time-zone/>
+    <locale/>
+    <country/>
+    <global-position/>
+    <phone/>
+    <mobile/>
+    <fax/>
+    <address iso="false"/>
+
+  </user-fields>
+</config>

--- a/modules/wem-api/src/test/resource/com/enonic/wem/api/userstore/config/userStoreConfig_wrongRoot.xml
+++ b/modules/wem-api/src/test/resource/com/enonic/wem/api/userstore/config/userStoreConfig_wrongRoot.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<wrong-root>
+  <user-fields>
+
+    <!-- Name -->
+    <prefix/>
+    <first-name/>
+    <middle-name/>
+    <last-name/>
+    <suffix/>
+    <initials/>
+    <nick-name/>
+
+    <!-- Photo -->
+    <photo/>
+
+    <!-- Personal info -->
+    <personal-id/>
+    <member-id/>
+    <organization/>
+    <birthday/>
+    <gender/>
+    <title/>
+    <description/>
+    <html-email/>
+    <home-page/>
+    <time-zone/>
+    <locale/>
+    <country/>
+    <global-position/>
+    <phone/>
+    <mobile/>
+    <fax/>
+    <address/>
+
+  </user-fields>
+</wrong-root>

--- a/modules/wem-api/src/test/resource/com/enonic/wem/api/userstore/config/userStoreConfig_wrongStructure.xml
+++ b/modules/wem-api/src/test/resource/com/enonic/wem/api/userstore/config/userStoreConfig_wrongStructure.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<config>
+
+  <!-- Name -->
+  <prefix/>
+  <first-name/>
+  <middle-name/>
+  <last-name/>
+  <suffix/>
+  <initials/>
+  <nick-name/>
+
+  <!-- Photo -->
+  <photo/>
+
+  <!-- Personal info -->
+  <personal-id/>
+  <member-id/>
+  <organization/>
+  <birthday/>
+  <gender/>
+  <title/>
+  <description/>
+  <html-email/>
+  <home-page/>
+  <time-zone/>
+  <locale/>
+  <country/>
+  <global-position/>
+  <phone/>
+  <mobile/>
+  <fax/>
+  <address/>
+
+</config>


### PR DESCRIPTION
Implement userstore config parsing/serializing in API. We need to handle this manually since it's a little complex to use JAXB for this structure. The code should be placed in com.enonic.wem.api.userstore.config.UserStoreConfigParser and com.enonic.wem.api.userstore.config.UserStoreConfigSerializer.
