### PR TITLE
CMS-3941 When content selected, spacebar does not deselect a row in Brow...

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
@@ -105,6 +105,18 @@ module api.ui.grid {
             return <GridOptions<T>>this.slickGrid.getOptions();
         }
 
+        getCheckboxSelectorPlugin(): Slick.Plugin<T> {
+            return this.checkboxSelectorPlugin;
+        }
+
+        registerPlugin(plugin: Slick.Plugin<T>) {
+            this.slickGrid.unregisterPlugin(plugin);
+        }
+
+        unregisterPlugin(plugin: Slick.Plugin<T>) {
+            this.slickGrid.unregisterPlugin(plugin);
+        }
+
         render() {
             this.slickGrid.render();
             super.render();
@@ -167,10 +179,23 @@ module api.ui.grid {
 
         selectRow(row: number) {
             // Prevent unnecessary render on the same row
-            if (this.getSelectedRows().length > 1
-                || (this.getSelectedRows().length < 2 && this.getSelectedRows().indexOf(row) < 0)) {
+            var rows = this.getSelectedRows();
+            if (rows.length > 1 || (rows.length < 2 && rows.indexOf(row) < 0)) {
                 this.slickGrid.setSelectedRows([row]);
             }
+        }
+
+        toggleRow(row: number) {
+            // Prevent unnecessary render on the same row
+            var rows = this.getSelectedRows(),
+                index = rows.indexOf(row);
+            if (index < 0) {
+                rows.push(row);
+                rows.sort();
+            } else {
+                rows.splice(index, 1);
+            }
+            this.slickGrid.setSelectedRows(rows);
         }
 
         selectAll() {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -76,6 +76,17 @@ module api.ui.treegrid {
                 selectActiveRow: false
             }));
 
+            /*
+             * Default checkbox plugin should be unselected, because the
+             * cell navigation is disabled. Enabling it will break the
+             * key custom key navigation. Without it plugin is having
+             * some spacebar handling error, due to active cell can't be set.
+             */
+            var selectorPlugin = this.grid.getCheckboxSelectorPlugin();
+            if (selectorPlugin) {
+                this.grid.unregisterPlugin(this.grid.getCheckboxSelectorPlugin())
+            }
+
             this.actions = new TreeGridToolbarActions(this.grid);
 
             this.onClicked(() => {
@@ -111,6 +122,11 @@ module api.ui.treegrid {
                         elem.removeClass("collapse").addClass("expand");
                         var node = this.gridData.getItem(data.row);
                         this.collapseNode(node);
+                    } else if (data.cell === 0) {
+                        this.active = true;
+                        if (elem.getAttribute("type") === "checkbox") {
+                            this.grid.toggleRow(data.row);
+                        }
                     } else {
                         this.active = true;
                         this.grid.selectRow(data.row);
@@ -162,6 +178,9 @@ module api.ui.treegrid {
                             this.expandNode(node);
                         }
                     }
+                }),
+                new KeyBinding('space', () => {
+                    this.deselectAll();
                 })
             ];
 


### PR DESCRIPTION
...se Panel

Disabled selector plugin registration in the  `TreeGrid`.
Added spacebar key binding.
Updated `TreeGrid` selection handling.
