### PR TITLE
CMS-3393 Image Picker - Add support for keyboard usage

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/common/js/content/inputtype/image/SelectedOptionView.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/content/inputtype/image/SelectedOptionView.ts
@@ -10,6 +10,8 @@ module api.content.inputtype.image {
 
         private selectionChangeListeners: {(option: SelectedOptionView, checked: boolean): void;}[] = [];
 
+        private focusChangeListeners: {(option: SelectedOptionView, focused: boolean): void;}[] = [];
+
         constructor(option: api.ui.selector.Option<api.content.ContentSummary>) {
             super(option);
         }
@@ -24,18 +26,37 @@ module api.content.inputtype.image {
             this.appendChild(label);
 
             this.check = new api.ui.CheckboxInput();
+
             this.check.onClicked((event: MouseEvent) => {
                 // swallow event to prevent scaling when clicked on checkbox
                 event.stopPropagation();
             });
+
+            this.check.onMouseDown((event: MouseEvent) => {
+                // swallow event and prevent checkbox focus on click
+                event.stopPropagation();
+                event.preventDefault();
+            })
+
             this.check.onValueChanged((event: api.ui.ValueChangedEvent) => {
                 this.notifyChecked(event.getNewValue() == 'true');
+            });
+
+            this.check.onFocus(() => {
+                this.notifyFocused(true);
+            });
+            this.check.onBlur(() => {
+                this.notifyFocused(false);
             });
             this.appendChild(this.check);
         }
 
         getIcon(): api.dom.ImgEl {
             return this.icon;
+        }
+
+        getCheckbox(): api.ui.CheckboxInput {
+            return this.check;
         }
 
         toggleChecked() {
@@ -52,9 +73,26 @@ module api.content.inputtype.image {
             this.selectionChangeListeners.push(listener);
         }
 
-        removeCheckListener(listener: {(option: SelectedOptionView, checked: boolean): void;}) {
+        unChecked(listener: {(option: SelectedOptionView, checked: boolean): void;}) {
             this.selectionChangeListeners = this.selectionChangeListeners.filter(function (curr) {
                 return curr != listener;
+            });
+        }
+
+        // both focus nad blur events
+        onFocused(listener: {(option: SelectedOptionView, focused: boolean): void;}) {
+            this.focusChangeListeners.push(listener);
+        }
+
+        unFocused(listener: {(option: SelectedOptionView, focused: boolean): void;}) {
+            this.focusChangeListeners = this.focusChangeListeners.filter(function (curr) {
+                return curr != listener;
+            });
+        }
+
+        notifyFocused(focused: boolean) {
+            this.focusChangeListeners.forEach((listener) => {
+                listener(this, focused);
             });
         }
 

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/dom/Element.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/dom/Element.ts
@@ -206,6 +206,22 @@ module api.dom {
             return gotFocus;
         }
 
+        giveBlur(): boolean {
+            if (!this.isVisible()) {
+                return false;
+            }
+            if (this.el.isDisabled()) {
+                return false;
+            }
+            this.el.blur();
+            var gotBlur: boolean = document.activeElement != this.el.getHTMLElement();
+            if (!gotBlur) {
+                console.log("Element.giveBlur(): Failed to give blur to Element: class = " + api.util.getClassName(this) + ", id = " +
+                    this.getId());
+            }
+            return gotBlur;
+        }
+
         getHTMLElement(): HTMLElement {
             return this.el.getHTMLElement();
         }
@@ -554,6 +570,22 @@ module api.dom {
 
         unKeyPressed(listener: (event: KeyboardEvent) => void) {
             this.getEl().removeEventListener("keypress", listener);
+        }
+
+        onFocus(listener: (event: FocusEvent) => void) {
+            this.getEl().addEventListener("focus", listener);
+        }
+
+        unFocus(listener: (event: FocusEvent) => void) {
+            this.getEl().removeEventListener("focus", listener);
+        }
+
+        onBlur(listener: (event: FocusEvent) => void) {
+            this.getEl().addEventListener("blur", listener);
+        }
+
+        unBlur(listener: (event: FocusEvent) => void) {
+            this.getEl().removeEventListener("blur", listener);
         }
     }
 }

--- a/modules/wem-webapp/src/main/webapp/admin/common/js/dom/ElementHelper.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/common/js/dom/ElementHelper.ts
@@ -405,5 +405,9 @@ module api.dom {
             this.el.focus();
         }
 
+        blur() {
+            this.el.blur();
+        }
+
     }
 }

--- a/modules/wem-webapp/src/main/webapp/admin/common/styles/api/app/wizard/form-icon.less
+++ b/modules/wem-webapp/src/main/webapp/admin/common/styles/api/app/wizard/form-icon.less
@@ -10,7 +10,8 @@
   }
 
   img {
-    width: 64px;
+    width: auto;
+    max-width: 64px;
   }
 
   .progress-bar {


### PR DESCRIPTION
Added support for the Tabulation and Enter, Backspace and Delete keys
for the selected options.
Added implementation of the `focus` and `blur` events.
Renamed `removeCheckListener` to `unChecked`.
Fixed wizard panel form icon from being stretched.
