### PR TITLE
CMS-2015 Make content_list return all root content when path is not give...

### DIFF
--- a/modules/wem-api/src/main/java/com/enonic/wem/api/command/content/ContentCommands.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/command/content/ContentCommands.java
@@ -23,6 +23,11 @@ public final class ContentCommands
         return new GetContents();
     }
 
+    public GetRootContent getRoot()
+    {
+        return new GetRootContent();
+    }
+
     public GetChildContent getChildren()
     {
         return new GetChildContent();

--- a/modules/wem-api/src/main/java/com/enonic/wem/api/command/content/GetRootContent.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/command/content/GetRootContent.java
@@ -1,0 +1,30 @@
+package com.enonic.wem.api.command.content;
+
+import com.enonic.wem.api.command.Command;
+import com.enonic.wem.api.content.Contents;
+
+public class GetRootContent
+    extends Command<Contents>
+{
+
+    @Override
+    public boolean equals( final Object o )
+    {
+        if ( this == o )
+        {
+            return true;
+        }
+
+        if ( !( o instanceof GetContents ) )
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void validate()
+    {
+    }
+}

--- a/modules/wem-core/src/main/java/com/enonic/wem/core/content/ContentModule.java
+++ b/modules/wem-core/src/main/java/com/enonic/wem/core/content/ContentModule.java
@@ -38,6 +38,7 @@ public final class ContentModule
         commands.add( GenerateContentNameHandler.class );
         commands.add( GetChildContentHandler.class );
         commands.add( GetContentsHandler.class );
+        commands.add( GetRootContentHandler.class );
         commands.add( GetContentTreeHandler.class );
         commands.add( GetContentVersionHandler.class );
         commands.add( GetContentVersionHistoryHandler.class );

--- a/modules/wem-core/src/main/java/com/enonic/wem/core/content/GetRootContentHandler.java
+++ b/modules/wem-core/src/main/java/com/enonic/wem/core/content/GetRootContentHandler.java
@@ -1,0 +1,63 @@
+package com.enonic.wem.core.content;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.jcr.Session;
+
+import com.enonic.wem.api.command.content.GetRootContent;
+import com.enonic.wem.api.content.Content;
+import com.enonic.wem.api.content.ContentPath;
+import com.enonic.wem.api.content.Contents;
+import com.enonic.wem.api.space.Space;
+import com.enonic.wem.api.space.Spaces;
+import com.enonic.wem.core.command.CommandContext;
+import com.enonic.wem.core.command.CommandHandler;
+import com.enonic.wem.core.content.dao.ContentDao;
+import com.enonic.wem.core.space.dao.SpaceDao;
+
+public class GetRootContentHandler
+    extends CommandHandler<GetRootContent>
+{
+
+    private SpaceDao spaceDao;
+
+    private ContentDao contentDao;
+
+    public GetRootContentHandler()
+    {
+        super( GetRootContent.class );
+    }
+
+    @Override
+    public void handle( final CommandContext context, final GetRootContent command )
+        throws Exception
+    {
+
+        final Session jcrSession = context.getJcrSession();
+        final Spaces spaces = spaceDao.getAllSpaces( jcrSession );
+        final List<Content> contents = new ArrayList<>();
+        for ( Space space : spaces )
+        {
+            Content content = contentDao.select( ContentPath.rootOf( space.getName() ), jcrSession );
+            if ( null != content )
+            {
+                contents.add( content );
+            }
+        }
+        command.setResult( Contents.from( contents ) );
+    }
+
+    @Inject
+    public void setSpaceDao( final SpaceDao spaceDao )
+    {
+        this.spaceDao = spaceDao;
+    }
+
+    @Inject
+    public void setContentDao( final ContentDao contentDao )
+    {
+        this.contentDao = contentDao;
+    }
+}

--- a/modules/wem-core/src/test/java/com/enonic/wem/core/content/GetRootContentHandlerTest.java
+++ b/modules/wem-core/src/test/java/com/enonic/wem/core/content/GetRootContentHandlerTest.java
@@ -1,0 +1,123 @@
+package com.enonic.wem.core.content;
+
+import javax.jcr.Session;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.enonic.wem.api.Client;
+import com.enonic.wem.api.command.content.GetRootContent;
+import com.enonic.wem.api.content.Content;
+import com.enonic.wem.api.content.ContentPath;
+import com.enonic.wem.api.content.ContentSelector;
+import com.enonic.wem.api.content.Contents;
+import com.enonic.wem.api.space.Space;
+import com.enonic.wem.api.space.Spaces;
+import com.enonic.wem.core.command.AbstractCommandHandlerTest;
+import com.enonic.wem.core.content.dao.ContentDao;
+import com.enonic.wem.core.space.dao.SpaceDao;
+
+import static org.junit.Assert.*;
+
+public class GetRootContentHandlerTest
+    extends AbstractCommandHandlerTest
+{
+
+    private GetRootContentHandler handler;
+
+    private SpaceDao spaceDao;
+
+    private ContentDao contentDao;
+
+    @Before
+    public void setUp()
+        throws Exception
+    {
+
+        super.client = Mockito.mock( Client.class );
+        super.initialize();
+
+        handler = new GetRootContentHandler();
+
+        spaceDao = Mockito.mock( SpaceDao.class );
+
+        contentDao = Mockito.mock( ContentDao.class );
+
+        handler.setContentDao( contentDao );
+        handler.setSpaceDao( spaceDao );
+    }
+
+    @Test
+    public void getRootContent_no_spaces()
+        throws Exception
+    {
+
+        GetRootContent getRootContentCommand = new GetRootContent();
+        Mockito.when( spaceDao.getAllSpaces( Mockito.isA( Session.class ) ) ).thenReturn( Spaces.empty() );
+
+        handler.handle( this.context, getRootContentCommand );
+
+        Mockito.verify( contentDao, Mockito.times( 0 ) ).select( Mockito.isA( ContentSelector.class ), Mockito.isA( Session.class ) );
+
+        assertEquals( 0, getRootContentCommand.getResult().getSize() );
+    }
+
+    @Test
+    public void getRootContent_empty_spaces()
+        throws Exception
+    {
+        GetRootContent getRootContentCommand = new GetRootContent();
+
+        Mockito.when( spaceDao.getAllSpaces( Mockito.isA( Session.class ) ) ).thenReturn(
+            Spaces.from( createSpace( "test1" ), createSpace( "test2" ) ) );
+
+        handler.handle( this.context, getRootContentCommand );
+
+        Mockito.verify( contentDao, Mockito.times( 2 ) ).select( Mockito.isA( ContentSelector.class ), Mockito.isA( Session.class ) );
+
+        assertEquals( 0, getRootContentCommand.getResult().getSize() );
+
+    }
+
+    @Test
+    public void getRootContent_non_empty_spaces()
+        throws Exception
+    {
+        GetRootContent getRootContentCommand = new GetRootContent();
+
+        Space test1 = createSpace( "test1" );
+        Space test2 = createSpace( "test2" );
+
+        Content root1 = createContent( "root1" );
+        Content root2 = createContent( "root2" );
+
+        Mockito.when( spaceDao.getAllSpaces( Mockito.isA( Session.class ) ) ).thenReturn( Spaces.from( test1, test2 ) );
+
+        Mockito.when( contentDao.select( Mockito.eq( ContentPath.rootOf( test1.getName() ) ), Mockito.isA( Session.class ) ) ).thenReturn(
+            root1 );
+
+        Mockito.when( contentDao.select( Mockito.eq( ContentPath.rootOf( test2.getName() ) ), Mockito.isA( Session.class ) ) ).thenReturn(
+            root2 );
+
+        handler.handle( this.context, getRootContentCommand );
+
+        Mockito.verify( contentDao, Mockito.times( 2 ) ).select( Mockito.isA( ContentSelector.class ), Mockito.isA( Session.class ) );
+
+        assertEquals( 2, getRootContentCommand.getResult().getSize() );
+
+        assertEquals( getRootContentCommand.getResult(), Contents.from( root1, root2 ) );
+
+    }
+
+    private Space createSpace( String name )
+    {
+        return Space.newSpace().displayName( name ).createdTime( DateTime.now() ).modifiedTime( DateTime.now() ).name( name ).build();
+    }
+
+    private Content createContent( String name )
+    {
+        return Content.newContent().name( name ).displayName( name ).modifiedTime( DateTime.now() ).createdTime( DateTime.now() ).build();
+    }
+}

--- a/modules/wem-web/src/main/java/com/enonic/wem/admin/rest/resource/content/ContentResource.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/admin/rest/resource/content/ContentResource.java
@@ -100,12 +100,21 @@ public class ContentResource
     @Path("list")
     public ContentSummaryListJson list( @QueryParam("path") String path )
     {
-        final ContentPath parentPath = ContentPath.from( path );
+        final Contents contents;
+        if ( StringUtils.isEmpty( path ) )
+        {
+            contents = client.execute( Commands.content().getRoot() );
 
-        final GetChildContent getChildContent = Commands.content().getChildren();
-        getChildContent.parentPath( parentPath );
+        }
+        else
+        {
+            final ContentPath parentPath = ContentPath.from( path );
 
-        final Contents contents = client.execute( getChildContent );
+            final GetChildContent getChildContent = Commands.content().getChildren();
+            getChildContent.parentPath( parentPath );
+
+            contents = client.execute( getChildContent );
+        }
         return new ContentSummaryListJson( contents );
     }
 

--- a/modules/wem-web/src/main/java/com/enonic/wem/admin/rpc/content/ListContentRpcHandler.java
+++ b/modules/wem-web/src/main/java/com/enonic/wem/admin/rpc/content/ListContentRpcHandler.java
@@ -21,12 +21,21 @@ public final class ListContentRpcHandler
     public void handle( final JsonRpcContext context )
         throws Exception
     {
-        final ContentPath parentPath = ContentPath.from( context.param( "path" ).required().asString() );
+        final Contents contents;
 
-        final GetChildContent getChildContent = Commands.content().getChildren();
-        getChildContent.parentPath( parentPath );
+        if ( context.param( "path" ).isNull() )
+        {
+            contents = client.execute( Commands.content().getRoot() );
+        }
+        else
+        {
+            final ContentPath parentPath = ContentPath.from( context.param( "path" ).required().asString() );
 
-        final Contents contents = client.execute( getChildContent );
+            final GetChildContent getChildContent = Commands.content().getChildren();
+            getChildContent.parentPath( parentPath );
+
+            contents = client.execute( getChildContent );
+        }
         context.setResult( new ListContentJsonResult( contents ) );
     }
 }

--- a/modules/wem-web/src/test/java/com/enonic/wem/admin/rest/resource/content/ContentResourceTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/admin/rest/resource/content/ContentResourceTest.java
@@ -23,6 +23,7 @@ import com.enonic.wem.api.command.content.FindContent;
 import com.enonic.wem.api.command.content.GenerateContentName;
 import com.enonic.wem.api.command.content.GetChildContent;
 import com.enonic.wem.api.command.content.GetContents;
+import com.enonic.wem.api.command.content.GetRootContent;
 import com.enonic.wem.api.command.content.RenameContent;
 import com.enonic.wem.api.command.content.UpdateContent;
 import com.enonic.wem.api.command.content.UpdateContentResult;
@@ -103,6 +104,19 @@ public class ContentResourceTest
         String jsonString = resource().path( "content" ).queryParam( "path", "/my_a_content" ).get( String.class );
 
         assertJson( "get_content_by_path.json", jsonString );
+    }
+
+    @Test
+    public void get_root_content()
+        throws Exception
+    {
+        final Content aContent = createContent( "aaa", "my_a_content", "mymodule:my_type" );
+        final Content bContent = createContent( "bbb", "my_b_content", "mymodule:my_type" );
+        Mockito.when( client.execute( Mockito.isA( GetRootContent.class ) ) ).thenReturn( Contents.from( aContent, bContent ) );
+
+        String jsonString = resource().path( "content/list" ).get( String.class );
+
+        assertJson( "list_content.json", jsonString );
     }
 
     @Test


### PR DESCRIPTION
...n

Created new command GetRootContent and GetRootContentHandler under Content Commands, which only retrieves each root content of each space. Written unit tests for handler and resource.
