### PR TITLE
XP-315 The dateTime value sent in update content must contain correct timezone

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/util/DateHelper.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/util/DateHelper.ts
@@ -10,6 +10,10 @@ module api.util {
             return (new Date().getTimezoneOffset() / 60) * -1;
         }
 
+        public static getTZOffsetFromDate(s: Date): number {
+            return (s.getTimezoneOffset() / 60) * -1;
+        }
+
         public static parseUTCTime(localTime: string): string {
             var values = localTime.split(':');
             var date = new Date();
@@ -199,7 +203,7 @@ module api.util {
         }
 
         static parseOffset(value: string, offsetSeparator: string = "+"): number {
-            if(value != null && (value[value.length - 1] == "Z" || value[value.length - 1] == "z")) {
+            if(DateHelper.isUTCdate(value)) {
                 return 0;
             } else {
                 var dateStr = (value || '').trim();
@@ -217,6 +221,18 @@ module api.util {
 
                 return offset;
             }
+        }
+
+        /**
+         * Returns true if passed string ends with 'z'
+         * @param value
+         * @returns {number}
+         */
+        static isUTCdate(value: string): boolean {
+            if (value != null && (value[value.length - 1] == "Z" || value[value.length - 1] == "z")) {
+                return true;
+            }
+            return false;
         }
 
         /**

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/util/DateTime.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/util/DateTime.ts
@@ -130,14 +130,21 @@ module api.util {
             if (!DateTime.isValidDateTime(s)) {
                 throw new Error("Cannot parse DateTime from string: " + s);
             }
-            var withoutTZ = DateTime.trimTZ(s);
-            var date = DateHelper.parseLongDateTime(withoutTZ, DateTime.DATE_TIME_SEPARATOR, DateTime.DATE_SEPARATOR, DateTime.TIME_SEPARATOR, DateTime.FRACTION_SEPARATOR);
-            var offset = DateHelper.parseOffset(s);
-            var timezone : Timezone = null;
-            if(offset != null) {
-                timezone = Timezone.create().setOffset(offset).build();
+
+            var date, timezone;
+
+            if(DateHelper.isUTCdate(s)) {
+                date = DateHelper.parseUTCDateTime(s);
+                timezone = Timezone.create().setOffset(DateHelper.getTZOffset()).build();
             } else {
-                timezone = Timezone.create().buildDefault();
+                var withoutTZ = DateTime.trimTZ(s);
+                date = DateHelper.parseLongDateTime(withoutTZ, DateTime.DATE_TIME_SEPARATOR, DateTime.DATE_SEPARATOR, DateTime.TIME_SEPARATOR, DateTime.FRACTION_SEPARATOR);
+                var offset = DateHelper.parseOffset(s);
+                if(offset != null) {
+                    timezone = Timezone.fromOffset(offset);
+                } else {
+                    timezone = Timezone.create().setOffset(DateHelper.getTZOffset()).build();
+                }
             }
 
             if (!date) {
@@ -165,7 +172,7 @@ module api.util {
                 .setMinutes(s.getMinutes())
                 .setSeconds(s.getSeconds())
                 .setFractions(s.getMilliseconds())
-                //.setTimezone(timezone)
+                .setTimezone(Timezone.fromOffset(DateHelper.getTZOffsetFromDate(s))) // replace with timezone picker value
                 .build();
         }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/util/Timezone.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/util/Timezone.ts
@@ -59,28 +59,24 @@ module api.util {
            return true;
         }
 
-        /*static fromString(s: string): Timezone {
-            if (!Timezone.isValidTimezone(s)) {
-                throw new Error("Cannot parse Timezone from string: " + s);
+       static isValidOffset(s: number): boolean {
+            if (s > -13 && s < 13) {
+                return true;
             }
 
-            var date = DateHelper.parseLongTimezone(s, Timezone.DATE_TIME_SEPARATOR, Timezone.DATE_SEPARATOR, Timezone.TIME_SEPARATOR, Timezone.FRACTION_SEPARATOR);
+            return false;
+        }
 
-            if (!date) {
-                throw new Error("Cannot parse Timezone from string: " + s);
+        static fromOffset(s: number): Timezone {
+            if (!Timezone.isValidOffset(s)) {
+                throw new Error("Passed Timezone ofsset is invalid: " + s);
             }
 
             return Timezone.create()
-                .setYear(date.getFullYear())
-                .setMonth(date.getMonth())
-                .setDay(date.getDate())
-                .setHours(date.getHours())
-                .setMinutes(date.getMinutes())
-                .setSeconds(date.getSeconds())
-                .setFractions(date.getMilliseconds())
+                .setOffset(s)
                 .build();
-         }
-        */
+        }
+
 
         public static create(): TimezoneBuilder {
             return new TimezoneBuilder();


### PR DESCRIPTION
...mezone

- As on the back-end an Instant is used as a backing type - DateTime comes from back-end in UTC format, which was not expected by DateTime domain object on the front-end.