### PR TITLE
CMS-1423 Content Manager Form - Add extra padding after last item

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/wizard/ContentDataPanel.js
+++ b/modules/wem-webapp/src/main/webapp/admin/resources/app/view/contentManager/wizard/ContentDataPanel.js
@@ -19,11 +19,20 @@ Ext.define('Admin.view.contentManager.wizard.ContentDataPanel', {
     maxWidth: 680,
     contentType: undefined,
 
+    bodyPadding: '0 0 100 0',
+
     content: null, // content to be edited
 
     jsonSubmit: true,
 
     autoDestroy: true,
+
+    listeners: {
+        afterlayout: function () {
+            //Set height to auto manually, so we have bottom padding. For some reason you can't set it through config
+            this.setBodyStyle('height', 'auto');
+        }
+    },
 
     initComponent: function () {
         this.items = [];


### PR DESCRIPTION
When scrolling in the form, we need to add some more "air" after the last item in the form - all to give a better feeling for the user.

Total space should be 40px
