### PR TITLE
CMS-264 Implement CreateUserStore handler in API

### DIFF
--- a/modules/wem-core/src/main/java/com/enonic/wem/core/userstore/CreateUserStoreHandler.java
+++ b/modules/wem-core/src/main/java/com/enonic/wem/core/userstore/CreateUserStoreHandler.java
@@ -1,0 +1,40 @@
+package com.enonic.wem.core.userstore;
+
+import org.springframework.stereotype.Component;
+
+import com.enonic.wem.api.command.userstore.CreateUserStore;
+import com.enonic.wem.api.userstore.UserStore;
+import com.enonic.wem.core.command.CommandContext;
+
+import com.enonic.cms.core.security.user.UserEntity;
+import com.enonic.cms.core.security.userstore.StoreNewUserStoreCommand;
+import com.enonic.cms.core.security.userstore.UserStoreKey;
+
+@Component
+public class CreateUserStoreHandler
+    extends UserStoreHandler<CreateUserStore>
+{
+
+    public CreateUserStoreHandler()
+    {
+        super( CreateUserStore.class );
+    }
+
+    @Override
+    public void handle( final CommandContext context, final CreateUserStore command )
+        throws Exception
+    {
+        UserStore userStore = command.getUserStore();
+        UserEntity storer = userDao.findBuiltInEnterpriseAdminUser(); // TODO get logged in user
+        StoreNewUserStoreCommand storeCommand = new StoreNewUserStoreCommand();
+        storeCommand.setConnectorName( userStore.getConnectorName() );
+        storeCommand.setName( userStore.getName().toString() );
+        storeCommand.setDefaultStore( userStore.isDefaultStore() );
+        storeCommand.setConfig( convertToOldConfig( userStore.getConfig() ) );
+        storeCommand.setStorer( storer.getKey() );
+        UserStoreKey newUserStore = userStoreService.storeNewUserStore( storeCommand );
+        updateUserstoreAdministrators( storer, newUserStore, userStore.getAdministrators() );
+        command.setResult( userStore.getName() );
+    }
+
+}

--- a/modules/wem-core/src/main/java/com/enonic/wem/core/userstore/UserStoreHandler.java
+++ b/modules/wem-core/src/main/java/com/enonic/wem/core/userstore/UserStoreHandler.java
@@ -1,0 +1,192 @@
+package com.enonic.wem.core.userstore;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.enonic.wem.api.account.AccountKey;
+import com.enonic.wem.api.account.AccountKeys;
+import com.enonic.wem.api.command.Command;
+import com.enonic.wem.api.userstore.config.UserStoreConfig;
+import com.enonic.wem.api.userstore.config.UserStoreFieldConfig;
+import com.enonic.wem.core.command.CommandHandler;
+import com.enonic.wem.core.search.account.AccountIndexData;
+import com.enonic.wem.core.search.account.AccountIndexDataEntity;
+import com.enonic.wem.core.search.account.AccountSearchService;
+import com.enonic.wem.core.search.account.Group;
+
+import com.enonic.cms.core.security.SecurityService;
+import com.enonic.cms.core.security.group.GroupEntity;
+import com.enonic.cms.core.security.group.GroupKey;
+import com.enonic.cms.core.security.group.GroupSpecification;
+import com.enonic.cms.core.security.group.GroupType;
+import com.enonic.cms.core.security.group.UpdateGroupCommand;
+import com.enonic.cms.core.security.user.UserEntity;
+import com.enonic.cms.core.security.userstore.UserStoreEntity;
+import com.enonic.cms.core.security.userstore.UserStoreKey;
+import com.enonic.cms.core.security.userstore.UserStoreService;
+import com.enonic.cms.core.security.userstore.config.UserStoreUserFieldConfig;
+import com.enonic.cms.core.user.field.UserFieldType;
+import com.enonic.cms.store.dao.GroupDao;
+import com.enonic.cms.store.dao.UserDao;
+import com.enonic.cms.store.dao.UserStoreDao;
+
+public abstract class UserStoreHandler<T extends Command>
+    extends CommandHandler<T>
+{
+
+    protected UserDao userDao;
+
+    protected UserStoreDao userStoreDao;
+
+    protected UserStoreService userStoreService;
+
+    protected SecurityService securityService;
+
+    protected AccountSearchService searchService;
+
+    protected GroupDao groupDao;
+
+
+    public UserStoreHandler( final Class<T> type )
+    {
+        super( type );
+    }
+
+    protected com.enonic.cms.core.security.userstore.config.UserStoreConfig convertToOldConfig( UserStoreConfig config )
+    {
+        com.enonic.cms.core.security.userstore.config.UserStoreConfig oldConfig =
+            new com.enonic.cms.core.security.userstore.config.UserStoreConfig();
+        for ( UserStoreFieldConfig fieldConfig : config )
+        {
+            oldConfig.addUserFieldConfig( convertToOldFieldConfig( fieldConfig ) );
+        }
+        return oldConfig;
+    }
+
+    protected UserStoreUserFieldConfig convertToOldFieldConfig( UserStoreFieldConfig fieldConfig )
+    {
+        UserStoreUserFieldConfig oldFieldConfig = new UserStoreUserFieldConfig( UserFieldType.fromName( fieldConfig.getName() ) );
+        oldFieldConfig.setIso( fieldConfig.isIso() );
+        oldFieldConfig.setReadOnly( fieldConfig.isReadOnly() );
+        oldFieldConfig.setRemote( fieldConfig.isReadOnly() );
+        oldFieldConfig.setRequired( fieldConfig.isRequired() );
+        return oldFieldConfig;
+    }
+
+    protected GroupEntity getGroupEntity( AccountKey accountKey )
+    {
+        UserStoreEntity userStoreEntity = userStoreDao.findByName( accountKey.getUserStore() );
+        if ( accountKey.isGroup() || accountKey.isRole() )
+        {
+            List<GroupEntity> groups =
+                groupDao.findByUserStoreKeyAndGroupname( userStoreEntity.getKey(), accountKey.getLocalName(), false );
+            if ( groups.size() > 0 )
+            {
+                return groups.get( 0 );
+            }
+        }
+        else
+        {
+            UserEntity user = userDao.findByUserStoreKeyAndUsername( userStoreEntity.getKey(), accountKey.getLocalName() );
+            return user.getUserGroup();
+        }
+        return null;
+    }
+
+    protected void updateUserstoreAdministrators( UserEntity user, UserStoreKey userStoreKey, AccountKeys administrators )
+    {
+        GroupSpecification spec = new GroupSpecification();
+        spec.setType( GroupType.USERSTORE_ADMINS );
+        spec.setDeletedState( GroupSpecification.DeletedState.NOT_DELETED );
+        spec.setUserStoreKey( userStoreKey );
+        List<GroupEntity> adminGroups = userStoreService.getGroups( spec );
+        if ( adminGroups.size() == 1 )
+        {
+            GroupEntity adminGroup = adminGroups.get( 0 );
+            UpdateGroupCommand command = new UpdateGroupCommand( user.getKey(), adminGroup.getGroupKey() );
+            command.setName( adminGroup.getName() );
+            for ( AccountKey administratorKey : administrators )
+            {
+                final GroupEntity groupMember = getGroupEntity( administratorKey );
+                command.addMember( groupMember );
+            }
+            userStoreService.updateGroup( command );
+
+            indexGroup( adminGroup.getGroupKey() );
+        }
+
+        spec.setType( GroupType.AUTHENTICATED_USERS );
+        spec.setDeletedState( GroupSpecification.DeletedState.NOT_DELETED );
+        adminGroups = userStoreService.getGroups( spec );
+        if ( adminGroups.size() == 1 )
+        {
+            indexGroup( adminGroups.get( 0 ).getGroupKey() );
+        }
+    }
+
+    protected void indexGroup( final GroupKey groupKey )
+    {
+        final GroupEntity groupEntity = securityService.getGroup( groupKey );
+        if ( groupEntity == null )
+        {
+            searchService.deleteIndex( String.valueOf( groupKey ) );
+            return;
+        }
+
+        final Group group = new Group();
+        group.setKey( new com.enonic.wem.core.search.account.AccountKey( groupEntity.getGroupKey().toString() ) );
+        group.setName( groupEntity.getName() );
+
+        group.setDisplayName( groupEntity.getDescription() );
+
+        group.setGroupType( groupEntity.getType() );
+        if ( groupEntity.getUserStore() != null )
+        {
+            group.setUserStoreName( groupEntity.getUserStore().getName() );
+        }
+
+        group.setLastModified( null );
+
+        final AccountIndexData accountIndexData = new AccountIndexDataEntity( group );
+
+        searchService.index( accountIndexData );
+    }
+
+    @Autowired
+    public void setUserDao( final UserDao userDao )
+    {
+        this.userDao = userDao;
+    }
+
+    @Autowired
+    public void setUserStoreDao( final UserStoreDao userStoreDao )
+    {
+        this.userStoreDao = userStoreDao;
+    }
+
+    @Autowired
+    public void setUserStoreService( final UserStoreService userStoreService )
+    {
+        this.userStoreService = userStoreService;
+    }
+
+    @Autowired
+    public void setSecurityService( final SecurityService securityService )
+    {
+        this.securityService = securityService;
+    }
+
+    @Autowired
+    public void setSearchService( final AccountSearchService searchService )
+    {
+        this.searchService = searchService;
+    }
+
+    @Autowired
+    public void setGroupDao( final GroupDao groupDao )
+    {
+        this.groupDao = groupDao;
+    }
+
+}

--- a/modules/wem-core/src/test/java/com/enonic/wem/core/userstore/CreateUserStoreHandlerTest.java
+++ b/modules/wem-core/src/test/java/com/enonic/wem/core/userstore/CreateUserStoreHandlerTest.java
@@ -1,0 +1,126 @@
+package com.enonic.wem.core.userstore;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.google.common.collect.Lists;
+
+import com.enonic.wem.api.Client;
+import com.enonic.wem.api.account.AccountKeys;
+import com.enonic.wem.api.command.Commands;
+import com.enonic.wem.api.userstore.UserStore;
+import com.enonic.wem.api.userstore.UserStoreName;
+import com.enonic.wem.api.userstore.config.UserStoreConfig;
+import com.enonic.wem.api.userstore.config.UserStoreFieldConfig;
+import com.enonic.wem.core.client.StandardClient;
+import com.enonic.wem.core.command.CommandInvokerImpl;
+import com.enonic.wem.core.search.account.AccountSearchService;
+
+import com.enonic.cms.core.security.SecurityService;
+import com.enonic.cms.core.security.group.GroupEntity;
+import com.enonic.cms.core.security.group.GroupSpecification;
+import com.enonic.cms.core.security.user.UserEntity;
+import com.enonic.cms.core.security.userstore.StoreNewUserStoreCommand;
+import com.enonic.cms.core.security.userstore.UserStoreKey;
+import com.enonic.cms.core.security.userstore.UserStoreService;
+import com.enonic.cms.store.dao.GroupDao;
+import com.enonic.cms.store.dao.UserDao;
+import com.enonic.cms.store.dao.UserStoreDao;
+
+import static org.junit.Assert.*;
+
+public class CreateUserStoreHandlerTest
+    extends UserStoreHandlerTest
+{
+
+    private UserDao userDao;
+
+    private UserStoreDao userStoreDao;
+
+    private UserStoreService userStoreService;
+
+    private SecurityService securityService;
+
+    private AccountSearchService searchService;
+
+    private GroupDao groupDao;
+
+    private Client client;
+
+    @Before
+    public void setUp()
+    {
+        userStoreService = Mockito.mock( UserStoreService.class );
+        userDao = Mockito.mock( UserDao.class );
+        userStoreDao = Mockito.mock( UserStoreDao.class );
+        securityService = Mockito.mock( SecurityService.class );
+        searchService = Mockito.mock( AccountSearchService.class );
+        groupDao = Mockito.mock( GroupDao.class );
+
+        CreateUserStoreHandler handler = new CreateUserStoreHandler();
+        handler.setUserDao( userDao );
+        handler.setUserStoreService( userStoreService );
+        handler.setUserStoreDao( userStoreDao );
+        handler.setSecurityService( securityService );
+        handler.setSearchService( searchService );
+        handler.setGroupDao( groupDao );
+
+        StandardClient standardClient = new StandardClient();
+        CommandInvokerImpl commandInvoker = new CommandInvokerImpl();
+        commandInvoker.setHandlers( handler );
+        standardClient.setInvoker( commandInvoker );
+
+        client = standardClient;
+
+    }
+
+    @Test
+    public void testCreateUserStore()
+        throws Exception
+    {
+        final UserEntity admin = createUser( "10000", "system", "admin" );
+        createGroup( "AAAAAAAAAA", "default", "developers" );
+        createUser( "BBBBBBBBBBB", "default", "aro" );
+        Mockito.when( userDao.findBuiltInEnterpriseAdminUser() ).thenReturn( admin );
+        Mockito.when( userStoreService.storeNewUserStore( Mockito.any( StoreNewUserStoreCommand.class ) ) ).thenReturn(
+            new UserStoreKey( "666" ) );
+        GroupEntity enonicAdmin = createGroup( "HJGJHG534534HGJH", "enonic", "admin" );
+        Mockito.when( userStoreService.getGroups( Mockito.any( GroupSpecification.class ) ) ).thenReturn(
+            Lists.newArrayList( enonicAdmin ) );
+        UserStoreName userStoreName = client.execute( Commands.userStore().create().userStore( createUserStore() ) );
+        assertEquals( UserStoreName.from( "enonic" ), userStoreName );
+    }
+
+    private UserStore createUserStore()
+    {
+        UserStore userStore = new UserStore( UserStoreName.from( "enonic" ) );
+        userStore.setConnectorName( "local" );
+        userStore.setAdministrators( AccountKeys.from( "user:default:aro", "group:default:developers" ) );
+        userStore.setConfig( createUserStoreConfig() );
+        return userStore;
+    }
+
+    private UserStoreConfig createUserStoreConfig()
+    {
+        UserStoreConfig userStoreConfig = new UserStoreConfig();
+        userStoreConfig.addField( new UserStoreFieldConfig( "first-name" ) );
+        userStoreConfig.addField( new UserStoreFieldConfig( "last-name" ) );
+        return userStoreConfig;
+    }
+
+    public UserDao getUserDao()
+    {
+        return userDao;
+    }
+
+    public UserStoreDao getUserStoreDao()
+    {
+        return userStoreDao;
+    }
+
+    public GroupDao getGroupDao()
+    {
+        return groupDao;
+    }
+}

--- a/modules/wem-core/src/test/java/com/enonic/wem/core/userstore/DeleteUserStoresHandlerTest.java
+++ b/modules/wem-core/src/test/java/com/enonic/wem/core/userstore/DeleteUserStoresHandlerTest.java
@@ -1,32 +1,16 @@
 package com.enonic.wem.core.userstore;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.google.common.collect.Sets;
-
 import com.enonic.wem.api.Client;
 import com.enonic.wem.api.command.Commands;
 import com.enonic.wem.api.userstore.UserStoreNames;
-import com.enonic.wem.core.account.IsQualifiedUsername;
 import com.enonic.wem.core.client.StandardClient;
 import com.enonic.wem.core.command.CommandInvokerImpl;
 
-import com.enonic.cms.core.security.group.GroupEntity;
-import com.enonic.cms.core.security.group.GroupKey;
-import com.enonic.cms.core.security.group.GroupType;
 import com.enonic.cms.core.security.user.UserEntity;
-import com.enonic.cms.core.security.user.UserKey;
-import com.enonic.cms.core.security.user.UserType;
-import com.enonic.cms.core.security.userstore.UserStoreEntity;
-import com.enonic.cms.core.security.userstore.UserStoreKey;
 import com.enonic.cms.core.security.userstore.UserStoreService;
 import com.enonic.cms.store.dao.GroupDao;
 import com.enonic.cms.store.dao.UserDao;
@@ -35,6 +19,7 @@ import com.enonic.cms.store.dao.UserStoreDao;
 import static org.junit.Assert.*;
 
 public class DeleteUserStoresHandlerTest
+    extends UserStoreHandlerTest
 {
     private Client client;
 
@@ -43,9 +28,6 @@ public class DeleteUserStoresHandlerTest
     private UserStoreDao userStoreDao;
 
     private GroupDao groupDao;
-
-    private static final String USERSTORE_KEY = "123";
-
 
     @Before
     public void setUp()
@@ -113,69 +95,18 @@ public class DeleteUserStoresHandlerTest
         assertEquals( 1, deletedCount.intValue() );
     }
 
-
-    private UserEntity createUser( final String key, final String userStore, final String name )
-        throws Exception
+    public UserDao getUserDao()
     {
-        final UserEntity user = Mockito.mock( UserEntity.class, Mockito.CALLS_REAL_METHODS );
-        user.setKey( new UserKey( key ) );
-        user.setType( UserType.NORMAL );
-        user.setEmail( "user@email.com" );
-        user.setUserStore( createUserStore( userStore, USERSTORE_KEY ) );
-        user.setName( name );
-        user.setDisplayName( name + " User" );
-
-        final GroupEntity userGroup = createGroup( "U" + key, userStore, "userGroup" + key );
-        userGroup.setType( GroupType.USER );
-        user.setUserGroup( userGroup );
-
-        mockAddUserToDaoByQualifiedName( user );
-        return user;
+        return userDao;
     }
 
-    private GroupEntity createGroup( final String key, final String userStore, final String name, final GroupEntity... members )
-        throws Exception
+    public UserStoreDao getUserStoreDao()
     {
-        final UserStoreEntity userStoreEntity = createUserStore( userStore, USERSTORE_KEY );
-        final GroupEntity group = Mockito.mock( GroupEntity.class, Mockito.CALLS_REAL_METHODS );
-        group.setKey( new GroupKey( key ) );
-        group.setType( GroupType.USERSTORE_GROUP );
-        group.setUserStore( userStoreEntity );
-        group.setName( name );
-        group.setDescription( "Group " + name );
-        group.setDeleted( false );
-        group.setMemberships( Sets.<GroupEntity>newHashSet() );
-
-        final Set<GroupEntity> memberSet = new HashSet<GroupEntity>();
-        memberSet.addAll( Arrays.asList( members ) );
-        group.setMembers( memberSet );
-
-        mockAddGroupToUserStore( userStoreEntity, group );
-        return group;
+        return userStoreDao;
     }
 
-    private void mockAddGroupToUserStore( final UserStoreEntity userStore, final GroupEntity group )
+    public GroupDao getGroupDao()
     {
-        final List<GroupEntity> userStoreResults = new ArrayList<GroupEntity>();
-        userStoreResults.add( group );
-        Mockito.when( groupDao.findByUserStoreKeyAndGroupname( userStore.getKey(), group.getName(), false ) ).thenReturn(
-            userStoreResults );
-    }
-
-    private UserStoreEntity createUserStore( final String name, final String userStoreKey )
-    {
-        final UserStoreEntity userStore = new UserStoreEntity();
-        userStore.setName( name );
-        userStore.setKey( new UserStoreKey( userStoreKey ) );
-
-        Mockito.when( userStoreDao.findByName( name ) ).thenReturn( userStore );
-
-        return userStore;
-    }
-
-    private void mockAddUserToDaoByQualifiedName( final UserEntity user )
-    {
-        Mockito.when( userDao.findByQualifiedUsername( Mockito.argThat( new IsQualifiedUsername( user.getQualifiedName() ) ) ) ).thenReturn(
-            user );
+        return groupDao;
     }
 }

--- a/modules/wem-core/src/test/java/com/enonic/wem/core/userstore/UserStoreHandlerTest.java
+++ b/modules/wem-core/src/test/java/com/enonic/wem/core/userstore/UserStoreHandlerTest.java
@@ -1,0 +1,103 @@
+package com.enonic.wem.core.userstore;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.mockito.Mockito;
+
+import com.google.common.collect.Sets;
+
+import com.enonic.wem.core.account.IsQualifiedUsername;
+
+import com.enonic.cms.core.security.group.GroupEntity;
+import com.enonic.cms.core.security.group.GroupKey;
+import com.enonic.cms.core.security.group.GroupType;
+import com.enonic.cms.core.security.user.UserEntity;
+import com.enonic.cms.core.security.user.UserKey;
+import com.enonic.cms.core.security.user.UserType;
+import com.enonic.cms.core.security.userstore.UserStoreEntity;
+import com.enonic.cms.core.security.userstore.UserStoreKey;
+import com.enonic.cms.store.dao.GroupDao;
+import com.enonic.cms.store.dao.UserDao;
+import com.enonic.cms.store.dao.UserStoreDao;
+
+public abstract class UserStoreHandlerTest
+{
+    private static final String USERSTORE_KEY = "123";
+
+    protected UserEntity createUser( final String key, final String userStore, final String name )
+        throws Exception
+    {
+        final UserEntity user = Mockito.mock( UserEntity.class, Mockito.CALLS_REAL_METHODS );
+        user.setKey( new UserKey( key ) );
+        user.setType( UserType.NORMAL );
+        user.setEmail( "user@email.com" );
+        user.setUserStore( createUserStore( userStore, USERSTORE_KEY ) );
+        user.setName( name );
+        user.setDisplayName( name + " User" );
+
+        final GroupEntity userGroup = createGroup( "U" + key, userStore, "userGroup" + key );
+        userGroup.setType( GroupType.USER );
+        user.setUserGroup( userGroup );
+
+        mockAddUserToDaoByQualifiedName( user );
+        return user;
+    }
+
+    protected GroupEntity createGroup( final String key, final String userStore, final String name, final GroupEntity... members )
+        throws Exception
+    {
+        final UserStoreEntity userStoreEntity = createUserStore( userStore, USERSTORE_KEY );
+        final GroupEntity group = Mockito.mock( GroupEntity.class, Mockito.CALLS_REAL_METHODS );
+        group.setKey( new GroupKey( key ) );
+        group.setType( GroupType.USERSTORE_GROUP );
+        group.setUserStore( userStoreEntity );
+        group.setName( name );
+        group.setDescription( "Group " + name );
+        group.setDeleted( false );
+        group.setMemberships( Sets.<GroupEntity>newHashSet() );
+
+        final Set<GroupEntity> memberSet = new HashSet<GroupEntity>();
+        memberSet.addAll( Arrays.asList( members ) );
+        group.setMembers( memberSet );
+
+        mockAddGroupToUserStore( userStoreEntity, group );
+        return group;
+    }
+
+    protected void mockAddGroupToUserStore( final UserStoreEntity userStore, final GroupEntity group )
+    {
+        final List<GroupEntity> userStoreResults = new ArrayList<GroupEntity>();
+        userStoreResults.add( group );
+        Mockito.when( getGroupDao().findByUserStoreKeyAndGroupname( userStore.getKey(), group.getName(), false ) ).thenReturn(
+            userStoreResults );
+    }
+
+    protected UserStoreEntity createUserStore( final String name, final String userStoreKey )
+    {
+        final UserStoreEntity userStore = new UserStoreEntity();
+        userStore.setName( name );
+        userStore.setKey( new UserStoreKey( userStoreKey ) );
+
+        Mockito.when( getUserStoreDao().findByName( name ) ).thenReturn( userStore );
+
+        return userStore;
+    }
+
+    protected void mockAddUserToDaoByQualifiedName( final UserEntity user )
+    {
+        Mockito.when(
+            getUserDao().findByQualifiedUsername( Mockito.argThat( new IsQualifiedUsername( user.getQualifiedName() ) ) ) ).thenReturn(
+            user );
+        Mockito.when( getUserDao().findByUserStoreKeyAndUsername( user.getUserStoreKey(), user.getName() ) ).thenReturn( user );
+    }
+
+    abstract public UserDao getUserDao();
+
+    abstract public UserStoreDao getUserStoreDao();
+
+    abstract public GroupDao getGroupDao();
+}


### PR DESCRIPTION
Implement CreateUserStore handler in API. The command is com.enonic.wem.api.command.userstore.CreateUserStore and the handler should be implemented on com.enonic.wem.core.userstore.CreateUserStoreHandler.

This task depends on CMS-266.
