### PR TITLE
XP-246 Add more unit tests for content.attachment package in API

### DIFF
--- a/modules/core-api/src/main/java/com/enonic/xp/content/attachment/Attachment.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/content/attachment/Attachment.java
@@ -130,6 +130,7 @@ public final class Attachment
             this.mimeType = attachment.mimeType;
             this.name = attachment.name;
             this.label = attachment.label;
+            this.size = attachment.size;
         }
 
         public Builder mimeType( final String mimeType )

--- a/modules/core-api/src/main/java/com/enonic/xp/content/attachment/Attachments.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/content/attachment/Attachments.java
@@ -57,7 +57,7 @@ public final class Attachments
         return new Attachments( listBuilder.build() );
     }
 
-    private Attachments add( final Iterable<Attachment> attachments )
+    public Attachments add( final Iterable<Attachment> attachments )
     {
         final ImmutableList.Builder<Attachment> listBuilder = ImmutableList.builder();
         listBuilder.addAll( this.list );

--- a/modules/core-api/src/test/java/com/enonic/xp/content/attachment/AttachmentsTest.java
+++ b/modules/core-api/src/test/java/com/enonic/xp/content/attachment/AttachmentsTest.java
@@ -1,0 +1,131 @@
+package com.enonic.xp.content.attachment;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import static org.junit.Assert.*;
+
+public class AttachmentsTest
+{
+    @Test
+    public void getByLabel()
+    {
+        Attachment a1 = Attachment.newAttachment().
+            mimeType( "image/jpg" ).
+            label( "My Image 1" ).
+            name( "MyImage.jpg" ).
+            build();
+
+        Attachment a2 = Attachment.newAttachment().
+            mimeType( "image/gif" ).
+            label( "My Image 2" ).
+            name( "MyImage.something.gif" ).
+            build();
+
+        Attachments attachments = Attachments.from( a1, a2 );
+
+        assertTrue( attachments.isNotEmpty() );
+
+        assertTrue( attachments.hasByLabel( "My Image 1" ) );
+        assertFalse( attachments.hasByLabel( "My Image 3" ) );
+
+        assertEquals( a1, attachments.byLabel( "My Image 1" ) );
+        assertNull( attachments.byLabel( "My Image 3" ) );
+    }
+
+    @Test
+    public void getByName()
+    {
+        Attachment a1 = Attachment.newAttachment().
+            mimeType( "image/jpg" ).
+            label( "My Image 1" ).
+            name( "MyImage.jpg" ).
+            build();
+
+        Attachment a2 = Attachment.newAttachment().
+            mimeType( "image/gif" ).
+            label( "My Image 2" ).
+            name( "MyImage.something.gif" ).
+            build();
+
+        Attachments attachments = Attachments.from( ImmutableList.of( a1, a2 ) );
+
+        assertFalse( attachments.isEmpty() );
+
+        assertTrue( attachments.hasByName( "MyImage.something.gif" ) );
+        assertFalse( attachments.hasByName( "MyImage.gif" ) );
+
+        assertEquals( a2, attachments.byName( "MyImage.something.gif" ) );
+        assertNull( attachments.byName( "MyImage.gif" ) );
+    }
+
+    @Test
+    public void fromBuilder()
+    {
+
+        Attachment a1 = Attachment.newAttachment().
+            mimeType( "image/jpg" ).
+            label( "My Image 1" ).
+            name( "MyImage.jpg" ).
+            build();
+
+        Attachment a2 = Attachment.newAttachment().
+            mimeType( "image/gif" ).
+            label( "My Image 2" ).
+            name( "MyImage.something.gif" ).
+            build();
+
+        Attachment a3 = Attachment.newAttachment().
+            mimeType( "image/png" ).
+            label( "My Image 3" ).
+            name( "MyImage2.png" ).
+            build();
+
+        Attachments attachments = Attachments.builder().add( a1 ).addAll( Attachments.from( a2, a3 ) ).build();
+
+        assertEquals( 3, attachments.getSize() );
+        assertEquals( a1, attachments.first() );
+        assertEquals( a2, attachments.get( 1 ) );
+        assertEquals( a3, attachments.last() );
+    }
+
+    @Test
+    public void fromEmpty()
+    {
+        Attachment a1 = Attachment.newAttachment().
+            mimeType( "image/jpg" ).
+            label( "My Image 1" ).
+            name( "MyImage.jpg" ).
+            build();
+
+        Attachment a2 = Attachment.newAttachment().
+            mimeType( "image/gif" ).
+            label( "My Image 2" ).
+            name( "MyImage.something.gif" ).
+            build();
+
+        Attachment a3 = Attachment.newAttachment().
+            mimeType( "image/png" ).
+            label( "My Image 3" ).
+            name( "MyImage2.png" ).
+            build();
+
+        Attachments attachments = Attachments.empty();
+
+        assertTrue( attachments.isEmpty() );
+
+        Attachments newAttachments = attachments.add( a1 );
+
+        assertTrue( attachments.isEmpty() );
+        assertEquals( 1, newAttachments.getSize() );
+        assertEquals( a1, newAttachments.get( 0 ) );
+
+        Attachments newestAttachments = newAttachments.add( ImmutableList.of( a2, a3 ) );
+
+        assertEquals( 1, newAttachments.getSize() );
+        assertEquals( 3, newestAttachments.getSize() );
+        assertEquals( newAttachments.first(), newestAttachments.first() );
+    }
+
+}

--- a/modules/core-api/src/test/java/com/enonic/xp/content/attachment/CreateAttachmentTest.java
+++ b/modules/core-api/src/test/java/com/enonic/xp/content/attachment/CreateAttachmentTest.java
@@ -2,67 +2,73 @@ package com.enonic.xp.content.attachment;
 
 import org.junit.Test;
 
+import com.google.common.io.ByteSource;
+
 import static org.junit.Assert.*;
 
-public class AttachmentTest
+public class CreateAttachmentTest
 {
     @Test
     public void getNameWithoutExtension()
     {
-        assertEquals( "MyImage", Attachment.newAttachment().
+
+        assertEquals( "MyImage", CreateAttachment.create().
             mimeType( "image/jpg" ).
+            label( "My Image 1" ).
             name( "MyImage.jpg" ).
+            byteSource( ByteSource.empty() ).
             build().getNameWithoutExtension() );
 
-        assertEquals( "MyImage.something", Attachment.newAttachment().
+        assertEquals( "MyImage.something", CreateAttachment.create().
             mimeType( "image/gif" ).
+            label( "My Image 2" ).
             name( "MyImage.something.gif" ).
+            byteSource( ByteSource.empty() ).
             build().getNameWithoutExtension() );
-    }
-
-    @Test
-    public void getBinaryReference()
-    {
-        assertEquals( "MyImage.jpg", Attachment.newAttachment().
-            mimeType( "image/jpg" ).
-            name( "MyImage.jpg" ).
-            build().getBinaryReference().toString() );
-
-        assertEquals( "MyImage.something.gif", Attachment.newAttachment().
-            mimeType( "image/gif" ).
-            name( "MyImage.something.gif" ).
-            build().getBinaryReference().toString() );
     }
 
     @Test
     public void getExtension()
     {
-        assertEquals( "jpg", Attachment.newAttachment().
-            mimeType( "image/jpg" ).
+        assertEquals( "jpg", CreateAttachment.create().
             name( "MyImage.jpg" ).
+            byteSource( ByteSource.empty() ).
             build().getExtension() );
 
-        assertEquals( "gif", Attachment.newAttachment().
-            mimeType( "image/gif" ).
+        assertEquals( "gif", CreateAttachment.create().
+            byteSource( ByteSource.empty() ).
             name( "MyImage.gif" ).
             build().getExtension() );
 
-        assertEquals( "jpeg", Attachment.newAttachment().
-            mimeType( "image/jpeg" ).
+        assertEquals( "jpeg", CreateAttachment.create().
+            byteSource( ByteSource.empty() ).
             name( "MyImage.jpeg" ).
             build().getExtension() );
 
-        assertEquals( "png", Attachment.newAttachment().
-            mimeType( "image/png" ).
+        assertEquals( "png", CreateAttachment.create().
+            byteSource( ByteSource.empty() ).
             name( "MyImage.png" ).
             build().getExtension() );
 
-        assertEquals( "jpg", Attachment.newAttachment().
-            mimeType( "image/jpg" ).
+        assertEquals( "jpg", CreateAttachment.create().
+            byteSource( ByteSource.empty() ).
             name( "MyImage.something.jpg" ).
             build().getExtension() );
     }
 
+    @Test
+    public void getBinaryReference()
+    {
+        assertEquals( "MyImage.jpg", CreateAttachment.create().
+            byteSource( ByteSource.empty() ).
+            name( "MyImage.jpg" ).
+            build().getBinaryReference().toString() );
+
+        assertEquals( "MyImage.something.gif", CreateAttachment.create().
+            byteSource( ByteSource.empty() ).
+            name( "MyImage.something.gif" ).
+            build().getBinaryReference().toString() );
+    }
 
     @Test
     public void serializeAttachment()

--- a/modules/core-api/src/test/java/com/enonic/xp/content/attachment/CreateAttachmentsTest.java
+++ b/modules/core-api/src/test/java/com/enonic/xp/content/attachment/CreateAttachmentsTest.java
@@ -1,0 +1,116 @@
+package com.enonic.xp.content.attachment;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteSource;
+
+import static org.junit.Assert.*;
+
+public class CreateAttachmentsTest
+{
+    @Test
+    public void getByName()
+    {
+        CreateAttachment a1 = CreateAttachment.create().
+            mimeType( "image/jpg" ).
+            byteSource( ByteSource.empty() ).
+            label( "My Image 1" ).
+            name( "MyImage.jpg" ).
+            build();
+
+        CreateAttachment a2 = CreateAttachment.create().
+            mimeType( "image/gif" ).
+            byteSource( ByteSource.empty() ).
+            label( "My Image 2" ).
+            name( "MyImage.something.gif" ).
+            build();
+
+        CreateAttachments attachments = CreateAttachments.from( a1, a2 );
+
+        assertEquals( 2, attachments.getNames().size() );
+
+        assertEquals( a1, attachments.getByName( "MyImage.jpg" ) );
+        assertNull( attachments.getByName( "MyImage3.png" ) );
+    }
+
+    @Test
+    public void empty()
+    {
+        CreateAttachments attachments = CreateAttachments.empty();
+
+        assertTrue( attachments.isEmpty() );
+    }
+
+    @Test
+    public void fromBuilder()
+    {
+        CreateAttachment a1 = CreateAttachment.create().
+            mimeType( "image/jpg" ).
+            byteSource( ByteSource.empty() ).
+            label( "My Image 1" ).
+            name( "MyImage.jpg" ).
+            build();
+
+        CreateAttachment a2 = CreateAttachment.create().
+            mimeType( "image/gif" ).
+            byteSource( ByteSource.empty() ).
+            label( "My Image 2" ).
+            name( "MyImage.something.gif" ).
+            build();
+
+        CreateAttachment a3 = CreateAttachment.create().
+            mimeType( "image/png" ).
+            byteSource( ByteSource.empty() ).
+            label( "My Image 3" ).
+            name( "MyImage2.png" ).
+            build();
+
+        CreateAttachments attachments = CreateAttachments.builder().add( a1 ).add( CreateAttachments.from( a2, a3 ) ).build();
+
+        assertEquals( 3, attachments.getSize() );
+        assertEquals( a1, attachments.first() );
+    }
+
+    @Test
+    public void fromIterable()
+    {
+        CreateAttachment a1 = CreateAttachment.create().
+            mimeType( "image/jpg" ).
+            byteSource( ByteSource.empty() ).
+            label( "My Image 1" ).
+            name( "MyImage.jpg" ).
+            build();
+
+        CreateAttachment a2 = CreateAttachment.create().
+            mimeType( "image/gif" ).
+            byteSource( ByteSource.empty() ).
+            label( "My Image 2" ).
+            name( "MyImage.something.gif" ).
+            build();
+
+        CreateAttachment a3 = CreateAttachment.create().
+            mimeType( "image/png" ).
+            byteSource( ByteSource.empty() ).
+            label( "My Image 3" ).
+            name( "MyImage2.png" ).
+            build();
+
+        CreateAttachments attachments = CreateAttachments.from( ImmutableList.of( a1, a2 ) );
+
+        assertEquals( 2, attachments.getSize() );
+        Iterator it = attachments.iterator();
+        assertEquals( a1, it.next() );
+        assertEquals( a2, it.next() );
+
+        CreateAttachments newAttachments = CreateAttachments.from( (Iterable<CreateAttachment>) ImmutableList.of( a2, a3 ) );
+
+        assertEquals( 2, newAttachments.getSize() );
+        it = newAttachments.iterator();
+        assertEquals( a2, it.next() );
+        assertEquals( a3, it.next() );
+    }
+
+}

--- a/modules/core-api/src/test/java/com/enonic/xp/content/attachment/UpdateAttachmentsParamsTest.java
+++ b/modules/core-api/src/test/java/com/enonic/xp/content/attachment/UpdateAttachmentsParamsTest.java
@@ -1,0 +1,30 @@
+package com.enonic.xp.content.attachment;
+
+import org.junit.Test;
+
+import com.enonic.xp.content.ContentId;
+
+import static org.junit.Assert.*;
+
+public class UpdateAttachmentsParamsTest
+{
+
+    @Test
+    public void fromBuilder()
+    {
+        ContentId id = ContentId.from( "id-1" );
+
+        Attachment attachment = Attachment.newAttachment().
+            mimeType( "image/jpg" ).
+            name( "MyImage.jpg" ).
+            build();
+
+        UpdateAttachmentsParams params = UpdateAttachmentsParams.newUpdateAttachments( id ).
+            addAttachments( attachment ).build();
+
+        assertEquals( id, params.getContentId() );
+        assertEquals( 1, params.getAttachments().getSize() );
+        assertEquals( attachment, params.getAttachments().first() );
+    }
+
+}

--- a/modules/core-api/src/test/java/com/enonic/xp/support/AbstractImmutableEntityListTest.java
+++ b/modules/core-api/src/test/java/com/enonic/xp/support/AbstractImmutableEntityListTest.java
@@ -5,9 +5,10 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 
-import com.enonic.xp.support.AbstractImmutableEntityList;
-
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
 
 public class AbstractImmutableEntityListTest
 {
@@ -25,27 +26,32 @@ public class AbstractImmutableEntityListTest
     }
 
     @Test
-    public void get()
+    public void testAccessors()
     {
         MyList list = new MyList( ImmutableList.of( "a", "b", "c" ) );
+        MyList emptyList = new MyList( ImmutableList.of() );
 
         assertEquals( "a", list.get( 0 ) );
         assertEquals( "b", list.get( 1 ) );
         assertEquals( "c", list.get( 2 ) );
-    }
 
-    @Test
-    public void first()
-    {
-        MyList list = new MyList( ImmutableList.of( "a", "b", "c" ) );
+        assertEquals( 3, list.getSize() );
+
+        assertTrue( list.contains( "b" ) );
+
         assertEquals( "a", list.first() );
+        assertNull( emptyList.first() );
+        assertEquals( "c", list.last() );
+        assertNull( emptyList.last() );
     }
 
     @Test
-    public void last()
+    public void testEquals()
     {
-        MyList list = new MyList( ImmutableList.of( "a", "b", "c" ) );
-        assertEquals( "c", list.last() );
+        MyList list1 = new MyList( ImmutableList.of( "a", "b", "c" ) );
+        MyList list2 = new MyList( ImmutableList.of( "a", "c", "b" ) );
+
+        assertFalse( list1.equals( list2 ) );
     }
 
     private class MyList


### PR DESCRIPTION
- added missing size param to Attachment.Builder
- made Attachments.add(iterable) public to cover it with tests