### PR TITLE
XP-116 Datetime, date and time - picker boxes remain open after moving focus to another input

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
@@ -114,8 +114,9 @@ module api.content.form.inputtype.image {
                 optionView.getCheckbox().giveFocus();
             });
 
-            optionView.getCheckbox().onKeyDown((event: KeyboardEvent) => {
+            optionView.getCheckbox().onKeyPressed((event: KeyboardEvent) => {
                 var checkbox = optionView.getCheckbox();
+
                 switch (event.which) {
                 case 32: // Spacebar
                     var isChecked = !checkbox.isChecked();
@@ -133,14 +134,12 @@ module api.content.form.inputtype.image {
                 case 13: // Enter
                     this.notifyEditSelectedOptions([selectedOption]);
                     break;
-                case 9: // tab
-                    this.hideImageSelectorDialog();
-                    break;
                 }
                 event.stopPropagation();
             });
 
             optionView.getCheckbox().onFocus((event: FocusEvent) => this.showImageSelectorDialog(selectedOption));
+            //optionView.getCheckbox().onBlur((event: FocusEvent) => this.hideImageSelectorDialog());
 
             optionView.onChecked((view: ImageSelectorSelectedOptionView, checked: boolean) => {
                 if (checked) {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
@@ -114,9 +114,8 @@ module api.content.form.inputtype.image {
                 optionView.getCheckbox().giveFocus();
             });
 
-            optionView.getCheckbox().onKeyPressed((event: KeyboardEvent) => {
+            optionView.getCheckbox().onKeyDown((event: KeyboardEvent) => {
                 var checkbox = optionView.getCheckbox();
-
                 switch (event.which) {
                 case 32: // Spacebar
                     var isChecked = !checkbox.isChecked();
@@ -134,12 +133,14 @@ module api.content.form.inputtype.image {
                 case 13: // Enter
                     this.notifyEditSelectedOptions([selectedOption]);
                     break;
+                case 9: // tab
+                    this.hideImageSelectorDialog();
+                    break;
                 }
                 event.stopPropagation();
             });
 
             optionView.getCheckbox().onFocus((event: FocusEvent) => this.showImageSelectorDialog(selectedOption));
-            //optionView.getCheckbox().onBlur((event: FocusEvent) => this.hideImageSelectorDialog());
 
             optionView.onChecked((view: ImageSelectorSelectedOptionView, checked: boolean) => {
                 if (checked) {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/time/DatePicker.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/time/DatePicker.ts
@@ -86,9 +86,7 @@ module api.ui.time {
 
             this.input = api.ui.text.TextInput.middle();
             this.input.onClicked((e: MouseEvent) => {
-                //e.stopPropagation();
                 e.preventDefault();
-
                 this.popup.show();
             });
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/time/DatePicker.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/time/DatePicker.ts
@@ -86,7 +86,7 @@ module api.ui.time {
 
             this.input = api.ui.text.TextInput.middle();
             this.input.onClicked((e: MouseEvent) => {
-                e.stopPropagation();
+                //e.stopPropagation();
                 e.preventDefault();
 
                 this.popup.show();
@@ -104,7 +104,7 @@ module api.ui.time {
 
             var popupBuilder = new DatePickerPopupBuilder().
                 setCalendar(this.calendar).
-                setCloseOnOutsideClick(builder.closeOnOutsideClick);
+                setCloseOnOutsideClick(false);
             this.popup = popupBuilder.build();
             this.popup.onShown(() => {
                 new DatePickerShownEvent(this).fire();
@@ -118,7 +118,6 @@ module api.ui.time {
             this.appendChild(wrapper);
 
             this.popupTrigger.onClicked((e: MouseEvent) => {
-                e.stopPropagation();
                 e.preventDefault();
 
                 if (this.popup.isVisible()) {
@@ -186,10 +185,14 @@ module api.ui.time {
             });
 
             this.input.onKeyDown((event: KeyboardEvent) => {
-                if (api.ui.KeyHelper.isTabKey(event)) {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    this.popupTrigger.giveFocus();
+                if (api.ui.KeyHelper.isTabKey(event)) { // handles tab navigation events on date input
+                    if(!event.shiftKey) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        this.popupTrigger.giveFocus();
+                    } else {
+                        this.popup.hide();
+                    }
                 }
             });
 
@@ -199,11 +202,14 @@ module api.ui.time {
                 }
             });
 
-            api.dom.Body.get().onKeyDown((e: KeyboardEvent) => this.outsideTabListener(e));
+            api.dom.Body.get().onKeyDown((e: KeyboardEvent) => this.popupTabListener(e));
+            if (builder.closeOnOutsideClick){
+                api.dom.Body.get().onClicked((e: MouseEvent) => this.outsideClickListener(e));
+            }
         }
 
-        // as popup blur and focus events behave incorrectly - we manually catch tab navigation event below
-        private outsideTabListener(e: KeyboardEvent) {
+        // as popup blur and focus events behave incorrectly - we manually catch tab navigation event in popup below
+        private popupTabListener(e: KeyboardEvent) {
             if (api.ui.KeyHelper.isTabKey(e) && !this.getEl().contains(<HTMLElement> e.target)) {
                 if (this.popup.isVisible()) {
                     e.stopPropagation();
@@ -211,6 +217,12 @@ module api.ui.time {
                     this.popupTrigger.getEl().focus();
                     this.popup.hide();
                 }
+            }
+        }
+
+        private outsideClickListener(e: MouseEvent) {
+            if (!this.getEl().contains(<HTMLElement> e.target)) {
+                this.popup.hide();
             }
         }
 


### PR DESCRIPTION
-In order to correctly hide popup - moved outside click listener event handling one level up - to the level of popup parent, not popup itself 
-Improved tab navigation behavior, including shift+tab cases