### PR TITLE
CMS-682 Small fixes after new design merging

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/app-account.jsp
+++ b/modules/wem-webapp/src/main/webapp/admin/app-account.jsp
@@ -5,7 +5,6 @@
 <head>
   <meta charset="utf-8"/>
   <title>Enonic WEM Admin</title>
-  <link rel="stylesheet" type="text/css" href="resources/lib/ext/resources/css/ext-all.css">
   <link rel="stylesheet" type="text/css" href="resources/css/icons.css">
   <link rel="stylesheet" type="text/css" href="resources/css/user-preview.css">
   <link rel="stylesheet" type="text/css" href="resources/css/user-preview-panel.css">

--- a/modules/wem-webapp/src/main/webapp/admin/app-content-manager.jsp
+++ b/modules/wem-webapp/src/main/webapp/admin/app-content-manager.jsp
@@ -5,7 +5,6 @@
 <head>
   <meta charset="utf-8"/>
   <title>Enonic WEM Admin</title>
-  <link rel="stylesheet" type="text/css" href="resources/lib/ext/resources/css/ext-all.css">
   <link rel="stylesheet" type="text/css" href="resources/css/icons.css">
   <link rel="stylesheet" type="text/css" href="resources/css/admin-preview-panel.css">
 

--- a/modules/wem-webapp/src/main/webapp/admin/app-content-studio.jsp
+++ b/modules/wem-webapp/src/main/webapp/admin/app-content-studio.jsp
@@ -5,7 +5,6 @@
 <head>
   <meta charset="utf-8"/>
   <title>Enonic WEM Admin</title>
-  <link rel="stylesheet" type="text/css" href="resources/lib/ext/resources/css/ext-all.css">
   <link rel="stylesheet" type="text/css" href="resources/css/icons.css">
   <link rel="stylesheet" type="text/css" href="resources/css/contentstudio-preview-panel.css">
 

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/ShowPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/ShowPanel.js
@@ -13,11 +13,11 @@ Ext.define('Admin.view.contentManager.ShowPanel', {
 
     initComponent: function () {
 
-        this.tbar = {
-            xtype: 'browseToolbar'
-        };
-
         this.items = [
+            {
+                region: 'north',
+                xtype: 'browseToolbar'
+            },
             {
                 xtype: 'contentTreeGridPanel',
                 region: 'center',

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/TreeGridPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/TreeGridPanel.js
@@ -4,6 +4,8 @@ Ext.define('Admin.view.contentManager.TreeGridPanel', {
     store: 'Admin.store.contentManager.ContentStore',
     treeStore: 'Admin.store.contentManager.ContentTreeStore',
 
+    border: false,
+
     iconClasses: {
         "myModule:mySite": 'icon-site-32',
         "myModule:myType": 'icon-content-32',

--- a/modules/wem-webapp/src/main/webapp/admin/resources/css/admin-top-bar.css
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/css/admin-top-bar.css
@@ -1,7 +1,10 @@
 .x-toolbar.admin-topbar-panel {
-    background: #000 none !important;
     color: #FFF;
     padding: 6px;
+    background: black; /* for non-css3 browsers */
+    filter: progid:DXImageTransform.Microsoft.gradient(gradientType = 1, startColorstr = '#000000', endColorstr = '#363639'); /* for IE */
+    background: -webkit-gradient(linear, left top, right top, from(#000), to(#363639)); /* for webkit browsers */
+    background: -moz-linear-gradient(left, #000, #363639); /* for firefox 3.6+ */
 }
 
 .admin-topbar-panel .start-button button {


### PR DESCRIPTION
Here's a new list of minor things to fix after merging in new design

```
Top bar should have a "fade-to-grey" effect according to design
Content manager app has a blue border around it, must be removed
Search box must be reduced in width - to match width of navigation panel
grey border around content manager app must be removed
Big grey borders below content manager buttons/around browese list must be shrinked to 1px
```
