### PR TITLE
CMS-269 Implement userstore_delete rpc handler

### DIFF
--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest/rpc/userstore/DeleteUserStoreJsonResult.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest/rpc/userstore/DeleteUserStoreJsonResult.java
@@ -1,0 +1,22 @@
+package com.enonic.wem.web.rest.rpc.userstore;
+
+import org.codehaus.jackson.node.ObjectNode;
+
+import com.enonic.wem.web.json.JsonResult;
+
+public class DeleteUserStoreJsonResult
+    extends JsonResult
+{
+    private int deletedUserStores;
+
+    public DeleteUserStoreJsonResult( int deletedUserStores )
+    {
+        this.deletedUserStores = deletedUserStores;
+    }
+
+    @Override
+    protected void serialize( final ObjectNode json )
+    {
+        json.put( "deleted", deletedUserStores );
+    }
+}

--- a/modules/wem-web/src/main/java/com/enonic/wem/web/rest/rpc/userstore/DeleteUserStoreRpcHandler.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/web/rest/rpc/userstore/DeleteUserStoreRpcHandler.java
@@ -1,0 +1,25 @@
+package com.enonic.wem.web.rest.rpc.userstore;
+
+import com.enonic.wem.api.command.Commands;
+import com.enonic.wem.api.userstore.UserStoreNames;
+import com.enonic.wem.web.json.rpc.JsonRpcContext;
+import com.enonic.wem.web.rest.rpc.AbstractDataRpcHandler;
+
+public class DeleteUserStoreRpcHandler
+    extends AbstractDataRpcHandler
+{
+    public DeleteUserStoreRpcHandler()
+    {
+        super( "userstore_delete" );
+    }
+
+    @Override
+    public void handle( final JsonRpcContext context )
+        throws Exception
+    {
+        final String[] names = context.param( "name" ).required().asStringArray();
+        final UserStoreNames userStoreNames = UserStoreNames.from( names );
+        final Integer userStoresDeleted = client.execute( Commands.userStore().delete().names( userStoreNames ) );
+        context.setResult( new DeleteUserStoreJsonResult( userStoresDeleted ) );
+    }
+}

--- a/modules/wem-web/src/test/java/com/enonic/wem/web/rest/rpc/userstore/DeleteUserStoreRpcHandlerTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/web/rest/rpc/userstore/DeleteUserStoreRpcHandlerTest.java
@@ -1,0 +1,49 @@
+package com.enonic.wem.web.rest.rpc.userstore;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.enonic.wem.api.Client;
+import com.enonic.wem.api.command.userstore.DeleteUserStores;
+import com.enonic.wem.web.json.rpc.JsonRpcHandler;
+import com.enonic.wem.web.rest.rpc.AbstractRpcHandlerTest;
+
+public class DeleteUserStoreRpcHandlerTest
+    extends AbstractRpcHandlerTest
+{
+
+    private Client client;
+
+    @Override
+    protected JsonRpcHandler createHandler()
+        throws Exception
+    {
+        client = Mockito.mock( Client.class );
+        final DeleteUserStoreRpcHandler handler = new DeleteUserStoreRpcHandler();
+        handler.setClient( client );
+        return handler;
+    }
+
+    @Test
+    public void testRequestDeleteSingle()
+        throws Exception
+    {
+        setResult( 1 );
+
+        testSuccess( "deleteUserStore_param_single.json", "deleteUserStore_result.json" );
+    }
+
+    @Test
+    public void testRequestDeleteMultiple()
+        throws Exception
+    {
+        setResult( 1 );
+
+        testSuccess( "deleteUserStore_param_multiple.json", "deleteUserStore_result.json" );
+    }
+
+    private void setResult( final int result )
+    {
+        Mockito.when( client.execute( Mockito.any( DeleteUserStores.class ) ) ).thenReturn( result );
+    }
+}

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/rest/rpc/userstore/deleteUserStore_param_multiple.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/rest/rpc/userstore/deleteUserStore_param_multiple.json
@@ -1,0 +1,6 @@
+{
+    "name": [
+        "default",
+        "enonic"
+    ]
+}

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/rest/rpc/userstore/deleteUserStore_param_single.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/rest/rpc/userstore/deleteUserStore_param_single.json
@@ -1,0 +1,3 @@
+{
+    "name": [ "default" ]
+}

--- a/modules/wem-web/src/test/resources/com/enonic/wem/web/rest/rpc/userstore/deleteUserStore_result.json
+++ b/modules/wem-web/src/test/resources/com/enonic/wem/web/rest/rpc/userstore/deleteUserStore_result.json
@@ -1,0 +1,4 @@
+{
+    "success": true,
+    "deleted": 1
+}


### PR DESCRIPTION
Implement userstore_delete rpc handler ontop of new API. It should take multiple names. Implement inside package com.enonic.wem.web.rest.rpc.userstore. This task depends on CMS-260.
