### PR TITLE
CMS-2571 Ensure Publish action is disabled until Form validates

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
@@ -32,6 +32,8 @@ module app.wizard {
 
         private previewAction: api.ui.Action;
 
+        private publishAction: api.ui.Action;
+
         constructor(params: ContentWizardPanelParams, callback: (wizard: ContentWizardPanel) => void) {
 
             console.log("ContentWizardPanel.constructor started");
@@ -60,6 +62,7 @@ module app.wizard {
 
             var actions = new app.wizard.action.ContentWizardActions(this);
             this.previewAction = actions.getPreviewAction();
+            this.publishAction = actions.getPublishAction();
 
             var mainToolbar = new ContentWizardToolbar({
                 saveAction: actions.getSaveAction(),
@@ -84,7 +87,7 @@ module app.wizard {
             else {
                 this.siteWizardStepForm = null;
             }
-            this.contentWizardStepForm = new ContentWizardStepForm();
+            this.contentWizardStepForm = new ContentWizardStepForm(this.publishAction);
 
             if (this.siteContent || this.createSite) {
                 var pageWizardStepFormConfig: page.PageWizardStepFormConfig = {

--- a/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/wizard/ContentWizardStepForm.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/wizard/ContentWizardStepForm.ts
@@ -8,8 +8,11 @@ module app.wizard {
 
         private formView: api.form.FormView;
 
-        constructor() {
+        private publishAction: api.ui.Action;
+
+        constructor(publishAction:api.ui.Action) {
             super();
+            this.publishAction = publishAction;
         }
 
         renderNew(formContext: api.form.FormContext, form: api.form.Form) {
@@ -34,6 +37,10 @@ module app.wizard {
             });
 
             this.appendChild(this.formView)
+
+            this.formView.onValidityChanged((event:api.form.event.FormValidityChangedEvent) => {
+                this.publishAction.setEnabled(event.isValid());
+            });
         }
 
         getForm(): api.form.Form {

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/_module.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/_module.ts
@@ -49,6 +49,7 @@
 ///<reference path='data/json/_module.ts' />
 ///<reference path='data/_module.ts' />
 
+///<reference path='form/event/_module.ts' />
 ///<reference path='form/json/_module.ts' />
 ///<reference path='form/_module.ts' />
 ///<reference path='form/input/_module.ts' />
@@ -63,7 +64,6 @@
 ///<reference path='form/inputtype/text/_module.ts' />
 ///<reference path='form/formitemset/_module.ts' />
 ///<reference path='form/layout/_module.ts' />
-
 ///<reference path='item/_module.ts' />
 
 ///<reference path='node/_module.ts' />

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/form/FormItemView.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/form/FormItemView.ts
@@ -63,5 +63,13 @@ module api.form {
                 listener(content);
             })
         }
+
+        onValidityChanged(listener:(event:api.form.inputtype.support.ValidityChangedEvent)=>void) {
+            //Should be implemented in child classes
+        }
+
+        unValidityChanged(listener:(event:api.form.inputtype.support.ValidityChangedEvent)=>void) {
+            //Should be implemented in child classes
+        }
     }
 }

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/form/event/FormEvent.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/form/event/FormEvent.ts
@@ -1,0 +1,10 @@
+module api.form.event {
+
+    export class FormEvent {
+
+        constructor() {
+
+        }
+
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/form/event/FormEventNames.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/form/event/FormEventNames.ts
@@ -1,0 +1,7 @@
+module api.form.event {
+
+    export enum FormEventNames {
+
+        FormValidityChanged
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/form/event/FormValidityChangedEvent.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/form/event/FormValidityChangedEvent.ts
@@ -1,0 +1,23 @@
+module api.form.event {
+
+    export class FormValidityChangedEvent extends FormEvent {
+
+        private valid:boolean;
+
+        private validationRecorder:api.form.ValidationRecorder;
+
+        constructor(valid:boolean, validationRecorder?:api.form.ValidationRecorder) {
+            super();
+            this.valid = valid;
+            this.validationRecorder = validationRecorder;
+        }
+
+        isValid( ):boolean {
+            return this.valid;
+        }
+
+        getValidationRecorder():api.form.ValidationRecorder {
+            return this.validationRecorder;
+        }
+    }
+}

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/form/event/_module.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/form/event/_module.ts
@@ -1,0 +1,3 @@
+///<reference path='FormEvent.ts' />
+///<reference path='FormValidityChangedEvent.ts' />
+///<reference path='FormEventNames.ts' />

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/form/input/InputView.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/form/input/InputView.ts
@@ -125,5 +125,13 @@ module api.form.input {
         giveFocus(): boolean {
             return this.inputTypeView.giveFocus();
         }
+
+        onValidityChanged(listener:(event:api.form.inputtype.support.ValidityChangedEvent)=>void) {
+            this.inputTypeView.onValidityChanged(listener);
+        }
+
+        unValidityChanged(listener:(event:api.form.inputtype.support.ValidityChangedEvent)=>void) {
+            this.inputTypeView.unValidityChanged(listener);
+        }
     }
 }

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/form/inputtype/InputTypeView.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/form/inputtype/InputTypeView.ts
@@ -1,5 +1,7 @@
 module api.form.inputtype {
 
+    import ValidityChangedEvent = api.form.inputtype.support.ValidityChangedEvent;
+
     export interface InputTypeView {
 
         getHTMLElement():HTMLElement;
@@ -51,5 +53,9 @@ module api.form.inputtype {
          * Returns true if focus was successfully given.
          */
         giveFocus(): boolean;
+
+        onValidityChanged(listener:(event:ValidityChangedEvent)=>void);
+
+        unValidityChanged(listener:(event:ValidityChangedEvent)=>void);
     }
 }

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/form/inputtype/content/image/ImageSelector.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/form/inputtype/content/image/ImageSelector.ts
@@ -1,5 +1,7 @@
 module api.form.inputtype.content.image {
 
+    import ValidityChangedEvent = api.form.inputtype.support.ValidityChangedEvent;
+
     export interface ImageSelectorConfig {
 
         relationshipType: {
@@ -267,6 +269,14 @@ module api.form.inputtype.content.image {
             contentEl.appendChild(pathEl);
 
             return imgEl.toString() + contentEl.toString();
+
+        }
+
+        onValidityChanged(listener:(event:ValidityChangedEvent)=>void) {
+
+        }
+
+        unValidityChanged(listener:(event:ValidityChangedEvent)=>void) {
 
         }
 


### PR DESCRIPTION
Added enable/disable of Publish button during form validation. Currently it works only on input fields outside
of field sets and layouts (validation notifying should be implemented for them separately)
