### PR TITLE
CMS-4001 Make scroller work properly with key navigation.

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/dom/ElementHelper.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/dom/ElementHelper.ts
@@ -439,6 +439,24 @@ module api.dom {
             return this;
         }
 
+        getBoundingClientRect(): ClientRect {
+            return this.el.getBoundingClientRect();
+        }
+
+        scrollIntoView(top?: boolean): ElementHelper {
+            this.el.scrollIntoView(top);
+            return this;
+        }
+
+        getScrollTop(): number {
+            return this.el.scrollTop;
+        }
+
+        setScrollTop(top: number): ElementHelper {
+            this.el.scrollTop = top;
+            return this;
+        }
+
         getFontSize(): string {
             return this.getComputedProperty('font-size');
         }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
@@ -234,14 +234,19 @@ module api.ui.grid {
                 if (selected.length === 1) {
                     if (row >= 0) {
                         this.selectRow(row);
+                        return row;
                     } else {
                         this.clearSelection();
+                        return 0;
                     }
                 } else if (selected.length > 1) {
                     row = Math.max(row, 0);
                     this.selectRow(row);
+                    return row;
                 }
             }
+
+            return -1;
         }
 
         moveSelectedDown() {
@@ -252,7 +257,11 @@ module api.ui.grid {
                     : 0;
 
                 this.selectRow(row);
+
+                return row;
             }
+
+            return -1;
         }
 
         addSelectedUp() {
@@ -260,24 +269,33 @@ module api.ui.grid {
                 var selected: number[] = this.getSelectedRows().sort();
 
                 if (selected.length > 0 && (selected[0] - 1) >= 0) {
-                    selected.push(selected[0] - 1);
+                    var row = selected[0] - 1;
+                    selected.push(row);
                     selected = selected.sort();
                     this.setSelectedRows(selected);
+                    return row;
                 }
             }
+
+            return -1;
         }
 
-        addSelectedDown() {
+        addSelectedDown(): number {
             if (this.slickGrid.getDataLength() > 0) {
                 var selected: number[] = this.getSelectedRows().sort();
 
                 if (selected.length > 0 && (selected[selected.length - 1] + 1) < this.slickGrid.getDataLength()) {
-                    selected.push(selected[selected.length - 1] + 1);
+                    var row = selected[selected.length - 1] + 1;
+                    selected.push(row);
                     this.setSelectedRows(selected);
+                    return row;
                 } else if (selected.length === 0) {
                     this.moveSelectedDown();
+                    return 0;
                 }
             }
+
+            return -1;
         }
 
         // Operate with cells

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -141,22 +141,22 @@ module api.ui.treegrid {
             var keyBindings = [
                 new KeyBinding('up', () => {
                     if (this.active) {
-                        this.grid.moveSelectedUp();
+                        this.scrollToRow(this.grid.moveSelectedUp());
                     }
                 }),
                 new KeyBinding('down', () => {
                     if (this.active) {
-                        this.grid.moveSelectedDown();
+                        this.scrollToRow(this.grid.moveSelectedDown());
                     }
                 }),
                 new KeyBinding('shift+up', () => {
                     if (this.active) {
-                        this.grid.addSelectedUp();
+                        this.scrollToRow(this.grid.addSelectedUp());
                     }
                 }),
                 new KeyBinding('shift+down', () => {
                     if (this.active) {
-                        this.grid.addSelectedDown();
+                        this.scrollToRow(this.grid.addSelectedDown());
                     }
                 }),
                 new KeyBinding('left', () => {
@@ -266,6 +266,16 @@ module api.ui.treegrid {
 
         hasToolbar(): boolean {
             return !!this.toolbar;
+        }
+
+        private scrollToRow(row: number) {
+            if (row > -1 && this.grid.getSelectedRows().length > 0) {
+                if (this.grid.getEl().getScrollTop() > row * 45) {
+                    this.grid.getEl().setScrollTop(row * 45);
+                } else if (this.grid.getEl().getScrollTop() + this.grid.getEl().getHeight() < (row + 1) * 45) {
+                    this.grid.getEl().setScrollTop((row + 1) * 45 - this.grid.getEl().getHeight());
+                }
+            }
         }
 
         /**


### PR DESCRIPTION
Added `TreeGrid.scrollToRow()` method, that scrolls to the row by its number.
Updated `Grid`'s selection methods. They are now return selected row number.
