### PR TITLE
CMS-3491 Split screen - Make focus always start in form

### DIFF
--- a/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/wem-webapp/src/main/webapp/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
@@ -170,7 +170,10 @@ module app.wizard {
                         app.Router.setHash("new/" + this.contentType.getName());
                     }
                     if (this.liveFormPanel) {
-                        this.liveFormPanel.loadPageIfNotLoaded();
+                        this.liveFormPanel.loadPageIfNotLoaded().then(() => {
+                            // Return focus to wizard, since dropbox in live edit steales it
+                            this.giveInitialFocus();
+                        });
                     }
                 });
 


### PR DESCRIPTION
Return focu to wizard form after live edit page is loaded
