### PR TITLE
CMS-3491 Split screen - Make focus always start in form

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/Dropdown.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/Dropdown.ts
@@ -225,13 +225,13 @@ module api.ui.selector.dropdown {
             var option = this.getOptionByRow(index);
             if (option != null) {
                 this.selectOption(option);
+                api.dom.FormEl.moveFocusToNextFocusable(this.input);
             }
         }
 
         selectOption(option: Option<OPTION_DISPLAY_VALUE>, silent: boolean = false) {
 
             this.dropdownDropdown.markSelections([option]);
-            api.dom.FormEl.moveFocusToNextFocusable(this.input);
             if (!silent) {
                 this.notifyOptionSelected(option);
             }


### PR DESCRIPTION
Focus transfer occures now only on actual row selection.
