### PR TITLE
CMS-3988 spinner should be showed, when list of recently used types  is ...

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/create/NewContentDialog.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/create/NewContentDialog.ts
@@ -60,6 +60,9 @@ module app.create {
             this.contentListMask = new api.ui.mask.LoadMask(this.contentList);
             this.recentListMask = new api.ui.mask.LoadMask(this.recentList);
 
+            this.contentList.appendChild(this.contentListMask);
+            this.recentList.appendChild(this.recentListMask);
+
             this.listItems = [];
             this.checkReloadListItems = true;
 


### PR DESCRIPTION
...refreshing in the NewContentDialog

Fixed bug with spinners not shown. Reason: they were not appended to the
lists in HTML.
