### PR TITLE
XP-47 Wizard - Possible to upload media in _templates folder

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/create/NewContentDialog.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/create/NewContentDialog.ts
@@ -34,12 +34,16 @@ module app.create {
 
         private listItems: NewContentDialogListItem[];
 
+        private uploaderEnabled: boolean;
+
         constructor() {
             this.contentDialogTitle = new NewContentDialogTitle("Create Content", "");
 
             super({
                 title: this.contentDialogTitle
             });
+
+            this.uploaderEnabled = true;
 
             this.addClass("new-content-dialog");
 
@@ -130,24 +134,31 @@ module app.create {
             // meaning that to know when we left some element
             // we need to compare it to the one currently dragged over
             this.onDragEnter((event: DragEvent) => {
-                var target = <HTMLElement> event.target;
+                if(this.uploaderEnabled) {
+                    var target = <HTMLElement> event.target;
 
-                if (!!dragOverEl || dragOverEl == this.getHTMLElement()) {
-                    uploaderContainer.show();
+                    if (!!dragOverEl || dragOverEl == this.getHTMLElement()) {
+                        uploaderContainer.show();
+                    }
+                    dragOverEl = target;
                 }
-                dragOverEl = target;
             });
 
             this.onDragLeave((event: DragEvent) => {
-                var targetEl = <HTMLElement> event.target;
+                if(this.uploaderEnabled) {
+                    var targetEl = <HTMLElement> event.target;
 
-                if (dragOverEl == targetEl) {
-                    uploaderContainer.hide();
+                    if (dragOverEl == targetEl) {
+                        uploaderContainer.hide();
+                    }
                 }
             });
 
             this.onDrop((event: DragEvent) => {
-                uploaderContainer.hide();
+                if(this.uploaderEnabled) {
+                    uploaderContainer.hide();
+                }
+
             });
         }
 
@@ -249,11 +260,21 @@ module app.create {
             } else {
                 this.contentDialogTitle.setPath('');
             }
+
+            this.uploaderEnabled = !this.parentContent || !this.parentContent.getType().isTemplateFolder();
+            this.mediaUploader.reset();
+            this.fileInput.reset();
+            this.mediaUploader.setEnabled(this.uploaderEnabled);
+            this.fileInput.getUploader().setEnabled(this.uploaderEnabled);
+
             super.show();
 
-            this.fileInput.reset().giveFocus();
-
-            this.mediaUploader.reset();
+            this.fileInput.giveFocus();
+            if(this.uploaderEnabled) {
+                this.removeClass("no-uploader");
+            } else {
+                this.addClass("no-uploader");
+            }
 
             // CMS-3711: reload content types each time when dialog is show.
             // It is slow but newly create content types are displayed.

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/text/FileInput.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/text/FileInput.ts
@@ -107,6 +107,10 @@ module api.ui.text {
             return this;
         }
 
+        getUploader(): MediaUploader{
+            return this.mediaUploader;
+        }
+
         onUploadStarted(listener: (event: FileUploadStartedEvent<Content>) => void) {
             this.mediaUploader.onUploadStarted(listener);
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/uploader/Uploader.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/uploader/Uploader.ts
@@ -130,32 +130,33 @@ module api.ui.uploader {
                 new KeyBinding('backspace', resetHandler)
             ]);
 
-            if (this.config.disabled) {
-                if (Uploader.debug) {
-                    console.log('Skipping init, because of config.disabled = true', this);
-                }
+
+            if (this.config.deferred) {
+                this.onShown((event) => this.initHandler.call(this, event));
             } else {
-                if (this.config.deferred) {
-                    this.onShown((event) => this.initHandler.call(this, event));
-                } else {
-                    this.onRendered((event) => this.initHandler.call(this, event));
-                }
+                this.onRendered((event) => this.initHandler.call(this, event));
             }
 
             this.onRemoved((event) => this.destroyHandler.call(this, event));
         }
 
         private initHandler() {
-            if (Uploader.debug) {
-                console.log('Initing uploader', this);
-            }
-            if (!this.uploader && this.config.url) {
-                this.uploader = this.initUploader(this.dropzone.getId());
+            if (this.config.disabled) {
+                if (Uploader.debug) {
+                    console.log('Skipping init, because of config.disabled = true', this);
+                }
+            } else {
+                if (Uploader.debug) {
+                    console.log('Initing uploader', this);
+                }
+                if (!this.uploader && this.config.url) {
+                    this.uploader = this.initUploader(this.dropzone.getId());
 
-                if (this.value) {
-                    this.setValue(this.value);
-                } else {
-                    this.setDropzoneVisible();
+                    if (this.value) {
+                        this.setValue(this.value);
+                    } else {
+                        this.setDropzoneVisible();
+                    }
                 }
             }
         }
@@ -336,6 +337,8 @@ module api.ui.uploader {
         }
 
         setEnabled(enabled: boolean): Uploader<MODEL> {
+            this.config.disabled = !enabled;
+
             if (!enabled) {
                 this.dropzone.getEl().setAttribute('disabled', 'true');
             } else {

--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/apps/content/new/new-content-dialog.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/apps/content/new/new-content-dialog.less
@@ -142,6 +142,23 @@
 
   }
 
+  &.no-uploader {
+    .dialog-buttons {
+       &:before {
+          content: '';
+       }
+    }
+
+    .file-input {
+      .uploader {
+        pointer-events: none;
+        cursor: default;
+        opacity: 0.5;
+      }
+    }
+
+  }
+
   .uploader-container {
     display: none;
     position: absolute;


### PR DESCRIPTION
-disabled possibilty to upload media in 'new content dialog' if parent content is template folder ('portal:template-folder')
-updated 'uploader.ts' to correctly handle enabling/disabling uploader
-updated 'FileInput.ts' to return uploader used