### PR TITLE
XP-182 Live Edit - Improve robustness by not allowing a full page reload...

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
@@ -360,6 +360,11 @@ module app.wizard {
             return deferred.promise;
         }
 
+        saveChanges(): wemQ.Promise<Content> {
+            this.liveFormPanel.skipNextReloadConfirmation(true);
+            return super.saveChanges();
+        }
+
         preLayoutNew(): wemQ.Promise<void> {
             var deferred = wemQ.defer<void>();
 

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveFormPanel.ts
@@ -123,6 +123,12 @@ module app.wizard.page {
             this.partInspectionPanel = new PartInspectionPanel();
             this.layoutInspectionPanel = new LayoutInspectionPanel();
 
+            api.dom.WindowDOM.get().asWindow().onbeforeunload = (event) => {
+                // the reload is triggered by the main frame,
+                // so let the live edit know it to skip the popup
+                this.liveEditPageProxy.skipNextReloadConfirmation(true);
+            };
+
             var saveAction = new api.ui.Action('Apply');
             saveAction.onExecuted(() => {
                 var itemView = this.pageView.getSelectedView();
@@ -260,6 +266,10 @@ module app.wizard.page {
             });
         }
 
+        skipNextReloadConfirmation(skip: boolean) {
+            this.liveEditPageProxy.skipNextReloadConfirmation(skip);
+        }
+
         loadPage() {
             if (this.pageSkipReload == false && !this.pageLoading) {
 
@@ -323,6 +333,10 @@ module app.wizard.page {
 
             this.liveEditPageProxy.onPageLocked((event: api.liveedit.PageLockedEvent) => {
                 this.inspectPage();
+            });
+
+            this.liveEditPageProxy.onPageUnloaded((event: api.liveedit.PageUnloadedEvent) => {
+                this.contentWizardPanel.close();
             });
 
             this.liveEditPageProxy.onPageTextModeStarted((event: api.liveedit.PageTextModeStartedEvent) => {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/dom/IFrameEl.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/dom/IFrameEl.ts
@@ -8,9 +8,8 @@ module api.dom {
             super(new NewElementBuilder().
                 setTagName("iframe").
                 setClassName(className));
-            this.onLoaded((event: UIEvent) => {
-                this.loaded = true;
-            });
+
+            this.onLoaded((event: UIEvent) => this.loaded = true);
         }
 
         public setSrc(src: string): api.dom.IFrameEl {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageUnloadedEvent.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageUnloadedEvent.ts
@@ -1,0 +1,24 @@
+module api.liveedit {
+
+    export class PageUnloadedEvent extends api.event.Event {
+
+        private pageView: PageView;
+
+        constructor(pageView: PageView) {
+            super();
+            this.pageView = pageView;
+        }
+
+        getPageView(): PageView {
+            return this.pageView;
+        }
+
+        static on(handler: (event: PageUnloadedEvent) => void, contextWindow: Window = window) {
+            api.event.Event.bind(api.ClassHelper.getFullName(this), handler, contextWindow);
+        }
+
+        static un(handler?: (event: PageUnloadedEvent) => void, contextWindow: Window = window) {
+            api.event.Event.unbind(api.ClassHelper.getFullName(this), handler, contextWindow);
+        }
+    }
+}

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/SkipLiveEditReloadConfirmationEvent.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/SkipLiveEditReloadConfirmationEvent.ts
@@ -1,0 +1,24 @@
+module api.liveedit {
+
+    export class SkipLiveEditReloadConfirmationEvent extends api.event.Event {
+
+        private skip: boolean;
+
+        constructor(skip: boolean) {
+            super();
+            this.skip = skip;
+        }
+
+        isSkip(): boolean {
+            return this.skip;
+        }
+
+        static on(handler: (event: SkipLiveEditReloadConfirmationEvent) => void, contextWindow: Window = window) {
+            api.event.Event.bind(api.ClassHelper.getFullName(this), handler, contextWindow);
+        }
+
+        static un(handler?: (event: SkipLiveEditReloadConfirmationEvent) => void, contextWindow: Window = window) {
+            api.event.Event.unbind(api.ClassHelper.getFullName(this), handler, contextWindow);
+        }
+    }
+}

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/_module.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/_module.ts
@@ -4,6 +4,7 @@
 ///<reference path='ItemTypeConfig.ts' />
 ///<reference path='RegionItemType.ts' />
 ///<reference path='InitializeLiveEditEvent.ts' />
+///<reference path='SkipLiveEditReloadConfirmationEvent.ts' />
 ///<reference path='ComponentItemType.ts' />
 ///<reference path='PageItemType.ts' />
 ///<reference path='ContentItemType.ts' />
@@ -38,6 +39,7 @@
 
 ///<reference path='PageLockedEvent.ts' />
 ///<reference path='PageUnlockedEvent.ts' />
+///<reference path='PageUnloadedEvent.ts' />
 ///<reference path='PageTextModeStartedEvent.ts' />
 ///<reference path='ImageOpenUploadDialogEvent.ts' />
 ///<reference path='ImageUploadedEvent.ts' />


### PR DESCRIPTION
... when clicking in LE

- added a live edit reload confirmation dialog, that is not triggered if the whole page is reloaded
- fixed save triggering the confirmation bug
- also closed the wizard if navigating away