### PR TITLE
CMS-3476 Replace ExtJS grid - Try letting ContentGridPanel2 use ContentS...

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
@@ -67,6 +67,14 @@ module api.ui.grid {
                 this.slickGrid.registerPlugin(checkboxSelectorPlugin);
             }
 
+            ResponsiveManager.onAvailableSizeChanged(this, () => {
+                this.resizeCanvas();
+            });
+
+            this.onRemoved((event) => {
+                ResponsiveManager.unAvailableSizeChanged(this);
+            });
+
             // The only way to dataIdProperty before adding items
             this.dataView.setItems([], options.dataIdProperty);
         }
@@ -133,7 +141,9 @@ module api.ui.grid {
         }
 
         resetActiveCell() {
-            this.slickGrid.resetActiveCell();
+            if (this.slickGrid.getActiveCell()) {
+                this.slickGrid.resetActiveCell();
+            }
         }
 
         navigateUp() {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/app/browse/grid/grid-panel2.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/app/browse/grid/grid-panel2.less
@@ -11,15 +11,23 @@
     }
 
     .slick-cell {
-      .default-slick-cell-styling();
+      .default-slick-cell-styling(4px 8px);
+      cursor: pointer;
+
+      // fixes
+      margin-left: -1px; // invalid 'right' value calc for certain width
+      height: 45px;      // firefox ignores SlickGrid.rowHeight
     }
 
     .slick-row {
-      &.odd {
-        background-color: #fafafa;
+
+
+      &:hover, &.odd:hover {
+        background-color: @admin-light-gray-bg;
       }
-      input[type=checkbox] {
-        margin:10px;
+
+      &.odd {
+        background-color: @admin-almost-white-bg;
       }
 
       .selected h6 {
@@ -30,11 +38,30 @@
         color: white;
       }
 
+      .slick-cell-checkboxsel {
+        label {
+          display: inline-block;
+          width: 100%;
+          height: 100%;
+          vertical-align:middle;
+          background: url("../images/admin-unchecked.gif") center no-repeat;
+        }
+
+        input[type="checkbox"] {
+          display: none;
+        }
+
+        &.selected label {
+          background: url("../images/admin-checked.gif") center no-repeat;
+        }
+
+      }
 
       .toggle {
-        height: 9px;
+        position: absolute;
+        top: 1px;
+        height: 100%;
         width: 9px;
-        display: inline-block;
       }
 
       .toggle.expand {
@@ -43,6 +70,36 @@
 
       .toggle.collapse {
         background: url("../images/collapse.gif") no-repeat center center;
+      }
+
+      .viewer {
+        display: inline-block;
+        width: 100%;
+        height: 100%;
+        .names-and-icon-view {
+          margin-left: 25px;
+          .wrapper {
+            margin-right: 15px;
+            .icon {
+              position: absolute;
+              width: 32px;
+              height: 32px;
+              top: 50%;
+              left: 0;
+              margin-top: -16px;
+            }
+          }
+          .names-view {
+            margin-top: 3px;
+          }
+
+        }
+      }
+
+      .modified {
+        line-height: 37px;
+        text-align: right;
+        padding-right: 25px;
       }
 
     }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/variables/color.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/variables/color.less
@@ -1,4 +1,5 @@
 @admin-light-gray-bg: #eee;
+@admin-almost-white-bg: #fafafa;
 @admin-medium-gray-border: #ccc;
 @admin-white: #fff;
 @admin-almost-white: #f2f2f2;

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/variables/mixins.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/variables/mixins.less
@@ -116,9 +116,9 @@
   animation: @name @duration @delay @ease;
 }
 
-.default-slick-cell-styling() {
+.default-slick-cell-styling(@padding: 8px) {
   border: none;
-  padding:8px;
+  padding: @padding;
   .box-sizing(border-box);
 }
 


### PR DESCRIPTION
...ummaryViewer to display the name column

Replaced basic `NamesAndIconView` with `ContentSummaryViewer` element.
Major update of the display style:
Updated columns width, colors, text align.
Updated Grid code, so it will react on Responsive UI events.
Fixed several Firefox bugs, concerning grid.
