### PR TITLE
CMS-1874 Create SchemaBrowseFilterPanel

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin2/apps/schema-manager/js/app/browse/SchemaBrowseEvents.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/apps/schema-manager/js/app/browse/SchemaBrowseEvents.ts
@@ -37,9 +37,9 @@ module app_browse {
 
     export class NewSchemaEvent extends api_event.Event {
 
-        private schemaType: string;
+        private schemaType:string;
 
-        constructor(schemaType?: string) {
+        constructor(schemaType?:string) {
             super('newSchema');
 
             this.schemaType = schemaType;
@@ -155,6 +155,35 @@ module app_browse {
 
         static on(handler:(event:ShowContextMenuEvent) => void) {
             api_event.onEvent('showContextMenu', handler);
+        }
+    }
+
+    export class SchemaBrowseSearchEvent extends api_event.Event {
+
+        filterParams;
+
+        constructor(filterParams?) {
+            super('schemaBrowseSearch');
+            this.filterParams = filterParams;
+        }
+
+        static on(handler:(event:SchemaBrowseSearchEvent)=>void) {
+            api_event.onEvent('schemaBrowseSearch', handler);
+        }
+
+        getFilterParams() {
+            return this.filterParams;
+        }
+    }
+
+    export class SchemaBrowseResetEvent extends api_event.Event {
+
+        constructor() {
+            super('schemaBrowseReset');
+        }
+
+        static on(handler:(event:SchemaBrowseResetEvent)=>void) {
+            api_event.onEvent('schemaBrowseReset', handler);
         }
     }
 

--- a/modules/wem-webapp/src/main/webapp/admin2/apps/schema-manager/js/app/browse/SchemaBrowseFilterPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/apps/schema-manager/js/app/browse/SchemaBrowseFilterPanel.ts
@@ -1,0 +1,53 @@
+module app_browse {
+
+    export class SchemaBrowseFilterPanel extends api_app_browse.BrowseFilterPanel {
+
+
+        constructor() {
+            super();
+            this.updateFacets([
+                {
+                    "name": "Type",
+                    "displayName": "Type",
+                    "terms": [
+                        { "name": "Content Type", "key": 'contentType', "count": 6 },
+                        { "name": "Relationship Type", "key": 'relationshipType', "count": 2 },
+                        { "name": "Mixin", "key": 'mixin', "count": 5 }
+                    ]
+                },
+                {
+                    "name": "Module",
+                    "displayName": "Module",
+                    "terms": [
+                        { "name": "system", "key": 'system', "count": 4 },
+                        { "name": "demo", "key": 'demo', "count": 7 },
+                        { "name": "B", "key": 'b', "count": 1 },
+                        { "name": "C", "key": 'c', "count": 3 }
+                    ]
+                }
+            ]);
+            var searchAction = new api_app_browse.FilterSearchAction();
+            searchAction.addExecutionListener((action:api_app_browse.FilterSearchAction)=> {
+                var params = app_browse.createLoadContentParams(action.getFilterValues());
+                api_remote.RemoteService.schema_list(params, (response) => {
+                    if (response && response.success) {
+                        if (this.isDirty()) {
+                            new SchemaBrowseSearchEvent(params).fire();
+                        } else {
+                            new SchemaBrowseResetEvent().fire();
+                        }
+                        //TODO: update filter facets when they are implemented
+                    }
+                });
+
+            });
+            var resetAction = new api_app_browse.FilterResetAction();
+            resetAction.addExecutionListener((action:api_app_browse.FilterResetAction)=> {
+                //TODO: reset filter facets when they are implemented
+                new SchemaBrowseResetEvent().fire();
+            });
+            this.setFilterSearchAction(searchAction);
+            this.setFilterResetAction(resetAction);
+        }
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin2/apps/schema-manager/js/app/browse/SchemaBrowsePanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/apps/schema-manager/js/app/browse/SchemaBrowsePanel.ts
@@ -12,7 +12,7 @@ module app_browse {
             this.gridPanel = components.gridPanel = new SchemaTreeGridPanel('schemaTreeGrid');
             this.detailPanel = components.detailPanel = new SchemaBrowseItemPanel();
 
-            this.filterPanel = new api_app_browse.BrowseFilterPanel();
+            this.filterPanel = new app_browse.SchemaBrowseFilterPanel();
 
             super(this.toolbar, this.gridPanel, this.detailPanel, this.filterPanel);
 
@@ -38,5 +38,36 @@ module app_browse {
             });
 
         }
+    }
+
+
+    export function createLoadContentParams(filterPanelValues:any) {
+        var params:any = {types: [], modules: []};
+        var paramTypes = params.types;
+        var paramModules = params.modules;
+        var typeFilter = filterPanelValues.Type;
+        var moduleFilter = filterPanelValues.Module;
+        if (typeFilter) {
+            if (typeFilter.some(function (item) {
+                return item == 'Relationship Type'
+            })) {
+                paramTypes.push('RELATIONSHIP_TYPE');
+            }
+            if (typeFilter.some(function (item) {
+                return item == 'Content Type'
+            })) {
+                paramTypes.push('CONTENT_TYPE');
+            }
+            if (typeFilter.some(function (item) {
+                return item == 'Mixin'
+            })) {
+                paramTypes.push('MIXIN');
+            }
+        }
+        moduleFilter.forEach(function (moduleName) {
+            paramModules.push(moduleName);
+        });
+        params.search = filterPanelValues.query;
+        return params;
     }
 }

--- a/modules/wem-webapp/src/main/webapp/admin2/apps/schema-manager/js/app/browse/SchemaTreeGridPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/apps/schema-manager/js/app/browse/SchemaTreeGridPanel.ts
@@ -18,6 +18,26 @@ module app_browse {
             GridDeselectEvent.on((event) => {
                 this.deselect(event.getModels()[0].data.name);
             });
+
+
+            SchemaBrowseSearchEvent.on((event:SchemaBrowseSearchEvent) => {
+                this.setActiveList('grid');
+                if (event.getFilterParams()) {
+                    // show  ids
+                    this.setRemoteSearchParams(event.getFilterParams());
+                    this.refresh();
+                } else {
+                    // show none
+                    this.removeAll();
+                    this.updateResultCount(0);
+                }
+            });
+
+            SchemaBrowseResetEvent.on((event:SchemaBrowseResetEvent) => {
+                this.setActiveList('tree');
+                this.setRemoteSearchParams({});
+                this.refresh();
+            })
         }
 
         private createColumns() {

--- a/modules/wem-webapp/src/main/webapp/admin2/apps/schema-manager/js/main.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/apps/schema-manager/js/main.ts
@@ -9,6 +9,7 @@
 ///<reference path='app/browse/SchemaBrowseToolbar.ts' />
 ///<reference path='app/browse/SchemaBrowseItemPanel.ts' />
 ///<reference path='app/browse/SchemaBrowsePanel.ts' />
+///<reference path='app/browse/SchemaBrowseFilterPanel.ts'/>
 ///<reference path='app/browse/SchemaViewActions.ts' />
 ///<reference path='app/browse/SchemaItemStatisticsPanel.ts' />
 ///<reference path='app/browse/SchemaItemViewToolbar.ts' />


### PR DESCRIPTION
Extend reusable class in api: BrowseFilterPanel.

Should have same functionality as the filter panel in the old schema manager.

Implement usage of it in SchemaBrowsePanel.

TODO: There are no facets in server response, need to be implemented in future
