### PR TITLE
CMS-3215 Multiselect in combobox - Design improvements

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/common/lib/slickgrid/slick.checkboxselectcolumn.js
+++ b/modules/wem-webapp/src/main/webapp/admin/common/lib/slickgrid/slick.checkboxselectcolumn.js
@@ -73,7 +73,8 @@
 
         function handleClick(e, args) {
             // clicking on a row select checkbox
-            if (_grid.getColumns()[args.cell].id === _options.columnId && $(e.target).is(":checkbox")) {
+            if (_grid.getColumns()[args.cell].id === _options.columnId &&
+                (($(e.target).is("label") && $(e.target).has(":checkbox").length) || $(e.target).is(":checkbox"))) {
                 // if editing, try to commit
                 if (_grid.getEditorLock().isActive() && !_grid.getEditorLock().commitCurrentEdit()) {
                     e.preventDefault();
@@ -98,7 +99,8 @@
         }
 
         function handleHeaderClick(e, args) {
-            if (args.column.id == _options.columnId && $(e.target).is(":checkbox")) {
+            if (args.column.id == _options.columnId &&
+                (($(e.target).is("label") && $(e.target).has(":checkbox").length) || $(e.target).is(":checkbox"))) {
                 // if editing, try to commit
                 if (_grid.getEditorLock().isActive() && !_grid.getEditorLock().commitCurrentEdit()) {
                     e.preventDefault();
@@ -106,7 +108,7 @@
                     return;
                 }
 
-                if ($(e.target).is(":checked")) {
+                if ($(e.target).has(":checked").length || $(e.target).is(":checked")) {
                     var rows = [];
                     for (var i = 0; i < _grid.getDataLength(); i++) {
                         rows.push(i);
@@ -137,8 +139,8 @@
         function checkboxSelectionFormatter(row, cell, value, columnDef, dataContext) {
             if (dataContext) {
                 return _selectedRowsLookup[row]
-                    ? "<input type='checkbox' checked='checked'>"
-                    : "<input type='checkbox'>";
+                    ? "<label><input type='checkbox' checked='checked'></label>"
+                    : "<label><input type='checkbox'></label>";
             }
             return null;
         }

--- a/modules/wem-webapp/src/main/webapp/admin/common/styles/api/ui/selector/combobox/combobox.less
+++ b/modules/wem-webapp/src/main/webapp/admin/common/styles/api/ui/selector/combobox/combobox.less
@@ -99,14 +99,25 @@
     }
 
     .slick-cell-checkboxsel {
-      input[type="checkbox"] {
-        width: 20px;
+      label {
+        display: inline-block;
+        width: 100%;
+        height: 100%;
+        min-width: 16px;
+        min-height: 16px;
         margin: 0;
-        &:focus {
-          box-shadow: none;
-          border: none;
-        }
+        vertical-align:middle;
+        background: url(/admin/common/images/admin-unchecked.gif) center no-repeat;
       }
+
+      input[type="checkbox"] {
+        display: none;
+      }
+
+      &.selected label {
+        background: url(/admin/common/images/admin-checked.gif) center no-repeat;
+      }
+
     }
 
     .slick-cell {
@@ -117,10 +128,15 @@
         cursor: pointer;
       }
 
+      &.slick-cell-checkboxsel {
+        padding-right: 0;
+      }
+
       &.selected {
         font-style: italic;
         color: #d3d3d3;
       }
+
     }
   }
 


### PR DESCRIPTION
Updated SlickGrid checkbox selection plugin.
Applied the same styling, as used in facets and browse panel.
Fixed padding so that space is equal both sides of the checkbox.
