### PR TITLE
CMS-2007 Facet refactoring

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/app/browse/filter/BrowseFilterPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/app/browse/filter/BrowseFilterPanel.ts
@@ -4,7 +4,7 @@ module api_app_browse_filter {
 
         private listeners:BrowseFilterPanelListener[] = [];
 
-        private facetContainer:FacetContainer;
+        private facetContainer:api_facet.FacetGroupView;
 
         private searchField:api_app_browse_filter.TextSearchField;
 
@@ -12,13 +12,13 @@ module api_app_browse_filter {
 
         private searchFilterTypingTimer:number;
 
-        constructor(facetData?:FacetGroupData[]) {
+        constructor(facetData?:api_facet.TermsFacet[]) {
             super('BrowseFilterPanel');
             this.addClass('filter-panel');
 
             this.searchField = this.createSearchFieldEl();
             this.clearFilter = this.createClearFilterEl();
-            this.facetContainer = new FacetContainer(facetData);
+            this.facetContainer = new api_facet.FacetGroupView(facetData);
 
             api_app_browse_filter.FilterSearchEvent.on((event:api_app_browse_filter.FilterSearchEvent) => {
                 if (this.isDirty()) {
@@ -60,7 +60,7 @@ module api_app_browse_filter {
             return clearFilter;
         }
 
-        updateFacets(facetGroupsData:FacetGroupData[]) {
+        updateFacets(facetGroupsData:api_facet.TermsFacet[]) {
             this.facetContainer.update(facetGroupsData)
         }
 

--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/facet/Facet.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/facet/Facet.ts
@@ -1,0 +1,6 @@
+module api_facet {
+
+    export interface Facet {
+
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/facet/FacetGroupView.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/facet/FacetGroupView.ts
@@ -1,36 +1,36 @@
-module api_app_browse_filter {
+module api_facet {
 
-    export class FacetContainer extends api_dom.DivEl {
+    export class FacetGroupView extends api_dom.DivEl {
 
-        private facetGroups:FacetGroup[] = [];
-        private lastFacetGroup:FacetGroup;
+        private facetGroups:TermsFacetView[] = [];
+        private lastFacetGroup:TermsFacetView;
 
-        constructor(data?:FacetGroupData[]) {
-            super('FacetContainer');
+        constructor(data?:TermsFacet[]) {
+            super('FacetGroupView');
 
             if (data) {
                 for (var i = 0; i < data.length; i++) {
-                    this.addFacetGroup(new FacetGroup(data[i]));
+                    this.addFacetGroup(new TermsFacetView(data[i]));
                 }
             }
 
-            api_app_browse_filter.FilterSearchEvent.on((event) => {
+            api_app_browse_filter.FilterSearchEvent.on((event:api_app_browse_filter.FilterSearchEvent) => {
                 if (event.getTarget()) {
-                    this.lastFacetGroup = (<Facet>event.getTarget()).getFacetGroup();
+                    this.lastFacetGroup = (<TermsFacetEntryView>event.getTarget()).getFacetGroup();
                 } else {
                     this.lastFacetGroup = undefined;
                 }
-            })
+            });
         }
 
-        private addFacetGroup(facetGroup:FacetGroup) {
+        private addFacetGroup(facetGroup:TermsFacetView) {
             this.facetGroups.push(facetGroup);
             this.appendChild(facetGroup);
         }
 
         private getFacetGroup(name:string) {
             for (var i = 0; i < this.facetGroups.length; i++) {
-                var facetGroup:FacetGroup = this.facetGroups[i];
+                var facetGroup:TermsFacetView = this.facetGroups[i];
                 if (facetGroup.getName() == name) {
                     return facetGroup;
                 }
@@ -38,15 +38,16 @@ module api_app_browse_filter {
             return null;
         }
 
-        update(facetGroupsData:FacetGroupData[]) {
+        update(facetGroupsData:api_facet.TermsFacet[]) {
             for (var i = 0; i < facetGroupsData.length; i++) {
-                var facetGroupData = facetGroupsData[i];
-                var facetGroup:FacetGroup = this.getFacetGroup(facetGroupData.name);
+                var termsFacet = facetGroupsData[i];
+                var facetGroup:TermsFacetView = this.getFacetGroup(termsFacet.name);
 
                 if (facetGroup != null && facetGroup != this.lastFacetGroup) {
-                    facetGroup.update(facetGroupData);
+                    facetGroup.update(termsFacet);
                 } else if (facetGroup == null) {
-                    this.addFacetGroup(new FacetGroup(facetGroupData));
+                    facetGroup = new TermsFacetView(termsFacet);
+                    this.addFacetGroup(facetGroup);
                 }
             }
         }
@@ -60,7 +61,7 @@ module api_app_browse_filter {
 
         getValues():any[] {
             var values = [];
-            var facetGroup:FacetGroup;
+            var facetGroup:TermsFacetView;
             for (var i = 0; i < this.facetGroups.length; i++) {
                 facetGroup = this.facetGroups[i];
                 values[facetGroup.getName()] = facetGroup.getValues();

--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/facet/TermsFacet.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/facet/TermsFacet.ts
@@ -1,0 +1,8 @@
+module api_facet {
+
+    export interface TermsFacet extends Facet {
+        name:string;
+        displayName:string;
+        terms:TermsFacetEntry[];
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/facet/TermsFacetEntry.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/facet/TermsFacetEntry.ts
@@ -1,0 +1,8 @@
+module api_facet {
+
+    export interface TermsFacetEntry {
+        count:number;
+        name:string;
+        displayName:string;
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/facet/TermsFacetEntryView.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/facet/TermsFacetEntryView.ts
@@ -1,12 +1,6 @@
-module api_app_browse_filter {
+module api_facet {
 
-    export interface FacetData {
-        count:number;
-        name:string;
-        displayName:string;
-    }
-
-    export class Facet extends api_dom.DivEl {
+    export class TermsFacetEntryView extends api_dom.DivEl {
 
         private checkbox:api_dom.InputEl;
 
@@ -14,9 +8,9 @@ module api_app_browse_filter {
 
         private name:string;
 
-        private facetGroup:FacetGroup;
+        private facetGroup:TermsFacetView;
 
-        constructor(facetData:FacetData, facetGroup:FacetGroup) {
+        constructor(facetData:TermsFacetEntry, facetGroup:TermsFacetView) {
             super('Facet', 'facet');
             this.name = facetData.name;
 
@@ -41,7 +35,7 @@ module api_app_browse_filter {
             }
         }
 
-        getFacetGroup():FacetGroup {
+        getFacetGroup():TermsFacetView {
             return this.facetGroup;
         }
 
@@ -49,7 +43,7 @@ module api_app_browse_filter {
             return this.name;
         }
 
-        update(facetData:FacetData) {
+        update(facetData:TermsFacetEntry) {
             this.label.getEl().setInnerHtml(facetData.displayName + ' (' + facetData.count + ')');
             if (facetData.count > 0 || this.isSelected()) {
                 this.show();

--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/facet/TermsFacetView.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/facet/TermsFacetView.ts
@@ -1,18 +1,12 @@
-module api_app_browse_filter {
+module api_facet {
 
-    export interface FacetGroupData {
-        name:string;
-        displayName:string;
-        terms:FacetData[];
-    }
+    export class TermsFacetView extends api_dom.DivEl {
 
-    export class FacetGroup extends api_dom.DivEl {
-
-        private facets:Facet[] = [];
+        private facets:TermsFacetEntryView[] = [];
 
         private name:string;
 
-        constructor(facetGroupData:FacetGroupData) {
+        constructor(facetGroupData:TermsFacet) {
             super('FacetGroup', 'facet-group');
             this.name = facetGroupData.name;
 
@@ -26,7 +20,7 @@ module api_app_browse_filter {
                 if (facetData.count > 0) {
                     needHide = false;
                 }
-                this.addFacet(new Facet(facetData, this));
+                this.addFacet(new TermsFacetEntryView(facetData, this));
             }
 
             if (needHide) {
@@ -34,14 +28,14 @@ module api_app_browse_filter {
             }
         }
 
-        private addFacet(facet:Facet) {
+        private addFacet(facet:TermsFacetEntryView) {
             this.appendChild(facet);
             this.facets.push(facet);
         }
 
-        private getFacet(name:string):Facet {
+        private getFacet(name:string):TermsFacetEntryView {
             for (var i = 0; i < this.facets.length; i++) {
-                var facet:Facet = this.facets[i];
+                var facet:TermsFacetEntryView = this.facets[i];
                 if (facet.getName() == name) {
                     return facet;
                 }
@@ -49,18 +43,18 @@ module api_app_browse_filter {
             return null;
         }
 
-        update(facetGroupData:FacetGroupData) {
+        update(facetGroupData:TermsFacet) {
             var needHide = true;
             for (var i = 0; i < facetGroupData.terms.length; i++) {
                 var facetData = facetGroupData.terms[i];
                 if (facetData.count > 0) {
                     needHide = false;
                 }
-                var facet:Facet = this.getFacet(facetData.name);
+                var facet:TermsFacetEntryView = this.getFacet(facetData.name);
                 if (facet != null) {
                     facet.update(facetData);
                 } else {
-                    this.addFacet(new Facet(facetData, this));
+                    this.addFacet(new TermsFacetEntryView(facetData, this));
                 }
             }
 

--- a/modules/wem-webapp/src/main/webapp/admin2/api/js/main.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/api/js/main.ts
@@ -180,13 +180,17 @@
 ///<reference path='app/browse/GridContainer.ts'/>
 
 ///<reference path='app/browse/filter/FilterSearchEvent.ts' />
-///<reference path='app/browse/filter/Facet.ts' />
-///<reference path='app/browse/filter/FacetGroup.ts' />
-///<reference path='app/browse/filter/FacetContainer.ts' />
 ///<reference path='app/browse/filter/BrowseFilterPanelListener.ts' />
 ///<reference path='app/browse/filter/BrowseFilterPanel.ts' />
 ///<reference path='app/browse/filter/TextSearchField.ts'/>
 ///<reference path='app/browse/filter/ClearFilterButton.ts'/>
+
+///<reference path='facet/TermsFacetEntryView.ts' />
+///<reference path='facet/TermsFacetView.ts' />
+///<reference path='facet/FacetGroupView.ts' />
+///<reference path='facet/Facet.ts' />
+///<reference path='facet/TermsFacet.ts' />
+///<reference path='facet/TermsFacetEntry.ts' />
 
 ///<reference path='app/view/ViewItem.ts' />
 ///<reference path='app/view/ItemStatisticsPanel.ts' />

--- a/modules/wem-webapp/src/main/webapp/admin2/apps/content-manager/js/app/browse/filter/ContentBrowseFilterPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin2/apps/content-manager/js/app/browse/filter/ContentBrowseFilterPanel.ts
@@ -2,7 +2,7 @@ module app_browse_filter {
 
     export class ContentBrowseFilterPanel extends api_app_browse_filter.BrowseFilterPanel {
 
-        constructor(facetData?:api_app_browse_filter.FacetGroupData[]) {
+        constructor(facetData?:api_facet.TermsFacet[]) {
             super(facetData);
 
             this.addListener({onSearch: (values:any[])=> {


### PR DESCRIPTION
All facet related components are moved to api_facet module.
All component names are changed to be the same as in java code:
Facet to TermsFacetEntry, FacetGroup to TermsFacet, added
Facet interface. FacetContainer was renamed to FacetGroupView
