### PR TITLE
CMS-513 Content Types 2.0: Generate form for content edit from content t...

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/app-content-manager.jsp
+++ b/modules/wem-webapp/src/main/webapp/admin/app-content-manager.jsp
@@ -60,7 +60,8 @@
 
       requires: [
         'Admin.view.TabPanel',
-        'Admin.lib.UriHelper'
+        'Admin.lib.UriHelper',
+        'Admin.lib.RemoteService'
       ],
 
       launch: function () {

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/controller/account/Controller.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/controller/account/Controller.js
@@ -152,7 +152,7 @@ Ext.define('Admin.controller.account.Controller', {
                         if (rpcResp.success) {
                             handleRpcResponse(rpcResp);
                         }
-                    })
+                    });
                 },
                 createTabFromResponse: createUserTabFn
             };
@@ -175,7 +175,7 @@ Ext.define('Admin.controller.account.Controller', {
                         if (rpcResp.success) {
                             handleRpcResponse(rpcResp);
                         }
-                    })
+                    });
                 },
                 createTabFromResponse: createGroupTabFn
             };
@@ -240,7 +240,7 @@ Ext.define('Admin.controller.account.Controller', {
                         if (rpcResp.success) {
                             handleRpcResponse(rpcResp);
                         }
-                    })
+                    });
                 },
                 createTabFromResponse: createUserWizardFn
             };

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/controller/contentManager/Controller.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/controller/contentManager/Controller.js
@@ -49,31 +49,78 @@ Ext.define('Admin.controller.contentManager.Controller', {
         } else {
             content = [].concat(content);
         }
-
         var tabs = this.getCmsTabPanel();
+        var createContentTabFn = function (response) {
+            if (Ext.isFunction(callback)) {
+                callback();
+            }
+            var contentData = response.contentType;
+            return {
+                xtype: 'contentWizardPanel',
+                title: 'New Content',
+                data: contentData
+            };
+        };
+        var createSiteTabFn = function (response) {
+            if (Ext.isFunction(callback)) {
+                callback();
+            }
+            return {
+                xtype: 'panel',
+                title: 'New Site',
+                html: 'Site wizard will be here',
+                data: response
+            };
+        };
+        var openEditContentTabFn = function (selectedContent) {
+            var requestConfig = {
+                doTabRequest: function (handleRpcResponse) {
+                    Admin.lib.RemoteService.contentType_get({contentType: 'News:Article'}, function (rpcResponse) {
+                        if (rpcResponse.success) {
+                            handleRpcResponse(rpcResponse);
+                        }
+                    });
+                },
+                createTabFromResponse: createContentTabFn
+            };
+            var tabItem = {
+                itemId: 'edit-content-tab-' + selectedContent.get('path'),
+                title: selectedContent.get('displayName'),
+                closable: true,
+                layout: 'fit'
+            };
+            tabs.addTab(tabItem, undefined, requestConfig);
+        };
+        var openEditSiteTabFn = function (selectedContent) {
+            var requestConfig = {
+                doTabRequest: function (handleRpcResponse) {
+                    // data call here
+                },
+                createTabFromResponse: createSiteTabFn
+            };
+            var tabItem = {
+                itemId: 'edit-site-tab-' + selectedContent.get('path'),
+                title: selectedContent.get('displayName'),
+                closable: true,
+                layout: 'fit'
+            };
+            tabs.addTab(tabItem, undefined, requestConfig);
+        };
+
         var i;
         if (tabs) {
             var tab;
             for (i = 0; i < content.length; i += 1) {
                 var data = content[i];
+                //TODO: implement when content specification will be developed
                 switch (data.get('type')) {
-                case 'contentType':
-                    tab = {
-                        xtype: 'contentWizardPanel',
-                        title: 'New Content',
-                        data: data
-                    };
+                case 'myModule:myType':
+                    openEditContentTabFn(data);
                     break;
-                case 'site':
-                    tab = {
-                        xtype: 'panel',
-                        title: 'New Site',
-                        html: 'Site wizard will be here',
-                        data: data
-                    };
+                case 'myModule:mySite':
+                    openEditSiteTabFn(data);
                     break;
                 }
-                tabs.addTab(tab);
             }
         }
     },
@@ -84,10 +131,35 @@ Ext.define('Admin.controller.contentManager.Controller', {
             var tab;
             switch (type) {
             case 'contentType':
-                tab = {
-                    xtype: 'contentWizardPanel',
-                    title: 'New Content'
+                //This is stub, logic for new content creation will be added later
+                var createContentTabFn = function (response) {
+                    var contentData = response.contentType;
+                    return {
+                        xtype: 'contentWizardPanel',
+                        title: 'New Content',
+                        data: contentData
+                    };
                 };
+                var openEditContentTabFn = function (selectedContent) {
+                    var requestConfig = {
+                        doTabRequest: function (handleRpcResponse) {
+                            Admin.lib.RemoteService.contentType_get({contentType: 'News:Article'}, function (rpcResponse) {
+                                if (rpcResponse.success) {
+                                    handleRpcResponse(rpcResponse);
+                                }
+                            });
+                        },
+                        createTabFromResponse: createContentTabFn
+                    };
+                    var tabItem = {
+                        itemId: 'new-content-tab',
+                        title: 'New Content',
+                        closable: true,
+                        layout: 'fit'
+                    };
+                    tabs.addTab(tabItem, undefined, requestConfig);
+                };
+                openEditContentTabFn();
                 break;
             case 'site':
                 tab = {
@@ -95,9 +167,10 @@ Ext.define('Admin.controller.contentManager.Controller', {
                     html: 'New site wizard here',
                     title: 'New Site'
                 };
+                tabs.addTab(tab);
                 break;
             }
-            tabs.addTab(tab);
+
         }
     },
 
@@ -160,5 +233,6 @@ Ext.define('Admin.controller.contentManager.Controller', {
         }
         return win;
     }
+
 
 });

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/lib/RemoteService.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/lib/RemoteService.js
@@ -15,7 +15,7 @@ Ext.define('Admin.lib.RemoteService', {
                 "account_find", "account_getGraph", "account_changePassword", "account_verifyUniqueEmail", "account_suggestUserName",
                 "account_createOrUpdate", "account_delete", "account_get", "util_getCountries", "util_getLocales", "util_getTimeZones",
                 "userstore_getAll", "userstore_get", "userstore_getConnectors", "userstore_createOrUpdate", "userstore_delete",
-                "content_createOrUpdate"
+                "content_createOrUpdate", "contentType_get"
             ]
         };
 
@@ -88,6 +88,10 @@ Ext.define('Admin.lib.RemoteService', {
     },
 
     content_createOrUpdate: function (params, callback) {
+        console.log(params, callback);
+    },
+
+    contentType_get: function (params, callback) {
         console.log(params, callback);
     },
 

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/wizard/ContentDataPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/wizard/ContentDataPanel.js
@@ -1,0 +1,46 @@
+Ext.define('Admin.view.contentManager.wizard.ContentDataPanel', {
+    extend: 'Ext.panel.Panel',
+    alias: 'widget.contentDataPanel',
+
+    typeMapping: {
+        TextLine: "textfield",
+        TextArea: "textarea"
+    },
+
+    initComponent: function () {
+        var me = this;
+        var fieldSet = {
+            xtype: 'fieldset',
+            title: 'A Separator',
+            padding: '10px 15px',
+            items: []
+        };
+        me.items = [fieldSet];
+        Ext.each(this.contentItems, function (contentItem) {
+            var item = Ext.create({
+                xclass: "widget." + me.parseItemType(contentItem),
+                fieldLabel: contentItem.label,
+                name: contentItem.name,
+                itemId: contentItem.name,
+                cls: 'span-3',
+                listeners: {
+                    render: function (cmp) {
+                        Ext.tip.QuickTipManager.register({
+                            target: cmp.el,
+                            text: contentItem.helpText
+                        });
+                    }
+                }
+            });
+
+            fieldSet.items.push(item);
+        });
+
+        me.callParent(arguments);
+    },
+
+    parseItemType: function (contentItem) {
+        return this.typeMapping[contentItem.inputType.name];
+    }
+
+});

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/wizard/ContentWizardPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/wizard/ContentWizardPanel.js
@@ -3,7 +3,8 @@ Ext.define('Admin.view.contentManager.wizard.ContentWizardPanel', {
     alias: 'widget.contentWizardPanel',
     requires: [
         'Admin.view.WizardPanel',
-        'Admin.view.contentManager.wizard.ContentWizardToolbar'
+        'Admin.view.contentManager.wizard.ContentWizardToolbar',
+        'Admin.view.contentManager.wizard.ContentDataPanel'
     ],
 
     layout: {
@@ -24,13 +25,14 @@ Ext.define('Admin.view.contentManager.wizard.ContentWizardPanel', {
     initComponent: function () {
         var me = this;
         me.headerData = {
-            displayName: 'New Content'
+            displayName: me.data ? me.data.name : 'New Content'
         };
         var contentWizardHeader = Ext.create('Ext.container.Container', {
             itemId: 'wizardHeader',
             styleHtmlContent: true,
             autoHeight: true,
             cls: 'admin-wizard-header-container',
+            labelCls: 'label',
             listeners: {
                 afterrender: {
                     fn: function () {
@@ -126,7 +128,8 @@ Ext.define('Admin.view.contentManager.wizard.ContentWizardPanel', {
     getSteps: function () {
         var dataStep = {
             stepTitle: "Data",
-            xtype: 'panel'
+            xtype: 'contentDataPanel',
+            contentItems: this.data ? this.data.items : []
         };
         var treeStep = {
             stepTitle: "Tree",

--- a/modules/wem-webapp/src/main/webapp/admin/resources/css/main.css
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/css/main.css
@@ -1299,3 +1299,15 @@ li.admin-user-item:hover {
 .admin-memberships-graph {
     border-bottom: 1px solid #F0F0F0 !important;
 }
+
+.span-1 .x-form-item-body {
+    width: 200px !important;
+}
+
+.span-2 .x-form-item-body {
+    width: 400px !important;
+}
+
+.span-3 .x-form-item-body {
+    width: 600px !important;
+}


### PR DESCRIPTION
...ype

Implement dynamic generation of the form to edit content data (Data step in new/edit content in Content Manager app). The fields and layout of the form depends on the content type definition.

This task is only for the UI part, there is a separate task for creating the RPC handler that will return the details of the content type.

```
Skip implementation of validation logic: required, immutable, occurrences, validationRegexp.
The field "customText" does not have anything to do with gui. Use "label" as label text for the field.
The"helpText" is typically used as information to the user about input. Should be displayed as a tooltip or similar.
The "inputType" specifies the kind of input in the GUI (ignore the value of "formItemType").
```
