### PR TITLE
CMS-4295 When content was edited, old name still present in the grid vie...

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
@@ -257,14 +257,7 @@ module app.browse {
         }
 
         updateContentNode(content: api.content.Content) {
-            var root = this.getRoot();
-            root.treeToList().forEach((child: TreeNode<ContentSummaryAndCompareStatus>) => {
-                var curContent: ContentSummaryAndCompareStatus = child.getData();
-                if (child.getData().getId() == content.getId()) {
-                    curContent.setContentSummary(content);
-                    this.updateNode(curContent);
-                }
-            });
+            this.updateNode(new ContentSummaryAndCompareStatus(content, null));
         }
 
         appendContentNode(content: api.content.Content) {


### PR DESCRIPTION
...w

Simplified the `ContentTreeGrid.updateContentNode()` method.
Updated `TreeGrid.updateNode()` method to flush cached viewers.
