### PR TITLE
CMS-5210 Wizard - Admin - Hide security step if current user does not ha...

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/security/RoleKeys.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/security/RoleKeys.ts
@@ -4,5 +4,6 @@ module api.security {
 
         public static EVERYONE: PrincipalKey = PrincipalKey.ofRole('system.everyone');
 
+        public static ADMIN: PrincipalKey = PrincipalKey.ofRole('system.admin');
     }
 }


### PR DESCRIPTION
...ve acl_read permissions

-Added check for user permissions, if user not allowed to edit permissions he won't see 'Security' step in the botton of content panel