### PR TITLE
CMS-1835 Add type definitions for account_get in RemoteService.ts

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/lib/RemoteContentTypeModel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/lib/RemoteContentTypeModel.ts
@@ -114,4 +114,61 @@ module api_remote {
         allowedFromTypes:string[];
         allowedToTypes:string[];
     }
+
+    export interface Account {
+        key:string;
+        type:string;
+        name:string;
+        userStore:string;
+        qualifiedName:string;
+        builtIn:bool;
+        displayName:string;
+        modifiedTime?:Date;
+        createdTime?:Date;
+        editable:bool;
+        deleted:bool;
+        image_url:string;
+        email?:string;
+        profile?:UserProfile;
+        memberships?:Account[];
+        members?:Account[];
+    }
+
+    export interface UserProfile {
+        firstName:string;
+        lastName:string;
+        middleName:string;
+        birthday?:Date;
+        country:string;
+        description:string;
+        initials:string;
+        globalPosition:string;
+        htmlEmail:string;
+        locale?:string;
+        nickName:string;
+        personalId:string;
+        memberId:string;
+        organization:string;
+        prefix:string;
+        suffix:string;
+        title:string;
+        homePage:string;
+        mobile:string;
+        fax:string;
+        phone:string;
+        gender?:string;
+        timezone?:string;
+        addresses:Address[];
+    }
+
+    export interface Address {
+        country:string;
+        isoCountry:string;
+        region:string;
+        isoRegion:string;
+        label:string;
+        street:string;
+        postalCode:string;
+        postalAddress:string;
+    }
 }

--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/lib/RemoteService.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/lib/RemoteService.ts
@@ -273,7 +273,7 @@ module api_remote {
 
     export interface RemoteCallDeleteRelationshipTypeResult extends RemoteCallResultBase {
         successes:DeleteRelationshipTypeSuccess[];
-        failures:DeleteRelationshipTypeFailure[]; 
+        failures:DeleteRelationshipTypeFailure[];
     }
 
     export interface RemoteCallGetRelationshipTypeParams {
@@ -296,6 +296,14 @@ module api_remote {
         updated:bool;
     }
 
+    export interface RemoteCallGetAccountParams {
+        key:string;
+    }
+
+    export interface RemoteCallGetAccountResult extends RemoteCallResultBase, Account {
+
+    }
+
     export interface RemoteServiceInterface {
         account_find (params, callback):void;
         account_getGraph (params, callback):void;
@@ -304,7 +312,7 @@ module api_remote {
         account_suggestUserName (params, callback):void;
         account_createOrUpdate (params, callback):void;
         account_delete (params, callback):void;
-        account_get (params, callback):void;
+        account_get (params:RemoteCallGetAccountParams, callback:(result:RemoteCallGetAccountResult)=>void):void;
         util_getCountries (params, callback):void;
         util_getLocales (params, callback):void;
         util_getTimeZones (params, callback):void;
@@ -400,7 +408,7 @@ module api_remote {
             console.log(params, callback);
         }
 
-        account_get(params, callback):void {
+        account_get(params:RemoteCallGetAccountParams, callback:(result:RemoteCallGetAccountResult)=>void):void {
             console.log(params, callback);
         }
 


### PR DESCRIPTION
Add strict typing for the parameter and result values of RemoteServiceInterface.account_get()
- Check the RpcHandler method in Java to find the exact values accepted and returned.
- Use optional types (optParam?: string) where appropriate.
- Avoid use of any as much as possible and use concrete types.
