### PR TITLE
CMS-4182 TreeGrid - Automatic loading of remaining children

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/CompareContentGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/CompareContentGrid.ts
@@ -30,7 +30,7 @@ module app.wizard {
                     ]).
                     setPartialLoadEnabled(true).
                     setLoadBufferSize(20). // rows count
-                    prependClasses("content-tree-grid")
+                    prependClasses("compare-content-grid")
             );
 
             this.content = content;

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/dom/Element.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/dom/Element.ts
@@ -911,12 +911,28 @@ module api.dom {
                 setParentElement(parent));
         }
 
-        static fromString(s: string): Element {
+        static fromString(s: string, setLoadExistingChildren:boolean = true): Element {
             var elementAsJQ = wemjq(s);
             var elementASHtmlElement = elementAsJQ.get(0);
-            return new Element(new ElementFromHelperBuilder().
-                setHelper(new ElementHelper(elementASHtmlElement)).
-                setLoadExistingChildren(true));
+            return !!elementASHtmlElement ? new Element(new ElementFromHelperBuilder().
+                                                setHelper(new ElementHelper(elementASHtmlElement)).
+                                                setLoadExistingChildren(setLoadExistingChildren))
+                                          : null;
+        }
+
+        static elementsFromRequest(s: string, setLoadExistingChildren:boolean = true): Element[] {
+            var elementAsJQ = wemjq(s);
+            var elements = [];
+            elementAsJQ.each((index, elem) => {
+                var e = wemjq(elem);
+                elements.push(
+                new Element(new ElementFromHelperBuilder().
+                    setHelper(new ElementHelper(e.get(0))).
+                    setLoadExistingChildren(setLoadExistingChildren))
+                );
+            });
+
+            return elements;
         }
     }
 }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeNode.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeNode.ts
@@ -19,7 +19,10 @@ module api.ui.treegrid {
         private children: TreeNode<DATA>[];
 
         constructor(builder: TreeNodeBuilder<DATA>) {
-            this.id = builder.getId();
+
+            // The id's should not repeat. make shore that empty id's will be set to unique.
+            this.id = builder.getId() || Math.random().toString(36).substring(2);
+
             this.data = builder.getData();
             this.parent = builder.getParent();
             this.setChildren(builder.getChildren());

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/compare-content-grid.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/compare-content-grid.less
@@ -1,0 +1,9 @@
+.compare-content-grid {
+  .grid .slick-row {
+    .modified, .status {
+      text-align: right;
+      padding-right: 25px;
+      font-size: 0.9em;
+    }
+  }
+}

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/styles.less
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/styles/styles.less
@@ -96,6 +96,7 @@
 @import "apps/content/browse/content-tree-grid";
 @import "apps/content/new/new-content-dialog";
 @import "apps/content/wizard/content-wizard-panel";
+@import "apps/content/wizard/compare-content-grid";
 @import "apps/content/wizard/site/module-view";
 @import "apps/content/wizard/page/page-wizard-step-form";
 @import "apps/content/wizard/content/wizard-preview-dialog";


### PR DESCRIPTION
Created a separate styles for the `CompareContentGrid`.
Added the generation of the id's for the  empty nodes.
Removed `TreeGrid.canvasElement` property.
Simplified and optimized the DOM selection for the animation and
postload in `TreeGrid`.
Added `Element.elementsFromRequest()` static method to get the array of
objects from string.
