### PR TITLE
CMS-2186 Schema Manager: Make "Schema edit" use new REST API

### DIFF
--- a/modules/wem-web/src/test/java/com/enonic/wem/admin/rest/resource/schema/relationship/RelationshipTypeResourceTest.java
+++ b/modules/wem-web/src/test/java/com/enonic/wem/admin/rest/resource/schema/relationship/RelationshipTypeResourceTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.WebApplicationException;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -93,7 +94,7 @@ public class RelationshipTypeResourceTest
             QualifiedRelationshipTypeNames.from( QualifiedRelationshipTypeName.from( "the_relationship_type" ) );
         Mockito.when( client.execute( Commands.relationshipType().get().qualifiedNames( names ) ) ).thenReturn( relationshipTypes );
 
-        AbstractRelationshipTypeJson result = resource.get( "the_relationship_type", RelationshipTypeResource.FORMAT_JSON );
+        AbstractRelationshipTypeJson result = resource.get( "the_relationship_type" );
         assertNotNull( result );
 
         RelationshipTypeResultJson resultJson = ( (RelationshipTypeJson) result ).getRelationshipType();
@@ -120,7 +121,7 @@ public class RelationshipTypeResourceTest
             QualifiedRelationshipTypeNames.from( QualifiedRelationshipTypeName.from( "the_relationship_type" ) );
         Mockito.when( client.execute( Commands.relationshipType().get().qualifiedNames( names ) ) ).thenReturn( relationshipTypes );
 
-        AbstractRelationshipTypeJson result = resource.get( "the_relationship_type", RelationshipTypeResource.FORMAT_XML );
+        AbstractRelationshipTypeJson result = resource.getConfig( "the_relationship_type" );
         assertNotNull( result );
 
         RelationshipTypeConfigJson resultJson = (RelationshipTypeConfigJson) result;
@@ -130,13 +131,13 @@ public class RelationshipTypeResourceTest
             resultJson.getRelationshipTypeXml() );
     }
 
-    @Test(expected = NotFoundException.class)
+    @Test(expected = WebApplicationException.class)
     public void testRequestGetRelationshipTypeJson_not_found()
         throws Exception
     {
         Mockito.when( client.execute( Mockito.any( GetRelationshipTypes.class ) ) ).thenReturn( RelationshipTypes.empty() );
 
-        resource.get( "the_relationship_type", RelationshipTypeResource.FORMAT_XML );
+        resource.getConfig( "the_relationship_type" );
     }
 
     @Test

--- a/modules/wem-webapp/src/main/webapp/admin/api/js/main.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/api/js/main.ts
@@ -181,11 +181,18 @@
 ///<reference path='content/json/module.ts' />
 ///<reference path='content/module.ts' />
 
+
 ///<reference path='schema/content/form/json/module.ts' />
 ///<reference path='schema/content/form/module.ts' />
 ///<reference path='schema/content/json/module.ts' />
 ///<reference path='schema/content/module.ts' />
 ///<reference path="schema/relationshiptype/json/RelationshipTypeJson.ts" />
+
+///<reference path='schema/mixin/module.ts'/>
+///<reference path='schema/mixin/json/module.ts'/>
+
+///<reference path='schema/relationshiptype/module.ts' />
+///<reference path='schema/relationshiptype/json/module.ts' />
 
 ///<reference path='page/json/module.ts' />
 ///<reference path='page/module.ts' />

--- a/modules/wem-webapp/src/main/webapp/admin/api/js/schema/mixin/GetMixinByQualifiedNameRequest.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/api/js/schema/mixin/GetMixinByQualifiedNameRequest.ts
@@ -1,0 +1,22 @@
+module api_schema_mixin {
+
+    export class GetMixinByQualifiedNameRequest extends MixinResourceRequest {
+        private qualifiedName:string;
+
+        constructor(qualifiedName:string) {
+            super();
+            super.setMethod("GET");
+            this.qualifiedName = qualifiedName;
+        }
+
+        getParams():Object {
+            return {
+                qualifiedName: this.qualifiedName
+            };
+        }
+
+        getRequestPath():api_rest.Path {
+            return super.getResourcePath();
+        }
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin/api/js/schema/mixin/GetMixinConfigByQualifiedNameRequest.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/api/js/schema/mixin/GetMixinConfigByQualifiedNameRequest.ts
@@ -1,0 +1,23 @@
+module api_schema_mixin {
+
+    export class GetMixinConfigByQualifiedNameRequest extends MixinResourceRequest {
+
+        private qualifiedName:string;
+
+        constructor(qualifiedName:string) {
+            super();
+            super.setMethod("GET");
+            this.qualifiedName = qualifiedName;
+        }
+
+        getParams():Object {
+            return {
+                qualifiedName: this.qualifiedName
+            };
+        }
+
+        getRequestPath():api_rest.Path {
+            return api_rest.Path.fromParent(super.getResourcePath(), "config");
+        }
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin/api/js/schema/mixin/MixinResourceRequest.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/api/js/schema/mixin/MixinResourceRequest.ts
@@ -1,0 +1,15 @@
+module api_schema_mixin {
+
+    export class MixinResourceRequest extends api_rest.ResourceRequest {
+        private resourceUrl:api_rest.Path;
+
+        constructor() {
+            super();
+            this.resourceUrl = api_rest.Path.fromParent(super.getRestPath(), "schema/mixin");
+        }
+
+        getResourcePath():api_rest.Path {
+            return this.resourceUrl;
+        }
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin/api/js/schema/mixin/module.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/api/js/schema/mixin/module.ts
@@ -1,1 +1,4 @@
 ///<reference path="Mixin.ts" />
+///<reference path="MixinResourceRequest.ts"/>
+///<reference path="GetMixinConfigByQualifiedNameRequest.ts"/>
+///<reference path="GetMixinByQualifiedNameRequest.ts"/>

--- a/modules/wem-webapp/src/main/webapp/admin/api/js/schema/relationshiptype/GetRelationshipTypeByQualifiedNameRequest.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/api/js/schema/relationshiptype/GetRelationshipTypeByQualifiedNameRequest.ts
@@ -1,0 +1,23 @@
+module api_schema_relationshiptype {
+
+    export class GetRelationshipTypeByQualifiedNameRequest extends RelationshipTypeResourceRequest {
+
+        private qualifiedName:string;
+
+        constructor(qualifiedName:string) {
+            super();
+            super.setMethod("GET");
+            this.qualifiedName = qualifiedName;
+        }
+
+        getParams():Object {
+            return {
+                qualifiedName: this.qualifiedName
+            };
+        }
+
+        getRequestPath():api_rest.Path {
+            return super.getResourcePath();
+        }
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin/api/js/schema/relationshiptype/GetRelationshipTypeConfigByQualifiedNameRequest.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/api/js/schema/relationshiptype/GetRelationshipTypeConfigByQualifiedNameRequest.ts
@@ -1,0 +1,23 @@
+module api_schema_relationshiptype {
+
+    export class GetRelationshipTypeConfigByQualifiedNameRequest extends RelationshipTypeResourceRequest {
+
+        private qualifiedName:string;
+
+        constructor(qualifiedName:string) {
+            super();
+            super.setMethod("GET");
+            this.qualifiedName = qualifiedName;
+        }
+
+        getParams():Object {
+            return {
+                qualifiedName: this.qualifiedName
+            };
+        }
+
+        getRequestPath():api_rest.Path {
+            return api_rest.Path.fromParent(super.getResourcePath(), "config");
+        }
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin/api/js/schema/relationshiptype/RelationshipTypeResourceRequest.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/api/js/schema/relationshiptype/RelationshipTypeResourceRequest.ts
@@ -1,0 +1,16 @@
+module api_schema_relationshiptype {
+
+    export class RelationshipTypeResourceRequest extends api_rest.ResourceRequest {
+
+        private resourceUrl:api_rest.Path;
+
+        constructor() {
+            super();
+            this.resourceUrl = api_rest.Path.fromParent(super.getRestPath(), "schema/relationship");
+        }
+
+        getResourcePath():api_rest.Path {
+            return this.resourceUrl;
+        }
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin/api/js/schema/relationshiptype/module.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/api/js/schema/relationshiptype/module.ts
@@ -1,1 +1,4 @@
 ///<reference path="RelationshipType.ts" />
+///<reference path="RelationshipTypeResourceRequest.ts" />
+///<reference path="GetRelationshipTypeByQualifiedNameRequest.ts" />
+///<reference path="GetRelationshipTypeConfigByQualifiedNameRequest.ts" />

--- a/modules/wem-webapp/src/main/webapp/admin/apps/schema-manager/js/app/SchemaAppPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/apps/schema-manager/js/app/SchemaAppPanel.ts
@@ -92,16 +92,11 @@ module app {
 
                         switch (schemaModel.data.type) {
                         case SchemaAppPanel.CONTENT_TYPE:
-                            var contentTypeGetParams:api_remote_contenttype.GetParams = {
-                                qualifiedNames: [schemaModel.data.qualifiedName],
-                                format: 'JSON'
-                            };
-                            api_remote_contenttype.RemoteContentTypeService.contentType_get(contentTypeGetParams,
-                                (result:api_remote_contenttype.GetResult) => {
+                            new api_schema_content.GetContentTypeByQualifiedNameRequest(schemaModel.data.qualifiedName).
+                                send().done((jsonResponse) => {
+                                    var contentType = new api_schema_content.ContentType(jsonResponse.json);
 
-                                    var contentType:api_remote_contenttype.ContentType = result.contentTypes[0];
-
-                                    tabMenuItem = new api_app.AppBarTabMenuItem(contentType.name, tabId, true);
+                                    tabMenuItem = new api_app.AppBarTabMenuItem(contentType.getName(), tabId, true);
 
                                     schemaWizardPanel = new app_wizard.ContentTypeWizardPanel();
                                     schemaWizardPanel.setPersistedItem(contentType);
@@ -110,35 +105,30 @@ module app {
                                 });
                             break;
                         case SchemaAppPanel.RELATIONSHIP_TYPE:
-                            var relationshipTypeGetParams:api_remote_relationshiptype.GetParams = {
-                                qualifiedName: schemaModel.data.qualifiedName,
-                                format: 'JSON'
-                            };
-                            api_remote_relationshiptype.RemoteRelationshipTypeService.relationshipType_get(relationshipTypeGetParams,
-                                (result:api_remote_relationshiptype.GetResult) => {
+                            new api_schema_relationshiptype.GetRelationshipTypeByQualifiedNameRequest(schemaModel.data.qualifiedName).
+                                send().done((jsonResponse) => {
+                                    var relationshipType = new api_schema_relationshiptype.RelationshipType(jsonResponse.json.relationshipType);
 
-                                    tabMenuItem = new api_app.AppBarTabMenuItem(result.relationshipType.displayName, tabId, true);
+                                    tabMenuItem = new api_app.AppBarTabMenuItem(relationshipType.getDisplayName(), tabId, true);
 
                                     schemaWizardPanel = new app_wizard.RelationshipTypeWizardPanel();
-                                    schemaWizardPanel.setPersistedItem(result.relationshipType);
+                                    schemaWizardPanel.setPersistedItem(relationshipType);
 
                                     this.addWizardPanel(tabMenuItem, schemaWizardPanel);
                                 });
                             break;
                         case SchemaAppPanel.MIXIN:
-                            var mixinGetParams:api_remote_mixin.GetParams = {
-                                qualifiedName: schemaModel.data.qualifiedName,
-                                format: 'JSON'
-                            };
-                            api_remote_mixin.RemoteMixinService.mixin_get(mixinGetParams, (result:api_remote_mixin.GetResult) => {
+                            new api_schema_mixin.GetMixinByQualifiedNameRequest(schemaModel.data.qualifiedName).
+                                send().done((jsonResponse)=> {
+                                    var mixin:api_schema_mixin.Mixin = new api_schema_mixin.Mixin(jsonResponse.json);
+                                    tabMenuItem = new api_app.AppBarTabMenuItem(mixin.getDisplayName(), tabId, true);
 
-                                tabMenuItem = new api_app.AppBarTabMenuItem(result.mixin.displayName, tabId, true);
+                                    schemaWizardPanel = new app_wizard.MixinWizardPanel();
+                                    schemaWizardPanel.setPersistedItem(mixin);
 
-                                schemaWizardPanel = new app_wizard.MixinWizardPanel();
-                                schemaWizardPanel.setPersistedItem(result.mixin);
+                                    this.addWizardPanel(tabMenuItem, schemaWizardPanel);
+                                });
 
-                                this.addWizardPanel(tabMenuItem, schemaWizardPanel);
-                            });
                             break;
                         }
                     }

--- a/modules/wem-webapp/src/main/webapp/admin/apps/schema-manager/js/app/wizard/ContentTypeWizardPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/apps/schema-manager/js/app/wizard/ContentTypeWizardPanel.ts
@@ -14,7 +14,7 @@ module app_wizard {
 
         private contentTypeWizardHeader:api_app_wizard.WizardHeaderWithName;
 
-        private persistedContentType:api_remote_contenttype.ContentType;
+        private persistedContentType:api_schema_content.ContentType;
 
         private contentTypeForm:app_wizard.ContentTypeForm;
 
@@ -46,23 +46,18 @@ module app_wizard {
             this.addStep(new api_app_wizard.WizardStep("Content Type"), this.contentTypeForm);
         }
 
-        setPersistedItem(contentType:api_remote_contenttype.ContentType) {
+        setPersistedItem(contentType:api_schema_content.ContentType) {
             super.setPersistedItem(contentType);
 
-            this.contentTypeWizardHeader.setName(contentType.name);
-            this.formIcon.setSrc(contentType.iconUrl);
+            this.contentTypeWizardHeader.setName(contentType.getName());
+            this.formIcon.setSrc(contentType.getIconUrl());
 
             this.persistedContentType = contentType;
 
-            var contentTypeGetParams:api_remote_contenttype.GetParams = {
-                qualifiedNames: [contentType.qualifiedName],
-                format: 'XML'
-            };
+            new api_schema_content.GetContentTypeConfigByQualifiedNameRequest(contentType.getQualifiedName()).send().done((response:any) => {
+                this.contentTypeForm.setFormData({"xml": response.json.contentTypeXml});
+            });
 
-            api_remote_contenttype.RemoteContentTypeService.contentType_get(contentTypeGetParams,
-                (result:api_remote_contenttype.GetResult) => {
-                    this.contentTypeForm.setFormData({"xml": result.contentTypeXmls[0]});
-                })
         }
 
         persistNewItem(successCallback?:() => void) {

--- a/modules/wem-webapp/src/main/webapp/admin/apps/schema-manager/js/app/wizard/MixinWizardPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/apps/schema-manager/js/app/wizard/MixinWizardPanel.ts
@@ -14,7 +14,7 @@ module app_wizard {
 
         private mixinWizardHeader:api_app_wizard.WizardHeaderWithName;
 
-        private persistedMixin:api_remote_mixin.Mixin;
+        private persistedMixin:api_schema_mixin.Mixin;
 
         private mixinForm:MixinForm;
 
@@ -45,22 +45,18 @@ module app_wizard {
             this.addStep(new api_app_wizard.WizardStep("Mixin"), this.mixinForm);
         }
 
-        setPersistedItem(mixin:api_remote_mixin.Mixin) {
+        setPersistedItem(mixin:api_schema_mixin.Mixin) {
             super.setPersistedItem(mixin);
 
-            this.mixinWizardHeader.setName(mixin.name);
-            this.formIcon.setSrc(mixin.iconUrl);
+            this.mixinWizardHeader.setName(mixin.getName());
+            this.formIcon.setSrc(mixin.getIcon());
 
             this.persistedMixin = mixin;
 
-            var mixinGetParams:api_remote_mixin.GetParams = {
-                qualifiedName: mixin.name,
-                format: 'XML'
-            };
-
-            api_remote_mixin.RemoteMixinService.mixin_get(mixinGetParams, (result:api_remote_mixin.GetResult) => {
-                this.mixinForm.setFormData({"xml": result.mixinXml})
+            new api_schema_mixin.GetMixinConfigByQualifiedNameRequest(mixin.getName()).send().done((response:any) => {
+                this.mixinForm.setFormData({"xml": response.json.mixinXml});
             });
+
         }
 
         persistNewItem(successCallback?:() => void) {

--- a/modules/wem-webapp/src/main/webapp/admin/apps/schema-manager/js/app/wizard/RelationshipTypeWizardPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/apps/schema-manager/js/app/wizard/RelationshipTypeWizardPanel.ts
@@ -15,7 +15,7 @@ module app_wizard {
 
         private relationShipTypeWizardHeader:api_app_wizard.WizardHeaderWithName;
 
-        private persistedRelationshipType:api_remote_relationshiptype.RelationshipType;
+        private persistedRelationshipType:api_schema_relationshiptype.RelationshipType;
 
         private relationshipTypeForm:RelationshipTypeForm;
 
@@ -45,23 +45,23 @@ module app_wizard {
             this.addStep(new api_app_wizard.WizardStep("Relationship Type"), this.relationshipTypeForm);
         }
 
-        setPersistedItem(relationshipType:api_remote_relationshiptype.RelationshipType) {
+        setPersistedItem(relationshipType:api_schema_relationshiptype.RelationshipType) {
             super.setPersistedItem(relationshipType);
 
-            this.relationShipTypeWizardHeader.setName(relationshipType.name);
-            this.formIcon.setSrc(relationshipType.iconUrl);
+            this.relationShipTypeWizardHeader.setName(relationshipType.getName());
+            this.formIcon.setSrc(relationshipType.getIcon());
 
             this.persistedRelationshipType = relationshipType;
 
             var relationshipTypeGetParams:api_remote_relationshiptype.GetParams = {
-                qualifiedName: relationshipType.name,
+                qualifiedName: relationshipType.getName(),
                 format: 'XML'
             };
 
-            api_remote_relationshiptype.RemoteRelationshipTypeService.relationshipType_get(relationshipTypeGetParams,
-                (result:api_remote_relationshiptype.GetResult) => {
-                    this.relationshipTypeForm.setFormData({"xml": result.relationshipTypeXml})
-                });
+            new api_schema_relationshiptype.GetRelationshipTypeConfigByQualifiedNameRequest(relationshipType.getName()).send().done((response:any) => {
+                this.relationshipTypeForm.setFormData({"xml": response.json.relationshipTypeXml});
+            });
+
         }
 
         persistNewItem(successCallback?:() => void) {


### PR DESCRIPTION
When handling app_browse.EditSchemaEvent use new REST API for each schema type.
- GetContentTypeBy..., GetMixinBy..., GetRelationshipTypeBy....
  And of course, change each XxxWizardPanel accept the new domain classes:
- api_schema_content.ContentType, api_schema_relationshiptype, api_mixin.Mixin

Also RelationshipTypeResource was refactored: method get was broken on two methods: get and getConf
