### PR TITLE
CMS-624 Drop "Tree" step from Content Manager

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/wizard/ContentWizardPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/wizard/ContentWizardPanel.js
@@ -137,10 +137,6 @@ Ext.define('Admin.view.contentManager.wizard.ContentWizardPanel', {
             contentType: this.data ? this.data.contentType : undefined,
             content: this.data ? this.data.content : null
         };
-        var treeStep = {
-            stepTitle: "Tree",
-            xtype: 'panel'
-        };
         var pageStep = {
             stepTitle: 'Page',
             xtype: 'panel'
@@ -158,7 +154,7 @@ Ext.define('Admin.view.contentManager.wizard.ContentWizardPanel', {
             xtype: 'panel'
         };
 
-        return [dataStep, treeStep, pageStep, metaStep, securityStep, summaryStep];
+        return [dataStep, pageStep, metaStep, securityStep, summaryStep];
 
     },
 


### PR DESCRIPTION
Remove this step from the Content manager wizard, leaving Page as step 2.
