### PR TITLE
CMS-4721 Principal Wizards - Grid collapses after the Principal or UserS...

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/UserAppPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/UserAppPanel.ts
@@ -206,6 +206,7 @@ module app {
                             setPrincipalType(principalType).
                             setPrincipalPath(principalPath).
                             setUserStore(userStore).
+                            setParentOfSameType(userItem.getType() === UserTreeGridItemType.PRINCIPAL).
                             createForNew();
                     }).then((wizard: app.wizard.PrincipalWizardPanel) => {
                         this.handleWizardCreated(wizard, tabName);

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserBrowsePanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserBrowsePanel.ts
@@ -31,7 +31,7 @@ module app.browse {
             });
 
             api.security.UserItemCreatedEvent.on((event) => {
-                this.userTreeGrid.appendUserNode(event.getPrincipal(), event.getUserStore());
+                this.userTreeGrid.appendUserNode(event.getPrincipal(), event.getUserStore(), event.isParentOfSameType());
                 this.setFilterPanelRefreshNeeded(true);
             });
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserItemsTreeGrid.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserItemsTreeGrid.ts
@@ -128,7 +128,7 @@ module app.browse {
             this.resetAndRender();
         }
 
-        appendUserNode(principal: api.security.Principal, userStore: api.security.UserStore, nextToSelection?: boolean) {
+        appendUserNode(principal: api.security.Principal, userStore: api.security.UserStore, parentOfSameType?: boolean) {
             if (!principal) { // UserStore type
 
                 var userTreeGridItem = new UserTreeGridItemBuilder().
@@ -156,7 +156,7 @@ module app.browse {
                     setType(UserTreeGridItemType.PRINCIPAL).
                     build();
 
-                this.appendNode(userTreeGridItem, false, false);
+                this.appendNode(userTreeGridItem, parentOfSameType, false);
 
             }
         }

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/filter/PrincipalBrowseFilterPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/filter/PrincipalBrowseFilterPanel.ts
@@ -22,15 +22,17 @@ module app.browse.filter {
             this.onSearch(this.searchFacets);
         }
 
-        private resetFacets() {
+        private resetFacets(supressEvent?: boolean) {
 
-            new PrincipalBrowseResetEvent().fire();
+            if (!supressEvent) { // then fire usual reset event with content grid reloading
+                new PrincipalBrowseResetEvent().fire();
+            }
         }
 
         private searchFacets(event: api.app.browse.filter.SearchEvent) {
             var searchText = event.getSearchInputValues().getTextSearchFieldValue();
             if (!searchText) {
-                this.resetFacets();
+                this.resetFacets(true);
                 return;
             }
             new FindPrincipalsRequest().

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/GroupWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/GroupWizardPanel.ts
@@ -60,7 +60,7 @@ module app.wizard {
                     this.getPrincipalWizardHeader().disableNameInput();
                     this.wizardHeader.setAutoGenerationEnabled(false);
                     api.notify.showFeedback('Group was created!');
-                    new api.security.UserItemCreatedEvent(principal, this.getUserStore()).fire();
+                    new api.security.UserItemCreatedEvent(principal, this.getUserStore(), this.isParentOfSameType()).fire();
 
                     return principal;
                 });

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanel.ts
@@ -26,6 +26,8 @@ module app.wizard {
 
         principalNamedListeners: {(event: PrincipalNamedEvent): void}[];
 
+        private parentOfSameType: boolean;
+
         private userStore: UserStore;
 
         constructor(params: PrincipalWizardPanelParams, callback: (wizard: PrincipalWizardPanel) => void) {
@@ -35,6 +37,8 @@ module app.wizard {
 
             this.principalType = params.persistedType;
             this.principalPath = params.persistedPath;
+
+            this.parentOfSameType = params.parentOfSameType;
 
             this.userStore = params.userStore;
 
@@ -104,6 +108,10 @@ module app.wizard {
             });
 
 
+        }
+
+        isParentOfSameType(): boolean {
+            return this.parentOfSameType;
         }
 
         getUserStore(): UserStore {

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanelFactory.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanelFactory.ts
@@ -21,6 +21,8 @@ module app.wizard {
 
         private userStore: UserStore;
 
+        private parentOfSameType: boolean;
+
         setPrincipalToEdit(value: PrincipalKey): PrincipalWizardPanelFactory {
             this.principalKey = value;
             return this;
@@ -41,6 +43,10 @@ module app.wizard {
             return this;
         }
 
+        setParentOfSameType(value: boolean): PrincipalWizardPanelFactory {
+            this.parentOfSameType = value;
+            return this;
+        }
 
         setAppBarTabId(value: api.app.bar.AppBarTabId): PrincipalWizardPanelFactory {
             this.appBarTabId = value;
@@ -76,6 +82,7 @@ module app.wizard {
                 setPrincipalType(this.principalType).
                 setPrincipalPath(this.principalPath).
                 setUserStore(this.userStore).
+                setParentOfSameType(this.parentOfSameType).
                 setAppBarTabId(this.appBarTabId);
 
             this.resolvePrincipalWizardPanel(deferred, wizardParams);

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanelParams.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanelParams.ts
@@ -10,6 +10,8 @@ module app.wizard {
 
         userStore: api.security.UserStore;
 
+        parentOfSameType: boolean;
+
         setPersistedPrincipal(value: api.security.Principal): PrincipalWizardPanelParams {
             this.persistedPrincipal = value;
             return this;
@@ -35,8 +37,8 @@ module app.wizard {
             return this;
         }
 
-        setPersistedPath(value: string): PrincipalWizardPanelParams {
-            this.persistedPath = value;
+        setParentOfSameType(value: boolean): PrincipalWizardPanelParams {
+            this.parentOfSameType = value;
             return this;
         }
 

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/RoleWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/RoleWizardPanel.ts
@@ -59,7 +59,7 @@ module app.wizard {
                     this.getPrincipalWizardHeader().disableNameInput();
                     this.wizardHeader.setAutoGenerationEnabled(false);
                     api.notify.showFeedback('Role was created!');
-                    new api.security.UserItemCreatedEvent(principal, this.getUserStore()).fire();
+                    new api.security.UserItemCreatedEvent(principal, this.getUserStore(), this.isParentOfSameType()).fire();
 
                     return principal;
                 });

--- a/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserWizardPanel.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserWizardPanel.ts
@@ -160,7 +160,7 @@ module app.wizard {
                     this.wizardHeader.disableNameInput();
                     this.wizardHeader.setAutoGenerationEnabled(false);
                     api.notify.showFeedback('User was created!');
-                    new api.security.UserItemCreatedEvent(principal, this.getUserStore()).fire();
+                    new api.security.UserItemCreatedEvent(principal, this.getUserStore(), this.isParentOfSameType()).fire();
 
                     return principal;
                 });

--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/security/UserItemCreatedEvent.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/security/UserItemCreatedEvent.ts
@@ -4,11 +4,13 @@ module api.security {
 
         private principal: Principal;
         private userStore: UserStore;
+        private parentOfSameType: boolean;
 
-        constructor(principal: Principal, userStore: UserStore) {
+        constructor(principal: Principal, userStore: UserStore, parentOfSameType?: boolean) {
             super();
             this.principal = principal;
             this.userStore = userStore;
+            this.parentOfSameType = parentOfSameType;
         }
 
         public getPrincipal(): Principal {
@@ -17,6 +19,10 @@ module api.security {
 
         public getUserStore(): UserStore {
             return this.userStore;
+        }
+
+        public isParentOfSameType(): boolean {
+            return this.parentOfSameType;
         }
 
         static on(handler: (event: UserItemCreatedEvent) => void) {


### PR DESCRIPTION
...tore were deleted or created.

Fixed the bug by updating the filter grid refresh calls.
Adding a parameter to the new principal event to determine whether the
newly created node should be placed on the same level as selection or
not.
