### PR TITLE
CMS-3190 FormItemSet looks bad in ContextWindow form when no occurences

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/contextwindow/image/ImageSelectPanelSelectedOptionView.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/contextwindow/image/ImageSelectPanelSelectedOptionView.ts
@@ -22,7 +22,7 @@ module app.contextwindow.image {
             title.getEl().setInnerHtml(this.content.getName().toString());
 
             var subtitle = new api.dom.DivEl("subtitle");
-            subtitle.getEl().setInnerHtml(api.util.limitString(this.content.getPath().toString(), 32));
+            subtitle.getEl().setInnerHtml(this.content.getPath().toString());
 
             container.appendChild(title);
             container.appendChild(subtitle);

--- a/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/contextwindow/image/RecentGrid.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/contextwindow/image/RecentGrid.ts
@@ -30,7 +30,7 @@ module app.contextwindow.image {
             title.getEl().setInnerHtml(dataContext.getDisplayName());
 
             var subtitle = new api.dom.H6El();
-            subtitle.getEl().setInnerHtml(api.util.limitString(dataContext.path.refString, 43));
+            subtitle.getEl().setInnerHtml(dataContext.path.refString);
 
             rowEl.appendChild(image);
             rowEl.appendChild(title);

--- a/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/contextwindow/inspect/BaseInspectionPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/contextwindow/inspect/BaseInspectionPanel.ts
@@ -26,7 +26,7 @@ module app.contextwindow.inspect {
 
         setMainName(value: string) {
             if (this.nameAndIcon) {
-                this.nameAndIcon.setMainName(api.util.limitString(value, 20));
+                this.nameAndIcon.setMainName(value);
             }
         }
 

--- a/modules/wem-webapp/src/main/webapp/admin/common/styles/apps/content/contextwindow.less
+++ b/modules/wem-webapp/src/main/webapp/admin/common/styles/apps/content/contextwindow.less
@@ -107,7 +107,9 @@
 
   .inspection-panel {
     font-size: 12px;
-    padding:10px;
+    padding: 10px;
+    overflow-y: scroll;
+    width: 100% !important;
 
     .icon {
       font-size: 48px;
@@ -255,10 +257,6 @@
     .template-panel {
       padding:15px;
     }
-  }
-
-  .inspection-panel {
-    overflow-y:scroll;
   }
 
   .image-selector-small();


### PR DESCRIPTION
Removed limitString function usage.
Fixes inspection panel width (close button was not aligned to right).
