### PR TITLE
CMS-1029 Content Manager - New selector

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/model/contentStudio/ContentTypeModel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/model/contentStudio/ContentTypeModel.js
@@ -4,6 +4,7 @@ Ext.define('Admin.model.contentStudio.ContentTypeModel', {
     fields: [
         'qualifiedName',
         'name',
+        'displayName',
         'module',
         { name: 'createdTime', type: 'date', defaultValue: new Date() },
         { name: 'modifiedTime', type: 'date', defaultValue: new Date() },

--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/NewContentWindow.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/NewContentWindow.js
@@ -28,7 +28,7 @@ Ext.define('Admin.view.contentManager.NewContentWindow', {
                           '<img src="{iconUrl}?size=32"/>' +
                           '</div>' +
                           '<div class="admin-data-view-description">' +
-                          '<h6>{name}</h6>' +
+                          '<h6>{displayName}</h6>' +
                           '<p>{qualifiedName}</p>' +
                           '</div>' +
                           '<div class="x-clear"></div>' +


### PR DESCRIPTION
Update to use "Display Name" in listing of content types. Currently "Name" is used as title for each item in list.
