### PR TITLE
CMS-406 Creating or updating a user fails when it has multiple addresses...

### DIFF
--- a/modules/wem-core/src/main/java/com/enonic/wem/core/account/dao/AccountJcrMapping.java
+++ b/modules/wem-core/src/main/java/com/enonic/wem/core/account/dao/AccountJcrMapping.java
@@ -239,7 +239,8 @@ public class AccountJcrMapping
     private void addAddressNode( final Address address, final Node addressesNode )
         throws RepositoryException
     {
-        final Node addressNode = addressesNode.addNode( ADDRESS );
+        long size = addressesNode.getNodes().getSize();
+        final Node addressNode = addressesNode.addNode( ADDRESS + size );
         addressNode.setProperty( COUNTRY, address.getCountry() );
         addressNode.setProperty( ISO_COUNTRY, address.getIsoCountry() );
         addressNode.setProperty( ISO_REGION, address.getIsoRegion() );
@@ -290,7 +291,7 @@ public class AccountJcrMapping
         final Node addresses = JcrHelper.getNodeOrNull( profileNode, ADDRESSES );
         if ( addresses != null )
         {
-            final NodeIterator addressNodeIt = addresses.getNodes( ADDRESS );
+            final NodeIterator addressNodeIt = addresses.getNodes();
             while ( addressNodeIt.hasNext() )
             {
                 Node addressNode = addressNodeIt.nextNode();

--- a/modules/wem-migrate/src/main/java/com/enonic/wem/migrate/jcr/JcrAccountsImporter.java
+++ b/modules/wem-migrate/src/main/java/com/enonic/wem/migrate/jcr/JcrAccountsImporter.java
@@ -311,7 +311,7 @@ public class JcrAccountsImporter
         final boolean defaultUserStore = ( (Integer) userStoreFields.get( "DOM_BDEFAULTSTORE" ) == 1 );
         final String connectorName = (String) userStoreFields.get( "DOM_SCONFIGNAME" );
         final byte[] xmlBytes = (byte[]) userStoreFields.get( "DOM_XMLDATA" );
-        final String userStoreXmlConfig = new String( xmlBytes, "UTF-8" );
+        final String userStoreXmlConfig = xmlBytes == null ? null : new String( xmlBytes, "UTF-8" );
 
         final UserStore userStore = new UserStore( UserStoreName.from( userStoreName ) );
         userStore.setDefaultStore( defaultUserStore );


### PR DESCRIPTION
... in the profile

There is a javax.jcr.ItemExistsException thrown when trying to save a user that has more than one address defined in his profile. This was detected in the import task, but it should fail as well when updating or creating from the admin console.

The problem seems to be that the JCR repository does not allow same-name siblings. We should probably avoid using children with the same name anyway. So instead of using address as the node name for each address node, use the address + index as the node name.

Now the structure is:

```
user
    profile
        addresses
            address
            address
```

It should be:

```
user
    profile
        addresses
            address1
            address2
```
