### PR TITLE
XP-16 Page Template form - Adjustments to "supports" field

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -178,6 +178,10 @@ module api.ui.selector.combobox {
             this.comboBoxDropdown.setOptions(options, this.getSelectedOptions());
         }
 
+        removeAllOptions() {
+            this.comboBoxDropdown.removeAllOptions();
+        }
+
         addOption(option: Option<OPTION_DISPLAY_VALUE>) {
             this.comboBoxDropdown.addOption(option);
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
@@ -232,7 +232,7 @@ module api.ui.selector.combobox {
             });
         }
 
-        private createOptions(items: OPTION_DISPLAY_VALUE[]): api.ui.selector.Option<OPTION_DISPLAY_VALUE>[] {
+        createOptions(items: OPTION_DISPLAY_VALUE[]): api.ui.selector.Option<OPTION_DISPLAY_VALUE>[] {
             var options = [];
             items.forEach((itemInst: OPTION_DISPLAY_VALUE) => {
                 options.push(this.createOption(itemInst));

--- a/modules/core-api/src/main/java/com/enonic/xp/schema/content/ContentTypeForms.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/schema/content/ContentTypeForms.java
@@ -32,7 +32,7 @@ public class ContentTypeForms
             label( "Supports" ).
             helpText( "Choose which content types this page template supports" ).
             inputType( InputTypes.CONTENT_TYPE_FILTER ).
-            required( false ).
+            required( true ).
             multiple( true ).
             build() ).
         build();


### PR DESCRIPTION
-Support field made required, min 1, max 1
-The list contains the same content-types that are available in the NewContentDialogue within the site + all the media:* types. (i.e. abstract types should not be listed..)
-List is sorted alphabetically desc, on displayName