### PR TITLE
XP-248 Add more unit tests for content.query package in API

### DIFF
--- a/modules/core-api/src/main/java/com/enonic/xp/content/query/ContentQueryHit.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/content/query/ContentQueryHit.java
@@ -50,4 +50,13 @@ public class ContentQueryHit
         return true;
     }
 
+
+
+    @Override
+    public int hashCode()
+    {
+        int result = contentId != null ? contentId.hashCode() : 0;
+        result = 31 * result + ( score != +0.0f ? Float.floatToIntBits( score ) : 0 );
+        return result;
+    }
 }

--- a/modules/core-api/src/test/java/com/enonic/xp/content/query/ContentQueryHitTest.java
+++ b/modules/core-api/src/test/java/com/enonic/xp/content/query/ContentQueryHitTest.java
@@ -1,0 +1,43 @@
+package com.enonic.xp.content.query;
+
+import org.junit.Test;
+
+import com.enonic.xp.content.ContentId;
+import com.enonic.xp.support.AbstractEqualsTest;
+
+public class ContentQueryHitTest
+{
+    @Test
+    public void equals()
+    {
+        AbstractEqualsTest equalsTest = new AbstractEqualsTest()
+        {
+            @Override
+            public Object getObjectX()
+            {
+                return new ContentQueryHit( 99, ContentId.from( "testId" ) );
+            }
+
+            @Override
+            public Object[] getObjectsThatNotEqualsX()
+            {
+                return new Object[]{new ContentQueryHit( 0, ContentId.from( "testId2" ) ),
+                    new ContentQueryHit( 99, ContentId.from( "testId3" ) ), new Object()};
+            }
+
+            @Override
+            public Object getObjectThatEqualsXButNotTheSame()
+            {
+                return new ContentQueryHit( new Float( 99 ), ContentId.from( "testId" ) );
+            }
+
+            @Override
+            public Object getObjectThatEqualsXButNotTheSame2()
+            {
+                return new ContentQueryHit( 99f, ContentId.from( "testId" ) );
+            }
+        };
+
+        equalsTest.assertEqualsAndHashCodeContract();
+    }
+}

--- a/modules/core-api/src/test/java/com/enonic/xp/content/query/ContentQueryResultTest.java
+++ b/modules/core-api/src/test/java/com/enonic/xp/content/query/ContentQueryResultTest.java
@@ -1,0 +1,26 @@
+package com.enonic.xp.content.query;
+
+import org.junit.Test;
+
+import com.enonic.xp.aggregation.Aggregations;
+import com.enonic.xp.content.ContentId;
+
+import static org.junit.Assert.*;
+
+public class ContentQueryResultTest
+{
+    @Test
+    public void testBuilder()
+    {
+        final ContentQueryResult queryResult = ContentQueryResult.newResult( 5 ).
+            addContentHit( ContentId.from( "testId" ), 3 ).
+            setAggregations( Aggregations.empty() ).
+            build();
+
+        assertNotNull( queryResult );
+        assertEquals( 5, queryResult.getTotalSize() );
+        assertEquals( 1, queryResult.getContentIds().size() );
+        assertTrue( queryResult.getAggregations().isEmpty() );
+        assertEquals( 1, queryResult.getContentQueryHits().size() );
+    }
+}

--- a/modules/core-api/src/test/java/com/enonic/xp/content/query/ContentQueryTest.java
+++ b/modules/core-api/src/test/java/com/enonic/xp/content/query/ContentQueryTest.java
@@ -1,0 +1,65 @@
+package com.enonic.xp.content.query;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.enonic.xp.data.Value;
+import com.enonic.xp.query.aggregation.GeoDistanceAggregationQuery;
+import com.enonic.xp.query.expr.CompareExpr;
+import com.enonic.xp.query.expr.FieldExpr;
+import com.enonic.xp.query.expr.QueryExpr;
+import com.enonic.xp.query.expr.ValueExpr;
+import com.enonic.xp.query.filter.RangeFilter;
+import com.enonic.xp.schema.content.ContentTypeName;
+import com.enonic.xp.schema.content.ContentTypeNames;
+import com.enonic.xp.util.GeoPoint;
+
+import static org.junit.Assert.*;
+
+public class ContentQueryTest
+{
+    @Test
+    public void testBuilder()
+    {
+        final ContentQuery query = createTestQuery();
+
+        assertNotNull( query );
+        assertEquals( 10, query.getFrom() );
+        assertEquals( 10, query.getSize() );
+        assertEquals( 3, query.getAggregationQueries().getSize() );
+        assertEquals( 3, query.getContentTypes().getSize() );
+        assertNotNull( query.getQueryExpr() );
+        assertEquals( 1, query.getQueryFilters().getSize() );
+    }
+
+    private ContentQuery createTestQuery()
+    {
+        final GeoDistanceAggregationQuery query1 = GeoDistanceAggregationQuery.create( "geo" ).
+            unit( "inch" ).
+            origin( GeoPoint.from( "20,30" ) ).
+            build();
+
+        final GeoDistanceAggregationQuery query2 = GeoDistanceAggregationQuery.create( "geo" ).
+            unit( "inch" ).
+            origin( GeoPoint.from( "20,30" ) ).
+            build();
+        final GeoDistanceAggregationQuery query3 = GeoDistanceAggregationQuery.create( "geo" ).
+            unit( "inch" ).
+            origin( GeoPoint.from( "20,30" ) ).
+            build();
+
+        final ContentQuery.Builder builder = ContentQuery.newContentQuery();
+        builder.addContentTypeName( ContentTypeName.imageMedia() );
+        builder.addContentTypeNames( ContentTypeNames.from( ContentTypeName.archiveMedia(), ContentTypeName.dataMedia() ) );
+        builder.aggregationQuery( query1 );
+        builder.aggregationQueries( Arrays.asList( query2, query3 ) );
+        builder.from( 10 );
+        builder.size( 10 );
+        builder.queryExpr( QueryExpr.from( CompareExpr.eq( FieldExpr.from( "name" ), ValueExpr.string( "testerson" ) ) ) );
+        builder.queryFilter( RangeFilter.create().from( Value.newDouble( 2.0 ) ).to( Value.newDouble( 10.0 ) ).build() );
+
+        return builder.build();
+    }
+
+}


### PR DESCRIPTION
-added more unit tests for data package 'com.enonic.xp.content.query' so we cover more than 85% line coverage.