### PR TITLE
CMS-3460 Keyboard shortcuts to Close and Delete actions does not work wh...

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/action/DeleteContentAction.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/action/DeleteContentAction.ts
@@ -3,7 +3,7 @@ module app.wizard.action {
     export class DeleteContentAction extends api.ui.Action {
 
         constructor(wizardPanel: api.app.wizard.WizardPanel<api.content.Content>) {
-            super("Delete", "mod+del");
+            super("Delete", "mod+del", true);
             this.onExecuted(() => {
                 api.ui.dialog.ConfirmationDialog.get()
                     .setQuestion("Are you sure you want to delete this content?")

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/wizard/CloseAction.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/wizard/CloseAction.ts
@@ -3,7 +3,7 @@ module api.app.wizard {
     export class CloseAction extends api.ui.Action {
 
         constructor(wizardPanel: api.app.wizard.WizardPanel<any>, checkCanClose: boolean = true) {
-            super("Close", "mod+f4");
+            super("Close", "mod+alt+f4", true);
             this.onExecuted(() => {
                 wizardPanel.close(checkCanClose);
             });


### PR DESCRIPTION
...en an input has focus

Make Close and Delete combinations global so Mousetrap will allow them inside inputs; change close combination to mod+alt+f4 since mod+f4 is Chrome combination to close tab
