### PR TITLE
CMS-4714 Principal Wizards - WizardPanel failed to initialize properly

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/GroupRoleWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/GroupRoleWizardPanel.ts
@@ -91,7 +91,9 @@ module app.wizard {
         hasUnsavedChanges(): boolean {
             var persistedPrincipal = this.getPersistedItem();
             if (persistedPrincipal == undefined) {
-                return true;
+                return this.wizardHeader.getName() !== "" ||
+                    this.wizardHeader.getDisplayName() !== "" ||
+                    this.membersWizardStepForm.getMembers().length !== 0;
             } else {
                 return !this.isPersistedEqualsViewed();
             }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanel.ts
@@ -30,7 +30,6 @@ module app.wizard {
 
         constructor(params: PrincipalWizardPanelParams, callback: (wizard: PrincipalWizardPanel) => void) {
 
-
             this.isPrincipalFormValid = false;
             this.principalNamedListeners = [];
 
@@ -49,7 +48,6 @@ module app.wizard {
             });
 
             this.wizardHeader = new WizardHeaderWithDisplayNameAndNameBuilder().build();
-
             this.wizardHeader.setPath(this.principalPath);
 
             if (params.persistedPrincipal) {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserWizardPanel.ts
@@ -271,7 +271,10 @@ module app.wizard {
         hasUnsavedChanges(): boolean {
             var persistedPrincipal = this.getPersistedItem();
             if (persistedPrincipal == undefined) {
-                return true;
+                return this.wizardHeader.getName() !== "" ||
+                    this.wizardHeader.getDisplayName() !== "" ||
+                    this.userEmailWizardStepForm.getEmail() !== "" ||
+                    this.userMembershipsWizardStepForm.getMemberships().length !== 0;
             } else {
                 return !this.isPersistedEqualsViewed();
             }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserstoreWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserstoreWizardPanel.ts
@@ -224,7 +224,9 @@ module app.wizard {
         hasUnsavedChanges(): boolean {
             var persistedUserStore: UserStore = this.getPersistedItem();
             if (persistedUserStore == undefined) {
-                return true;
+                return this.wizardHeader.getName() !== "" ||
+                    this.wizardHeader.getDisplayName() !== "" ||
+                    this.permissionsWizardStepForm.getPermissions().getEntries().length !== 0;
             } else {
                 var viewedUserStore = this.assembleViewedUserStore();
                 return !viewedUserStore.equals(this.getPersistedItem());

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardPanel.ts
@@ -339,8 +339,7 @@ module api.app.wizard {
             if (this.hasUnsavedChanges()) {
                 this.askUserForSaveChangesBeforeClosing();
                 return false;
-            }
-            else {
+            } else {
                 return true;
             }
         }


### PR DESCRIPTION
Fixed the close dialog bug, when closing the new, not modified userItem.
Fixed bug with Principal wizard panel initialization for new, when
selection is on principal.
