### PR TITLE
CMS-3108 Make removed FormItemSetViewOccurrence stay removed after save

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
@@ -215,6 +215,7 @@ module app.wizard {
                         setParentContent(this.parentContent).
                         setPersistedContent(persistedContent).
                         setAttachments(attachments).
+                        setShowEmptyFormItemSetOccurrences(this.isNew()).
                         build();
 
                     this.contentWizardStepForm.renderExisting(formContext, contentData, persistedContent.getForm());

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/app/wizard/WizardPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/app/wizard/WizardPanel.ts
@@ -56,6 +56,8 @@ module api.app.wizard {
 
         private stepNavigatorAndToolbarContainer: api.dom.DivEl;
 
+        private new: boolean;
+
         constructor(params: WizardPanelParams, callback: Function) {
             super();
 
@@ -63,6 +65,7 @@ module api.app.wizard {
 
             this.tabId = params.tabId;
             this.persistedItem = params.persistedItem;
+            this.new = params.persistedItem == null;
             this.header = params.header;
             this.mainToolbar = params.mainToolbar;
             this.stepToolbar = params.stepToolbar;
@@ -140,6 +143,10 @@ module api.app.wizard {
             this.onShown((event) => {
                 this.onWizardShown();
             });
+        }
+
+        isNew(): boolean {
+            return this.new;
         }
 
         onWizardShown() {

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/form/FormContext.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/form/FormContext.ts
@@ -8,9 +8,12 @@ module api.form {
 
         private attachments: api.content.attachment.Attachments;
 
+        private showEmptyFormItemSetOccurrences: boolean;
+
         constructor(builder: FormContextBuilder) {
             this.parentContent = builder.parentContent;
             this.persistedContent = builder.persistedContent;
+            this.showEmptyFormItemSetOccurrences = builder.showEmptyFormItemSetOccurrences;
             this.attachments = builder.attachments;
         }
 
@@ -34,6 +37,10 @@ module api.form {
         getAttachments() : api.content.attachment.Attachments{
             return this.attachments;
         }
+
+        getShowEmptyFormItemSetOccurrences(): boolean {
+            return this.showEmptyFormItemSetOccurrences;
+        }
     }
 
     export class FormContextBuilder {
@@ -43,6 +50,8 @@ module api.form {
         persistedContent: api.content.Content;
 
         attachments: api.content.attachment.Attachments;
+
+        showEmptyFormItemSetOccurrences: boolean;
 
         public setParentContent(value: api.content.Content): FormContextBuilder {
             this.parentContent = value;
@@ -56,6 +65,11 @@ module api.form {
 
         public setAttachments(value: api.content.attachment.Attachments): FormContextBuilder {
             this.attachments = value;
+            return this;
+        }
+
+        public setShowEmptyFormItemSetOccurrences(value: boolean): FormContextBuilder {
+            this.showEmptyFormItemSetOccurrences = value;
             return this;
         }
 

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/form/formitemset/FormItemSetOccurrences.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/form/formitemset/FormItemSetOccurrences.ts
@@ -24,12 +24,25 @@ module api.form.formitemset {
             this.formItemSet = formItemSet;
             this.parent = parent;
             this.dataSets = dataSets;
-
             if (dataSets != null && dataSets.length > 0) {
                 this.constructOccurrencesForData();
             }
             else {
                 this.constructOccurrencesForNoData();
+            }
+        }
+
+        constructOccurrencesForNoData() {
+            if (this.getAllowedOccurrences().getMinimum() > 0) {
+
+                for (var i = 0; i < this.getAllowedOccurrences().getMinimum(); i++) {
+                    this.addOccurrence(this.createNewOccurrence(this, i));
+                }
+            }
+            else {
+                if (this.context.getShowEmptyFormItemSetOccurrences()) {
+                    this.addOccurrence(this.createNewOccurrence(this, 0));
+                }
             }
         }
 


### PR DESCRIPTION
Added property showEmptyFormItemSetOccurrences in FormContext (false by default). True for new content
and false for edited content
