### PR TITLE
CMS-3734 Replace ExtJS grid - Let only content at root display full path

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/grid/ContentGridPanel2.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/grid/ContentGridPanel2.ts
@@ -28,8 +28,8 @@ module app.browse.grid {
                         new GridColumnBuilder<TreeNode<ContentSummaryAndCompareStatus>>().
                             setName("Name").
                             setId("displayName").
-                            setField("content.displayName").
-                            setFormatter(this.defaultNameFormatter).
+                            setField("contentSummary.displayName").
+                            setFormatter(this.nameFormatter).
                             build(),
 
                         new GridColumnBuilder<TreeNode<ContentSummaryAndCompareStatus>>().
@@ -45,7 +45,7 @@ module app.browse.grid {
                         new GridColumnBuilder<TreeNode<ContentSummaryAndCompareStatus>>().
                             setName("ModifiedTime").
                             setId("modifiedTime").
-                            setField("content.modifiedTime").
+                            setField("contentSummary.modifiedTime").
                             setCssClass("modified").
                             setMinWidth(150).
                             setMaxWidth(170).
@@ -78,7 +78,7 @@ module app.browse.grid {
             });
         }
 
-        private statusFormatter(row: number, cell: number, value: any, columnDef: any, item: ContentSummaryAndCompareStatus) {
+        private statusFormatter(row: number, cell: number, value: any, columnDef: any, node: TreeNode<ContentSummaryAndCompareStatus>) {
 
             var compareLabel: string = api.content.CompareStatus[value];
 
@@ -108,9 +108,9 @@ module app.browse.grid {
             }
         }
 
-        private defaultNameFormatter(row: number, cell: number, value: any, columnDef: any, item: ContentSummaryAndCompareStatus) {
+        private nameFormatter(row: number, cell: number, value: any, columnDef: any, node: TreeNode<ContentSummaryAndCompareStatus>) {
             var contentSummaryViewer = new ContentSummaryViewer();
-            contentSummaryViewer.setObject(item.getContentSummary());
+            contentSummaryViewer.setObject(node.getData().getContentSummary(), node.calcLevel() > 1);
             return contentSummaryViewer.toString();
         }
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/NamesAndIconView.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/NamesAndIconView.ts
@@ -65,9 +65,9 @@ module api.app {
             return this;
         }
 
-        setSubName(value: string): NamesAndIconView
+        setSubName(value: string, title?: string): NamesAndIconView
         {
-            this.namesView.setSubName(value);
+            this.namesView.setSubName(value, title);
             return this;
         }
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/NamesView.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/NamesView.ts
@@ -30,11 +30,11 @@ module api.app {
             return this;
         }
 
-        setSubName(value: string): NamesView
+        setSubName(value: string, title?: string): NamesView
         {
             this.subNameEl.setText(value);
             if (this.addTitleAttribute) {
-                this.subNameEl.getEl().setAttribute("title", value);
+                this.subNameEl.getEl().setAttribute("title", title || value);
             }
             return this;
         }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentPath.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentPath.ts
@@ -47,6 +47,10 @@ module api.content {
             return this.elements.length > 1;
         }
 
+        getRelativePath(): string {
+            return (this.elements[this.elements.length - 1] || "");
+        }
+
         getParentPath(): ContentPath {
 
             if (this.elements.length < 1) {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatus.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatus.ts
@@ -2,17 +2,17 @@ module api.content {
 
     export class ContentSummaryAndCompareStatus implements api.ui.treegrid.TreeItem {
 
-        private content: ContentSummary;
+        private contentSummary: ContentSummary;
 
         private compareContentResult: CompareContentResult;
 
-        constructor(content: ContentSummary, compareContentResult: CompareContentResult) {
-            this.content = content;
+        constructor(contentSummary: ContentSummary, compareContentResult: CompareContentResult) {
+            this.contentSummary = contentSummary;
             this.compareContentResult = compareContentResult;
         }
 
         getContentSummary(): ContentSummary {
-            return this.content;
+            return this.contentSummary;
         }
 
         getCompareContentResult(): CompareContentResult {
@@ -24,11 +24,11 @@ module api.content {
         }
 
         getId(): string {
-            return this.content.getId();
+            return this.contentSummary.getId();
         }
 
         hasChildren(): boolean {
-            return this.content.hasChildren();
+            return this.contentSummary.hasChildren();
         }
     }
 }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryViewer.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryViewer.ts
@@ -10,10 +10,11 @@ module api.content {
             this.appendChild(this.namesAndIconView);
         }
 
-        setObject(content: ContentSummary) {
+        setObject(content: ContentSummary, relativePath: boolean = false) {
             super.setObject(content);
+            var subName = relativePath ? content.getPath().getRelativePath() : content.getPath().toString();
             this.namesAndIconView.setMainName(content.getDisplayName()).
-                setSubName(content.getPath().toString()).
+                setSubName(subName, content.getPath().toString()).
                 setIconUrl(content.getIconUrl() + '?crop=false');
             if (content.isSite()) {
                 this.addClass("site");

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -249,7 +249,7 @@ module api.ui.treegrid {
                     }
                     toggleSpan.getEl().setMarginLeft(16 * (node.calcLevel() - 1) + "px");
 
-                    return toggleSpan.toString() + formatter(row, cell, value, columnDef, node.getData());
+                    return toggleSpan.toString() + formatter(row, cell, value, columnDef, node);
                 };
 
                 columns[0].setFormatter(toggleFormatter);


### PR DESCRIPTION
Fixed name formatter return value.
Updated ContentGridPanle mapping names.\
Added a second parameter to the NamesView.setSubName() to be able to add
a different title.
