### PR TITLE
CMS-3952 Wrong behavior: when new child added to expanded content, paren...

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
@@ -273,19 +273,12 @@ module app.browse {
                 });
         }
 
-        updateDataChildrenStatus(parentNode: TreeNode<ContentSummaryAndCompareStatus>): wemQ.Promise<TreeNode<ContentSummaryAndCompareStatus>> {
-            return ContentSummaryAndCompareStatusFetcher.fetchChildren(parentNode.getData().getId()).then((result: ContentResponse<ContentSummaryAndCompareStatus>) => {
-                var hasChildren = (result.getMetadata().getTotalHits() > 0);
-                if (parentNode.getData()) {
-                    parentNode.getData().setContentSummary(new ContentSummaryBuilder(parentNode.getData().getContentSummary()).
-                        setHasChildren(hasChildren).
-                        setDeletable(!hasChildren).
-                        build());
-                    this.refreshNode(parentNode);
-                    return parentNode;
-                }
+        updateNodeData(parentNode: TreeNode<ContentSummaryAndCompareStatus>): wemQ.Promise<TreeNode<ContentSummaryAndCompareStatus>> {
+            return ContentSummaryAndCompareStatusFetcher.fetch(parentNode.getData().getId()).then((content: ContentSummaryAndCompareStatus) => {
+                parentNode.setData(content);
+                this.refreshNode(parentNode);
+                return parentNode;
             });
-
         }
     }
 }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/CompareContentGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/CompareContentGrid.ts
@@ -63,19 +63,12 @@ module app.wizard {
             return data.getId();
         }
 
-        updateDataChildrenStatus(parentNode: TreeNode<ContentSummaryAndCompareStatus>): wemQ.Promise<TreeNode<ContentSummaryAndCompareStatus>> {
-            return ContentSummaryAndCompareStatusFetcher.fetchChildren(parentNode.getData().getId()).then((result: ContentResponse<ContentSummaryAndCompareStatus>) => {
-                var hasChildren = (result.getMetadata().getTotalHits() > 0);
-                if (parentNode.getData()) {
-                    parentNode.getData().setContentSummary(new ContentSummaryBuilder(parentNode.getData().getContentSummary()).
-                        setHasChildren(hasChildren).
-                        setDeletable(!hasChildren).
-                        build());
-                    this.refreshNode(parentNode);
-                    return parentNode;
-                }
+        updateNodeData(parentNode: TreeNode<ContentSummaryAndCompareStatus>): wemQ.Promise<TreeNode<ContentSummaryAndCompareStatus>> {
+            return ContentSummaryAndCompareStatusFetcher.fetch(parentNode.getData().getId()).then((content: ContentSummaryAndCompareStatus) => {
+                parentNode.setData(content);
+                this.refreshNode(parentNode);
+                return parentNode;
             });
-
         }
     }
 }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -615,7 +615,7 @@ module api.ui.treegrid {
                             this.notifyDataChanged(new DataChangedEvent<DATA>([node], DataChangedEvent.ACTION_ADDED));
 
                             if (parentNode != root) {
-                                this.updateDataChildrenStatus(parentNode).then((node: TreeNode<DATA>) => {
+                                this.updateNodeData(parentNode).then((node: TreeNode<DATA>) => {
                                     if (!stashedParentNode) {
                                         this.updateSelectedNode(node);
                                     }
@@ -659,11 +659,11 @@ module api.ui.treegrid {
                 }
             });
             root.treeToList().forEach((child: TreeNode<DATA>) => {
-                this.updateDataChildrenStatus(child);
+                this.updateNodeData(child);
             });
             if (this.stash) {
                 this.stash.treeToList().forEach((child: TreeNode<DATA>) => {
-                    this.updateDataChildrenStatus(child);
+                    this.updateNodeData(child);
                 });
             }
             this.notifyDataChanged(new DataChangedEvent<DATA>(deleted, DataChangedEvent.ACTION_DELETED));
@@ -732,7 +732,6 @@ module api.ui.treegrid {
         }
 
         private updateSelectedNode(node: TreeNode<DATA>) {
-            //  this.updateDataChildrenStatus(node);
             this.getGrid().clearSelection();
             this.refreshNode(node);
             var row = this.gridData.getRowById(node.getId());
@@ -930,7 +929,7 @@ module api.ui.treegrid {
             this.grid.renderGrid();
         }
 
-        updateDataChildrenStatus(parentNode: TreeNode<DATA>): wemQ.Promise<TreeNode<DATA>> {
+        updateNodeData(parentNode: TreeNode<DATA>): wemQ.Promise<TreeNode<DATA>> {
             return null;
         }
     }


### PR DESCRIPTION
...t content becomes collapsed. - refresh for stashed tree after deletion added. - refresh children status replaced by full node data update.
