### PR TITLE
CMS-3512 Bug when dragging a second FormItemSetView to first position

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/data/DataSet.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/data/DataSet.ts
@@ -43,11 +43,15 @@ module api.data {
             this.dataById = newDataById;
         }
 
-        moveData(index: number, destinationIndex: number) {
-
-            api.util.ArrayHelper.moveElement(index, destinationIndex, this.dataArray);
-            this.dataArray.forEach((data: Data, index: number) => {
-                data.setArrayIndex(index);
+        moveDataByName(name: string, index: number, destinationIndex: number) {
+            this.dataArray.forEach((data: Data) => {
+                if (data.getName() == name) {
+                    if (data.getArrayIndex() == index) {
+                        data.setArrayIndex(destinationIndex);
+                    } else if (data.getArrayIndex() == destinationIndex) {
+                        data.setArrayIndex(index);
+                    }
+                }
             });
         }
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/form/FormItemSetOccurrences.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/form/FormItemSetOccurrences.ts
@@ -140,10 +140,8 @@ module api.form {
         }
 
         moveOccurrence(index: number, destinationIndex: number) {
-
             super.moveOccurrence(index, destinationIndex);
-
-            this.parentDataSet.moveData(index, destinationIndex);
+            this.parentDataSet.moveDataByName(this.getFormItem().getName(), index, destinationIndex);
         }
     }
 }


### PR DESCRIPTION
Fixed moveData method (renamed to moveDataByName) in DataSet to avoid data corruption during d&d sorting
