### PR TITLE
CMS-3251 ComboBox: Support for selecting multiple options using spacebar

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/common/js/ui/selector/DropdownGrid.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/ui/selector/DropdownGrid.ts
@@ -275,6 +275,27 @@ module api.ui.selector {
             this.grid.navigateUp();
         }
 
+        resetActiveSelection() {
+
+            if (this.grid.getActiveCell()) {
+                this.grid.resetActiveCell();
+            }
+        }
+
+        toggleRowSelection(row: number) {
+            var rows = this.grid.getSelectedRows();
+            var index = rows.indexOf(row);
+
+            if (index >= 0) {
+                rows.splice(index, 1);
+            } else {
+                rows.push(row);
+            }
+
+            this.grid.setSelectedRows(rows);
+
+        }
+
         onRowSelection(listener: (event: DropdownGridRowSelectedEvent) => void) {
             this.rowSelectionListeners.push(listener);
         }

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/ui/selector/combobox/ComboBoxDropdown.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/ui/selector/combobox/ComboBoxDropdown.ts
@@ -65,12 +65,12 @@ module api.ui.selector.combobox {
             return this.emptyDropdown.isVisible() || this.dropdownGrid.isVisible();
         }
 
-        setOptions(options: Option<OPTION_DISPLAY_VALUE>[]) {
+        setOptions(options: Option<OPTION_DISPLAY_VALUE>[], selectedOptions: Option<OPTION_DISPLAY_VALUE>[] = []) {
 
             this.dropdownGrid.setOptions(options);
 
-            if (this.dropdownGrid.isVisible() || this.emptyDropdown.isVisible()) {
-                this.showDropdown([]);
+            if (this.isDropdownShown()) {
+                this.showDropdown(selectedOptions);
             }
         }
 
@@ -162,6 +162,14 @@ module api.ui.selector.combobox {
 
         navigateToPreviousRow() {
             this.dropdownGrid.navigateToPreviousRow();
+        }
+
+        toggleRowSelection(row: number) {
+            this.dropdownGrid.toggleRowSelection(row);
+        }
+
+        resetActiveSelection() {
+            this.dropdownGrid.resetActiveSelection();
         }
 
         applyMultipleSelection() {


### PR DESCRIPTION
- Fixed bug with row selection with an Enter key. (Row was selected twice, if it was selected again in filtered dropdown)
- Fixed a nasty related bug with row filtering and multiple selection.
  (Rows wasn't selected property with multiple selection after filtering.)
- Implemented selection with a spacebar.
- Replaced deprecated boolean checks, that already have a method
  equivalent.
- Replaced `if` - `else if` - `else if` - `...` with `switch`
