### PR TITLE
XP-352 Preserve image orientation in image thumbnails

### DIFF
--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentImageHelper.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentImageHelper.java
@@ -9,11 +9,7 @@ import com.enonic.xp.admin.impl.rest.resource.BaseImageHelper;
 interface ContentImageHelper
     extends BaseImageHelper
 {
-    public enum ImageFilter
-    {
-        SCALE_SQUARE_FILTER,
-        SCALE_MAX_FILTER
-    }
+    BufferedImage readImage( final ByteSource blob, final ImageParams imageParams );
 
-    BufferedImage readImage( final ByteSource blob, final int size, final ImageFilter imageFilter );
+    BufferedImage readAndRotateImage( final ByteSource blob, final ImageParams imageParams );
 }

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ImageParams.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ImageParams.java
@@ -1,0 +1,76 @@
+package com.enonic.xp.admin.impl.rest.resource.content;
+
+public class ImageParams
+{
+    private int size;
+
+    private int orientation;
+
+    private boolean cropRequired;
+
+    public ImageParams( Builder builder )
+    {
+        this.size = builder.size;
+        this.orientation = builder.orientation;
+        this.cropRequired = builder.cropRequired;
+    }
+
+    public boolean isCropRequired()
+    {
+        return cropRequired;
+    }
+
+    public int getSize()
+    {
+        return size;
+    }
+
+    public int getOrientation()
+    {
+        return orientation;
+    }
+
+    public static Builder newImageParams()
+    {
+        return new Builder();
+    }
+
+    protected static class Builder
+    {
+        private int size;
+
+        private int orientation;
+
+        private boolean cropRequired;
+
+        private Builder()
+        {
+
+        }
+
+        ;
+
+        public Builder size( int size )
+        {
+            this.size = size;
+            return this;
+        }
+
+        public Builder orientation( int orientation )
+        {
+            this.orientation = orientation;
+            return this;
+        }
+
+        public Builder cropRequired( boolean cropRequired )
+        {
+            this.cropRequired = cropRequired;
+            return this;
+        }
+
+        public ImageParams build()
+        {
+            return new ImageParams( this );
+        }
+    }
+}

--- a/modules/core-api/src/main/java/com/enonic/xp/media/MediaInfoService.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/media/MediaInfoService.java
@@ -8,5 +8,5 @@ public interface MediaInfoService
 {
     MediaInfo parseMediaInfo( ByteSource byteSource );
 
-    Integer getOrientation( ByteSource byteSource );
+    Integer getImageOrientation( ByteSource byteSource );
 }

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/media/MediaInfoServiceImpl.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/media/MediaInfoServiceImpl.java
@@ -58,7 +58,7 @@ public final class MediaInfoServiceImpl
     }
 
     @Override
-    public Integer getOrientation( ByteSource byteSource )
+    public Integer getImageOrientation( ByteSource byteSource )
     {
         Metadata metadata = this.parseMetadata( byteSource );
         String orientation = metadata.get( Metadata.ORIENTATION );


### PR DESCRIPTION
When creating image attachments besides source one we use ImageIO that is not preserving image metadata such as image orientation. Thus when fethcing image not from source attachment and trying to get it orientation we won't get expected result. So:
[Added] Added 'tiffOrientation' entry to Content's extraData when processing newly added image. Previously only 'Orientation' image metadata was taken into Content's extraData but it is pure text which is not static (may vary through devices). 'tiffOrientation' is a number according to specification.
Updated and refactored required code