### PR TITLE
CMS-4731 Modal Window - Cancel by clicking outside

### DIFF
--- a/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/modules/wem-admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
@@ -18,6 +18,8 @@ module api.ui.dialog {
 
         private actions: api.ui.Action[] = [];
 
+        private mouseClickListener: {(MouseEvent): void};
+
         constructor(config: ModalDialogConfig) {
             super("modal-dialog");
 
@@ -31,6 +33,21 @@ module api.ui.dialog {
 
             this.buttonRow = new ModalDialogButtonRow();
             this.appendChild(this.buttonRow);
+
+            this.mouseClickListener = (event: MouseEvent) => {
+                if (this.isVisible()) {
+                    for (var element = event.target; element; element = (<any>element).parentNode) {
+                        if (element == this.getHTMLElement()) {
+                            return;
+                        }
+                    }
+                    this.close();
+                }
+            };
+
+            api.dom.Body.get().onMouseDown(this.mouseClickListener);
+
+            this.onRemoved(() => api.dom.Body.get().unMouseDown(this.mouseClickListener));
         }
 
         setCancelAction(action: api.ui.Action) {


### PR DESCRIPTION
Added outside click listener to the `ModalDialog`.
