### PR TITLE
XP-339 Improve detection of media type for uploaded content

### DIFF
--- a/modules/core-api/src/main/java/com/enonic/xp/media/MediaInfo.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/media/MediaInfo.java
@@ -16,6 +16,8 @@ public class MediaInfo
 
     public static final String MEDIA_SOURCE_SIZE = "bytesize";
 
+    public static final String BINARY_FILE_MIME = "application/octet-stream";
+
     private MediaInfo( final Builder builder )
     {
         this.mediaType = builder.mediaType;

--- a/modules/core-api/src/main/java/com/enonic/xp/media/MediaInfoService.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/media/MediaInfoService.java
@@ -9,4 +9,6 @@ public interface MediaInfoService
     MediaInfo parseMediaInfo( ByteSource byteSource );
 
     Integer getOrientation( ByteSource byteSource );
+
+    boolean isIllegibleMediaMimeType( String mimeType );
 }

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/ContentTypeFromMimeTypeResolver.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/ContentTypeFromMimeTypeResolver.java
@@ -49,6 +49,7 @@ final class ContentTypeFromMimeTypeResolver
         // Archive
         MAP.put( "application/zip", ContentTypeName.archiveMedia() );
         MAP.put( "application/gzip", ContentTypeName.archiveMedia() );
+        MAP.put( "application/x-rar-compressed", ContentTypeName.archiveMedia() );
 
         // Text
         MAP.put( "text/plain", ContentTypeName.textMedia() );

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/CreateMediaCommand.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/CreateMediaCommand.java
@@ -36,7 +36,8 @@ final class CreateMediaCommand
     private Content doExecute()
     {
         final MediaInfo mediaInfo = mediaInfoService.parseMediaInfo( params.getByteSource() );
-        if ( params.getMimeType() == null && mediaInfo.getMediaType() != null )
+        if ( ( params.getMimeType() == null || mediaInfoService.isIllegibleMediaMimeType( params.getMimeType() ) ) &&
+            mediaInfo.getMediaType() != null )
         {
             params.mimeType( mediaInfo.getMediaType() );
         }

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
@@ -41,7 +41,7 @@ final class UpdateMediaCommand
     private Content doExecute()
     {
         final MediaInfo mediaInfo = mediaInfoService.parseMediaInfo( params.getByteSource() );
-        if ( params.getMimeType() == null )
+        if ( params.getMimeType() == null || mediaInfoService.isIllegibleMediaMimeType( params.getMimeType() ) )
         {
             params.mimeType( mediaInfo.getMediaType() );
         }

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/media/MediaInfoServiceImpl.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/media/MediaInfoServiceImpl.java
@@ -66,6 +66,12 @@ public final class MediaInfoServiceImpl
         return orientation == null ? 0 : Integer.valueOf( orientation );
     }
 
+    @Override
+    public boolean isIllegibleMediaMimeType( final String mimeType )
+    {
+        return MediaInfo.BINARY_FILE_MIME.equalsIgnoreCase( mimeType );
+    }
+
     private Metadata parseMetadata( final ByteSource byteSource )
     {
         final ParseContext context = new ParseContext();

--- a/modules/core-impl/src/test/java/com/enonic/xp/core/impl/media/MediaInfoServiceTest.java
+++ b/modules/core-impl/src/test/java/com/enonic/xp/core/impl/media/MediaInfoServiceTest.java
@@ -54,4 +54,11 @@ public class MediaInfoServiceTest
         final ByteSource byteSource = Resources.asByteSource( getClass().getResource( "Multiple-FNumber-entries.JPG" ) );
         final MediaInfo mediaInfo = this.service.parseMediaInfo( byteSource );
     }
+
+    @Test
+    public void testIllegibleCheck()
+    {
+        assertTrue( service.isIllegibleMediaMimeType( MediaInfo.BINARY_FILE_MIME ) );
+        assertFalse( service.isIllegibleMediaMimeType( "application/gzip" ) );
+    }
 }


### PR DESCRIPTION
- [Fixed] CreateMedia and UpdateMedia commands to use value detected by MediaInfoService for  mimetype when "application/octet-stream" type is within the request params.
- Added"application/x-rar-compressed" type to MimeTypeResolver
- Added appropriate test.