### PR TITLE
XP-164 User Store Wizard: 'save before close' dialog appears when all da...

### DIFF
--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/security/SecurityResource.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/security/SecurityResource.java
@@ -105,6 +105,18 @@ public final class SecurityResource
         return new UserStoreJson( userStore, userStorePermissions, principals );
     }
 
+    @GET
+    @Path("userstore/default")
+    public UserStoreJson getDefaultUserStore( )
+    {
+        final UserStore userStore =  UserStore.newUserStore().displayName( "" ).key( UserStoreKey.createDefault() ).build();
+
+        final UserStoreAccessControlList userStorePermissions = securityService.getUserStorePermissions( UserStoreKey.system() );
+
+        final Principals principals = securityService.getPrincipals( userStorePermissions.getAllPrincipals() );
+        return new UserStoreJson( userStore, userStorePermissions, principals );
+    }
+
     @POST
     @Path("userstore/create")
     public UserStoreJson createUserStore( final CreateUserStoreJson params )

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/SecurityWizardStepForm.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/SecurityWizardStepForm.ts
@@ -1,9 +1,6 @@
 module app.wizard {
 
     import UserStoreAccessControlList = api.security.acl.UserStoreAccessControlList;
-    import UserStoreAccessControlListView = api.ui.security.acl.UserStoreAccessControlListView;
-    import UserStoreAccessControlEntryView = api.ui.security.acl.UserStoreAccessControlEntryView;
-    import UserStoreAccessControlEntry = api.security.acl.UserStoreAccessControlEntry;
     import UserStoreAccessControlComboBox = api.ui.security.acl.UserStoreAccessControlComboBox;
     import Content = api.content.Content;
     import UserStore = api.security.UserStore;
@@ -52,13 +49,33 @@ module app.wizard {
 
         }
 
-        layout(userStore: UserStore) {
+        layout(userStore: UserStore, defaultUserStore: UserStore) {
+            this.userStore = userStore;
+
+            this.comboBox.clearSelection();
+
+            if(defaultUserStore)
+            {
+                defaultUserStore.getPermissions().getEntries().forEach((item) => {
+                    this.comboBox.selectReadOnly(item);
+                });
+            }
+
+            userStore.getPermissions().getEntries().forEach((item) => {
+                if (!this.comboBox.isSelected(item)) {
+                    this.comboBox.select(item);
+                }
+            });
+
+        }
+
+        layoutReadOnly(userStore: UserStore) {
             this.userStore = userStore;
 
             this.comboBox.clearSelection();
             userStore.getPermissions().getEntries().forEach((item) => {
                 if (!this.comboBox.isSelected(item)) {
-                    this.comboBox.select(item);
+                    this.comboBox.selectReadOnly(item);
                 }
             });
 

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserStoreWizardPanelFactory.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserStoreWizardPanelFactory.ts
@@ -15,6 +15,7 @@ module app.wizard {
 
         private userStoreToEdit: UserStore;
 
+        private defaultUserStore: UserStore;
 
         setUserStore(value: UserStore): UserStoreWizardPanelFactory {
             this.userStore = value;
@@ -35,7 +36,10 @@ module app.wizard {
 
             this.creatingForNew = true;
 
-            return this.newUserStoreWizardPanelForNew();
+            return this.loadDefaultUserStore().then((defaultUserStore: UserStore) => {
+                this.defaultUserStore = defaultUserStore;
+                return this.newUserStoreWizardPanelForNew();
+            });
         }
 
         createForEdit(): wemQ.Promise<UserStoreWizardPanel> {
@@ -44,12 +48,19 @@ module app.wizard {
 
             return this.loadUserStoreToEdit().then((loadedUserStoreToEdit: UserStore) => {
                 this.userStoreToEdit = loadedUserStoreToEdit;
-                return this.newUserStoreWizardPanelForEdit();
+                return this.loadDefaultUserStore().then((defaultUserStore: UserStore) => {
+                    this.defaultUserStore = defaultUserStore;
+                    return this.newUserStoreWizardPanelForEdit();
+                });
             });
         }
 
         private loadUserStoreToEdit(): wemQ.Promise<UserStore> {
             return new api.security.GetUserStoreByKeyRequest(this.userStoreKey).sendAndParse();
+        }
+
+        private loadDefaultUserStore(): wemQ.Promise<UserStore> {
+            return new api.security.GetDefaultUserStoreRequest().sendAndParse();
         }
 
         private newUserStoreWizardPanelForNew(): wemQ.Promise<app.wizard.UserStoreWizardPanel> {
@@ -58,6 +69,7 @@ module app.wizard {
 
             var wizardParams = new app.wizard.UserStoreWizardPanelParams().
                 setUserStoreKey(this.userStoreKey).
+                setDefaultUserStore(this.defaultUserStore).
                 setAppBarTabId(this.appBarTabId);
 
             this.resolveUserStoreWizardPanel(deferred, wizardParams);
@@ -72,6 +84,7 @@ module app.wizard {
             var wizardParams = new UserStoreWizardPanelParams().
                 setUserStoreKey(this.userStoreKey).
                 setUserStore(this.userStoreToEdit).
+                setDefaultUserStore(this.defaultUserStore).
                 setAppBarTabId(this.appBarTabId);
 
             this.resolveUserStoreWizardPanel(deferred, wizardParams);

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserStoreWizardPanelParams.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserStoreWizardPanelParams.ts
@@ -4,8 +4,15 @@ module app.wizard {
 
         userStore: api.security.UserStore;
 
+        defaultUserStore: api.security.UserStore;
+
         setUserStore(value: api.security.UserStore): UserStoreWizardPanelParams {
             this.userStore = value;
+            return this;
+        }
+
+        setDefaultUserStore(value: api.security.UserStore): UserStoreWizardPanelParams {
+            this.defaultUserStore = value;
             return this;
         }
 

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserstoreWizardPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserstoreWizardPanel.ts
@@ -21,7 +21,7 @@ module app.wizard {
 
         private permissionsWizardStepForm: SecurityWizardStepForm;
 
-        private userStore: UserStoreKey;
+        private defaultUserStore: UserStore;
 
         isUserStoreFormValid: boolean;
         userStorePath: string;
@@ -38,6 +38,7 @@ module app.wizard {
             this.userStoreNamedListeners = [];
 
             this.userStorePath = params.persistedPath;
+            this.defaultUserStore = params.defaultUserStore;
 
             var iconUrl = api.dom.ImgEl.PLACEHOLDER;
             this.formIcon = new FormIcon(iconUrl, "Click to upload icon");
@@ -152,6 +153,7 @@ module app.wizard {
             var deferred = wemQ.defer<void>();
 
             this.wizardHeader.initNames("", this.userStorePath, false);
+            this.permissionsWizardStepForm.layoutReadOnly(this.defaultUserStore);
 
             deferred.resolve(null);
             return deferred.promise;
@@ -187,7 +189,7 @@ module app.wizard {
             var deferred = wemQ.defer<void>();
 
             this.wizardHeader.initNames(existing.getDisplayName(), existing.getKey().getId(), false);
-            this.permissionsWizardStepForm.layout(existing);
+            this.permissionsWizardStepForm.layout(existing, this.defaultUserStore);
 
             deferred.resolve(null);
             return deferred.promise;
@@ -225,10 +227,10 @@ module app.wizard {
             if (persistedUserStore == undefined) {
                 return this.wizardHeader.getName() !== "" ||
                     this.wizardHeader.getDisplayName() !== "" ||
-                    this.permissionsWizardStepForm.getPermissions().getEntries().length !== 0;
+                    !this.permissionsWizardStepForm.getPermissions().equals(this.defaultUserStore.getPermissions());
             } else {
                 var viewedUserStore = this.assembleViewedUserStore();
-                return !viewedUserStore.equals(this.getPersistedItem());
+                return !this.getPersistedItem().equals(viewedUserStore);
             }
         }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/security/GetDefaultUserStoreRequest.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/security/GetDefaultUserStoreRequest.ts
@@ -1,0 +1,28 @@
+module api.security {
+
+    export class GetDefaultUserStoreRequest extends SecurityResourceRequest<UserStoreJson, UserStore> {
+
+        constructor() {
+            super();
+            super.setMethod("GET");
+        }
+
+        getParams(): Object {
+            return null;
+        }
+
+        getRequestPath(): api.rest.Path {
+            return api.rest.Path.fromParent(super.getResourcePath(), 'userstore/default');
+        }
+
+        sendAndParse(): wemQ.Promise<UserStore> {
+            return this.send().then((response: api.rest.JsonResponse<UserStoreJson>) => {
+                return this.fromJsonToUserStore(response.getResult());
+            });
+        }
+
+        fromJsonToUserStore(json: UserStoreJson): UserStore {
+            return UserStore.fromJson(json);
+        }
+    }
+}

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/security/_module.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/security/_module.ts
@@ -16,6 +16,7 @@
 ///<reference path="SecurityResourceRequest.ts"/>
 ///<reference path="ListUserStoresRequest.ts"/>
 ///<reference path="GetUserStoreByKeyRequest.ts"/>
+///<reference path="GetDefaultUserStoreRequest.ts"/>
 ///<reference path="PrincipalListJson.ts"/>
 ///<reference path="FindPrincipalsRequest.ts"/>
 ///<reference path="GetPrincipalByKeyRequest.ts"/>

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/UserStoreAccessControlComboBox.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/UserStoreAccessControlComboBox.ts
@@ -91,11 +91,12 @@ module api.ui.security.acl {
             throw new Error('Not supported, use createItemView instead');
         }
 
-        createItemView(entry: UserStoreAccessControlEntry): UserStoreACESelectedOptionView {
+        createItemView(entry: UserStoreAccessControlEntry, readOnly: boolean): UserStoreACESelectedOptionView {
 
             var option = {
                 displayValue: entry,
-                value: this.getItemId(entry)
+                value: this.getItemId(entry),
+                readOnly: readOnly
             };
             var itemView = new UserStoreACESelectedOptionView(option);
             itemView.onValueChanged((item: UserStoreAccessControlEntry) => {
@@ -112,6 +113,11 @@ module api.ui.security.acl {
                 this.removeOption(option, false);
             });
 
+            if(readOnly)
+            {
+                itemView.setEditable(false);
+            }
+
             // keep track of selected options for SelectedOptionsView
             this.list.push(selectedOption);
             return itemView;
@@ -119,7 +125,15 @@ module api.ui.security.acl {
 
 
         addOption(option: Option<UserStoreAccessControlEntry>): boolean {
-            this.addItem(option.displayValue);
+            if(option.readOnly)
+            {
+                this.addItemReadOnly(option.displayValue)
+            }
+            else
+            {
+                this.addItem(option.displayValue);
+            }
+
             return true;
         }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/UserStoreAccessControlEntryView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/UserStoreAccessControlEntryView.ts
@@ -13,6 +13,7 @@ module api.ui.security.acl {
 
         private accessSelector: UserStoreAccessSelector;
 
+        private removeButton: api.dom.AEl;
         private valueChangedListeners: {(item: UserStoreAccessControlEntry): void}[] = [];
         private editable: boolean = true;
 
@@ -28,15 +29,17 @@ module api.ui.security.acl {
 
 
             this.accessSelector = new UserStoreAccessSelector();
-            this.appendChild(this.accessSelector);
-
             this.accessSelector.onValueChanged((event: ValueChangedEvent) => {
                 this.ace.setAccess(event.getNewValue());
             })
 
-            var removeButton = new api.dom.AEl("icon-close");
-            removeButton.onClicked((event: MouseEvent) => this.notifyRemoveClicked(event));
-            this.appendChild(removeButton);
+            this.removeButton = new api.dom.AEl("icon-close");
+            this.removeButton.onClicked((event: MouseEvent) => {
+                if(this.editable)
+                {
+                    this.notifyRemoveClicked(event);
+                }
+            });
 
             this.setUserStoreAccessControlEntry(this.ace, true);
 
@@ -50,6 +53,14 @@ module api.ui.security.acl {
             if (editable != this.editable) {
                 this.accessSelector.setEnabled(editable);
                 this.editable = editable;
+            }
+
+            if(this.editable) {
+                this.removeClass("readonly");
+            }
+            else
+            {
+                this.addClass("readonly");
             }
         }
 
@@ -91,6 +102,12 @@ module api.ui.security.acl {
             return ace;
         }
 
+        doRender() {
+            super.doRender();
+            this.appendChild(this.accessSelector);
+            this.appendChild(this.removeButton);
+            return true;
+        }
     }
 
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/UserStoreAccessControlListView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/UserStoreAccessControlListView.ts
@@ -14,7 +14,7 @@ module api.ui.security.acl {
             super('access-control-list' + (className ? " " + className : ""));
         }
 
-        createItemView(entry: UserStoreAccessControlEntry): UserStoreAccessControlEntryView {
+        createItemView(entry: UserStoreAccessControlEntry, readOnly: boolean): UserStoreAccessControlEntryView {
             var itemView = new UserStoreAccessControlEntryView(entry);
             itemView.setEditable(this.itemsEditable);
             itemView.onRemoveClicked(() => {
@@ -23,6 +23,12 @@ module api.ui.security.acl {
             itemView.onValueChanged((item: UserStoreAccessControlEntry) => {
                 this.notifyItemValueChanged(item);
             });
+
+            if(readOnly)
+            {
+                itemView.setEditable(false);
+            }
+
             return itemView;
         }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownGrid.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownGrid.ts
@@ -220,6 +220,21 @@ module api.ui.selector {
             }
         }
 
+        markReadOnly(selectedOptions: Option<OPTION_DISPLAY_VALUE>[]) {
+
+            var stylesHash: Slick.CellCssStylesHash = {};
+            var rows: number[] = [];
+            selectedOptions.forEach((selectedOption: Option<OPTION_DISPLAY_VALUE>) => {
+                if(selectedOption.readOnly)
+                {
+                    var row = this.gridData.getRowById(selectedOption.value);
+                    rows.push(row);
+                    stylesHash[row] = {_checkbox_selector: "readonly" ,option: "readonly"};
+                }
+            });
+            this.grid.setCellCssStyles("readonly", stylesHash);
+        }
+
         hasActiveRow(): boolean {
             var activeCell = this.grid.getActiveCell();
             if (activeCell) {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/Option.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/Option.ts
@@ -8,6 +8,8 @@ module api.ui.selector {
 
         indices?: string[];
 
+        readOnly?: boolean;
+
     }
 
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -239,7 +239,7 @@ module api.ui.selector.combobox {
 
         handleRowSelected(index: number) {
             var option = this.getOptionByRow(index);
-            if (option != null) {
+            if (option != null && !option.readOnly) {
                 if (!this.isOptionSelected(option)) {
                     this.selectOption(option);
                 } else {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBoxDropdown.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBoxDropdown.ts
@@ -64,8 +64,21 @@ module api.ui.selector.combobox {
 
         setOptions(options: Option<OPTION_DISPLAY_VALUE>[], selectedOptions: Option<OPTION_DISPLAY_VALUE>[] = []) {
 
-            this.dropdownGrid.setOptions(options);
+            selectedOptions.forEach((selectedOption: Option<OPTION_DISPLAY_VALUE>) => {
+                if(selectedOption.readOnly)
+                {
+                    for(var i = 0; i < options.length; i++ )
+                    {
+                        if(selectedOption.value == options[i].value)
+                        {
+                            options[i].readOnly = true;
+                            break;
+                        }
+                    }
+                }
+            });
 
+            this.dropdownGrid.setOptions(options);
             if (this.isDropdownShown()) {
                 this.showDropdown(selectedOptions);
             }
@@ -114,6 +127,7 @@ module api.ui.selector.combobox {
                 this.dropdownGrid.show();
                 this.dropdownGrid.adjustGridHeight();
                 this.dropdownGrid.markSelections(selectedOptions);
+                this.dropdownGrid.markReadOnly(selectedOptions);
             } else {
                 this.dropdownGrid.hide();
                 this.emptyDropdown.getEl().setInnerHtml("No matching items");

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
@@ -163,6 +163,10 @@ module api.ui.selector.combobox {
             this.comboBox.selectOption(this.createOption(value));
         }
 
+        selectReadOnly(value: OPTION_DISPLAY_VALUE) {
+            this.comboBox.selectOption(this.createOptionReadOnly(value));
+        }
+
         selectByOption(option: Option<OPTION_DISPLAY_VALUE>) {
             this.comboBox.selectOption(option);
         }
@@ -195,6 +199,14 @@ module api.ui.selector.combobox {
             return {
                 value: this.getDisplayValueId(value),
                 displayValue: value
+            }
+        }
+
+        private createOptionReadOnly(value: OPTION_DISPLAY_VALUE): Option<OPTION_DISPLAY_VALUE> {
+            return {
+                value: this.getDisplayValueId(value),
+                displayValue: value,
+                readOnly: true
             }
         }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/list/ListBox.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/selector/list/ListBox.ts
@@ -57,6 +57,16 @@ module api.ui.selector.list {
             }
         }
 
+        addItemReadOnly(...items: I[]) {
+            this.items = this.items.concat(items);
+            items.forEach((item) => {
+                this.addItemView(item, true);
+            });
+            if (items.length > 0) {
+                this.notifyItemsAdded(items);
+            }
+        }
+
         removeItem(...items: I[]) {
             var itemsRemoved: I[] = [];
             this.items = this.items.filter((item) => {
@@ -78,7 +88,7 @@ module api.ui.selector.list {
             return this.items.length;
         }
 
-        createItemView(item: I): api.dom.Element {
+        createItemView(item: I, readOnly: boolean): api.dom.Element {
             throw new Error("You must override createListItem to create views for list items");
         }
 
@@ -112,8 +122,16 @@ module api.ui.selector.list {
             }
         }
 
-        private addItemView(item: I) {
-            var itemView = this.createItemView(item);
+        private addItemView(item: I, readOnly: boolean = false) {
+            if(readOnly)
+            {
+                var itemView = this.createItemView(item, readOnly);
+            }
+            else
+            {
+                var itemView = this.createItemView(item, false);
+            }
+
             this.itemViews[this.getItemId(item)] = itemView;
             this.appendChild(itemView);
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/ui/security/acl/userstore-access-control-entry.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/ui/security/acl/userstore-access-control-entry.less
@@ -38,6 +38,7 @@
     cursor: pointer;
     font-size: 12px;
     display: block;
+    text-decoration: none;
   }
 
   .permission-selector {
@@ -82,6 +83,15 @@
       padding: 40px 4px 4px;
     }
 
+  }
+
+  &.readonly {
+    opacity: 0.5;
+
+    .icon-close {
+      cursor: default;
+
+    }
   }
 
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/ui/selector/combobox/combobox.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/ui/selector/combobox/combobox.less
@@ -150,6 +150,12 @@
       &.selected {
         font-style: italic;
         color: #d3d3d3;
+
+        &.readonly {
+          opacity: 0.5;
+          cursor: default;
+          pointer-events: none;
+        }
       }
 
     }

--- a/modules/core-api/src/main/java/com/enonic/xp/security/UserStoreKey.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/security/UserStoreKey.java
@@ -8,6 +8,8 @@ public final class UserStoreKey
 {
     private final static UserStoreKey SYSTEM = new UserStoreKey( "system" );
 
+    private final static UserStoreKey DEFAULT = new UserStoreKey( "default" );
+
     private final static String RESERVED_USER_STORE_ID = PrincipalKey.ROLES_NODE_NAME;
 
     private final String id;
@@ -50,5 +52,10 @@ public final class UserStoreKey
     public static UserStoreKey system()
     {
         return SYSTEM;
+    }
+
+    public static UserStoreKey createDefault()
+    {
+        return DEFAULT;
     }
 }


### PR DESCRIPTION
...ta already

-access selector and close button are brought back for 'Permissions' field (were not shown after some code refactoring)
-taking into account that backend always returns some default permissions even when setting those in user manager - UserStore related classes updated to have possibility default values that are read only and can not be changed. New rest service added to backend to handle request for default permissions and return default user store. Permissions combobox behavior  updated to handle possibility to add read only values.