### PR TITLE
XP-392 Spinner does not disappear when an image is loaded in ImageSelect...

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -83,6 +83,25 @@ module api.content.form.inputtype.image {
                 this.uploadDialog.remove();
                 ResponsiveManager.unAvailableSizeChanged(this);
             });
+
+            this.onShown(() => {
+                this.updateSelectedItemsIcons();
+            });
+        }
+
+        private updateSelectedItemsIcons() {
+            if (this.contentComboBox.getSelectedOptions().length > 0) {
+                this.doLoadContent(this.propertyArray).then((contents: ContentSummary[]) => {
+                    contents.forEach((content: ContentSummary) => {
+                        this.selectedOptionsView.updateUploadedOption(<Option<ImageSelectorDisplayValue>>{
+                            value: content.getId(),
+                            displayValue: ImageSelectorDisplayValue.fromContentSummary(content)
+                        });
+                    });
+
+                    this.layoutInProgress = false;
+                });
+            }
         }
 
         availableSizeChanged() {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionView.ts
@@ -30,13 +30,21 @@ module api.content.form.inputtype.image {
             var content: ImageSelectorDisplayValue = this.getOption().displayValue;
 
             if (content.getContentSummary()) {
-                if (this.isVisible()) {
-                    this.showSpinner();
-                }
-                this.icon.setSrc(content.getImageUrl() + "?thumbnail=false&size=" + ImageSelectorSelectedOptionView.IMAGE_SIZE);
+                this.updateIconSrc(content);
                 this.label.getEl().setInnerHtml(content.getLabel());
             } else {
                 this.showProgress();
+            }
+        }
+
+        private updateIconSrc(content: ImageSelectorDisplayValue) {
+            var newIconSrc = content.getImageUrl() + "?thumbnail=false&size=" + ImageSelectorSelectedOptionView.IMAGE_SIZE;
+
+            if (this.icon.getSrc().indexOf(newIconSrc) == -1) {
+                if (this.isVisible()) {
+                    this.showSpinner();
+                }
+                this.icon.setSrc(newIconSrc);
             }
         }
 
@@ -85,10 +93,7 @@ module api.content.form.inputtype.image {
 
             this.onShown(() => {
                 if (this.getOption().displayValue.getContentSummary()) {
-                    if (this.icon.isLoaded()) {
-                        // refresh image in case it was changed by external wizard
-                        this.icon.refresh();
-                    } else {
+                    if (!this.icon.isLoaded()) {
                         this.showSpinner();
                     }
                 }


### PR DESCRIPTION
...or

-Issue was related to caching, if set same 'src' attribute to img tag it is not making backend call, thus required events not triggered that supposed to remove spinner
-[Added] Added fetching icons' data from backend on IconsSelector shown event to know if content was really updated or not.