### PR TITLE
XP-182 Live Edit - Improve robustness by not allowing a full page reload...

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
@@ -360,6 +360,11 @@ module app.wizard {
             return deferred.promise;
         }
 
+        saveChanges(): wemQ.Promise<Content> {
+            this.liveFormPanel.skipNextReloadConfirmation(true);
+            return super.saveChanges();
+        }
+
         preLayoutNew(): wemQ.Promise<void> {
             var deferred = wemQ.defer<void>();
 

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveEditPageProxy.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveEditPageProxy.ts
@@ -165,6 +165,10 @@ module app.wizard.page {
             this.liveEditIFrame.setSrc(pageUrl);
         }
 
+        public skipNextReloadConfirmation(skip: boolean) {
+            new api.liveedit.SkipLiveEditReloadConfirmationEvent(skip).fire(this.liveEditWindow);
+        }
+
         private handleIFrameLoadedEvent() {
 
             var liveEditWindow = this.liveEditIFrame.getHTMLElement()["contentWindow"];

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveFormPanel.ts
@@ -123,6 +123,12 @@ module app.wizard.page {
             this.partInspectionPanel = new PartInspectionPanel();
             this.layoutInspectionPanel = new LayoutInspectionPanel();
 
+            api.dom.WindowDOM.get().asWindow().onbeforeunload = (event) => {
+                // the reload is triggered by the main frame,
+                // so let the live edit know it to skip the popup
+                this.liveEditPageProxy.skipNextReloadConfirmation(true);
+            };
+
             var saveAction = new api.ui.Action('Apply');
             saveAction.onExecuted(() => {
                 var itemView = this.pageView.getSelectedView();
@@ -258,6 +264,10 @@ module app.wizard.page {
                     }
                 }
             });
+        }
+
+        skipNextReloadConfirmation(skip: boolean) {
+            this.liveEditPageProxy.skipNextReloadConfirmation(skip);
         }
 
         loadPage() {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/SkipLiveEditReloadConfirmationEvent.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/SkipLiveEditReloadConfirmationEvent.ts
@@ -1,0 +1,24 @@
+module api.liveedit {
+
+    export class SkipLiveEditReloadConfirmationEvent extends api.event.Event {
+
+        private skip: boolean;
+
+        constructor(skip: boolean) {
+            super();
+            this.skip = skip;
+        }
+
+        isSkip(): boolean {
+            return this.skip;
+        }
+
+        static on(handler: (event: SkipLiveEditReloadConfirmationEvent) => void, contextWindow: Window = window) {
+            api.event.Event.bind(api.ClassHelper.getFullName(this), handler, contextWindow);
+        }
+
+        static un(handler?: (event: SkipLiveEditReloadConfirmationEvent) => void, contextWindow: Window = window) {
+            api.event.Event.unbind(api.ClassHelper.getFullName(this), handler, contextWindow);
+        }
+    }
+}

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/_module.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/_module.ts
@@ -4,6 +4,7 @@
 ///<reference path='ItemTypeConfig.ts' />
 ///<reference path='RegionItemType.ts' />
 ///<reference path='InitializeLiveEditEvent.ts' />
+///<reference path='SkipLiveEditReloadConfirmationEvent.ts' />
 ///<reference path='ComponentItemType.ts' />
 ///<reference path='PageItemType.ts' />
 ///<reference path='ContentItemType.ts' />

--- a/modules/admin-ui/src/main/resources/web/admin/live-edit/js/LiveEditPage.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/live-edit/js/LiveEditPage.ts
@@ -34,7 +34,13 @@ module LiveEdit {
 
         private pageView: PageView;
 
+        private skipNextReloadConfirmation: boolean = false;
+
         constructor() {
+
+            api.liveedit.SkipLiveEditReloadConfirmationEvent.on((event: api.liveedit.SkipLiveEditReloadConfirmationEvent) => {
+                this.skipNextReloadConfirmation = event.isSkip();
+            });
 
             api.liveedit.InitializeLiveEditEvent.on((event: api.liveedit.InitializeLiveEditEvent) => {
 
@@ -70,6 +76,16 @@ module LiveEdit {
 
 
         private registerGlobalListeners(): void {
+
+            api.dom.WindowDOM.get().asWindow().onbeforeunload = (event) => {
+                if (!this.skipNextReloadConfirmation) {
+                    var message = "All unsaved changes will be lost.";
+                    event.returnValue = message;
+                    return message;
+                } else {
+                    this.skipNextReloadConfirmation = false;
+                }
+            };
 
             api.liveedit.ComponentLoadedEvent.on((event: api.liveedit.ComponentLoadedEvent) => {
 


### PR DESCRIPTION
... when clicking in LE

- added a live edit reload confirmation dialog, that is not triggered if the whole page is reloaded
- fixed save triggering the confirmation bug