### PR TITLE
CMS-3488 Introduce UI Framework for responsive layout

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
@@ -178,6 +178,14 @@ module app.wizard {
                     }
                 });
 
+                ResponsiveManager.onAvailableSizeChanged(this, () => {
+                    this.updateStickyToolbar()
+                });
+
+                this.onRemoved((event) => {
+                    ResponsiveManager.unAvailableSizeChanged(this);
+                });
+
                 this.constructing = false;
 
                 callback(this);
@@ -565,14 +573,12 @@ module app.wizard {
             this.getSplitPanel().addClass("toggle-live");
             this.getSplitPanel().removeClass("toggle-form prerendered");
             ResponsiveManager.fireResizeEvent();
-            this.updateStickyToolbar();
         }
 
         showWizard() {
             this.getSplitPanel().addClass("toggle-form");
             this.getSplitPanel().removeClass("toggle-live prerendered");
             ResponsiveManager.fireResizeEvent();
-            this.updateStickyToolbar();
         }
     }
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/inputtype/image/ImageSelector.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/inputtype/image/ImageSelector.ts
@@ -3,6 +3,7 @@ module api.content.inputtype.image {
     import ContentSummary = api.content.ContentSummary;
     import ComboBoxConfig = api.ui.selector.combobox.ComboBoxConfig;
     import ComboBox = api.ui.selector.combobox.ComboBox;
+    import ResponsiveManager = api.ui.ResponsiveManager;
     import LoadedDataEvent = api.util.loader.event.LoadedDataEvent;
     import LoadingDataEvent = api.util.loader.event.LoadingDataEvent;
 
@@ -78,9 +79,14 @@ module api.content.inputtype.image {
                 this.createImageContent(event.getUploadedItem());
             });
 
+            ResponsiveManager.onAvailableSizeChanged(this, () => {
+                this.availableSizeChanged();
+            });
+
             // Don't forget to clean up the modal dialog on remove
             this.onRemoved((event) => {
                 this.uploadDialog.remove();
+                ResponsiveManager.unAvailableSizeChanged(this);
             });
         }
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/form/FieldSetLabel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/form/FieldSetLabel.ts
@@ -10,6 +10,7 @@ module api.form {
             this.fieldSet = fieldSet;
 
             this.getEl().setInnerHtml(this.fieldSet.getLabel());
+            this.getEl().setAttribute("title", this.fieldSet.getLabel());
         }
     }
 }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/ResponsiveItem.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/ResponsiveItem.ts
@@ -57,9 +57,8 @@ module api.ui {
                 this.element.getEl().removeClass(this.rangeSize.getRangeClass());
                 this.fitToRange(); // update rangeSize
                 this.element.getEl().addClass(this.rangeSize.getRangeClass());
-
-                this.handle();     // Additional handler
             }
+            this.handle();         // Additional handler
         }
     }
 }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/ResponsiveManager.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/ResponsiveManager.ts
@@ -38,5 +38,11 @@ module api.ui {
             customEvent.initEvent('availablesizechange', false, true); // No bubbling
             ResponsiveManager.window.getHTMLElement().dispatchEvent(customEvent);
         }
+
+        static getWindow(): api.dom.Window {
+            return ResponsiveManager.window;
+        }
     }
+
+    ResponsiveManager.onAvailableSizeChanged(api.dom.Body.get());
 }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/SplitPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/SplitPanel.ts
@@ -223,6 +223,12 @@ module api.ui {
             ResponsiveManager.onAvailableSizeChanged(this);
             ResponsiveManager.onAvailableSizeChanged(this.firstPanel);
             ResponsiveManager.onAvailableSizeChanged(this.secondPanel);
+
+            this.onRemoved((event) => {
+                ResponsiveManager.unAvailableSizeChanged(this);
+                ResponsiveManager.unAvailableSizeChanged(this.firstPanel);
+                ResponsiveManager.unAvailableSizeChanged(this.secondPanel);
+            });
         }
 
         private startDrag() {
@@ -251,7 +257,6 @@ module api.ui {
 
             this.isFirstPanelFixed() ? this.setFirstPanelSize(fixedPanelSize) : this.setSecondPanelSize(fixedPanelSize);
             this.distribute();
-            ResponsiveManager.fireResizeEvent();
         }
 
         private splitterWithinBoundaries(offset: number) {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
@@ -110,60 +110,31 @@
     }
   }
 
-}
-
-.scroll-shadow() {
-  box-shadow: 0px 2px 6px -2px #000;
-}
-
-@media (max-width: 960px) {
-  .wizard-panel .wizard-back-panel .wizard-step-navigator-and-toolbar {
-    padding-left: 0;
+  ._720-960 {
+    .wizard-steps-panel {
+      left: 0px;
+      .scroller {
+        padding: 0 0 0 25px;
+      }
+    }
   }
-}
 
-._0-240, ._240-360, ._360-540, ._540-720, ._720-960 {
-  .wizard-panel .wizard-back-panel .wizard-step-navigator-and-toolbar {
-    padding-left: 0;
+  ._0-240, ._240-360, ._360-540, ._540-720, ._720-960 {
+    .wizard-step-navigator-and-toolbar {
+      padding-left: 0;
+    }
   }
-}
 
-@media (min-width: 720px) and (max-width: 960px) {
-  .wizard-panel .wizard-back-panel .wizard-step-deck-panel {
-    left: 25px;
+  ._0-240, ._240-360, ._360-540, ._540-720 {
+    .wizard-steps-panel {
+      left: 0px;
+      .scroller {
+        padding: 0 25px;
+      }
+    }
   }
-}
 
-._720-960 {
-  .wizard-panel .wizard-back-panel .wizard-step-deck-panel {
-    left: 25px;
-  }
-}
-
-@media (min-width: 540px) and (max-width: 720px) {
-  .wizard-panel .wizard-back-panel .wizard-step-deck-panel {
-    left: 25px;
-    right: 25px;
-  }
-}
-
-._540-720 {
-  .wizard-panel .wizard-back-panel .wizard-step-deck-panel {
-    left: 25px;
-    right: 25px;
-  }
-}
-
-._0-240, ._240-360, ._360-540 {
-  .wizard-back-panel();
-}
-
-@media (max-width: 540px) {
-  .wizard-back-panel();
-}
-
-.wizard-back-panel() {
-  .wizard-panel .wizard-back-panel {
+  ._0-240, ._240-360, ._360-540 {
     .wizard-step-deck-panel {
       left: 10px;
       right: 10px;
@@ -179,4 +150,8 @@
       margin-right: 10px;
     }
   }
+}
+
+.scroll-shadow() {
+  box-shadow: 0px 2px 6px -2px #000;
 }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-form.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-form.less
@@ -1,6 +1,7 @@
 .wizard-step-form {
 
-  width: @form-width;
+  max-width: @form-width;
+  overflow: visible;
 
   h3 {
     margin-top: 20px;
@@ -9,15 +10,8 @@
 
 }
 
-@media (max-width: 720px) {
-  .wizard-step-form-size();
-}
-
 ._0-240, ._240-360, ._360-540, ._540-720  {
-  .wizard-step-form-size();
-}
-
-.wizard-step-form-size() {
-  width: 100%;
-  min-width: 300px;
+  .wizard-step-form {
+    width: 100%;
+  }
 }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/form/field-set-view.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/form/field-set-view.less
@@ -6,6 +6,9 @@
   .field-set-label {
     font-size: 25px;
     margin-bottom: 15px;
+    overflow: hidden;
+    white-space: pre;
+    text-overflow: ellipsis;
   }
 
   .field-set-container > *:not(:last-child) {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/form/form-item-set-view.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/form/form-item-set-view.less
@@ -97,15 +97,7 @@
   color: white;
 }
 
-@media (max-width: 720px) {
-  .form-item-set-view-inputs();
-}
-
 ._0-240, ._240-360, ._360-540, ._540-720 {
-  .form-item-set-view-inputs();
-}
-
-.form-item-set-view-inputs() {
   .form-item-set-view {
     .input-view {
 
@@ -122,15 +114,7 @@
   }
 }
 
-@media (max-width: 540px) {
-  .form-item-set-view-small();
-}
-
 .context-window, ._0-240, ._240-360, ._360-540 {
-  .form-item-set-view-small();
-}
-
-.form-item-set-view-small() {
   .form-item-set-view {
     margin-left: -10px;
     margin-right: -10px;

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/form/input/input-view.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/form/input/input-view.less
@@ -73,15 +73,7 @@
   }
 }
 
-@media (max-width: 720px) {
-  .input-view-vertical();
-}
-
 .context-window, ._0-240, ._240-360, ._360-540, ._540-720 {
-  .input-view-vertical();
-}
-
-.input-view-vertical(){
   .input-view {
     .input-label {
       float: none;

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/ui/form/form.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/ui/form/form.less
@@ -62,10 +62,6 @@
   }
 }
 
-@media (max-width: 720px) {
-  .form-fieldset-vertical();
-}
-
 .context-window, ._0-240, ._240-360, ._360-540, ._540-720 {
   .form-fieldset-vertical();
 }
@@ -82,12 +78,6 @@
     label + .input-wrapper {
       margin-left: 0;
     }
-  }
-}
-
-@media (max-width: 540px) {
-  .form {
-    margin: 0 10px;
   }
 }
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
@@ -30,29 +30,20 @@
       .form-panel {
         width: 100% !important;
       }
-      .splitter, .live-form-panel {
+      & > .splitter, .live-form-panel {
         display: none;
       }
     }
 
     &.toggle-live {
-
-      @media (max-width: 960px) {
-        .split-screen();
-      }
-
-      ._0-240, ._240-360, ._360-540, ._540-720, ._720-960 {
-        .split-screen();
+      &._0-240, &._240-360, &._360-540, &._540-720, &._720-960 {
+        .live-form-panel {
+          width: 100% !important;
+        }
+        & > .splitter, .form-panel {
+          display: none;
+        }
       }
     }
-  }
-}
-
-.split-screen() {
-  .live-form-panel {
-    width: 100% !important;
-  }
-  .splitter, .form-panel {
-    display: none;
   }
 }


### PR DESCRIPTION
Fixed SplitPanel and ContentWindow resize in live edit.
Removed @media queries from the less.
Added top level (body) resize listener.
Optimized ContentWizardPanel resize event: add StickyToolbar update.
Fixed WizardStepForm responsive resizing in live panel issue.
Updated outdated styles.
Updated responsive layout.
Added `unAvailableSizeChanged()` call in `onRemoved()`  event handler.
