### PR TITLE
CMS-465 Editing some groups leads to display only few accounts in accoun...

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/wizard/group/WizardStepMembersPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/wizard/group/WizardStepMembersPanel.js
@@ -24,7 +24,7 @@ Ext.define('Admin.view.account.wizard.group.WizardStepMembersPanel', {
             name: 'members',
             itemId: 'members',
             value: memberKeys,
-            store: 'Admin.store.account.AccountStore',
+            store: Ext.create('Admin.store.account.AccountStore'),
             mode: 'local',
             displayField: 'displayName',
             itemClassResolver: function (values) {


### PR DESCRIPTION
...t grid

Select and edit group, return to account grid and check it's content. It should contain only several accounts.
However this bug is reproduced only on some groups.
