### PR TITLE
Xp 253: Fix reordering of TinyMCE inputs

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/form/FormItemOccurrences.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/form/FormItemOccurrences.ts
@@ -221,21 +221,23 @@ module api.form {
         }
 
         private doAddOccurrence(occurrence: FormItemOccurrence<V>) {
+            var countOccurrences = this.countOccurrences();
 
-            if (this.allowedOccurrences.maximumReached(this.countOccurrences())) {
+            if (this.allowedOccurrences.maximumReached(countOccurrences)) {
                 return;
             }
             var occurrenceView: V = this.createNewOccurrenceView(occurrence);
             var insertAtIndex = occurrence.getIndex();
             this.occurrences.splice(insertAtIndex, 0, occurrence);
 
-            var occurrenceViewBefore: api.dom.Element = this.getOccurrenceViewElementBefore(insertAtIndex);
-            if (occurrenceViewBefore != null) {
-                occurrenceView.insertAfterEl(occurrenceViewBefore);
-            }
-            else {
+            if (insertAtIndex == countOccurrences) {
                 this.occurrenceViewContainer.appendChild(occurrenceView);
             }
+            else {
+                var occurrenceViewBefore: api.dom.Element = this.getOccurrenceViewElementBefore(insertAtIndex);
+                occurrenceView.insertAfterEl(occurrenceViewBefore);
+            }
+
             occurrenceView.layout().then(() => {
                 this.notifyOccurrenceRendered(occurrence, occurrenceView);
             }).done();

--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/form/input/input-occurrence-view.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/form/input/input-occurrence-view.less
@@ -33,7 +33,6 @@
     .order(3);
 
     float: right;
-    width: 20px;
     text-decoration: none;
     cursor: pointer;
   }


### PR DESCRIPTION
1. Fixed disappearing right border of the editor
2. Fixed crash when adding a new editor after rearranging existing ones