### PR TITLE
XP-93 wizard tab - name fixups

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
@@ -147,7 +147,7 @@ module app {
                     }
 
                     tabMenuItem = new AppBarTabMenuItemBuilder().
-                        setLabel("<New " + this.convertName(contentTypeSummary.getDisplayName()) + ">").
+                        setLabel("<Unnamed " + this.convertName(contentTypeSummary.getDisplayName()) + ">").
                         setTabId(tabId).
                         setCloseAction(wizard.getCloseAction()).
                         build();

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/UserAppPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/UserAppPanel.ts
@@ -117,7 +117,7 @@ module app {
 
 
         private handleWizardCreated(wizard: UserItemWizardPanel<api.Equitable>, tabName: string) {
-            var tabMenuItem = new AppBarTabMenuItemBuilder().setLabel("<New " + tabName + ">").
+            var tabMenuItem = new AppBarTabMenuItemBuilder().setLabel("<Unnamed " + tabName + ">").
                 setTabId(wizard.getTabId()).
                 setCloseAction(wizard.getCloseAction()).
                 build();


### PR DESCRIPTION
Replaced "New" with "Unnamed" for the new tabs.