### PR TITLE
XP-40 Use best fit image to generate thumbnail for media type Image

### DIFF
--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentImageHelper.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentImageHelper.java
@@ -33,6 +33,18 @@ final class ContentImageHelper
         }
     }
 
+    BufferedImage readImage( final ByteSource blob )
+    {
+        try (final InputStream inputStream = blob.openStream())
+        {
+            return ImageHelper.toBufferedImage( inputStream );
+        }
+        catch ( IOException e )
+        {
+            throw Exceptions.unchecked( e );
+        }
+    }
+
     private BufferedImage readImage( final InputStream inputStream, final int size, final ImageFilter imageFilter )
     {
         final BufferedImage image = ImageHelper.toBufferedImage( inputStream );

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -96,6 +96,7 @@ import com.enonic.xp.content.ReorderChildContentsParams;
 import com.enonic.xp.content.ReorderChildContentsResult;
 import com.enonic.xp.content.ReorderChildParams;
 import com.enonic.xp.content.SetContentChildOrderParams;
+import com.enonic.xp.content.ThumbnailParams;
 import com.enonic.xp.content.UnableToDeleteContentException;
 import com.enonic.xp.content.UpdateContentParams;
 import com.enonic.xp.content.UpdateMediaParams;
@@ -106,6 +107,7 @@ import com.enonic.xp.content.attachment.CreateAttachments;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.form.InlineMixinsToFormItemsTransformer;
 import com.enonic.xp.index.ChildOrder;
+import com.enonic.xp.schema.content.ContentTypeName;
 import com.enonic.xp.schema.content.ContentTypeService;
 import com.enonic.xp.schema.mixin.MixinService;
 import com.enonic.xp.security.PrincipalKey;
@@ -206,15 +208,17 @@ public final class ContentResource
     {
         final DiskFileItem mediaFile = (DiskFileItem) form.get( "file" );
 
-        final CreateAttachment thumbnailAttachment = CreateAttachment.create().
-            name( AttachmentNames.THUMBNAIL ).
+        final CreateAttachment sourceAttachment = CreateAttachment.create().
+            name( form.getAsString( "name" ) ).
             mimeType( mediaFile.getContentType() ).
+            label( "source" ).
             byteSource( getFileItemByteSource( mediaFile ) ).
             build();
 
         final UpdateContentParams params = new UpdateContentParams().
             contentId( ContentId.from( form.getAsString( "id" ) ) ).
-            createAttachments( CreateAttachments.from( thumbnailAttachment ) );
+            createAttachments( CreateAttachments.from( sourceAttachment ) ).
+            thumbnailParams( ThumbnailParams.create( ) );
 
         final Content persistedContent = contentService.update( params );
 
@@ -339,10 +343,10 @@ public final class ContentResource
     @Path("setChildOrder")
     public ContentJson setChildOrder( final SetChildOrderJson params )
     {
-        final Content updatedContent = this.contentService.setChildOrder(SetContentChildOrderParams.create().
-                childOrder(params.getChildOrder().getChildOrder()).
-                contentId(ContentId.from(params.getContentId())).
-                build());
+        final Content updatedContent = this.contentService.setChildOrder( SetContentChildOrderParams.create().
+            childOrder( params.getChildOrder().getChildOrder() ).
+            contentId( ContentId.from( params.getContentId() ) ).
+            build());
 
         return new ContentJson( updatedContent, newContentIconUrlResolver(), inlineMixinsToFormItemsTransformer, principalsResolver );
     }
@@ -362,7 +366,7 @@ public final class ContentResource
                 build() );
         }
 
-        final ReorderChildContentsResult result = this.contentService.reorderChildren(builder.build());
+        final ReorderChildContentsResult result = this.contentService.reorderChildren( builder.build());
 
         return new ReorderChildrenResultJson( result );
     }
@@ -398,7 +402,7 @@ public final class ContentResource
     public ContentIdJson getByPath( @QueryParam("path") final String pathParam,
                                     @QueryParam("expand") @DefaultValue(EXPAND_FULL) final String expandParam )
     {
-        final Content content = contentService.getByPath(ContentPath.from(pathParam));
+        final Content content = contentService.getByPath( ContentPath.from(pathParam));
 
         if ( content == null )
         {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/app/view/ItemStatisticsHeader.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/app/view/ItemStatisticsHeader.ts
@@ -33,7 +33,7 @@ module api.app.view {
             var icon: HTMLImageElement = null;
             if (this.browseItem.getIconUrl()) {
                 var size = this.browseItem.getIconSize() || 64;
-                icon = api.util.loader.ImageLoader.get(this.browseItem.getIconUrl() + "?size=size", size, size);
+                icon = api.util.loader.ImageLoader.get(this.browseItem.getIconUrl(), size, size);
                 this.iconEl = <api.dom.ImgEl> new api.dom.Element(new api.dom.NewElementBuilder().
                     setTagName("img").
                     setHelper(new api.dom.ImgHelper(icon)));

--- a/modules/core-api/src/main/java/com/enonic/xp/content/CreateContentParams.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/content/CreateContentParams.java
@@ -39,6 +39,8 @@ public final class CreateContentParams
 
     private final Locale language;
 
+    private final ThumbnailParams thumbnailParams;
+
     private CreateContentParams( Builder builder )
     {
         this.data = builder.data;
@@ -54,6 +56,7 @@ public final class CreateContentParams
         this.createAttachments = builder.createAttachments;
         this.childOrder = builder.childOrder;
         this.language = builder.language;
+        this.thumbnailParams = builder.thumbnailParams;
     }
 
     public static Builder create()
@@ -131,6 +134,8 @@ public final class CreateContentParams
         return language;
     }
 
+    public ThumbnailParams getThumbnailParams() { return thumbnailParams; }
+
     public static final class Builder
     {
         private PropertyTree data;
@@ -159,6 +164,8 @@ public final class CreateContentParams
 
         private Locale language;
 
+        private ThumbnailParams thumbnailParams;
+
         private Builder()
         {
         }
@@ -178,6 +185,7 @@ public final class CreateContentParams
             this.createAttachments = source.createAttachments;
             this.childOrder = source.childOrder;
             this.language = source.language;
+            this.thumbnailParams = source.thumbnailParams;
         }
 
         public Builder contentData( final PropertyTree data )
@@ -262,6 +270,12 @@ public final class CreateContentParams
         public Builder language( final Locale language )
         {
             this.language = language;
+            return this;
+        }
+
+        public Builder thumbnailParams( final ThumbnailParams thumbnailParams )
+        {
+            this.thumbnailParams = thumbnailParams;
             return this;
         }
 

--- a/modules/core-api/src/main/java/com/enonic/xp/content/CreateMediaParams.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/content/CreateMediaParams.java
@@ -14,6 +14,8 @@ public class CreateMediaParams
 
     private ByteSource byteSource;
 
+    private ThumbnailParams thumbnailParams;
+
     public CreateMediaParams parent( final ContentPath value )
     {
         this.parent = value;
@@ -35,6 +37,12 @@ public class CreateMediaParams
     public CreateMediaParams byteSource( final ByteSource value )
     {
         this.byteSource = value;
+        return this;
+    }
+
+    public CreateMediaParams thumbnailParams( final ThumbnailParams value )
+    {
+        this.thumbnailParams = value;
         return this;
     }
 
@@ -65,4 +73,6 @@ public class CreateMediaParams
     {
         return byteSource;
     }
+
+    public ThumbnailParams getThumbnailParams() { return thumbnailParams; }
 }

--- a/modules/core-api/src/main/java/com/enonic/xp/content/Media.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/content/Media.java
@@ -1,6 +1,10 @@
 package com.enonic.xp.content;
 
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import com.enonic.xp.content.attachment.Attachment;
 
 public class Media
@@ -18,6 +22,25 @@ public class Media
 
     public Attachment getMediaAttachment()
     {
+        final String mediaAttachmentName = getData().getString( ContentPropertyNames.MEDIA );
+        if ( mediaAttachmentName == null )
+        {
+            return null;
+        }
+
+        return getAttachments().byName( mediaAttachmentName );
+    }
+
+    public Attachment getMediaAttachment(int size)
+    {
+        List<Attachment> sortedBySize = new ArrayList<>( getAttachments().getList() );
+        Collections.sort( sortedBySize, (a, b) ->  (int)(a.getSize() - b.getSize())  );
+
+        for(Attachment attachment: sortedBySize) {
+            if((size * size) < attachment.getSize())
+                return attachment;
+        }
+
         final String mediaAttachmentName = getData().getString( ContentPropertyNames.MEDIA );
         if ( mediaAttachmentName == null )
         {

--- a/modules/core-api/src/main/java/com/enonic/xp/content/ThumbnailParams.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/content/ThumbnailParams.java
@@ -1,0 +1,62 @@
+package com.enonic.xp.content;
+
+
+import com.google.common.base.Preconditions;
+
+import com.enonic.xp.schema.content.ContentTypeName;
+
+public class ThumbnailParams
+{
+    private int size;
+
+    private boolean crop;
+
+    public static final String DEFAULT_ICON_SIZE = "128";
+
+    public ThumbnailParams size(int value) {
+        this.size = value;
+        return this;
+    }
+
+    public ThumbnailParams crop(boolean value) {
+
+        this.crop = value;
+        return this;
+    }
+
+    public int getSize()
+    {
+        return size;
+    }
+
+    public boolean getCrop() { return crop; }
+
+    public void validate()
+    {
+        Preconditions.checkArgument( this.size > 0, "size must be more than zero: " + this.size );
+    }
+
+    public void setSize( final int size )
+    {
+        this.size = size;
+    }
+
+    public static ThumbnailParams create( ContentTypeName contentTypeName )
+    {
+        if(contentTypeName.isImageMedia())
+        {
+            ThumbnailParams thumbnailParams = new ThumbnailParams();
+            thumbnailParams.crop( false ).size( Integer.valueOf( DEFAULT_ICON_SIZE ) );
+            return thumbnailParams;
+        }
+
+        return null;
+    }
+
+    public static ThumbnailParams create()
+    {
+        ThumbnailParams thumbnailParams = new ThumbnailParams();
+        thumbnailParams.crop( true ).size( Integer.valueOf( DEFAULT_ICON_SIZE ) );
+        return thumbnailParams;
+    }
+}

--- a/modules/core-api/src/main/java/com/enonic/xp/content/UpdateContentParams.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/content/UpdateContentParams.java
@@ -17,6 +17,8 @@ public final class UpdateContentParams
 
     private boolean requireValid;
 
+    private ThumbnailParams thumbnailParams;
+
     public UpdateContentParams editor( final ContentEditor editor )
     {
         this.editor = editor;
@@ -44,6 +46,12 @@ public final class UpdateContentParams
     public UpdateContentParams requireValid( final boolean value )
     {
         this.requireValid = value;
+        return this;
+    }
+
+    public UpdateContentParams thumbnailParams( final ThumbnailParams value )
+    {
+        this.thumbnailParams = value;
         return this;
     }
 
@@ -78,4 +86,6 @@ public final class UpdateContentParams
     {
         return requireValid;
     }
+
+    public ThumbnailParams getThumbnailParams() { return thumbnailParams; }
 }

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/CreateMediaCommand.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/CreateMediaCommand.java
@@ -5,6 +5,7 @@ import com.google.common.base.Preconditions;
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.CreateContentParams;
 import com.enonic.xp.content.CreateMediaParams;
+import com.enonic.xp.content.ThumbnailParams;
 import com.enonic.xp.content.attachment.CreateAttachment;
 import com.enonic.xp.content.attachment.CreateAttachments;
 import com.enonic.xp.data.PropertyTree;
@@ -67,6 +68,7 @@ final class CreateMediaCommand
             displayName( params.getName() ).
             contentData( data ).
             createAttachments( CreateAttachments.from( mediaAttachment ) ).
+            thumbnailParams( ThumbnailParams.create( resolvedTypeFromMimeType ) ).
             inheritPermissions( true ).
             build();
 

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/ProxyContentProcessor.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/ProxyContentProcessor.java
@@ -42,7 +42,7 @@ class ProxyContentProcessor
     ProcessUpdateResult processEdit( final ContentTypeName contentTypeName, final UpdateContentParams updateContentParams,
                                      final CreateAttachments createAttachments )
     {
-        if ( contentTypeName.isImageMedia() )
+        if ( contentTypeName.isImageMedia() || updateContentParams.getThumbnailParams() != null )
         {
             return imageHandler.processUpdate( updateContentParams, createAttachments );
         }

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
@@ -3,6 +3,7 @@ package com.enonic.xp.core.impl.content;
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ThumbnailParams;
 import com.enonic.xp.content.UpdateContentParams;
 import com.enonic.xp.content.UpdateMediaParams;
 import com.enonic.xp.content.attachment.CreateAttachment;
@@ -69,6 +70,7 @@ final class UpdateMediaCommand
         final UpdateContentParams updateParams = new UpdateContentParams().
             contentId( params.getContent() ).
             createAttachments( CreateAttachments.from( mediaAttachment ) ).
+            thumbnailParams( ThumbnailParams.create( type ) ).
             editor( editable -> editable.data = data );
 
         return UpdateContentCommand.create( this ).


### PR DESCRIPTION
For Runar to review:
-adjusted thumbnail creation for image media type: when new media type is created and it is an image - generate thumbnail attachment (in addition to image source and scaled image attachments) which is already cropped and filtered with specified values
-adjusted thumbnail update for all content types: generate thumbnail attachment (in addition to image source and scaled image attachments) which is already cropped and filtered with specified values
-When thumbnail requested use thumbnail attached(already cropped) instead of cropping and filtering source image
-If thumbnail is absent or if 'size' param sent in request string is not equal to default value - crop and filter as before, but use best fit image depending on size as source
-small issue found in 'ItemStatisticsHeader.ts', url was constructed incorrectly