### PR TITLE
XP-135 Grid - keyboard operations stop working after sortting

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/SortContentDialog.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/SortContentDialog.ts
@@ -160,8 +160,8 @@ module app.browse {
         }
 
         close() {
-            super.close();
             this.remove();
+            super.close();
             this.isOpen = false;
             this.contentGrid.setChildOrder(null);
             this.gridDragHandler.clearContentMovements();


### PR DESCRIPTION
-keys were unbinded for sort modal dialog when closing because it contains treegrid which close handler was triggering keys unbinding after modal dialog close handler