### PR TITLE
CMS-1704 Add type definitions for contentType_tree in RemoteService.ts

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/lib/RemoteContentTypeModel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/lib/RemoteContentTypeModel.ts
@@ -15,6 +15,30 @@ module api_remote {
         form: FormItem[];
     }
 
+    export interface ContentTypeTreeNode extends ContentType {
+        iconUrl:string;
+        hasChildren:bool;
+        contentTypes:ContentTypeTreeNode[];
+    }
+
+    export interface ContentTreeNode {
+        allowsChildren:bool;
+        contents:ContentTreeNode[];
+        createdTime?:Date;
+        deletable:bool;
+        displayName:string;
+        editable:bool;
+        hasChildren:bool;
+        iconUrl:string;
+        id:string;
+        modifiedTime?:Date;
+        modifier:string;
+        name:string;
+        owner:string;
+        path:string;
+        type:string;
+    }
+
     export interface FormItem {
         FormItemSet?: FormItemSet;
         Layout?: Layout;

--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/lib/RemoteService.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/lib/RemoteService.ts
@@ -113,6 +113,14 @@ module api_remote {
         content: Content[];
     }
 
+    export interface RemoteCallGetContentTypeTreeParams {
+    }
+
+    export interface RemoteCallGetContentTypeTreeResult extends RemoteCallResultBase {
+        total:number;
+        contentTypes:ContentTypeTreeNode[];
+    }
+
     export interface RemoteServiceInterface {
         account_find (params, callback):void;
         account_getGraph (params, callback):void;
@@ -142,7 +150,7 @@ module api_remote {
         contentType_createOrUpdate (params:RemoteCallContentTypeCreateOrUpdateParams,
                                     callback:(result:RemoteCallContentTypeCreateOrUpdateResult)=>void):void;
         contentType_delete (params:RemoteCallContentTypeDeleteParams, callback:(result:RemoteCallContentTypeDeleteResult)=>void):void;
-        contentType_tree (params, callback):void;
+        contentType_tree (params:RemoteCallGetContentTypeTreeParams, callback:(result:RemoteCallGetContentTypeTreeResult)=>void):void;
         schema_tree (params, callback):void;
         schema_list (params, callback):void;
         system_getSystemInfo (params, callback):void;
@@ -294,7 +302,7 @@ module api_remote {
             console.log(params, callback);
         }
 
-        contentType_tree(params, callback):void {
+        contentType_tree(params:RemoteCallGetContentTypeTreeParams, callback:(result:RemoteCallGetContentTypeTreeResult)=>void):void {
             console.log(params, callback);
         }
 


### PR DESCRIPTION
Add strict typing for the parameter and result values of RemoteServiceInterface.contentType_tree()
- Check the RpcHandler method in Java to find the exact values accepted and returned.
- Use optional types (optParam?: string) where appropriate.
- Avoid use of any as much as possible and use concrete types.
- Look at types of space_list() and space_get() for reference.
