### PR TITLE
CMS-1746 Add type definitions for content_tree in RemoteService.ts

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/lib/RemoteService.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/lib/RemoteService.ts
@@ -180,6 +180,15 @@ module api_remote {
         failure?: string;
     }
 
+    export interface RemoteCallGetContentTreeParams {
+        contentIds?:string[];
+    }
+
+    export interface RemoteCallGetContentTreeResult extends RemoteCallResultBase {
+        total:number;
+        contents:ContentTreeNode[];
+    }
+
     export interface RemoteServiceInterface {
         account_find (params, callback):void;
         account_getGraph (params, callback):void;
@@ -200,7 +209,7 @@ module api_remote {
         content_createOrUpdate (params:RemoteCallCreateOrUpdateContentParams,
                                 callback:(result:RemoteCallCreateOrUpdateContentResult)=>void):void;
         content_list (params:RemoteCallContentListParams, callback:(result:RemoteCallContentListResult)=>void):void;
-        content_tree (params, callback):void;
+        content_tree (params:RemoteCallGetContentTreeParams, callback:(result:RemoteCallGetContentTreeResult)=>void):void;
         content_get (params:RemoteCallContentGetParams, callback:(result:RemoteCallContentGetResult)=>void):void;
         content_delete (params:RemoteCallContentDeleteParams, callback:(result:RemoteCallContentDeleteResult)=>void):void;
         content_find (params:RemoteCallContentFindParams, callback:(result:RemoteCallContentFindResult)=>void):void;
@@ -327,7 +336,7 @@ module api_remote {
             console.log(params, callback);
         }
 
-        content_tree(params, callback):void {
+        content_tree(params:RemoteCallGetContentTreeParams, callback:(result:RemoteCallGetContentTreeResult)=>void):void {
             console.log(params, callback);
         }
 


### PR DESCRIPTION
Add strict typing for the parameter and result values of RemoteServiceInterface.content_tree()
- Check the RpcHandler method in Java to find the exact values accepted and returned.
- Use optional types (optParam?: string) where appropriate.
- Avoid use of any as much as possible and use concrete types.
- Look at types of space_list() and space_get() for reference.
