### PR TITLE
 CMS-5167 Sorting - Sorting is buggy SortTabMenu's parent TabMenu was recently changed, that broke sorting behaviour. Updated required method in TabMenu to correctly remove all navigation items when needed.

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabMenu.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabMenu.ts
@@ -227,6 +227,8 @@ module api.ui.tab {
                 var newTab = this.getSelectedNavigationItem();
                 if (newTab) {
                     this.setButtonLabel(newTab.getLabel());
+                    this.updateActiveTab(newTab.getIndex());
+                    this.selectNavigationItem(newTab.getIndex());
                 }
             }
             this.notifyTabRemovedListeners(tab);


### PR DESCRIPTION

-when doing first commit accidently deleted required lines