### PR TITLE
CMS-1960 Right click deselects row when grid is in single selection mode

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/plugin/PersistentGridSelectionPlugin.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/plugin/PersistentGridSelectionPlugin.ts
@@ -27,6 +27,10 @@ Ext.define('Admin.plugin.PersistentGridSelectionPlugin', {
                 // It is not possible to check the checkbox in CheckboxModel when left clicking the column.
                 // Not sure if this is a bug since right clicking the column does check the checkbox (or shift/ctrl + left click).
                 // Forum thread: http://www.sencha.com/forum/showthread.php?173519-Grid-and-checkbox-column-click
+                // 0 is for left mouse button
+                if (event.button != 0) {
+                    return;
+                }
                 var targetElement = new Ext.Element(event.target);
                 var isCheckboxColumnIsClicked = targetElement.findParent('td.x-grid-cell-first') !== null;
                 if (isCheckboxColumnIsClicked) {

--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/ui/grid/TreeGridPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/ui/grid/TreeGridPanel.ts
@@ -62,7 +62,6 @@ module api_ui_grid {
                     }
                 },
                 store: gridStore,
-                selModel: Ext.create('Ext.selection.CheckboxModel', {headerWidth: 36}),
                 plugins: [
                     new Admin.plugin.PersistentGridSelectionPlugin({
                         keyField: this.keyField
@@ -144,7 +143,7 @@ module api_ui_grid {
          * Switches the view
          * @param listId the view to show can be either of TreeGridPanel.GRID or TreeGridPanel.TREE
          */
-        setActiveList(listId) {
+            setActiveList(listId) {
             this.activeList = listId;
             if (this.ext) {
                 (<Ext_layout_container_Card> this.ext.getLayout()).setActiveItem(listId);
@@ -177,7 +176,7 @@ module api_ui_grid {
             this.refreshNeeded = false;
         }
 
-        isRefreshNeeded(): bool {
+        isRefreshNeeded():bool {
             return this.refreshNeeded;
         }
 

--- a/modules/wem-webapp/src/main/webapp/admin2/apps/schema-manager/js/app/browse/SchemaTreeGridPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/apps/schema-manager/js/app/browse/SchemaTreeGridPanel.ts
@@ -131,6 +131,10 @@ module app_browse {
                     itemdblclick: (grid, record) => {
                         new EditSchemaEvent(grid.getSelection()).fire();
                     }
+                },
+                selModel: {
+                    allowDeselect: false,
+                    ignoreRightMouseSelection: true
                 }
             }
         }
@@ -148,6 +152,10 @@ module app_browse {
                     itemdblclick: (grid, record) => {
                         new EditSchemaEvent(grid.getSelection()).fire();
                     }
+                },
+                selModel: {
+                    allowDeselect: false,
+                    ignoreRightMouseSelection: true
                 }
             }
         }


### PR DESCRIPTION
Fix PersistentGridSelectionPlugin to not deselect item on other mouse click than left one
