### PR TITLE
XP-108 Browse - Disable New button if user does not have "create" permis...

### DIFF
--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -341,10 +341,10 @@ public final class ContentResource
     @Path("setChildOrder")
     public ContentJson setChildOrder( final SetChildOrderJson params )
     {
-        final Content updatedContent = this.contentService.setChildOrder( SetContentChildOrderParams.create().
-            childOrder( params.getChildOrder().getChildOrder() ).
-            contentId( ContentId.from( params.getContentId() ) ).
-            build() );
+        final Content updatedContent = this.contentService.setChildOrder(SetContentChildOrderParams.create().
+                childOrder(params.getChildOrder().getChildOrder()).
+                contentId(ContentId.from(params.getContentId())).
+                build());
 
         return new ContentJson( updatedContent, newContentIconUrlResolver(), inlineMixinsToFormItemsTransformer, principalsResolver );
     }
@@ -364,7 +364,7 @@ public final class ContentResource
                 build() );
         }
 
-        final ReorderChildContentsResult result = this.contentService.reorderChildren( builder.build() );
+        final ReorderChildContentsResult result = this.contentService.reorderChildren(builder.build());
 
         return new ReorderChildrenResultJson( result );
     }
@@ -374,7 +374,7 @@ public final class ContentResource
                                   @QueryParam("expand") @DefaultValue(EXPAND_FULL) final String expandParam )
     {
 
-        final ContentId id = ContentId.from( idParam );
+        final ContentId id = ContentId.from(idParam);
         final Content content = contentService.getById( id );
 
         if ( content == null )
@@ -400,7 +400,7 @@ public final class ContentResource
     public ContentIdJson getByPath( @QueryParam("path") final String pathParam,
                                     @QueryParam("expand") @DefaultValue(EXPAND_FULL) final String expandParam )
     {
-        final Content content = contentService.getByPath( ContentPath.from( pathParam ) );
+        final Content content = contentService.getByPath(ContentPath.from(pathParam));
 
         if ( content == null )
         {
@@ -418,6 +418,14 @@ public final class ContentResource
         {
             return new ContentJson( content, newContentIconUrlResolver(), inlineMixinsToFormItemsTransformer, principalsResolver );
         }
+    }
+
+    @GET
+    @Path("contentPermissions")
+    public RootPermissionsJson getPermissionsByPath( @QueryParam("path") final String pathParam )
+    {
+        final AccessControlList permissions = contentService.getPermissionsByPath( ContentPath.from( pathParam ) );
+        return new RootPermissionsJson( permissions, principalsResolver );
     }
 
     @POST

--- a/modules/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/get_content_permissions_success.json
+++ b/modules/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/get_content_permissions_success.json
@@ -1,0 +1,28 @@
+{
+  "permissions": [
+    {
+      "allow": ["READ"],
+      "deny": [],
+      "principal": {
+        "displayName": "Anonymous",
+        "key": "user:system:anonymous"
+      }
+    },
+    {
+      "allow": [
+        "READ",
+        "CREATE",
+        "MODIFY",
+        "DELETE",
+        "PUBLISH",
+        "READ_PERMISSIONS",
+        "WRITE_PERMISSIONS"
+      ],
+      "deny": [],
+      "principal": {
+        "displayName": "Admin",
+        "key": "user:system:admin"
+      }
+    }
+  ]
+}

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
@@ -281,6 +281,7 @@ module app.browse {
                                 }
                             }
                         });
+                        this.browseActions.updateActionsEnabledState(this.getBrowseItemPanel().getItems()); // update actions state in case of permission changes
                         this.contentTreeGrid.resetAndRender();
                     });
             });

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/GetContentPermissionsByPathRequest.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/GetContentPermissionsByPathRequest.ts
@@ -1,0 +1,32 @@
+module api.content {
+
+    import AccessControlList = api.security.acl.AccessControlList;
+
+    export class GetContentPermissionsByPathRequest extends ContentResourceRequest<json.ContentPermissionsJson, AccessControlList> {
+
+        private contentPath:ContentPath;
+
+        constructor(path:ContentPath) {
+            super();
+            super.setMethod("GET");
+            this.contentPath = path;
+        }
+
+        getParams():Object {
+            return {
+                path: this.contentPath.toString()
+            };
+        }
+
+        getRequestPath():api.rest.Path {
+            return api.rest.Path.fromParent(super.getResourcePath(), "contentPermissions");
+        }
+
+        sendAndParse(): wemQ.Promise<AccessControlList> {
+
+            return this.send().then((response: api.rest.JsonResponse<json.ContentPermissionsJson>) => {
+                return AccessControlList.fromJson(response.getResult().permissions);
+            });
+        }
+    }
+}

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/_module.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/_module.ts
@@ -30,6 +30,7 @@
 ///<reference path='GetContentSummaryByIdRequest' />
 ///<reference path='GetContentSummaryByIds' />
 ///<reference path='GetContentByPathRequest.ts' />
+///<reference path='GetContentPermissionsByPathRequest.ts' />
 ///<reference path='GetContentRootPermissionsRequest.ts' />
 ///<reference path='CreateContentRequest.ts' />
 ///<reference path='OrderContentRequest.ts' />

--- a/modules/core-api/src/main/java/com/enonic/xp/content/ContentService.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/content/ContentService.java
@@ -47,6 +47,8 @@ public interface ContentService
 
     Content getByPath( ContentPath path );
 
+    AccessControlList getPermissionsByPath( ContentPath path );
+
     Contents getByPaths( ContentPaths paths );
 
     FindContentByParentResult findByParent( FindContentByParentParams params );

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/ContentServiceImpl.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/ContentServiceImpl.java
@@ -338,6 +338,14 @@ public class ContentServiceImpl
     }
 
     @Override
+    public AccessControlList getPermissionsByPath( ContentPath path ) {
+        Content content = getByPath(path);
+        if(content != null && content.getPermissions() != null)
+            return content.getPermissions();
+        return AccessControlList.empty();
+    }
+
+    @Override
     public Contents getByPaths( final ContentPaths paths )
     {
         return GetContentByPathsCommand.create( paths ).


### PR DESCRIPTION
...sions

-Created new request 'GetContentPermissionsByPathRequest' that fetches content's permissions (by path)
-Created appropriate backend methods that accept content path and return content's permissions (please, verify that approach was correct, specifically part in ContentServiceImpl)
-Added test to ContentTestResource. Used existing test for root permissions as a base.
-Adjusted ContentTreeGridActions to check user permissions for selected item
-Added actions update for each time content tree grid updated - for cases when selected item's permissions are adjusted in separate tab