### PR TITLE
CMS-3133 Input Type Textline - Adjustments when used in "multiple" mode

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/common/styles/api/form/input/input-occurrence-view.less
+++ b/modules/wem-webapp/src/main/webapp/admin/common/styles/api/form/input/input-occurrence-view.less
@@ -41,8 +41,16 @@
       display: block;
     }
 
+    .remove-button {
+      font-size: 9px;
+    }
+
     .input-wrapper {
       margin: 0 30px 0 5px;
+    }
+
+    &:nth-last-of-type(2) {
+      margin-bottom: 5px;
     }
 
   }


### PR DESCRIPTION
Updated `remove` icon: it will be the same size, as in combobox
elements.
Reduced space between `Add` button and input elements in multiple mode.
