### PR TITLE
CMS-4585 User Manager - New Group and Role: validation

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/UserAppPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/UserAppPanel.ts
@@ -120,7 +120,7 @@ module app {
                 new app.wizard.PrincipalWizardPanelFactory().
                     setAppBarTabId(tabId).
                     setPrincipalType(principalType).
-                    setPrincipalPath(userItem.getDataPath()).
+                    setPrincipalPath(userItem.getPrincipal().getKey().toPath(true)).
                     setUserStore(userItem.getUserStore() ? userItem.getUserStore().getKey() : null).
                     createForNew().then((wizard: app.wizard.PrincipalWizardPanel) => {
                         tabMenuItem = new AppBarTabMenuItemBuilder().setLabel("[New " + tabName + "]").
@@ -161,7 +161,7 @@ module app {
                     new app.wizard.PrincipalWizardPanelFactory().
                         setAppBarTabId(tabId).
                         setPrincipalType(userItem.getPrincipal().getType()).
-                        setPrincipalPath(userItem.getDataPath()).
+                        setPrincipalPath(userItem.getPrincipal().getKey().toPath(true)).
                         setPrincipalToEdit(userItem.getPrincipal().getKey()).
                         createForEdit().then((wizard: app.wizard.PrincipalWizardPanel) => {
                             if (closeViewPanelMenuItem != null) {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserTreeGridItem.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserTreeGridItem.ts
@@ -97,28 +97,6 @@ module app.browse {
 
         }
 
-        getDataPath(): string {
-            var path = this.getDataId();
-            switch (this.type) {
-            case UserTreeGridItemType.PRINCIPAL:
-                var pathArray = path.split(":");
-                pathArray.pop();
-                path = pathArray.length === 0 ? "/" : "/" + pathArray.reverse().join("/") + "/";
-                path = path.replace(/(role|group|user)(\/)/g, "$1s/");
-                break;
-
-            case UserTreeGridItemType.ROLES:
-                path = path + "/";
-                break;
-
-            default:
-                path = "/" + path + "/";
-                break;
-            }
-            return path;
-
-        }
-
         hasChildren(): boolean {
             return (this.type === UserTreeGridItemType.USER_STORE || this.type === UserTreeGridItemType.GROUPS ||
                     this.type === UserTreeGridItemType.ROLES || this.type === UserTreeGridItemType.USERS);

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/view/UserItemStatisticsPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/view/UserItemStatisticsPanel.ts
@@ -57,7 +57,7 @@ module app.view {
             switch (type) {
                 case PrincipalType.USER:
                     item.setPathName(item.getModel().getPrincipal().getKey().getId());
-                    item.setPath(item.getModel().getDataPath());
+                    item.setPath(item.getModel().getPrincipal().getKey().toPath(true));
                     item.setIconSize(128);
                     break;
                 case PrincipalType.GROUP:

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/GroupRoleWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/GroupRoleWizardPanel.ts
@@ -52,13 +52,9 @@ module app.wizard {
         preLayoutNew(): wemQ.Promise<void> {
             var deferred = wemQ.defer<void>();
 
-            // Ensure a nameless and empty content is persisted before rendering new
-            this.saveChanges().
-                then(() => {
-                    deferred.resolve(null);
-                }).catch((reason) => {
-                    deferred.reject(reason);
-                }).done();
+            this.doLayoutPersistedItem(null);
+
+            deferred.resolve(null);
 
             return deferred.promise;
         }
@@ -66,14 +62,13 @@ module app.wizard {
         postLayoutNew(): wemQ.Promise<void> {
             var deferred = wemQ.defer<void>();
 
-            this.principalWizardHeader.initNames(this.getPersistedItem().getDisplayName(), this.getPersistedItem().getKey().getId(), false);
+            this.principalWizardHeader.initNames("", "", false);
 
             deferred.resolve(null);
             return deferred.promise;
         }
 
         layoutPersistedItem(persistedPrincipal: Principal): wemQ.Promise<void> {
-
             if (!this.constructing) {
 
                 var deferred = wemQ.defer<void>();
@@ -94,8 +89,7 @@ module app.wizard {
 
                 deferred.resolve(null);
                 return deferred.promise;
-            }
-            else {
+            } else {
                 return this.doLayoutPersistedItem(persistedPrincipal.clone());
             }
         }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/GroupWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/GroupWizardPanel.ts
@@ -52,13 +52,14 @@ module app.wizard {
         persistNewItem(): wemQ.Promise<Principal> {
              return this.produceCreateGroupRequest().sendAndParse().
                 then((principal: Principal) => {
+                    this.getPrincipalWizardHeader().disableNameInput();
                     api.notify.showFeedback('Group was created!');
                     return principal;
                 });
         }
 
         produceCreateGroupRequest(): CreateGroupRequest {
-            var key = PrincipalKey.ofGroup(this.getUserStore(), Math.random().toString(36).slice(2)),
+            var key = PrincipalKey.ofGroup(this.getUserStore(), this.principalWizardHeader.getName()),
                 name = this.principalWizardHeader.getDisplayName(),
                 members = this.getMembersWizardStepForm().getMembers().map((el) => { return el.getKey(); });
             return new CreateGroupRequest().setKey(key).setDisplayName(name).setMembers(members);

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanel.ts
@@ -69,6 +69,10 @@ module app.wizard {
 
             this.principalWizardHeader.setPath(this.principalPath);
 
+            if (params.persistedPrincipal) {
+                this.principalWizardHeader.disableNameInput();
+            }
+
             super({
                 tabId: params.tabId,
                 persistedItem: params.persistedPrincipal,
@@ -96,7 +100,7 @@ module app.wizard {
                     if (this.getPersistedItem()) {
                         app.Router.setHash("edit/" + this.getPersistedItem().getKey());
                     } else {
-                        app.Router.setHash("new/" + this.principalType);
+                        app.Router.setHash("new/" + PrincipalType[this.principalType].toLowerCase());
                     }
 
                     responsiveItem.update();
@@ -106,6 +110,10 @@ module app.wizard {
 
                 callback(this);
             });
+        }
+
+        getPrincipalWizardHeader(): WizardHeaderWithDisplayNameAndName {
+            return this.principalWizardHeader;
         }
 
         giveInitialFocus() {
@@ -118,6 +126,19 @@ module app.wizard {
             }
 
             this.startRememberFocus();
+        }
+
+        saveChanges(): wemQ.Promise<Principal> {
+            if (!this.principalWizardHeader.getName()) {
+                var deferred = wemQ.defer<Principal>();
+                api.notify.showError("Name can not be empty or null.");
+                // deferred.resolve(null);
+                deferred.reject(new Error("Name can not be empty or null."));
+                return deferred.promise;
+            } else {
+                return super.saveChanges();
+            }
+
         }
 
         createSteps(): wemQ.Promise<any[]> {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/RoleWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/RoleWizardPanel.ts
@@ -35,7 +35,6 @@ module app.wizard {
         }
 
         doLayoutPersistedItem(principal: Principal): wemQ.Promise<void> {
-
             var parallelPromises: wemQ.Promise<any>[] = [
                 // Load attachments?
                 this.createSteps()
@@ -52,13 +51,14 @@ module app.wizard {
         persistNewItem(): wemQ.Promise<Principal> {
              return this.produceCreateRoleRequest().sendAndParse().
                 then((principal: Principal) => {
+                    this.getPrincipalWizardHeader().disableNameInput();
                     api.notify.showFeedback('Role was created!');
                     return principal;
                 });
         }
 
         produceCreateRoleRequest(): CreateRoleRequest {
-            var key = PrincipalKey.ofRole(Math.random().toString(36).slice(2)),
+            var key = PrincipalKey.ofRole(this.principalWizardHeader.getName()),
                 name = this.principalWizardHeader.getDisplayName(),
                 members = this.getMembersWizardStepForm().getMembers().map((el) => { return el.getKey(); });
             return new CreateRoleRequest().setKey(key).setDisplayName(name).setMembers(members);

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardHeaderWithDisplayNameAndName.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardHeaderWithDisplayNameAndName.ts
@@ -130,6 +130,10 @@ module api.app.wizard {
             }
         }
 
+        disableNameInput() {
+            this.nameEl.getEl().setAttribute("disabled", "disabled");
+        }
+
         getName(): string {
             return this.nameEl.getValue();
         }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/security/PrincipalKey.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/security/PrincipalKey.ts
@@ -92,16 +92,16 @@ module api.security {
             return this.refString;
         }
 
-        toPath(): string {
-            if (this.isRole()) {
-                return api.util.StringHelper.format("/role/{0}",
-                    this.getId());
-            } else {
-                return api.util.StringHelper.format("/{0}/{1}/{2}",
-                    this.getUserStore().toString(),
-                    PrincipalType[this.getType()].toLowerCase(),
-                    this.getId());
+        toPath(toParent: boolean = false): string {
+            var path = this.isRole() ? "/roles/" :
+                api.util.StringHelper.format("/{0}/{1}/", this.getUserStore().toString(),
+                    PrincipalType[this.getType()].toLowerCase().replace(/(group|user)/g, "$&s"));
+
+            if (!toParent) {
+                path += this.getId();
             }
+
+            return path;
         }
 
         equals(o: api.Equitable): boolean {


### PR DESCRIPTION
Disabled the Principal creation on a new wizard initialization.
Added validation for the name filed in header, since other fields are
optional.
Disabled the name input for edit mode, since the key won't change in
future.
Fixed the `PrincipalKey.toPath()` method,.
Removed `UserTreeGridItem.getDataPath()`.
