### PR TITLE
CMS-3666 Replace ExtJS grid - Introduce generic wrapper

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/grid/ContentGridPanel2.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/grid/ContentGridPanel2.ts
@@ -5,45 +5,45 @@ module app.browse.grid {
     import ContentSummary = api.content.ContentSummary;
     import ContentSummaryViewer = api.content.ContentSummaryViewer;
 
+    import TreeGrid = api.app.browse.treegrid.TreeGrid;
+    import DateTimeFormatter = api.app.browse.treegrid.DateTimeFormatter;
 
-    export class ContentGridPanel2 extends api.app.browse.treegrid.TreeGrid<ContentSummary> {
+
+    export class ContentGridPanel2 extends TreeGrid<ContentSummary> {
 
         constructor() {
             super("content-grid");
 
-            var nameFormatter = (row:number, cell:number, value:any, columnDef:any, item:ContentSummary) => {
+            var nameFormatter = (row: number, cell: number, value: any, columnDef: any, item: ContentSummary) => {
                 var contentSummaryViewer = new ContentSummaryViewer();
                 contentSummaryViewer.setObject(item);
                 return contentSummaryViewer.toString();
             };
 
-            var column1 = <GridColumn<ContentSummary>> {
+            // GridColumn<TreeNode<ContentSummary>> is a valid type
+            var column1 = <GridColumn<any>> {
                 name: "Name",
                 id: "displayName",
                 field: "displayName",
                 formatter: nameFormatter
             };
-            var column2 = <GridColumn<ContentSummary>> {
+            var column2 = <GridColumn<any>> {
                 name: "ModifiedTime",
                 id: "modifiedTime",
                 field: "modifiedTime",
                 cssClass: "modified",
                 minWidth: 150,
                 maxWidth: 170,
-                formatter: api.app.browse.grid2.DateTimeFormatter.format
+                formatter: DateTimeFormatter.format
             };
 
             this.setColumns([column1, column2]);
 
             this.getGrid().subscribeOnDblClick((event, data) => {
                 if (this.isActive()) {
-                    new EditContentEvent([this.getGrid().getDataView().getItem(data.row)]).fire();
+                    new EditContentEvent([this.getGrid().getDataView().getItem(data.row).getData()]).fire();
                 }
             });
-        }
-
-        hasChildren(data: ContentSummary): boolean {
-            return data.hasChildren();
         }
 
         fetchChildren(parent?: ContentSummary): Q.Promise<ContentSummary[]> {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/browse/treegrid/ClearSelectionAction.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/browse/treegrid/ClearSelectionAction.ts
@@ -6,7 +6,7 @@ module api.app.browse.treegrid {
 
     export class ClearSelectionAction extends Action {
 
-        constructor(grid: Grid<Node>) {
+        constructor(grid: Grid<TreeNode<Node>>) {
             super("Clear Selection");
             this.setEnabled(true);
             this.onExecuted(() => {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/browse/treegrid/DateTimeFormatter.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/browse/treegrid/DateTimeFormatter.ts
@@ -1,4 +1,4 @@
-module api.app.browse.grid2 {
+module api.app.browse.treegrid {
 
     export class DateTimeFormatter {
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/browse/treegrid/SelectAllAction.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/browse/treegrid/SelectAllAction.ts
@@ -6,7 +6,7 @@ module api.app.browse.treegrid {
 
     export class SelectAllAction extends Action {
 
-        constructor(grid: Grid<Node>) {
+        constructor(grid: Grid<TreeNode<Node>>) {
             super("Select All");
             this.setEnabled(true);
             this.onExecuted(() => {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/browse/treegrid/TreeGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/browse/treegrid/TreeGrid.ts
@@ -21,9 +21,9 @@ module api.app.browse.treegrid {
 
         private gridOptions:GridOptions;
 
-        private grid: Grid<NODE>;
+        private grid: Grid<TreeNode<NODE>>;
 
-        private gridData: DataView<NODE>;
+        private gridData: DataView<TreeNode<NODE>>;
 
         private root: TreeNode<NODE>;
 
@@ -41,21 +41,24 @@ module api.app.browse.treegrid {
             this.root = new TreeNode<NODE>();
             this.root.setExpanded(true);
 
-            this.gridData = new DataView<NODE>();
-            this.gridData.setFilter((item: NODE, root: TreeNode<NODE>) => {
-                var node = root.findNode(item);
-
-                return node ? node.isVisible() : false;
+            this.gridData = new DataView<TreeNode<NODE>>();
+            this.gridData.setFilter((node: TreeNode<NODE>) => {
+                return node.isVisible();
             });
 
             /*
-            Note: SlickGrid recompile filter method,
-            so all non-global variables will become undefined.
-            To pass a parameter, we need to use setFilterArgs() method.
+             Note: We are using a proxy class to handle items/nodes and
+             track the selection, expansion, etc.
+             To have access to the complex properties, that are not in the root
+             of the object, like `node.data.id`, we need to specify a custom
+             column value extractor.
              */
-            this.gridData.setFilterArgs(this.root);
+            function nodeExtractor(node, column) {
+                return node["data"][column.field];
+            }
 
             this.gridOptions = <GridOptions>{
+                dataItemColumnValueExtractor: nodeExtractor,
                 editable: false,
                 enableAsyncPostRender: true,
                 enableCellNavigation: true,
@@ -67,7 +70,7 @@ module api.app.browse.treegrid {
                 autoHeight: true
             };
 
-            this.grid = new Grid<NODE>(this.gridData, this.columns, this.gridOptions);
+            this.grid = new Grid<TreeNode<NODE>>(this.gridData, this.columns, this.gridOptions);
 
             // Custom row selection required for valid behaviour
             this.grid.setSelectionModel(new Slick.RowSelectionModel({selectActiveRow: false}));
@@ -82,13 +85,13 @@ module api.app.browse.treegrid {
                     var elem = new ElementHelper(event.target);
                     if (elem.hasClass("expand")) {
                         elem.removeClass("expand").addClass("collapse");
-                        var item = this.gridData.getItem(data.row);
-                        this.expandData(item);
+                        var node = this.gridData.getItem(data.row);
+                        this.expandNode(node);
                     } else if (elem.hasClass("collapse")) {
                         this.active = false;
                         elem.removeClass("collapse").addClass("expand");
-                        var item = this.gridData.getItem(data.row);
-                        this.collapseData(item);
+                        var node = this.gridData.getItem(data.row);
+                        this.collapseNode(node);
                     } else {
                         this.active = true;
                         this.grid.selectRow(data.row);
@@ -111,18 +114,17 @@ module api.app.browse.treegrid {
                 new KeyBinding('left', () => {
                     var selected = this.grid.getSelectedRows();
                     if (selected.length === 1) {
-                        var item = this.gridData.getItem(selected[0]);
-                        var node = item ? this.root.findNode(item) : undefined;
+                        var node = this.gridData.getItem(selected[0]);
                         if (node && this.active) {
                             if (node.isExpanded()) {
                                 this.active = false;
-                                this.collapseData(item);
+                                this.collapseNode(node);
                             } else if (node.getParent() !== this.root) {
+                                node = node.getParent();
                                 this.active = false;
-                                item = node.getParent().getData();
-                                var row = this.gridData.getRowById(item.getId());
+                                var row = this.gridData.getRowById(node.getId());
                                 this.grid.selectRow(row);
-                                this.collapseData(item);
+                                this.collapseNode(node);
                             }
                         }
                     }
@@ -130,13 +132,12 @@ module api.app.browse.treegrid {
                 new KeyBinding('right', () => {
                     var selected = this.grid.getSelectedRows();
                     if (selected.length === 1) {
-                        var item = this.gridData.getItem(selected[0]);
-                        var node = item ? this.root.findNode(item) : undefined;
-                        if (node && item.hasChildren()
+                        var node = this.gridData.getItem(selected[0]);
+                        if (node && node.getData().hasChildren()
                             && !node.isExpanded() &&  this.active) {
 
                             this.active = false;
-                            this.expandData(item);
+                            this.expandNode(node);
                         }
                     }
                 })
@@ -162,7 +163,7 @@ module api.app.browse.treegrid {
 
             this.appendChild(this.grid);
 
-            this.expandData();
+            this.expandNode();
 
             this.onShown(() => {
                 this.grid.resizeCanvas();
@@ -177,7 +178,7 @@ module api.app.browse.treegrid {
             });
         }
 
-        getGrid(): Grid<NODE> {
+        getGrid(): Grid<TreeNode<NODE>> {
             return this.grid;
         }
 
@@ -200,21 +201,18 @@ module api.app.browse.treegrid {
             return deferred.promise;
         }
 
-        setColumns(columns: GridColumn<NODE>[]) {
+        setColumns(columns: GridColumn<TreeNode<NODE>>[]) {
             if (columns.length > 0) {
                 var formatter = columns[0].formatter;
-                var toggleFormatter = (row: number, cell: number, value: any, columnDef: any, item: NODE) => {
-                    var node = this.root.findNode(item);
-
+                var toggleFormatter = (row: number, cell: number, value: any, columnDef: any, node: TreeNode<NODE>) => {
                     var toggleSpan = new api.dom.SpanEl("toggle icon icon-xsmall");
-                    if (item.hasChildren()) {
+                    if (node.getData().hasChildren()) {
                         var toggleClass = node.isExpanded() ? "collapse" : "expand";
                         toggleSpan.addClass(toggleClass);
                     }
-
                     toggleSpan.getEl().setMarginLeft(16 * (node.calcLevel() - 1) + "px");
 
-                    return toggleSpan.toString() + formatter(row, cell, value, columnDef, item);
+                    return toggleSpan.toString() + formatter(row, cell, value, columnDef, node.getData());
                 };
 
                 columns[0].formatter = toggleFormatter;
@@ -225,31 +223,33 @@ module api.app.browse.treegrid {
             this.grid.setColumns(this.columns);
         }
 
-        private initData(nodeDatas: NODE[]) {
-            this.gridData.setItems(nodeDatas, "id");
+        private initData(nodes: TreeNode<NODE>[]) {
+            this.gridData.setItems(nodes, "id");
         }
 
-        private expandData(nodeData?: NODE) {
-            var node: TreeNode<NODE> = nodeData ? this.root.findNode(nodeData) : this.root,
-                rootItemList: NODE[],
-                nodeItemList: NODE[];
+        private expandNode(node?: TreeNode<NODE>) {
+            node = node || this.root;
+
+            var parent = node.getData(),
+                rootList: TreeNode<NODE>[],
+                nodeList: TreeNode<NODE>[];
 
             if (node) {
                 node.setExpanded(true);
 
                 if (node.hasChildren()) {
-                    nodeItemList = node.treeToItemList();
-                    rootItemList = this.root.treeToItemList();
-                    this.initData(rootItemList);
-                    this.updateExpanded(node, nodeItemList, rootItemList);
+                    rootList = this.root.treeToList();
+                    nodeList = node.treeToList();
+                    this.initData(rootList);
+                    this.updateExpanded(node, nodeList, rootList);
                 } else {
-                    this.fetchChildren(nodeData)
+                    this.fetchChildren(parent)
                         .then((items: NODE[]) => {
                             node.setChildrenFromItems(items);
-                            nodeItemList = node.treeToItemList();
-                            rootItemList = this.root.treeToItemList();
-                            this.initData(rootItemList);
-                            this.updateExpanded(node, nodeItemList, rootItemList);
+                            rootList = this.root.treeToList();
+                            nodeList = node.treeToList();
+                            this.initData(rootList);
+                            this.updateExpanded(node, nodeList, rootList);
                         }).catch((reason: any) => {
                             api.DefaultErrorHandler.handle(reason);
                         }).finally(() => {
@@ -258,18 +258,20 @@ module api.app.browse.treegrid {
             }
         }
 
-        private updateExpanded(node: TreeNode<NODE>, nodeItemList: NODE[], rootItemList: NODE[]) {
-            var nodeRow = node.getData() ? this.gridData.getRowById(node.getData().getId()) : -1,
+        private updateExpanded(node: TreeNode<NODE>,
+                               nodeList: TreeNode<NODE>[],
+                               rootList: TreeNode<NODE>[]) {
+            var nodeRow = node.getData() ? this.gridData.getRowById(node.getId()) : -1,
                 expandedRows = [],
                 animatedRows = [];
 
-            nodeItemList.forEach((elem, index) => {
+            nodeList.forEach((elem, index) => {
                 if (index > 0) {
                     expandedRows.push(this.gridData.getRowById(elem.getId()));
                 }
             });
 
-            rootItemList.forEach((elem) => {
+            rootList.forEach((elem) => {
                 var row = this.gridData.getRowById(elem.getId());
                 if (row > nodeRow && expandedRows.indexOf(row) < 0) {
                     animatedRows.push(row);
@@ -285,20 +287,18 @@ module api.app.browse.treegrid {
             }, 350);
         }
 
-        private collapseData(nodeData: NODE) {
-            var node = this.root.findNode(nodeData),
+        private collapseNode(node: TreeNode<NODE>) {
+            var nodeRow = this.gridData.getRowById(node.getId()),
                 animatedRows = [],
                 collapsedRows = [];
 
-            var nodeRow = this.gridData.getRowById(node.getData().getId());
-
-            node.treeToItemList().forEach((elem, index) => {
+            node.treeToList().forEach((elem, index) => {
                 if (index > 0) {
                     collapsedRows.push(this.gridData.getRowById(elem.getId()));
                 }
             });
 
-            this.root.treeToItemList().forEach((elem) => {
+            this.root.treeToList().forEach((elem) => {
                 var row = this.gridData.getRowById(elem.getId());
                 if (row > nodeRow && collapsedRows.indexOf(row) < 0) {
                     animatedRows.push(row);

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/browse/treegrid/TreeGridActions.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/browse/treegrid/TreeGridActions.ts
@@ -13,7 +13,7 @@ module api.app.browse.treegrid {
 
         private static INSTANCE: TreeGridActions;
 
-        static init(grid: Grid<Node>): TreeGridActions {
+        static init(grid: Grid<TreeNode<Node>>): TreeGridActions {
             new TreeGridActions(grid);
             return TreeGridActions.INSTANCE;
         }
@@ -22,7 +22,7 @@ module api.app.browse.treegrid {
             return TreeGridActions.INSTANCE;
         }
 
-        constructor(grid: Grid<Node>) {
+        constructor(grid: Grid<TreeNode<Node>>) {
             this.SELECT_ALL = new SelectAllAction(grid);
             this.CLEAR_SELECTION = new ClearSelectionAction(grid);
             this.allActions.push(this.SELECT_ALL, this.CLEAR_SELECTION);

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/browse/treegrid/TreeNode.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/browse/treegrid/TreeNode.ts
@@ -2,6 +2,8 @@ module api.app.browse.treegrid {
 
     export class TreeNode<NODE extends api.node.Node> {
 
+        private id: string;
+
         private data: NODE;
 
         private expanded: boolean;
@@ -13,11 +15,16 @@ module api.app.browse.treegrid {
         private children: TreeNode<NODE>[];
 
         constructor(data?: NODE, parent?: TreeNode<NODE>, expanded: boolean = false, selected: boolean = false) {
+            this.id = data ? data.getId() : "";
             this.data = data;
             this.parent = parent;
             this.children = [];
             this.expanded = expanded;
             this.selected = selected;
+        }
+
+        getId():string {
+            return this.id;
         }
 
         isExpanded(): boolean {
@@ -91,19 +98,24 @@ module api.app.browse.treegrid {
 
         /*
          Transforms tree into the list of nodes with current node as root.
+         @empty    - determines to get nodes with empty data.
          @expanded - determines to display only reachable nodes.
          @selected - determines to display only seleted nodes.
          */
-        treeToList(expanded: boolean = true, selected: boolean = false): TreeNode<NODE>[] {
+        treeToList(empty: boolean = false,
+                   expanded: boolean = true,
+                   selected: boolean = false): TreeNode<NODE>[] {
             var list: TreeNode<NODE>[] = [];
 
             if (this.selected === true || selected === false) {
-                list.push(this);
+                if (this.getData() || empty === true) {
+                    list.push(this);
+                }
             }
 
             if (this.expanded === true || expanded === false) {
                 this.children.forEach((child) => {
-                    list = list.concat(child.treeToList(expanded, selected));
+                    list = list.concat(child.treeToList(empty, expanded, selected));
                 });
             }
 
@@ -113,8 +125,10 @@ module api.app.browse.treegrid {
         /*
          Maps Node's list to Item's list.
          */
-        treeToItemList(expanded: boolean = true, selected: boolean = false): NODE[] {
-            var list: NODE[] = this.treeToList(expanded, selected)
+        treeToItemList(empty: boolean = false,
+                       expanded: boolean = true,
+                       selected: boolean = false): NODE[] {
+            var list: NODE[] = this.treeToList(empty, expanded, selected)
                 .map((node) => {
                     return node.getData();
                 })


### PR DESCRIPTION
Made GridView to use `TreeNode<Node>` instead of `Node`.
