### PR TITLE
XP-352 Preserve image orientation in image thumbnails

### DIFF
--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentIconResource.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentIconResource.java
@@ -27,6 +27,7 @@ import com.enonic.xp.content.ContentService;
 import com.enonic.xp.content.Media;
 import com.enonic.xp.content.attachment.Attachment;
 import com.enonic.xp.icon.Thumbnail;
+import com.enonic.xp.media.MediaInfoService;
 import com.enonic.xp.security.RoleKeys;
 
 
@@ -40,6 +41,8 @@ public final class ContentIconResource
     private ContentService contentService;
 
     private ContentImageHelper helper;
+
+    private MediaInfoService mediaInfoService;
 
     @GET
     @Path("{contentId}")
@@ -94,9 +97,11 @@ public final class ContentIconResource
             final ByteSource binary = contentService.getBinary( content.getId(), contentThumbnail.getBinaryReference() );
             if ( binary != null )
             {
-                ContentImageHelper.ImageFilter filter =
-                    crop ? ContentImageHelper.ImageFilter.SCALE_SQUARE_FILTER : ContentImageHelper.ImageFilter.SCALE_MAX_FILTER;
-                final BufferedImage thumbnailImage = helper.readImage( binary, size, filter );
+                final int imageOrientation = mediaInfoService.getImageOrientation( binary );
+                final ImageParams imageParams =
+                    ImageParams.newImageParams().size( size ).cropRequired( crop ).orientation( imageOrientation ).build();
+
+                final BufferedImage thumbnailImage = helper.readAndRotateImage( binary, imageParams );
                 return new ResolvedImage( thumbnailImage, contentThumbnail.getMimeType() );
             }
         }
@@ -111,9 +116,11 @@ public final class ContentIconResource
             final ByteSource binary = contentService.getBinary( media.getId(), imageAttachment.getBinaryReference() );
             if ( binary != null )
             {
-                ContentImageHelper.ImageFilter filter =
-                    crop ? ContentImageHelper.ImageFilter.SCALE_SQUARE_FILTER : ContentImageHelper.ImageFilter.SCALE_MAX_FILTER;
-                final BufferedImage contentImage = helper.readImage( binary, size, filter );
+                final int imageOrientation = mediaInfoService.getImageOrientation( media );
+                final ImageParams imageParams =
+                    ImageParams.newImageParams().size( size ).cropRequired( crop ).orientation( imageOrientation ).build();
+
+                final BufferedImage contentImage = helper.readAndRotateImage( binary, imageParams );
                 return new ResolvedImage( contentImage, imageAttachment.getMimeType() );
             }
         }
@@ -145,5 +152,11 @@ public final class ContentIconResource
     public void setContentImageHelper( ContentImageHelper contentImageHelper )
     {
         this.helper = contentImageHelper;
+    }
+
+    @Reference
+    public void setMediaInfoService( final MediaInfoService mediaInfoService )
+    {
+        this.mediaInfoService = mediaInfoService;
     }
 }

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentImageHelper.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentImageHelper.java
@@ -9,11 +9,7 @@ import com.enonic.xp.admin.impl.rest.resource.BaseImageHelper;
 interface ContentImageHelper
     extends BaseImageHelper
 {
-    public enum ImageFilter
-    {
-        SCALE_SQUARE_FILTER,
-        SCALE_MAX_FILTER
-    }
+    BufferedImage readImage( final ByteSource blob, final ImageParams imageParams );
 
-    BufferedImage readImage( final ByteSource blob, final int size, final ImageFilter imageFilter );
+    BufferedImage readAndRotateImage( final ByteSource blob, final ImageParams imageParams );
 }

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ImageParams.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ImageParams.java
@@ -1,0 +1,76 @@
+package com.enonic.xp.admin.impl.rest.resource.content;
+
+public class ImageParams
+{
+    private int size;
+
+    private int orientation;
+
+    private boolean cropRequired;
+
+    public ImageParams( Builder builder )
+    {
+        this.size = builder.size;
+        this.orientation = builder.orientation;
+        this.cropRequired = builder.cropRequired;
+    }
+
+    public boolean isCropRequired()
+    {
+        return cropRequired;
+    }
+
+    public int getSize()
+    {
+        return size;
+    }
+
+    public int getOrientation()
+    {
+        return orientation;
+    }
+
+    public static Builder newImageParams()
+    {
+        return new Builder();
+    }
+
+    protected static class Builder
+    {
+        private int size;
+
+        private int orientation;
+
+        private boolean cropRequired;
+
+        private Builder()
+        {
+
+        }
+
+        ;
+
+        public Builder size( int size )
+        {
+            this.size = size;
+            return this;
+        }
+
+        public Builder orientation( int orientation )
+        {
+            this.orientation = orientation;
+            return this;
+        }
+
+        public Builder cropRequired( boolean cropRequired )
+        {
+            this.cropRequired = cropRequired;
+            return this;
+        }
+
+        public ImageParams build()
+        {
+            return new ImageParams( this );
+        }
+    }
+}

--- a/modules/core-api/src/main/java/com/enonic/xp/media/MediaInfoService.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/media/MediaInfoService.java
@@ -3,10 +3,14 @@ package com.enonic.xp.media;
 import com.google.common.annotations.Beta;
 import com.google.common.io.ByteSource;
 
+import com.enonic.xp.content.Media;
+
 @Beta
 public interface MediaInfoService
 {
     MediaInfo parseMediaInfo( ByteSource byteSource );
 
-    Integer getOrientation( ByteSource byteSource );
+    Integer getImageOrientation( ByteSource byteSource );
+
+    Integer getImageOrientation( Media media );
 }

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/ImageContentProcessor.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/ImageContentProcessor.java
@@ -206,8 +206,24 @@ public final class ImageContentProcessor
         }
         TikaFieldNameFormatter.fillComputedFormItems( metadataMap.values(), mediaInfo );
 
+        addTiffOrientation( metadataMap.values(), mediaInfo );
+
         return extradatasBuilder.build();
     }
+
+    private void addTiffOrientation( Collection<ExtraData> extraDataList, MediaInfo mediaInfo )
+    {
+        for ( ExtraData extraData : extraDataList )
+        {
+            if ( "photo-info".equals( extraData.getName().getLocalName() ) )
+            {
+                extraData.getData().addString( "tiffOrientation",
+                                               mediaInfo.getMetadata().get( "tiffOrientation" ).toArray()[0].toString() );
+                return;
+            }
+        }
+    }
+
 
     public static class Builder
     {

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/media/MediaInfoServiceImpl.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/media/MediaInfoServiceImpl.java
@@ -17,6 +17,9 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import com.google.common.io.ByteSource;
 
+import com.enonic.xp.content.Media;
+import com.enonic.xp.data.Property;
+import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.media.MediaInfo;
 import com.enonic.xp.media.MediaInfoService;
 import com.enonic.xp.util.Exceptions;
@@ -58,12 +61,29 @@ public final class MediaInfoServiceImpl
     }
 
     @Override
-    public Integer getOrientation( ByteSource byteSource )
+    public Integer getImageOrientation( ByteSource byteSource )
     {
         Metadata metadata = this.parseMetadata( byteSource );
         String orientation = metadata.get( Metadata.ORIENTATION );
 
         return orientation == null ? 0 : Integer.valueOf( orientation );
+    }
+
+    @Override
+    public Integer getImageOrientation( Media media )
+    {
+        PropertyTree propertyTree = media.getExtraData( "media:photo-info" );
+
+        if ( propertyTree != null )
+        {
+            Property orientationProperty = propertyTree.getProperty( "tiffOrientation" );
+            if ( orientationProperty != null )
+            {
+                return Integer.valueOf( orientationProperty.getString() );
+            }
+        }
+
+        return 0;
     }
 
     private Metadata parseMetadata( final ByteSource byteSource )


### PR DESCRIPTION
- When creating image attachments besides source one we use ImageIO that is not preserving image metadata such as image orientation. Thus when fethcing image not
from source attachment and trying to get it orientation we won't get expected result. So:
- [Added]  Added  'tiffOrientation' entry to Content's extraData when processing newly added image. Previously only 'Orientation' image metadata was taken into Content's extraData but it is pure text which is not static (may vary through devices). 'tiffOrientation' is a number according to specification.
- Updated and refactored required code