### PR TITLE
CMS-3362 Double clicking ComboBoxOptionFilterInput shall not remove caret from input

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/common/js/ui/selector/DropdownGrid.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/ui/selector/DropdownGrid.ts
@@ -173,6 +173,10 @@ module api.ui.selector {
             return this.gridData.getLength() > 0;
         }
 
+        getSelectedOptionCount(): number {
+            return this.grid.getSelectedRows().length;
+        }
+
         getOptionCount(): number {
             return this.gridData.getLength();
         }
@@ -282,18 +286,21 @@ module api.ui.selector {
             }
         }
 
-        toggleRowSelection(row: number) {
+        toggleRowSelection(row: number, isMaximumReached: boolean = false) {
             var rows = this.grid.getSelectedRows();
+            var oldRows = rows.join();
             var index = rows.indexOf(row);
 
             if (index >= 0) {
                 rows.splice(index, 1);
-            } else {
+            } else if (!isMaximumReached) {
                 rows.push(row);
             }
 
-            this.grid.setSelectedRows(rows);
-
+            // update on changes only
+            if (oldRows !== rows.join()) {
+                this.grid.setSelectedRows(rows);
+            }
         }
 
         onRowSelection(listener: (event: DropdownGridRowSelectedEvent) => void) {

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -221,7 +221,7 @@ module api.ui.selector.combobox {
         selectRowOrApplySelection(index: number) {
 
             // fast alternative to isSelectionChanged()
-            if (this.applySelectionsButton.isVisible()) {
+            if (this.applySelectionsButton && this.applySelectionsButton.isVisible()) {
                 this.clearSelection(true);
                 this.comboBoxDropdown.applyMultipleSelection();
                 this.hideDropdown();
@@ -339,11 +339,30 @@ module api.ui.selector.combobox {
             }
         }
 
+        // Checks added occurrences
         maximumOccurrencesReached(): boolean {
             api.util.assert(this.multipleSelections,
                 "No point of calling maximumOccurrencesReached when no multiple selections are enabled");
 
             return this.selectedOptionsCtrl.maximumOccurrencesReached();
+        }
+
+        // Checks selected and added occurrences (with filtering)
+        maximumSelectionsReached(): boolean {
+            if (this.selectedOptionsCtrl && this.selectedOptionsCtrl.getMaximumOccurrences() !== 0) {
+
+                var totalSelected:number = this.comboBoxDropdown.getSelectedOptionCount();
+                var optionsMap = this.getDisplayedOptions().map((x) => { return x.value; }).join();
+                var selectedOptions: Option<OPTION_DISPLAY_VALUE>[] = this.selectedOptionsCtrl.getOptions();
+                for (var k in selectedOptions) {
+                    if (optionsMap.search(selectedOptions[k].value) < 0) {
+                        totalSelected++;
+                    }
+                }
+                return this.selectedOptionsCtrl.getMaximumOccurrences() <= totalSelected;
+            } else {
+                return false;
+            }
         }
 
         setInputIconUrl(iconUrl: string) {
@@ -472,8 +491,8 @@ module api.ui.selector.combobox {
                 this.selectRowOrApplySelection(this.comboBoxDropdown.getActiveRow());
                 break;
             case 32: // Spacebar
-                if (this.input.getEl().getAttribute('readonly')) {
-                    this.comboBoxDropdown.toggleRowSelection(this.comboBoxDropdown.getActiveRow());
+                if (this.input.getEl().getAttribute('readonly') && this.applySelectionsButton) {
+                    this.comboBoxDropdown.toggleRowSelection(this.comboBoxDropdown.getActiveRow(), this.maximumSelectionsReached());
                     event.stopPropagation();
                     event.preventDefault();
                 }

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/ui/selector/combobox/ComboBoxDropdown.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/ui/selector/combobox/ComboBoxDropdown.ts
@@ -82,6 +82,10 @@ module api.ui.selector.combobox {
             return this.dropdownGrid.hasOptions();
         }
 
+        getSelectedOptionCount(): number {
+            return this.dropdownGrid.getSelectedOptionCount();
+        }
+
         getOptionCount(): number {
             return this.dropdownGrid.getOptionCount();
         }
@@ -164,8 +168,8 @@ module api.ui.selector.combobox {
             this.dropdownGrid.navigateToPreviousRow();
         }
 
-        toggleRowSelection(row: number) {
-            this.dropdownGrid.toggleRowSelection(row);
+        toggleRowSelection(row: number, isMaximumReached: boolean = false) {
+            this.dropdownGrid.toggleRowSelection(row, isMaximumReached);
         }
 
         resetActiveSelection() {

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/ui/selector/combobox/SelectedOptionsCtrl.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/ui/selector/combobox/SelectedOptionsCtrl.ts
@@ -27,6 +27,10 @@ module api.ui.selector.combobox {
             return this.count() >= this.maximumOccurrences;
         }
 
+        getMaximumOccurrences():number {
+            return this.maximumOccurrences;
+        }
+
         getOptions():api.ui.selector.Option<T>[] {
             return this.selectedOptions.getOptions();
         }


### PR DESCRIPTION
Fixed caret disappear on double click on Input Filter.
Fixed row selection on spacebar press for combo boxes with max occurrences of one.
Added support for spacebar press disabling, when the selections count reached maximum (already selected and new selections reached maximumOccurences).
