### PR TITLE
XP-244 Add more unit tests for schema package in API

### DIFF
--- a/modules/core-api/src/test/java/com/enonic/xp/schema/relationship/RelationshipTypeTest.java
+++ b/modules/core-api/src/test/java/com/enonic/xp/schema/relationship/RelationshipTypeTest.java
@@ -6,11 +6,10 @@ import org.junit.Test;
 
 import com.enonic.xp.schema.content.ContentTypeName;
 import com.enonic.xp.schema.content.ContentTypeNames;
-import com.enonic.xp.schema.relationship.RelationshipType;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class RelationshipTypeTest
 {


### PR DESCRIPTION
- Used org.junit.Assert instead of the deprecated junit.framework.Assert