### PR TITLE
CMS-3333 Thumbnail displaying

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/browse/ContentTreeGridPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/browse/ContentTreeGridPanel.ts
@@ -87,7 +87,8 @@ module app.browse {
                                '</div>';
 
             var activeListType = this.getActiveList().getItemId();
-            return Ext.String.format(nameTemplate, activeListType, content.iconUrl, value, content.path);
+            var iconUrl = content.iconUrl + '?thumbnail=false&size=64';
+            return Ext.String.format(nameTemplate, activeListType, iconUrl, value, content.path);
         }
 
         private statusRenderer() {

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/app/NamesAndIconView.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/app/NamesAndIconView.ts
@@ -17,6 +17,8 @@ module api.app {
 
     export class NamesAndIconView extends api.dom.DivEl {
 
+        private wrapperDivEl: api.dom.DivEl;
+
         private iconImageEl: api.dom.ImgEl;
 
         private iconDivEl: api.dom.DivEl;
@@ -32,11 +34,14 @@ module api.app {
                 this.addClass(sizeClassName);
             }
 
+            this.wrapperDivEl = new api.dom.DivEl("wrapper");
+            this.appendChild(this.wrapperDivEl);
+
             this.iconImageEl = new api.dom.ImgEl(null,"icon");
-            this.appendChild(this.iconImageEl);
+            this.wrapperDivEl.appendChild(this.iconImageEl);
 
             this.iconDivEl = new api.dom.DivEl("icon");
-            this.appendChild(this.iconDivEl);
+            this.wrapperDivEl.appendChild(this.iconDivEl);
             this.iconDivEl.hide();
 
             this.namesView = new api.app.NamesView();
@@ -68,7 +73,7 @@ module api.app {
 
         setIconUrl(value: string): NamesAndIconView
         {
-            this.iconImageEl.setSrc(value);
+            this.iconImageEl.setSrc(value + '?thumbnail=false&size=64');
             this.iconDivEl.hide();
             this.iconImageEl.show();
             return this;

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/content/inputtype/image/SelectedOptionsView.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/content/inputtype/image/SelectedOptionsView.ts
@@ -130,7 +130,7 @@ module api.content.inputtype.image {
         private updateOptionViewLayout(optionView: SelectedOptionView, optionHeight: number) {
             optionView.getEl().setHeightPx(optionHeight);
             var iconHeight = optionView.getIcon().getEl().getHeightWithBorder();
-            if (iconHeight < optionHeight) {
+            if (iconHeight < optionHeight && iconHeight !== 0) {
                 optionView.getIcon().getEl().setMarginTop((optionHeight - iconHeight) / 2 + 'px');
             }
         }

--- a/modules/wem-webapp/src/main/webapp/admin/common/styles/api/app/names-and-icon-view.less
+++ b/modules/wem-webapp/src/main/webapp/admin/common/styles/api/app/names-and-icon-view.less
@@ -19,11 +19,22 @@
     position: relative;
     overflow: hidden;
 
-    .icon {
+    .wrapper {
+
       height: @size;
       width: @size;
-      margin-right:@icon-names-gap;
+      margin-right: @icon-names-gap;
       float: left;
+      line-height: @size - 2px;
+      vertical-align: middle;
+      text-align: center;
+
+      .icon {
+        max-width: 100%;
+        max-height: 100%;
+        margin: auto;
+        vertical-align: middle;
+      }
     }
 
     .names-view {

--- a/modules/wem-webapp/src/main/webapp/admin/common/styles/api/app/wizard/wizard-panel.less
+++ b/modules/wem-webapp/src/main/webapp/admin/common/styles/api/app/wizard/wizard-panel.less
@@ -22,6 +22,8 @@
       img {
         width: 64px;
         height: 64px;
+        max-width: 100%;
+        max-height: 100%;
       }
 
     }

--- a/modules/wem-webapp/src/main/webapp/admin/common/styles/api/form/inputtype/image-selector.less
+++ b/modules/wem-webapp/src/main/webapp/admin/common/styles/api/form/inputtype/image-selector.less
@@ -15,11 +15,13 @@
         color: #d3d3d3;
       }
 
-      .icon {
-        float: left;
+      .wrapper {
         width: 32px;
         height: 32px;
-        border: 1px @admin-medium-gray-border solid;
+
+        .icon {
+          border: 1px @admin-medium-gray-border solid;
+        }
       }
 
       .content-summary {
@@ -68,7 +70,9 @@
 
       img {
         display: block;
-        width: 100%;
+        max-height: 100%;
+        max-width: 100%;
+        margin: auto;
       }
 
       .label {

--- a/modules/wem-webapp/src/main/webapp/admin/common/styles/apps/content/browse/grid/tree-grid.less
+++ b/modules/wem-webapp/src/main/webapp/admin/common/styles/apps/content/browse/grid/tree-grid.less
@@ -1,14 +1,32 @@
-.admin-tree .admin-tree-thumbnail.site .overlay,
-.admin-grid .admin-grid-thumbnail.site .overlay {
-  right: 6px;
-  padding: 2px 6px;
-  line-height: 16px;
-  border-radius: 10px;
-  background: @admin-blue;
-  font-size: 14px;
+.admin-grid .admin-grid-thumbnail,
+.admin-tree .admin-tree-thumbnail {
+  width: 32px;
+  height: 32px;
+  margin: 0 15px 0 10px;
+  line-height: 30px;
+  vertical-align: middle;
+  text-align: center;
 
-  &:before {
-    content: "S";
+  img {
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 100%;
+    margin: auto;
+    vertical-align: middle;
+  }
+
+  &.site .overlay {
+    right: -9px;
+    padding: 2px 6px;
+    line-height: 16px;
+    border-radius: 10px;
+    background: @admin-blue;
+    font-size: 14px;
+
+    &:before {
+      content: "S";
+    }
   }
 }
 

--- a/modules/wem-webapp/src/main/webapp/admin/common/styles/apps/schema/browse/grid/tree-grid.less
+++ b/modules/wem-webapp/src/main/webapp/admin/common/styles/apps/schema/browse/grid/tree-grid.less
@@ -7,7 +7,7 @@
     .overlay {
       position: absolute;
       top: 0;
-      right: 15px; // equal to the right margin
+      right: 0;
       color: white;
       line-height: 12px;
       padding: 3px;

--- a/modules/wem-webapp/src/main/webapp/admin/common/styles/variables/mixins.less
+++ b/modules/wem-webapp/src/main/webapp/admin/common/styles/variables/mixins.less
@@ -150,5 +150,6 @@
   -webkit-align-items: @value;
   -moz-align-items: @value;
   -ms-align-items: @value;
+  -ms-flex-align: @value;
   align-items: @value;
 }


### PR DESCRIPTION
Updated image thumbnail scaling for the images in ContentTreeGridPanel,
Combobox, ImageSelector, ContentSelectedOptionView and in other
elements, that are using NamesAndIconView.
That images will use `scalemax` approach and will be automatically
centered.
Fixed bug with image margin in ContentSelectedOptionView.
Fixed flex align support in the IE.
