### PR TITLE
XP-268 Radio buttons are not visible for input type Single Selector

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/ui/radio-group.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/ui/radio-group.less
@@ -1,11 +1,10 @@
 .radio-group {
-  padding: 5px;
-  margin-bottom: 5px;
 
   .radio-button {
     margin-right: 10px;
     margin-bottom: 5px;
     min-width: 140px;
+    display: block;
 
     label {
       margin-left: 10px;
@@ -19,6 +18,12 @@
       margin-right: 0;
     }
 
+  }
+
+  .form-input input[type="radio"]  {
+    width: auto;
+    vertical-align: middle;
+    position: relative;
   }
 
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/reset.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/reset.less
@@ -52,8 +52,9 @@ sub {
   vertical-align: text-bottom;
 }
 
-input, textarea, select {
+input:not([type="radio"]), textarea, select {
   -webkit-appearance: none;
+  -moz-appearance: none;
   font-family: inherit;
   font-size: inherit;
   font-weight: inherit;


### PR DESCRIPTION
- Made radio inputs to ignore browser appearance settings
- Added same property value for firefox as for chrome for consistency
- Adjusted styling for radio input. Verified adjusted styling with Chrome and FF