### PR TITLE
XP-231 Validate required fields in GUI, to avoid server messages like "S...

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
@@ -363,6 +363,7 @@ module app.wizard {
             if (this.liveFormPanel) {
                 this.liveFormPanel.skipNextReloadConfirmation(true);
             }
+            this.setRequireValid(false);
             return super.saveChanges();
         }
 


### PR DESCRIPTION
...tatus 500 Server error"

- Bug occurred due to ContentWizardPanel's requiresValid parameter upon publish action is set to true, but if Save action pressed - parameter is not changed. Which means that after content publish, save requests contained  requiresValid = true, whereas logically save action does not require valid form parameters in ContentWizardPanel. Fixed via setting requiresValid = false in saveAction() method of ContentWizardPanel.