### PR TITLE
CMS-3935 Make input type Long

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/form/inputtype/long/Long.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/form/inputtype/long/Long.ts
@@ -51,6 +51,9 @@ module api.content.form.inputtype.long {
             if (api.util.isStringBlank(value.asString())) {
                 return true;
             } else {
+                if (isNaN(parseInt(value.asString()))) {
+                    throw new Error('Value is not a Number');
+                }
                 return false;
             }
         }

--- a/modules/wem-api/src/main/java/com/enonic/wem/api/data/type/JavaTypeConverters.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/data/type/JavaTypeConverters.java
@@ -89,7 +89,14 @@ final class JavaTypeConverters
         }
         else if ( value instanceof String )
         {
-            return new Long( (String) value );
+            if ( isNumber( value.toString() ) )
+            {
+                return new Long( (String) value );
+            }
+            else
+            {
+                return null;
+            }
         }
         else
         {
@@ -97,6 +104,21 @@ final class JavaTypeConverters
         }
     }
 
+    public static boolean isNumber( String strNum )
+    {
+        boolean ret = true;
+        try
+        {
+
+            Double.parseDouble( strNum );
+
+        }
+        catch ( NumberFormatException e )
+        {
+            ret = false;
+        }
+        return ret;
+    }
     private static Double convertToDouble( final Object value )
     {
         if ( value instanceof Number )
@@ -105,7 +127,11 @@ final class JavaTypeConverters
         }
         else if ( value instanceof String )
         {
-            return new Double( (String) value );
+            if ( isNumber( value.toString() ) )
+            {
+                return new Double( (String) value );
+            }
+            return null;
         }
         else
         {

--- a/modules/wem-api/src/main/java/com/enonic/wem/api/form/inputtype/Double.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/form/inputtype/Double.java
@@ -1,7 +1,5 @@
 package com.enonic.wem.api.form.inputtype;
 
-import org.apache.commons.lang.StringUtils;
-
 import com.enonic.wem.api.data.Property;
 import com.enonic.wem.api.data.Value;
 import com.enonic.wem.api.data.type.ValueTypes;
@@ -18,8 +16,8 @@ final class Double
     public void checkBreaksRequiredContract( final Property property )
         throws BreaksRequiredContractException
     {
-        final String stringValue = (String) property.getObject();
-        if ( StringUtils.isBlank( stringValue ) )
+        final java.lang.Double doubleValue = property.getDouble();
+        if ( doubleValue == null )
         {
             throw new BreaksRequiredContractException( property, this );
         }

--- a/modules/wem-api/src/main/java/com/enonic/wem/api/form/inputtype/Long.java
+++ b/modules/wem-api/src/main/java/com/enonic/wem/api/form/inputtype/Long.java
@@ -1,7 +1,5 @@
 package com.enonic.wem.api.form.inputtype;
 
-import org.apache.commons.lang.StringUtils;
-
 import com.enonic.wem.api.data.Property;
 import com.enonic.wem.api.data.Value;
 import com.enonic.wem.api.data.type.ValueTypes;
@@ -18,8 +16,8 @@ final class Long
     public void checkBreaksRequiredContract( final Property property )
         throws BreaksRequiredContractException
     {
-        final String stringValue = (String) property.getObject();
-        if ( StringUtils.isBlank( stringValue ) )
+        final java.lang.Long value = property.getLong();
+        if ( value == null )
         {
             throw new BreaksRequiredContractException( property, this );
         }


### PR DESCRIPTION
1. Java Long called  property.getLong() ( not getObject) and Java Double called property.getDouble()
2. when text typed in the Long-inputtype, Error will be thrown (Long.ts)
