### PR TITLE
CMS-801 Standard settings for "detail and list" panels in browse views

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/app-content-studio.js
+++ b/modules/wem-webapp/src/main/webapp/admin/app-content-studio.js
@@ -52,7 +52,7 @@ Ext.application({
                                             region: 'center',
                                             xtype: 'contentTypeTreeGridPanel',
                                             border: false,
-                                            flex: 2
+                                            flex: 1
                                         },
                                         {
                                             region: 'south',

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/ShowPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/account/ShowPanel.js
@@ -20,7 +20,7 @@ Ext.define('Admin.view.account.ShowPanel', {
             {
                 region: 'center',
                 xtype: 'accountGrid',
-                flex: 2
+                flex: 1
             },
             {
                 region: 'south',

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/ShowPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/ShowPanel.js
@@ -22,7 +22,7 @@ Ext.define('Admin.view.contentManager.ShowPanel', {
                 xtype: 'contentTreeGridPanel',
                 region: 'center',
                 itemId: 'contentList',
-                flex: 2
+                flex: 1
             },
             {
                 region: 'south',

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/userstore/MainPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/userstore/MainPanel.js
@@ -12,7 +12,7 @@ Ext.define('Admin.view.userstore.MainPanel', {
                 region: 'center',
                 id: 'userstoreGridID',
                 xtype: 'userstoreGrid',
-                flex: 2
+                flex: 1
             },
             {
                 region: 'south',


### PR DESCRIPTION
For all apps, the details panel and list panels in the browse view should by default be 50/50 in size. Currently the details panel is too small.
