### PR TITLE
XP-148 Impossible to 'Publish' content when it was moved to another loca...

### DIFF
--- a/modules/core-repo/src/main/java/com/enonic/wem/repo/internal/entity/MoveNodeCommand.java
+++ b/modules/core-repo/src/main/java/com/enonic/wem/repo/internal/entity/MoveNodeCommand.java
@@ -128,12 +128,9 @@ public class MoveNodeCommand
                 // when moving a Node "inheritPermissions" must be set to false so the permissions are kept with the transfer
                 nodeToMove = Node.newNode( nodeToMove ).inheritPermissions( false ).build();
             }
-            movedNode = doStoreNode( nodeToMove );
         }
-        else
-        {
-            movedNode = updateNodeMetadata( nodeToMove );
-        }
+
+        movedNode = doStoreNode( nodeToMove );
 
         if ( persistedNode.getHasChildren() )
         {


### PR DESCRIPTION
...tion

- Problem was that during move, only parent node's version was updated, which means that children nodes that got moved looked 'unchanged' for application. Adjusted doMove() method to call StoreNodeCommand with updateMetadataOnly flag set to false for each moved node, not only parent one. It results in overwriting version field of each moved node.