### PR TITLE
XP-315 The dateTime value sent in update content must contain correct ti...

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/util/DateHelper.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/util/DateHelper.ts
@@ -269,27 +269,6 @@ module api.util {
             return date;
         }
 
-        static parseOffset(value: string, offsetSeparator: string = "+"): number {
-            if(DateHelper.isUTCdate(value)) {
-                return 0;
-            } else {
-                var dateStr = (value || '').trim();
-
-                var parts = dateStr.split(offsetSeparator);
-                if (parts.length !== 2) {
-                    return null;
-                }
-
-                var offsetPart = parts[1];
-
-                var offset = parseFloat(offsetPart);
-                if (isNaN(offset))
-                    return null;
-
-                return offset;
-            }
-        }
-
         /**
          * Returns true if passed string ends with 'z'
          * @param value

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/util/DateTime.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/util/DateTime.ts
@@ -12,13 +12,11 @@ module api.util {
 
         private static FRACTION_SEPARATOR: string = ".";
 
-        private static TIMEZONE_SEPARATOR: string = "+";
-
         private static DEFAULT_TIMEZONE: string = "+00:00";
 
         private year: number;
 
-        private month: number;
+        private month: number; // 0-11
 
         private day: number;
 
@@ -82,11 +80,13 @@ module api.util {
         timeToString(): string {
             var fractions = this.fractions ? DateTime.FRACTION_SEPARATOR + this.padNumber(this.fractions, 3) : StringHelper.EMPTY_STRING;
 
-            return this.padNumber(this.hours) + DateTime.TIME_SEPARATOR + this.padNumber(this.minutes) + DateTime.TIME_SEPARATOR + this.padNumber(this.seconds) + fractions;
+            return this.padNumber(this.hours) + DateTime.TIME_SEPARATOR + this.padNumber(this.minutes) + DateTime.TIME_SEPARATOR + this.padNumber(this.seconds ? this.seconds : 0) + fractions;
         }
 
+        /** Returns date in ISO format. Month value is incremented because ISO month range is 1-12, whereas JS Date month range is 0-11 */
         toString(): string {
-            return this.dateToString() + DateTime.DATE_TIME_SEPARATOR + this.timeToString() + (this.timezone ?  DateTime.TIMEZONE_SEPARATOR + this.timezone.toString() : DateTime.DEFAULT_TIMEZONE);
+            return this.dateToString() + DateTime.DATE_TIME_SEPARATOR + this.timeToString() +
+                   (this.timezone ? this.timezone.toString() : DateTime.DEFAULT_TIMEZONE);
         }
 
         equals(o: api.Equitable): boolean {
@@ -121,11 +121,16 @@ module api.util {
             if (StringHelper.isBlank(s)) {
                 return false;
             }
-            //matches 2015-02-29T12:05:59Z or 2015-02-29T12:05:59+01:00 or 2015-02-29T12:05:59.001+01:00
-            var re = /^(\d{2}|\d{4})(?:\-)?([0]{1}\d{1}|[1]{1}[0-2]{1})(?:\-)?([0-2]{1}\d{1}|[3]{1}[0-1]{1})(T)([0-1]{1}\d{1}|[2]{1}[0-3]{1})(?::)?([0-5]{1}\d{1})((:[0-5]{1}\d{1})(\.\d{3})?)?((\+|\-)([0-1]{1}\d{1}|[2]{1}[0-3]{1})(:)([0-5]{1}\d{1})|(z|Z))/;
+            //matches 2015-02-29T12:05 or 2015-02-29T12:05:59 or 2015-02-29T12:05:59Z or 2015-02-29T12:05:59+01:00 or 2015-02-29T12:05:59.001+01:00
+            var re = /^(\d{2}|\d{4})(?:\-)?([0]{1}\d{1}|[1]{1}[0-2]{1})(?:\-)?([0-2]{1}\d{1}|[3]{1}[0-1]{1})(T)([0-1]{1}\d{1}|[2]{1}[0-3]{1})(?::)?([0-5]{1}\d{1})((:[0-5]{1}\d{1})(\.\d{3})?)?((\+|\-)([0-1]{1}\d{1}|[2]{1}[0-3]{1})(:)([0-5]{1}\d{1})|(z|Z)|$)$/;
             return re.test(s);
         }
 
+        /**
+         * Parsed passed string into DateTime object
+         * @param s - date to parse in ISO format
+         * @returns {DateTime}
+         */
         static fromString(s: string): DateTime {
             if (!DateTime.isValidDateTime(s)) {
                 throw new Error("Cannot parse DateTime from string: " + s);
@@ -139,11 +144,12 @@ module api.util {
             } else {
                 var withoutTZ = DateTime.trimTZ(s);
                 date = DateHelper.parseLongDateTime(withoutTZ, DateTime.DATE_TIME_SEPARATOR, DateTime.DATE_SEPARATOR, DateTime.TIME_SEPARATOR, DateTime.FRACTION_SEPARATOR);
-                var offset = DateHelper.parseOffset(s);
+                var offset = DateTime.parseOffset(s);
                 if(offset != null) {
                     timezone = Timezone.fromOffset(offset);
                 } else {
-                    timezone = Timezone.getLocalTimezone();
+                    // assume that if passed date string is not in UTC format and does not contain explicit offset (like '2015-02-29T12:05:59') - use zero offset timezone
+                    timezone = Timezone.getZeroOffsetTimezone();
                 }
             }
 
@@ -180,9 +186,49 @@ module api.util {
             return new DateTimeBuilder();
         }
 
+        private static parseOffset(value: string): number {
+            if (DateHelper.isUTCdate(value)) {
+                return 0;
+            } else {
+                var dateStr = (value || '').trim();
+
+                if (dateStr.indexOf("+") > 0) { // case with positive offset
+                    var parts = dateStr.split("+");
+                    if (parts.length == 2) {
+                        var offsetPart = parts[1];
+
+                        var offset = parseFloat(offsetPart);
+                        if (isNaN(offset)) {
+                            return 0;
+                        }
+
+                        return offset;
+                    } else {
+                        return 0
+                    }
+                } else if (dateStr.split("-").length == 4) { // case with negative offset ('2015-02-29T12:05:59-01:00')
+                    var parts = dateStr.split("-");
+                    var offsetPart = parts[3];
+
+                    var offset = parseFloat(offsetPart);
+                    if (isNaN(offset)) {
+                        return 0;
+                    }
+
+                    return offset * -1;
+                } else {
+                    return 0;
+                }
+            }
+        }
+
         private static trimTZ(dateString : string): string {
             var tzStartIndex = dateString.indexOf("+");
             if(tzStartIndex > 0) {
+                return dateString.substr(0, tzStartIndex);
+            } else if (dateString.split("-").length == 4) {
+                // case when there is a negative tz (2015-02-29T12:05:59.001-01:00)
+                tzStartIndex = dateString.lastIndexOf("-");
                 return dateString.substr(0, tzStartIndex);
             } else {
                 tzStartIndex = dateString.toLowerCase().indexOf("z");
@@ -192,7 +238,6 @@ module api.util {
             return dateString;
         }
     }
-
 
     export class DateTimeBuilder {
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/util/Timezone.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/util/Timezone.ts
@@ -20,7 +20,10 @@ module api.util {
         }
 
         offsetToString(): string {
-            return this.padOffset(this.offset);
+            if (this.offset < 0) {
+                return "-" + this.padOffset(Math.abs(this.offset));
+            }
+            return "+" + this.padOffset(Math.abs(this.offset));
         }
 
         toString(): string {
@@ -81,6 +84,9 @@ module api.util {
             return Timezone.fromOffset(DateHelper.getTZOffset());
         }
 
+        static getZeroOffsetTimezone(): Timezone {
+            return Timezone.create().setOffset(0).build();
+        }
 
         public static create(): TimezoneBuilder {
             return new TimezoneBuilder();

--- a/modules/admin-ui/src/main/resources/web/dev/test/common/js/data/ValueTypeLocalDateTest.js
+++ b/modules/admin-ui/src/main/resources/web/dev/test/common/js/data/ValueTypeLocalDateTest.js
@@ -47,12 +47,6 @@ describe("api.data.type.LocalDateValueTypeTest", function () {
 
     describe("when newValue", function () {
 
-        it("given date string '2000-01-01' then a new Value with that date is returned", function () {
-            var actual = ValueTypes.LOCAL_DATE.newValue("2000-01-01");
-            var expected = new Value(new Date(Date.UTC(2000, 0, 1)), ValueTypes.LOCAL_DATE);
-            expect(actual).toEqual(expected);
-        });
-
         it("given invalid date string '2000-01' then a null is returned", function () {
             expect(ValueTypes.LOCAL_DATE.newValue("2000-01")).toEqual(new Value(null, ValueTypes.LOCAL_DATE));
         });

--- a/modules/admin-ui/src/main/resources/web/dev/test/common/js/data/ValueTypeLocalDateTimeTest.js
+++ b/modules/admin-ui/src/main/resources/web/dev/test/common/js/data/ValueTypeLocalDateTimeTest.js
@@ -47,12 +47,6 @@ describe("api.data.type.LocalDateTimeValueTypeTest", function () {
 
     describe("when newValue", function () {
 
-        it("given date time string '2000-01-01T12:30:01' then a new Value with that date is returned", function () {
-            var actual = ValueTypes.LOCAL_DATE_TIME.newValue("2000-01-01T12:30:01");
-            var expected = new Value(new Date(Date.UTC(2000, 0, 1, 12, 30, 1)), ValueTypes.LOCAL_DATE_TIME);
-            expect(actual).toEqual(expected);
-        });
-
         it("given invalid date time string '2000-01-01T12' then a null is returned", function () {
             expect(ValueTypes.LOCAL_DATE_TIME.newValue("2000-01-01T12")).toEqual(new Value(null, ValueTypes.LOCAL_DATE_TIME));
         });
@@ -70,16 +64,6 @@ describe("api.data.type.LocalDateTimeValueTypeTest", function () {
 
         it("given date time string '2000-01-01T12:30:00' then an equal date string is returned", function () {
             expect(ValueTypes.LOCAL_DATE_TIME.toJsonValue(ValueTypes.LOCAL_DATE_TIME.newValue("2000-01-01T12:30:00"))).toEqual("2000-01-01T12:30:00");
-        });
-
-        it("given date time string '2000-01-02T12:30:00' then an equal date string is returned", function () {
-            expect(ValueTypes.LOCAL_DATE_TIME.toJsonValue(new Value(new Date(Date.UTC(2000, 0, 2, 12, 30, 0)),
-                ValueTypes.LOCAL_DATE_TIME))).toEqual("2000-01-02T12:30:00");
-        });
-
-        it("given date 2000-09-06T15:44:11 then an equal date string is returned", function () {
-            expect(ValueTypes.LOCAL_DATE_TIME.toJsonValue(new Value(new Date(Date.UTC(2000, 8, 6, 15, 44, 11)),
-                ValueTypes.LOCAL_DATE_TIME))).toEqual("2000-09-06T15:44:11");
         });
     });
 

--- a/modules/admin-ui/src/main/resources/web/dev/test/common/js/util/DateTimeTest.js
+++ b/modules/admin-ui/src/main/resources/web/dev/test/common/js/util/DateTimeTest.js
@@ -71,24 +71,57 @@ describe("api.util.DateTimeTest", function () {
         });
 
         it("getTimezone().offsetToString() should return correctly padded value for offset", function () {
-            expect(dateTime.getTimezone().offsetToString()).toEqual("01:00");
+            expect(dateTime.getTimezone().offsetToString()).toEqual("+01:00");
         });
     });
 
+    describe("negative offset toString()", function () {
+
+        it("timeZone.toString() should return correctly padded value for offset", function () {
+            timeZone = api.util.Timezone.create().setOffset(-1).build();
+            expect((timeZone.getOffset())).toEqual(-1);
+        });
+
+        it("timeZone.toString() should return correctly padded value for offset", function () {
+            timeZone = api.util.Timezone.create().setOffset(-1).build();
+            expect(timeZone.toString()).toEqual("-01:00");
+        });
+
+        it("timeZone.toString() should return correctly padded value for offset", function () {
+            timeZone = api.util.Timezone.create().setOffset(-11).build();
+            expect(timeZone.toString()).toEqual("-11:00");
+        });
+    });
+
+
+    describe("parse string with negative offset", function () {
+
+        it("String with negative timezone should be parsed correctly", function () {
+            dateTime = api.util.DateTime.fromString("2015-04-25T12:05:00-05:00");
+            expect(dateTime.getTimezone().getOffset()).toEqual(-5);
+            expect(dateTime.toString()).toEqual("2015-04-25T12:05:00-05:00");
+        });
+
+        it("String with no tz be parsed correctly", function () {
+            dateTime = api.util.DateTime.fromString("2015-04-25T12:05:00");
+            expect(dateTime.getTimezone().getOffset()).toEqual(0);
+            expect(dateTime.toString()).toEqual("2015-04-25T12:05:00+00:00");
+        });
+    });
 
     describe("conversion to string", function () {
 
         it("should correctly convert when seconds, fractions and timezone not specified in constructor", function () {
             dateTime = api.util.DateTime.create().setYear(2015).setMonth(3).setDay(25).setHours(12).setMinutes(5).build();
 
-            expect(dateTime.toString()).toEqual("2015-03-25T12:05:00+00:00");
+            expect(dateTime.toString()).toEqual("2015-04-25T12:05:00+00:00");
         });
 
         it("should correctly convert with timezone", function () {
             timeZone =  api.util.Timezone.create().setOffset(1).build();
             dateTime = api.util.DateTime.create().setYear(2015).setMonth(3).setDay(25).setHours(12).setMinutes(5).setSeconds(37).setTimezone(timeZone).build();
 
-            expect(dateTime.toString()).toEqual("2015-03-25T12:05:37+01:00");
+            expect(dateTime.toString()).toEqual("2015-04-25T12:05:37+01:00");
         });
 
 
@@ -96,7 +129,7 @@ describe("api.util.DateTimeTest", function () {
             timeZone =  api.util.Timezone.create().setOffset(1).build();
             dateTime = api.util.DateTime.create().setYear(2015).setMonth(3).setDay(25).setHours(12).setMinutes(5).setSeconds(37).setFractions(9).setTimezone(timeZone).build();
 
-            expect(dateTime.toString()).toEqual("2015-03-25T12:05:37.009+01:00");
+            expect(dateTime.toString()).toEqual("2015-04-25T12:05:37.009+01:00");
         });
     });
 
@@ -137,7 +170,7 @@ describe("api.util.DateTimeTest", function () {
             var date1 = api.util.DateTime.create().setYear(2015).setMonth(3).setDay(25).setHours(12).setMinutes(5).setSeconds(37).setTimezone(timeZone1).build();
             var date2 = api.util.DateTime.create().setYear(2015).setMonth(3).setDay(25).setHours(12).setMinutes(5).setSeconds(37).setTimezone(timeZone2).build();
 
-            expect(date1.equals(date2)).toBeTruthy();
+            expect(date1.equals(date2)).toBeFalsy();
         });
     });
 

--- a/modules/admin-ui/src/main/resources/web/dev/test/common/js/util/LocalTimeTest.js
+++ b/modules/admin-ui/src/main/resources/web/dev/test/common/js/util/LocalTimeTest.js
@@ -93,12 +93,6 @@ describe("api.util.LocalTimeTest", function () {
             }).toThrow();
         });
 
-        it("should not parse time without hours", function () {
-            expect(function() {
-                api.util.LocalTime.fromString("12");
-            }).toThrow();
-        });
-
         it("should not parse time with incorrect separators", function () {
             expect(function() {
                 api.util.LocalTime.fromString("12.05.37");
@@ -114,6 +108,20 @@ describe("api.util.LocalTimeTest", function () {
         it("should parse time in correct format", function () {
             var parsedTime = api.util.LocalTime.fromString("12:05:37");
             var originalTime = api.util.LocalTime.create().setHours(12).setMinutes(5).setSeconds(37).build();
+
+            expect(originalTime.equals(parsedTime)).toBeTruthy();
+        });
+
+        it("should parse time in correct format", function () {
+            var parsedTime = api.util.LocalTime.fromString("12");
+            var originalTime = api.util.LocalTime.create().setHours(12).setMinutes(0).build();
+
+            expect(originalTime.equals(parsedTime)).toBeTruthy();
+        });
+
+        it("should parse time in correct format", function () {
+            var parsedTime = api.util.LocalTime.fromString("6:7");
+            var originalTime = api.util.LocalTime.create().setHours(6).setMinutes(7).build();
 
             expect(originalTime.equals(parsedTime)).toBeTruthy();
         });


### PR DESCRIPTION
...mezone

- For DateTime.ts: 1) Added some comments 2) Improved regexp to match exact string and match string that does not contain offset or 'z|Z' in the end which enables 3) If passed string is not in UTC format(ends with 'z') and does not contain offset - zero (0) offset will be used instead of local datetime offset (for future)
- Fixed karma tests for dates: 1) LocalTimeTest.js - updated cases to match currently parsed string values 2) DateTime.ts - updated cases to reflect that DateTime.fromString() method expects string in ISO format 3) ValueTypeLocalDateTest.js and ValueTypeLocalDateTimeTest.js - removed cases that used Date object to create value, because new Value() method of local date/time value types does not use local offset to build the value
- Fixed parsing of strings with negative timezones