### PR TITLE
CMS-1946 Let ActionButton display action.shortcut in tooltip

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/ui/ActionButton.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/ui/ActionButton.ts
@@ -3,6 +3,7 @@ module api_ui{
     export class ActionButton extends api_dom.ButtonEl {
 
         private action:Action;
+        private tooltip:Tooltip;
 
         constructor(idPrefix:string, action:Action) {
             super(idPrefix);
@@ -23,6 +24,10 @@ module api_ui{
             } else {
                 var labelNode = new api_dom.TextNode(this.action.getLabel());
                 this.getEl().appendChild(labelNode.getText());
+            }
+
+            if (this.action.hasShortcut()) {
+                this.tooltip = new Tooltip(this, this.action.getShortcut().getCombination());
             }
 
             this.getEl().addEventListener("click", () => {


### PR DESCRIPTION
If the Action of an ActionButton has a shortcut. Create a tooltip for the action button, showing the shortcut combination.
