### PR TITLE
XP-201 User Store Wizard: 'Create Users' access selector for permissions...

### DIFF
--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/security/SecurityResource.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/security/SecurityResource.java
@@ -111,7 +111,7 @@ public final class SecurityResource
     {
         final UserStore userStore = UserStore.newUserStore().displayName( "" ).key( UserStoreKey.createDefault() ).build();
 
-        final UserStoreAccessControlList userStorePermissions = securityService.getUserStorePermissions( UserStoreKey.system() );
+        final UserStoreAccessControlList userStorePermissions = securityService.getDefaultUserStorePermissions();
 
         final Principals principals = securityService.getPrincipals( userStorePermissions.getAllPrincipals() );
         return new UserStoreJson( userStore, userStorePermissions, principals );

--- a/modules/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/security/SecurityResourceTest.java
+++ b/modules/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/security/SecurityResourceTest.java
@@ -47,6 +47,7 @@ import com.enonic.xp.security.acl.UserStoreAccessControlList;
 
 import static com.enonic.xp.security.PrincipalRelationship.from;
 import static com.enonic.xp.security.acl.UserStoreAccess.ADMINISTRATOR;
+import static com.enonic.xp.security.acl.UserStoreAccess.READ;
 
 public class SecurityResourceTest
     extends AbstractResourceTest
@@ -122,6 +123,26 @@ public class SecurityResourceTest
         String jsonString = request().path( "security/userstore" ).queryParam( "key", "local" ).get().getAsString();
 
         assertJson( "getUserstoreByKey.json", jsonString );
+    }
+
+    @Test
+    public void getDefaultUserStorePermissions()
+        throws Exception
+    {
+        final UserStoreAccessControlList userStoreAccessControlList = UserStoreAccessControlList.of(
+            UserStoreAccessControlEntry.create().principal( PrincipalKey.from( "role:system.authenticated" ) ).access( READ ).build(),
+            UserStoreAccessControlEntry.create().principal( PrincipalKey.from( "role:system.admin" ) ).access( ADMINISTRATOR ).build() );
+
+        final Principals principals =
+            Principals.from( Role.create().displayName( "Authenticated" ).key( PrincipalKey.from( "role:system.authenticated" ) ).build(),
+                             Role.create().displayName( "Administrator" ).key( PrincipalKey.from( "role:system.admin" ) ).build() );
+
+        Mockito.when( securityService.getDefaultUserStorePermissions() ).thenReturn( userStoreAccessControlList );
+        Mockito.when( securityService.getPrincipals( Mockito.isA( PrincipalKeys.class ) ) ).thenReturn( principals );
+
+        String jsonString = request().path( "security/userstore/default" ).get().getAsString();
+
+        assertJson( "getDefaultUserStorePermissions.json", jsonString );
     }
 
     @Test

--- a/modules/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/security/getDefaultUserStorePermissions.json
+++ b/modules/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/security/getDefaultUserStorePermissions.json
@@ -1,0 +1,22 @@
+{
+  "displayName": "",
+  "key": "default",
+  "permissions": [
+    {
+      "access": "READ",
+      "principal": {
+        "displayName": "Authenticated",
+        "key": "role:system.authenticated",
+        "modifiedTime": null
+      }
+    },
+    {
+      "access": "ADMINISTRATOR",
+      "principal": {
+        "displayName": "Administrator",
+        "key": "role:system.admin",
+        "modifiedTime": null
+      }
+    }
+  ]
+}

--- a/modules/core-api/src/main/java/com/enonic/xp/security/SecurityService.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/security/SecurityService.java
@@ -18,6 +18,8 @@ public interface SecurityService
 
     UserStoreAccessControlList getUserStorePermissions( UserStoreKey userStore );
 
+    UserStoreAccessControlList getDefaultUserStorePermissions();
+
     UserStore createUserStore( CreateUserStoreParams createUserStoreParams );
 
     UserStore updateUserStore( UpdateUserStoreParams updateUserStoreParams );

--- a/modules/core-security/src/main/java/com/enonic/xp/core/impl/security/SecurityServiceImpl.java
+++ b/modules/core-security/src/main/java/com/enonic/xp/core/impl/security/SecurityServiceImpl.java
@@ -138,6 +138,14 @@ public final class SecurityServiceImpl
     }
 
     @Override
+    public UserStoreAccessControlList getDefaultUserStorePermissions()
+    {
+        final RootNode rootNode = callWithContext( () -> this.nodeService.getRoot() );
+
+        return UserStoreNodeTranslator.userStorePermissionsFromNode( rootNode, rootNode, rootNode );
+    }
+
+    @Override
     public PrincipalRelationships getRelationships( final PrincipalKey from )
     {
         try


### PR DESCRIPTION
... is shown instead of 'Read'

- update logic of fetching default UserStore permissions (was not correct)
- added test for json