### PR TITLE
CMS-3667 Error when creating new content after previous content creation

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
@@ -71,6 +71,28 @@ module app {
             api.app.ShowBrowsePanelEvent.on((event) => {
                 this.handleBrowse(event);
             });
+
+            api.content.ContentCreatedEvent.on((event) => {
+                this.handleCreated(event);
+            });
+
+            api.content.ContentUpdatedEvent.on((event) => {
+                this.handleUpdated(event);
+            });
+        }
+
+        private handleCreated(event: api.content.ContentCreatedEvent) {
+
+            var wizard = event.getWizard(),
+                tabMenuItem = this.getAppBarTabMenu().getNavigationItemById(wizard.getTabId());
+            // update tab id so that new wizard for the same content type can be created
+            var newTabId = api.app.AppBarTabId.forEdit(event.getContent().getId());
+            tabMenuItem.setTabId(newTabId);
+            wizard.setTabId(newTabId);
+        }
+
+        private handleUpdated(event: api.content.ContentUpdatedEvent) {
+            // do something when content is updated
         }
 
         private handleBrowse(event: api.app.ShowBrowsePanelEvent) {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
@@ -211,14 +211,16 @@ module app.wizard {
                 });
 
                 ResponsiveManager.onAvailableSizeChanged(this, (item: ResponsiveItem) => {
-                    this.updateStickyToolbar();
-                    if (item.isInRangeOrSmaller(ResponsiveRanges._720_960)) {
-                        this.cycleViewModeButton.disableAction(this.contentWizardActions.getShowSplitEditAction());
-                        if (this.isSplitView()) {
-                            this.cycleViewModeButton.setCurrentAction(this.contentWizardActions.getShowFormAction());
+                    if (this.isVisible()) {
+                        this.updateStickyToolbar();
+                        if (item.isInRangeOrSmaller(ResponsiveRanges._720_960)) {
+                            this.cycleViewModeButton.disableAction(this.contentWizardActions.getShowSplitEditAction());
+                            if (this.isSplitView()) {
+                                this.cycleViewModeButton.setCurrentAction(this.contentWizardActions.getShowFormAction());
+                            }
+                        } else if (item.isInRangeOrBigger(ResponsiveRanges._960_1200)) {
+                            this.cycleViewModeButton.enableAction(this.contentWizardActions.getShowSplitEditAction());
                         }
-                    } else if (item.isInRangeOrBigger(ResponsiveRanges._960_1200)) {
-                        this.cycleViewModeButton.enableAction(this.contentWizardActions.getShowSplitEditAction());
                     }
                 });
 
@@ -366,7 +368,7 @@ module app.wizard {
                         setParentContent(this.parentContent).
                         setPersistedContent(content).
                         setAttachments(attachments).
-                        setShowEmptyFormItemSetOccurrences(this.isPersisted()).
+                        setShowEmptyFormItemSetOccurrences(this.isItemPersisted()).
                         build();
 
                     this.contentWizardStepForm.renderExisting(this.formContext, contentData, content.getForm());
@@ -503,8 +505,15 @@ module app.wizard {
                 execute().
                 then((content: Content) => {
 
-                    new api.content.ContentUpdatedEvent(content).fire();
-                    api.notify.showFeedback('Content was updated!');
+                    if (this.isRenderingNew()) {
+
+                        new api.content.ContentCreatedEvent(content, this).fire();
+                        api.notify.showFeedback('Content was created!');
+                    } else {
+
+                        new api.content.ContentUpdatedEvent(content, this).fire();
+                        api.notify.showFeedback('Content was updated!');
+                    }
 
                     return Q(this.liveFormPanel ? this.liveFormPanel.contentSaved() : null).then(() => content);
                 });

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/AppBarTabId.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/AppBarTabId.ts
@@ -1,35 +1,39 @@
-module api.app{
+module api.app {
 
     export class AppBarTabId {
 
-        private mode:string;
+        private mode: string;
 
-        private id:string;
+        private id: string;
 
-        static forNew(id?:string):AppBarTabId {
+        static forNew(id?: string): AppBarTabId {
             return new AppBarTabId("new", id);
         }
 
-        static forEdit(id:string):AppBarTabId {
-            return new AppBarTabId("new", id);
+        static forEdit(id: string): AppBarTabId {
+            return new AppBarTabId("edit", id);
         }
 
-        static forView(id:string):AppBarTabId {
+        static forView(id: string): AppBarTabId {
             return new AppBarTabId("view", id);
         }
 
-        constructor(mode:string, id:string) {
+        constructor(mode: string, id: string) {
             this.mode = mode;
             this.id = id;
         }
 
-        changeToEditMode(id:string) {
+        changeToEditMode(id: string) {
             this.mode = "edit";
             this.id = id;
         }
 
-        equals(other:AppBarTabId):boolean {
+        equals(other: AppBarTabId): boolean {
             return other.id == this.id && other.mode == this.mode;
+        }
+
+        toString(): string {
+            return this.mode + ":" + this.id;
         }
     }
 }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/AppBarTabMenuItem.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/AppBarTabMenuItem.ts
@@ -1,13 +1,13 @@
-module api.app{
+module api.app {
 
     export class AppBarTabMenuItem extends api.ui.tab.TabMenuItem {
 
-        private tabId:AppBarTabId;
+        private tabId: AppBarTabId;
 
-        private editing:boolean;
+        private editing: boolean;
 
-        constructor(label:string, tabId:AppBarTabId, editing?:boolean) {
-            super(label, {removable:true});
+        constructor(label: string, tabId: AppBarTabId, editing?: boolean) {
+            super(label, {removable: true});
             this.editing = editing;
             this.tabId = tabId;
 
@@ -17,12 +17,16 @@ module api.app{
             }
         }
 
-        isEditing():boolean {
+        isEditing(): boolean {
             return this.editing;
         }
 
-        getTabId():AppBarTabId {
+        getTabId(): AppBarTabId {
             return this.tabId;
+        }
+
+        setTabId(tabId: AppBarTabId) {
+            this.tabId = tabId;
         }
     }
 }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentCreatedEvent.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentCreatedEvent.ts
@@ -2,15 +2,21 @@ module api.content {
 
     export class ContentCreatedEvent extends api.event.Event {
 
-        private content:api.content.Content;
+        private content: api.content.Content;
+        private wizard: api.app.wizard.WizardPanel<Content>;
 
-        constructor(content:api.content.Content ) {
+        constructor(content: api.content.Content, wizard: api.app.wizard.WizardPanel<Content>) {
             super();
             this.content = content;
+            this.wizard = wizard;
         }
 
-        public getContent():api.content.Content {
+        public getContent(): api.content.Content {
             return this.content;
+        }
+
+        public getWizard(): api.app.wizard.WizardPanel<Content> {
+            return this.wizard;
         }
 
         static on(handler: (event: ContentCreatedEvent) => void) {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentUpdatedEvent.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/content/ContentUpdatedEvent.ts
@@ -2,15 +2,21 @@ module api.content {
 
     export class ContentUpdatedEvent extends api.event.Event {
 
-        private model:api.content.ContentSummary;
+        private content: api.content.Content;
+        private wizard: api.app.wizard.WizardPanel<Content>;
 
-        constructor( model:api.content.ContentSummary ) {
+        constructor(content: api.content.Content, wizard: api.app.wizard.WizardPanel<Content>) {
             super();
-            this.model = model;
+            this.content = content;
+            this.wizard = wizard;
         }
 
-        public getModel():api.content.ContentSummary {
-            return this.model;
+        public getContent(): api.content.Content {
+            return this.content;
+        }
+
+        public getWizard(): api.app.wizard.WizardPanel<Content> {
+            return this.wizard;
         }
 
         static on(handler: (event: ContentUpdatedEvent) => void) {
@@ -21,5 +27,4 @@ module api.content {
             api.event.Event.unbind(api.util.getFullName(this), handler);
         }
     }
-
 }


### PR DESCRIPTION
- updated the wizard and app bar tab ids after the content is saved so that new tab for the same content type can be created
- also fixed the sticky toolbar misplacement when wizard was not visible
