### PR TITLE
CMS-3724 Replace ExtJS grid - Support for setting Nodes to be displayed

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/CompareContentGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/CompareContentGrid.ts
@@ -35,9 +35,9 @@ module app.wizard {
             });
         }
 
-        private defaultNameFormatter(row: number, cell: number, value: any, columnDef: any, item: ContentSummaryAndCompareStatus) {
+        private defaultNameFormatter(row: number, cell: number, value: any, columnDef: any, node: TreeNode<ContentSummaryAndCompareStatus>) {
             var contentSummaryViewer = new ContentSummaryViewer();
-            contentSummaryViewer.setObject(item.getContentSummary());
+            contentSummaryViewer.setObject(node.getData().getContentSummary());
             return contentSummaryViewer.toString();
         }
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/module-manager/js/app/browse/ModuleTreeGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/module-manager/js/app/browse/ModuleTreeGrid.ts
@@ -25,27 +25,31 @@ module app.browse {
                             build(),
 
                         new GridColumnBuilder<TreeNode<ModuleSummary>>().
-                            setName("ModifiedTime").
-                            setId("modifiedTime").
-                            setField("modifiedTime").
-                            setWidth(150).
-                            setMinWidth(150).
-                            setFormatter(DateTimeFormatter.format).
-                            build() ,
-
-                        new GridColumnBuilder<TreeNode<ModuleSummary>>().
                             setName("Version").
                             setId("version").
                             setField("version").
-                            setMaxWidth(70).
+                            setCssClass("version").
                             setMinWidth(50).
-                            build() ,
+                            setMaxWidth(70).
+                            build(),
 
                         new GridColumnBuilder<TreeNode<ModuleSummary>>().
                             setName("State").
                             setId("state").
                             setField("state").
+                            setCssClass("state").
                             setMinWidth(80).
+                            setMaxWidth(100).
+                            build(),
+
+                        new GridColumnBuilder<TreeNode<ModuleSummary>>().
+                            setName("ModifiedTime").
+                            setId("modifiedTime").
+                            setField("modifiedTime").
+                            setCssClass("modified").
+                            setMinWidth(150).
+                            setMaxWidth(170).
+                            setFormatter(DateTimeFormatter.format).
                             build()
 
                     ]).prependClasses("module-grid")
@@ -53,6 +57,7 @@ module app.browse {
         }
 
         fetchChildren(parent?: ModuleSummary): Q.Promise<ModuleSummary[]> {
+            api.util.assertNull(parent, "Parent element is not a root");
             return new api.module.ListModulesRequest().sendAndParse();
         }
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentPath.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentPath.ts
@@ -47,7 +47,7 @@ module api.content {
             return this.elements.length > 1;
         }
 
-        getRelativePath(): string {
+        getLastElement(): string {
             return (this.elements[this.elements.length - 1] || "");
         }
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryViewer.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryViewer.ts
@@ -12,7 +12,7 @@ module api.content {
 
         setObject(content: ContentSummary, relativePath: boolean = false) {
             super.setObject(content);
-            var subName = relativePath ? content.getPath().getRelativePath() : content.getPath().toString();
+            var subName = relativePath ? content.getPath().getLastElement() : content.getPath().toString();
             this.namesAndIconView.setMainName(content.getDisplayName()).
                 setSubName(subName, content.getPath().toString()).
                 setIconUrl(content.getIconUrl() + '?crop=false');

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/app/names-view.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/app/names-view.less
@@ -14,6 +14,7 @@
     font-size: 12px;
     margin: 0;
     padding: 0;
+    line-height: normal;
     .ellipsis();
   }
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/ui/treegrid/tree-grid.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/api/ui/treegrid/tree-grid.less
@@ -76,7 +76,7 @@
     .slick-cell {
       .default-slick-cell-styling(4px 8px 4px 2px);
       cursor: pointer;
-
+      line-height: 37px;
       height: 45px;      // firefox ignores SlickGrid.rowHeight
     }
 
@@ -102,6 +102,7 @@
       .slick-cell-checkboxsel {
         min-width: 45px;
         padding-left: 8px;
+        line-height: normal;
 
         label {
           display: inline-block;
@@ -192,14 +193,6 @@
           z-index: 1;
         }
       }
-
-      .modified, .status {
-        line-height: 37px;
-        text-align: right;
-        padding-right: 25px;
-        font-size: 0.9em;
-      }
-
     }
   }
 }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/grid/content-grid-panel.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/grid/content-grid-panel.less
@@ -1,0 +1,7 @@
+.tree-grid .grid .slick-row {
+  .modified, .status {
+    text-align: right;
+    padding-right: 25px;
+    font-size: 0.9em;
+  }
+}

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/apps/module/browse/module-tree-grid.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/apps/module/browse/module-tree-grid.less
@@ -1,0 +1,9 @@
+.tree-grid .grid .slick-row {
+  .version, .state, .modified {
+    text-align: right;
+    font-size: 0.9em;
+  }
+  .modified {
+    padding-right: 25px;
+  }
+}

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/styles.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/styles.less
@@ -77,6 +77,7 @@
 @import "apps/content/browse/content-browse-toolbar";
 @import "apps/content/view/item-preview-panel";
 @import "apps/content/view/item-analytics-panel";
+@import "apps/content/browse/grid/content-grid-panel";
 @import "apps/content/browse/grid/tree-grid";
 @import "apps/content/new/new-content-dialog";
 @import "apps/content/wizard/content-wizard-panel";
@@ -92,3 +93,4 @@
 @import "apps/launcher/launcher";
 // app module
 @import "apps/module/install-module-dialog";
+@import "apps/module/browse/module-tree-grid";


### PR DESCRIPTION
Updated TreeGrid styles.
Moved ContentGridPanel and ModuleTreeGrid styles to a separate files.
Added parent parameter's assertNull check to
`ModuleTreeGrid.fetchChildren()`
Renamed `ContentPath.getRelativePath()` to
`ContentPath.getLastElement()`
