### PR TITLE
XP-267 Remove button 'Add' from the Single Selector Form View Panel

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/singleselector/SingleSelector.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/singleselector/SingleSelector.ts
@@ -19,13 +19,15 @@ module api.form.inputtype.singleselector {
         }[]
     }
 
-    export class SingleSelector extends api.form.inputtype.support.BaseInputTypeNotManagingAdd<SingleSelectorConfig,string> {
+    export class SingleSelector extends api.form.inputtype.support.BaseInputTypeSingleOccurrence<SingleSelectorConfig,string> {
 
         public static TYPE_DROPDOWN: string = "DROPDOWN";
         public static TYPE_RADIO: string = "RADIO";
         public static TYPE_COMBOBOX: string = "COMBOBOX";
 
         private type: string;
+
+        private selector: api.dom.Element;
 
         constructor(config: api.form.inputtype.InputTypeViewContext<SingleSelectorConfig>) {
             super(config, "single-selector");
@@ -45,19 +47,44 @@ module api.form.inputtype.singleselector {
             return ValueTypes.STRING.newNullValue();
         }
 
-        createInputOccurrenceElement(index: number, property: Property): api.dom.Element {
+        layoutProperty(input: api.form.Input, property: Property): wemQ.Promise<void> {
 
-            var name = this.getInput().getName() + "-" + index;
             if (SingleSelector.TYPE_RADIO == this.type) {
-                return this.createRadioElement(name, property);
+                this.selector = this.createRadioElement(input.getName(), property);
             }
             else if (SingleSelector.TYPE_COMBOBOX == this.type) {
-                return this.createComboBoxElement(name, property);
+                this.selector = this.createComboBoxElement(input.getName(), property);
             }
             else if (SingleSelector.TYPE_DROPDOWN == this.type) {
-                return this.createDropdownElement(name, property);
+                this.selector = this.createDropdownElement(input.getName(), property);
             }
-            return null;
+            this.appendChild(this.selector);
+
+            return wemQ<void>(null);
+        }
+
+        giveFocus(): boolean {
+            return this.selector.giveFocus();
+        }
+
+        validate(silent: boolean = true): api.form.inputtype.InputValidationRecording {
+            return new api.form.inputtype.InputValidationRecording();
+        }
+
+        onFocus(listener: (event: FocusEvent) => void) {
+            this.selector.onFocus(listener);
+        }
+
+        unFocus(listener: (event: FocusEvent) => void) {
+            this.selector.unFocus(listener);
+        }
+
+        onBlur(listener: (event: FocusEvent) => void) {
+            this.selector.onBlur(listener);
+        }
+
+        unBlur(listener: (event: FocusEvent) => void) {
+            this.selector.unBlur(listener);
         }
 
         private createComboBoxElement(name: string, property: Property): api.dom.Element {
@@ -157,23 +184,6 @@ module api.form.inputtype.singleselector {
             return !(args && args.searchString && item.displayValue.toUpperCase().indexOf(args.searchString.toUpperCase()) == -1);
         }
 
-        valueBreaksRequiredContract(value: Value): boolean {
-            return value.isNull() || !value.getType().equals(ValueTypes.STRING) || !this.isExistingValue(value.getString());
-        }
-
-        private isExistingValue(value: string): boolean {
-            var options = this.getContext().inputConfig.options || [];
-
-            return options.some((option: any) => {
-                return option.value == value;
-            });
-        }
-
-        hasInputElementValidUserInput(inputElement: api.dom.Element) {
-
-            // TODO
-            return true;
-        }
     }
 
     api.form.inputtype.InputTypeManager.register(new api.Class("SingleSelector", SingleSelector));


### PR DESCRIPTION
- Made Single Selector to extend BaseInputTypeSingleOccurrence instead of BaseInputTypeNotManagingAdd in order to reflect inability to have more that one input