### PR TITLE
CMS-4000 Make selecting more than one row using keyboard work again

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
@@ -255,6 +255,31 @@ module api.ui.grid {
             }
         }
 
+        addSelectedUp() {
+            if (this.slickGrid.getDataLength() > 0) {
+                var selected: number[] = this.getSelectedRows().sort();
+
+                if (selected.length > 0 && (selected[0] - 1) >= 0) {
+                    selected.push(selected[0] - 1);
+                    selected = selected.sort();
+                    this.setSelectedRows(selected);
+                }
+            }
+        }
+
+        addSelectedDown() {
+            if (this.slickGrid.getDataLength() > 0) {
+                var selected: number[] = this.getSelectedRows().sort();
+
+                if (selected.length > 0 && (selected[selected.length - 1] + 1) < this.slickGrid.getDataLength()) {
+                    selected.push(selected[selected.length - 1] + 1);
+                    this.setSelectedRows(selected);
+                } else if (selected.length === 0) {
+                    this.moveSelectedDown();
+                }
+            }
+        }
+
         // Operate with cells
         navigateUp() {
             this.slickGrid.navigateUp();

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -149,6 +149,16 @@ module api.ui.treegrid {
                         this.grid.moveSelectedDown();
                     }
                 }),
+                new KeyBinding('shift+up', () => {
+                    if (this.active) {
+                        this.grid.addSelectedUp();
+                    }
+                }),
+                new KeyBinding('shift+down', () => {
+                    if (this.active) {
+                        this.grid.addSelectedDown();
+                    }
+                }),
                 new KeyBinding('left', () => {
                     var selected = this.grid.getSelectedRows();
                     if (selected.length === 1) {


### PR DESCRIPTION
Added support for the `shift` key for the multi selection.
