### PR TITLE
XP-439

### DIFF
--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentIconResource.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentIconResource.java
@@ -27,6 +27,7 @@ import com.enonic.xp.content.ContentService;
 import com.enonic.xp.content.Media;
 import com.enonic.xp.content.attachment.Attachment;
 import com.enonic.xp.icon.Thumbnail;
+import com.enonic.xp.media.ImageOrientation;
 import com.enonic.xp.media.MediaInfoService;
 import com.enonic.xp.security.RoleKeys;
 
@@ -97,7 +98,7 @@ public final class ContentIconResource
             final ByteSource binary = contentService.getBinary( content.getId(), contentThumbnail.getBinaryReference() );
             if ( binary != null )
             {
-                final int imageOrientation = mediaInfoService.getImageOrientation( binary );
+                final ImageOrientation imageOrientation = mediaInfoService.getImageOrientation( binary );
                 final ImageParams imageParams =
                     ImageParams.newImageParams().size( size ).cropRequired( crop ).orientation( imageOrientation ).build();
 
@@ -126,7 +127,7 @@ public final class ContentIconResource
         return ResolvedImage.unresolved();
     }
 
-    private int getSourceAttachmentOrientation( final Media media )
+    private ImageOrientation getSourceAttachmentOrientation( final Media media )
     {
         final ByteSource sourceBinary = contentService.getBinary( media.getId(), media.getMediaAttachment().getBinaryReference() );
         return mediaInfoService.getImageOrientation( sourceBinary );

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentImageHelper.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentImageHelper.java
@@ -9,11 +9,7 @@ import com.enonic.xp.admin.impl.rest.resource.BaseImageHelper;
 interface ContentImageHelper
     extends BaseImageHelper
 {
-    public enum ImageFilter
-    {
-        SCALE_SQUARE_FILTER,
-        SCALE_MAX_FILTER
-    }
+    BufferedImage readImage( final ByteSource blob, final ImageParams imageParams );
 
-    BufferedImage readImage( final ByteSource blob, final int size, final ImageFilter imageFilter );
+    BufferedImage readAndRotateImage( final ByteSource blob, final ImageParams imageParams );
 }

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentImageResource.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentImageResource.java
@@ -24,6 +24,7 @@ import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentService;
 import com.enonic.xp.content.Media;
 import com.enonic.xp.content.attachment.Attachment;
+import com.enonic.xp.media.ImageOrientation;
 import com.enonic.xp.media.MediaInfoService;
 import com.enonic.xp.schema.content.ContentType;
 import com.enonic.xp.schema.content.ContentTypeName;
@@ -97,7 +98,7 @@ public final class ContentImageResource
             final ByteSource binary = contentService.getBinary( media.getId(), attachment.getBinaryReference() );
             if ( binary != null )
             {
-                final int imageOrientation = mediaInfoService.getImageOrientation( binary );
+                final ImageOrientation imageOrientation = mediaInfoService.getImageOrientation( binary );
                 final ImageParams imageParams = ImageParams.newImageParams().size( size ).orientation( imageOrientation ).build();
 
                 final BufferedImage contentImage = helper.readAndRotateImage( binary, imageParams );

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ImageParams.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ImageParams.java
@@ -1,0 +1,76 @@
+package com.enonic.xp.admin.impl.rest.resource.content;
+
+public class ImageParams
+{
+    private int size;
+
+    private int orientation;
+
+    private boolean cropRequired;
+
+    public ImageParams( Builder builder )
+    {
+        this.size = builder.size;
+        this.orientation = builder.orientation;
+        this.cropRequired = builder.cropRequired;
+    }
+
+    public boolean isCropRequired()
+    {
+        return cropRequired;
+    }
+
+    public int getSize()
+    {
+        return size;
+    }
+
+    public int getOrientation()
+    {
+        return orientation;
+    }
+
+    public static Builder newImageParams()
+    {
+        return new Builder();
+    }
+
+    protected static class Builder
+    {
+        private int size;
+
+        private int orientation;
+
+        private boolean cropRequired;
+
+        private Builder()
+        {
+
+        }
+
+        ;
+
+        public Builder size( int size )
+        {
+            this.size = size;
+            return this;
+        }
+
+        public Builder orientation( int orientation )
+        {
+            this.orientation = orientation;
+            return this;
+        }
+
+        public Builder cropRequired( boolean cropRequired )
+        {
+            this.cropRequired = cropRequired;
+            return this;
+        }
+
+        public ImageParams build()
+        {
+            return new ImageParams( this );
+        }
+    }
+}

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ImageParams.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ImageParams.java
@@ -1,17 +1,19 @@
 package com.enonic.xp.admin.impl.rest.resource.content;
 
-public class ImageParams
+import com.enonic.xp.media.ImageOrientation;
+
+public final class ImageParams
 {
-    private int size;
+    private final int size;
 
-    private int orientation;
+    private final ImageOrientation orientation;
 
-    private boolean cropRequired;
+    private final boolean cropRequired;
 
     public ImageParams( Builder builder )
     {
         this.size = builder.size;
-        this.orientation = builder.orientation;
+        this.orientation = builder.orientation != null ? builder.orientation : ImageOrientation.TopLeft;
         this.cropRequired = builder.cropRequired;
     }
 
@@ -25,7 +27,7 @@ public class ImageParams
         return size;
     }
 
-    public int getOrientation()
+    public ImageOrientation getOrientation()
     {
         return orientation;
     }
@@ -35,20 +37,17 @@ public class ImageParams
         return new Builder();
     }
 
-    protected static class Builder
+    static class Builder
     {
         private int size;
 
-        private int orientation;
+        private ImageOrientation orientation;
 
         private boolean cropRequired;
 
         private Builder()
         {
-
         }
-
-        ;
 
         public Builder size( int size )
         {
@@ -56,7 +55,7 @@ public class ImageParams
             return this;
         }
 
-        public Builder orientation( int orientation )
+        public Builder orientation( ImageOrientation orientation )
         {
             this.orientation = orientation;
             return this;

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserTreeGridActions.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserTreeGridActions.ts
@@ -3,6 +3,7 @@ module app.browse {
     import TreeGridActions = api.ui.treegrid.actions.TreeGridActions;
     import BrowseItem = api.app.browse.BrowseItem;
     import PrincipalType = api.security.PrincipalType;
+    import UserStore = api.security.UserStore;
     import GetPrincipalsByUserStoreRequest = api.security.GetPrincipalsByUserStoreRequest;
 
     export class UserTreeGridActions implements TreeGridActions<UserTreeGridItem> {
@@ -67,7 +68,7 @@ module app.browse {
                 if (principalsSelected == 1) {
                     this.DELETE.setEnabled(true);
                 } else {
-                    this.checkOnDeletable((<BrowseItem<UserTreeGridItem>>userItemBrowseItems[0]).getModel().getUserStore().getKey());
+                    this.establishDeleteActionState((<BrowseItem<UserTreeGridItem>>userItemBrowseItems[0]).getModel().getUserStore().getKey());
                 }
             } else {
                 this.DELETE.setEnabled(false);
@@ -81,16 +82,12 @@ module app.browse {
             return deferred.promise;
         }
 
-        private checkOnDeletable(key: api.security.UserStoreKey) {
-            new GetPrincipalsByUserStoreRequest(key,
-                [PrincipalType.USER, PrincipalType.GROUP]).
-                sendAndParse().then((principals: api.security.Principal[]) => {
-                    if (principals.length > 0) {
-                        this.DELETE.setEnabled(false);
-                    } else {
-                        this.DELETE.setEnabled(true);
-                    }
+        private establishDeleteActionState(key: api.security.UserStoreKey) {
+            if (key) {
+                UserStore.checkOnDeletable(key).then((result: boolean) => {
+                    this.DELETE.setEnabled(result);
                 });
+            }
         }
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanel.ts
@@ -5,6 +5,7 @@ module app.wizard {
     import PrincipalNamedEvent = api.security.PrincipalNamedEvent;
     import UserStore = api.security.UserStore;
     import UserStoreKey = api.security.UserStoreKey;
+    import PrincipalKey = api.security.PrincipalKey;
 
     import ConfirmationDialog = api.ui.dialog.ConfirmationDialog;
     import ResponsiveManager = api.ui.responsive.ResponsiveManager;
@@ -29,6 +30,8 @@ module app.wizard {
 
         private userStore: UserStore;
 
+        private persistedPrincipalKey: PrincipalKey;
+
         constructor(params: PrincipalWizardPanelParams, callback: (wizard: PrincipalWizardPanel) => void) {
 
             this.isPrincipalFormValid = false;
@@ -36,6 +39,9 @@ module app.wizard {
 
             this.principalType = params.persistedType;
             this.principalPath = params.persistedPath;
+            if (params.persistedPrincipal) {
+                this.persistedPrincipalKey = params.persistedPrincipal.getKey();
+            }
 
             this.parentOfSameType = params.parentOfSameType;
 
@@ -257,6 +263,10 @@ module app.wizard {
                 var viewedPrincipal = this.assembleViewedItem();
                 return !viewedPrincipal.equals(this.getPersistedItem());
             }
+        }
+
+        getPersistedItemKey(): PrincipalKey {
+            return this.persistedPrincipalKey;
         }
 
         assembleViewedItem(): Principal {

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserItemWizardPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserItemWizardPanel.ts
@@ -139,6 +139,10 @@ module app.wizard {
             throw new Error("Must be implemented by inheritors");
         }
 
+        getPersistedItemKey(): any {
+            throw new Error("Must be implemented by inheritors");
+        }
+
 
         getCloseAction(): api.ui.Action {
             return this.wizardActions.getCloseAction();

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserstoreWizardPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserstoreWizardPanel.ts
@@ -23,6 +23,8 @@ module app.wizard {
 
         private defaultUserStore: UserStore;
 
+        private persistedUserStoreKey: UserStoreKey;
+
         isUserStoreFormValid: boolean;
         userStorePath: string;
 
@@ -39,6 +41,9 @@ module app.wizard {
 
             this.userStorePath = params.persistedPath;
             this.defaultUserStore = params.defaultUserStore;
+            if (params.userStore) {
+                this.persistedUserStoreKey = params.userStore.getKey();
+            }
 
             var iconUrl = api.dom.ImgEl.PLACEHOLDER;
             this.formIcon = new FormIcon(iconUrl, "Click to upload icon");
@@ -240,6 +245,10 @@ module app.wizard {
             } else {
                 return this.wizardHeader.getName();
             }
+        }
+
+        getPersistedItemKey(): UserStoreKey {
+            return this.persistedUserStoreKey;
         }
 
         private assembleViewedUserStore(): UserStore {

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/action/UserStoreWizardActions.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/action/UserStoreWizardActions.ts
@@ -1,9 +1,22 @@
 module app.wizard.action {
 
+    import GetPrincipalsByUserStoreRequest = api.security.GetPrincipalsByUserStoreRequest;
+    import PrincipalType = api.security.PrincipalType;
+    import UserStore = api.security.UserStore;
+
     export class UserStoreWizardActions extends UserItemWizardActions<api.security.UserStore> {
 
         constructor(wizardPanel: app.wizard.UserItemWizardPanel<api.security.UserStore>) {
             super(wizardPanel);
+            this.establishDeleteActionState(wizardPanel.getPersistedItemKey());
+        }
+
+        private establishDeleteActionState(key: api.security.UserStoreKey) {
+            if (key) {
+                UserStore.checkOnDeletable(key).then((result: boolean) => {
+                    this.getDeleteAction().setEnabled(result);
+                });
+            }
         }
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -83,6 +83,25 @@ module api.content.form.inputtype.image {
                 this.uploadDialog.remove();
                 ResponsiveManager.unAvailableSizeChanged(this);
             });
+
+            this.onShown(() => {
+                this.updateSelectedItemsIcons();
+            });
+        }
+
+        private updateSelectedItemsIcons() {
+            if (this.contentComboBox.getSelectedOptions().length > 0) {
+                this.doLoadContent(this.propertyArray).then((contents: ContentSummary[]) => {
+                    contents.forEach((content: ContentSummary) => {
+                        this.selectedOptionsView.updateUploadedOption(<Option<ImageSelectorDisplayValue>>{
+                            value: content.getId(),
+                            displayValue: ImageSelectorDisplayValue.fromContentSummary(content)
+                        });
+                    });
+
+                    this.layoutInProgress = false;
+                });
+            }
         }
 
         availableSizeChanged() {
@@ -269,6 +288,7 @@ module api.content.form.inputtype.image {
                 var selectedOption = this.selectedOptionsView.getById(item.getId());
                 var option = selectedOption.getOption();
                 option.displayValue.setContentSummary(createdContent);
+                option.value = createdContent.getContentId().toString();
 
                 selectedOption.getOptionView().setOption(option);
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionView.ts
@@ -30,13 +30,21 @@ module api.content.form.inputtype.image {
             var content: ImageSelectorDisplayValue = this.getOption().displayValue;
 
             if (content.getContentSummary()) {
-                if (this.isVisible()) {
-                    this.showSpinner();
-                }
-                this.icon.setSrc(content.getImageUrl() + "?thumbnail=false&size=" + ImageSelectorSelectedOptionView.IMAGE_SIZE);
+                this.updateIconSrc(content);
                 this.label.getEl().setInnerHtml(content.getLabel());
             } else {
                 this.showProgress();
+            }
+        }
+
+        private updateIconSrc(content: ImageSelectorDisplayValue) {
+            var newIconSrc = content.getImageUrl() + "?thumbnail=false&size=" + ImageSelectorSelectedOptionView.IMAGE_SIZE;
+
+            if (this.icon.getSrc().indexOf(newIconSrc) == -1) {
+                if (this.isVisible()) {
+                    this.showSpinner();
+                }
+                this.icon.setSrc(newIconSrc);
             }
         }
 
@@ -85,10 +93,7 @@ module api.content.form.inputtype.image {
 
             this.onShown(() => {
                 if (this.getOption().displayValue.getContentSummary()) {
-                    if (this.icon.isLoaded()) {
-                        // refresh image in case it was changed by external wizard
-                        this.icon.refresh();
-                    } else {
+                    if (!this.icon.isLoaded()) {
                         this.showSpinner();
                     }
                 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/TinyMCE.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/TinyMCE.ts
@@ -46,7 +46,10 @@ module api.form.inputtype.text {
                     menubar: false,
                     statusbar: false,
                     paste_as_text: true,
-                    plugins: ['autoresize', 'table', 'link', 'paste', 'charmap', 'code'],
+                    plugins: ['autoresize', 'table', 'paste', 'charmap', 'code'],
+                    external_plugins: {
+                        "link": baseUrl + "/common/js/form/inputtype/text/plugins/link.js"
+                    },
                     autoresize_min_height: 100,
                     autoresize_bottom_margin: 0,
                     height: 100,
@@ -83,11 +86,10 @@ module api.form.inputtype.text {
                         });
                     },
                     init_instance_callback: (editor) => {
+                        this.editor = this.getEditor(textAreaEl.getId(), property);
                         editor.execCommand('mceAutoResize');
                     }
                 });
-
-                this.editor = this.getEditor(textAreaEl.getId(), property);
             });
 
             var textAreaWrapper = new api.dom.DivEl();
@@ -118,6 +120,7 @@ module api.form.inputtype.text {
             // TODO
             return true;
         }
+
     }
 
     api.form.inputtype.InputTypeManager.register(new api.Class("TinyMCE", TinyMCE));

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/_module.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/_module.ts
@@ -2,3 +2,4 @@
 ///<reference path='TextArea.ts' />
 ///<reference path='HtmlArea.ts' />
 ///<reference path='TinyMCE.ts' />
+// @include plugins/link.js

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/plugins/link.js
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/plugins/link.js
@@ -1,0 +1,412 @@
+/*global tinymce:true */
+
+tinymce.PluginManager.add('link', function (editor) {
+    function createLinkList(callback) {
+        return function () {
+            var linkList = editor.settings.link_list;
+
+            if (typeof linkList == "string") {
+                tinymce.util.XHR.send({
+                    url: linkList,
+                    success: function (text) {
+                        callback(tinymce.util.JSON.parse(text));
+                    }
+                });
+            } else if (typeof linkList == "function") {
+                linkList(callback);
+            } else {
+                callback(linkList);
+            }
+        };
+    }
+
+    function buildListItems(inputList, itemCallback, startItems) {
+        function appendItems(values, output) {
+            output = output || [];
+
+            tinymce.each(values, function (item) {
+                var menuItem = {text: item.text || item.title};
+
+                if (item.menu) {
+                    menuItem.menu = appendItems(item.menu);
+                } else {
+                    menuItem.value = item.value;
+
+                    if (itemCallback) {
+                        itemCallback(menuItem);
+                    }
+                }
+
+                output.push(menuItem);
+            });
+
+            return output;
+        }
+
+        return appendItems(inputList, startItems || []);
+    }
+
+    function showDialog(linkList) {
+        var data = {}, selection = editor.selection, dom = editor.dom, selectedElm, anchorElm, initialText;
+        var win, onlyText, textListCtrl, linkListCtrl, relListCtrl, targetListCtrl, classListCtrl, linkTitleCtrl, value;
+
+        function linkListChangeHandler(e) {
+            var textCtrl = win.find('#text');
+
+            if (!textCtrl.value() || (e.lastControl && textCtrl.value() == e.lastControl.text())) {
+                textCtrl.value(e.control.text());
+            }
+
+            win.find('#href').value(e.control.value());
+        }
+
+        function buildAnchorListControl(url) {
+            var anchorList = [];
+
+            tinymce.each(editor.dom.select('a:not([href])'), function (anchor) {
+                var id = anchor.name || anchor.id;
+
+                if (id) {
+                    anchorList.push({
+                        text: id,
+                        value:    '#' + id,
+                        selected: url.indexOf('#' + id) != -1
+                    });
+                }
+            });
+
+            if (anchorList.length) {
+                anchorList.unshift({text: 'None', value: ''});
+
+                return {
+                    name: 'anchor',
+                    type: 'listbox',
+                    label: 'Anchors',
+                    values: anchorList,
+                    onselect: linkListChangeHandler
+                };
+            }
+        }
+
+        function updateText() {
+            if (!initialText && data.text.length === 0 && onlyText) {
+                this.parent().parent().find('#text')[0].value(this.value());
+            }
+        }
+
+        function urlChange(e) {
+            var meta = e.meta || {};
+
+            if (linkListCtrl) {
+                linkListCtrl.value(editor.convertURL(this.value(), 'href'));
+            }
+
+            tinymce.each(e.meta, function (value, key) {
+                win.find('#' + key).value(value);
+            });
+
+            if (!meta.text) {
+                updateText.call(this);
+            }
+        }
+
+        function isOnlyTextSelected(anchorElm) {
+            var html = selection.getContent();
+
+            // Partial html and not a fully selected anchor element
+            if (/</.test(html) && (!/^<a [^>]+>[^<]+<\/a>$/.test(html) || html.indexOf('href=') == -1)) {
+                return false;
+            }
+
+            if (anchorElm) {
+                var nodes = anchorElm.childNodes, i;
+
+                if (nodes.length === 0) {
+                    return false;
+                }
+
+                for (i = nodes.length - 1; i >= 0; i--) {
+                    if (nodes[i].nodeType != 3) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        selectedElm = selection.getNode();
+        anchorElm = dom.getParent(selectedElm, 'a[href]');
+        onlyText = isOnlyTextSelected();
+
+        data.text = initialText = anchorElm ? (anchorElm.innerText || anchorElm.textContent) : selection.getContent({format: 'text'});
+        data.href = anchorElm ? dom.getAttrib(anchorElm, 'href') : '';
+
+        if (anchorElm) {
+            data.target = dom.getAttrib(anchorElm, 'target');
+        } else if (editor.settings.default_link_target) {
+            data.target = editor.settings.default_link_target;
+        }
+
+        if ((value = dom.getAttrib(anchorElm, 'rel'))) {
+            data.rel = value;
+        }
+
+        if ((value = dom.getAttrib(anchorElm, 'class'))) {
+            data['class'] = value;
+        }
+
+        if ((value = dom.getAttrib(anchorElm, 'title'))) {
+            data.title = value;
+        }
+
+        if (onlyText) {
+            textListCtrl = {
+                name: 'text',
+                type: 'textbox',
+                size: 40,
+                label: 'Text to display',
+                onchange: function () {
+                    data.text = this.value();
+                }
+            };
+        }
+
+        if (linkList) {
+            linkListCtrl = {
+                type: 'listbox',
+                label: 'Link list',
+                values: buildListItems(
+                    linkList,
+                    function (item) {
+                        item.value = editor.convertURL(item.value || item.url, 'href');
+                    },
+                    [{text: 'None', value: ''}]
+                ),
+                onselect: linkListChangeHandler,
+                value: editor.convertURL(data.href, 'href'),
+                onPostRender: function () {
+                    linkListCtrl = this;
+                }
+            };
+        }
+
+        targetListCtrl = {
+            name: 'target',
+            type: 'checkbox',
+            label: 'Open new window',
+            checked: false
+        };
+
+        if (editor.settings.link_title !== false) {
+            linkTitleCtrl = {
+                name: 'title',
+                type: 'textbox',
+                label: 'Tooltip',
+                value: data.title
+            };
+        }
+
+        win = editor.windowManager.open({
+            title: 'Insert link',
+            data: data,
+
+            bodyType: 'tabpanel',
+            body: [{
+                title: 'Content',
+                type: "form",
+                classes: 'link-tab-content',
+                items: [
+                    {
+                        name: 'href',
+                        type: 'textbox',
+                        classes: 'link-tab-content-target',
+                        size: 40,
+                        label: 'Target'
+                    },
+                    textListCtrl,
+                    linkTitleCtrl,
+                    targetListCtrl
+                ]
+            }, {
+                title: 'Download',
+                type: "form",
+                classes: 'link-tab-download',
+                items: [
+                    {
+                        name: 'href',
+                        type: 'textbox',
+                        classes: 'link-tab-download-target',
+                        size: 40,
+                        label: 'Target'
+                    },
+                    textListCtrl,
+                    linkTitleCtrl
+                ]
+            }, {
+                title: 'URL',
+                type: "form",
+                classes: 'link-tab-url',
+                items: [
+                    {
+                        name: 'href',
+                        type: 'filepicker',
+                        filetype: 'file',
+                        size: 40,
+                        label: 'URL',
+                        onchange: urlChange,
+                        onkeyup: updateText
+                    },
+                    textListCtrl,
+                    linkTitleCtrl,
+                    targetListCtrl
+                ]
+            }, {
+                title: 'Email',
+                type: "form",
+                classes: 'link-tab-email',
+                items: [
+                    {
+                        name: 'href',
+                        type: 'textbox',
+                        size: 40,
+                        label: 'Email'
+                    },
+                    textListCtrl,
+                    {
+                        name: 'subject',
+                        type: 'textbox',
+                        size: 40,
+                        label: 'Subject'
+                    }, {
+                        name: 'body',
+                        type: 'textbox',
+                        size: 40,
+                        label: 'Body'
+                    }
+                ]
+            }],
+            onSubmit: function (e) {
+                /*eslint dot-notation: 0*/
+                var href;
+                data = tinymce.extend(data, e.data);
+                href = data.href;
+
+                // Delay confirm since onSubmit will move focus
+                function delayedConfirm(message, callback) {
+                    var rng = editor.selection.getRng();
+
+                    window.setTimeout(function () {
+                        editor.windowManager.confirm(message, function (state) {
+                            editor.selection.setRng(rng);
+                            callback(state);
+                        });
+                    }, 0);
+                }
+
+                function insertLink() {
+                    var linkAttrs = {
+                        href: href,
+                        target: data.target ? data.target : null,
+                        rel: data.rel ? data.rel : null,
+                        "class": data["class"] ? data["class"] : null,
+                        title: data.title ? data.title : null
+                    };
+
+                    if (anchorElm) {
+                        editor.focus();
+
+                        if (onlyText && data.text != initialText) {
+                            if ("innerText" in anchorElm) {
+                                anchorElm.innerText = data.text;
+                            } else {
+                                anchorElm.textContent = data.text;
+                            }
+                        }
+
+                        dom.setAttribs(anchorElm, linkAttrs);
+
+                        selection.select(anchorElm);
+                        editor.undoManager.add();
+                    } else {
+                        if (onlyText) {
+                            editor.insertContent(dom.createHTML('a', linkAttrs, dom.encode(data.text)));
+                        } else {
+                            editor.execCommand('mceInsertLink', false, linkAttrs);
+                        }
+                    }
+                }
+
+                if (!href) {
+                    editor.execCommand('unlink');
+                    return;
+                }
+
+                // Is email and not //user@domain.com
+                if (href.indexOf('@') > 0 && href.indexOf('//') == -1 && href.indexOf('mailto:') == -1) {
+                    delayedConfirm(
+                        'The URL you entered seems to be an email address. Do you want to add the required mailto: prefix?',
+                        function (state) {
+                            if (state) {
+                                href = 'mailto:' + href;
+                            }
+
+                            insertLink();
+                        }
+                    );
+
+                    return;
+                }
+
+                // Is not protocol prefixed
+                if ((editor.settings.link_assume_external_targets && !/^\w+:/i.test(href)) ||
+                    (!editor.settings.link_assume_external_targets && /^\s*www\./i.test(href))) {
+                    delayedConfirm(
+                        'The URL you entered seems to be an external link. Do you want to add the required http:// prefix?',
+                        function (state) {
+                            if (state) {
+                                href = 'http://' + href;
+                            }
+
+                            insertLink();
+                        }
+                    );
+
+                    return;
+                }
+
+                insertLink();
+            }
+        });
+    }
+
+    editor.addButton('link', {
+        icon: 'link',
+        tooltip: 'Insert/edit link',
+        shortcut: 'Meta+K',
+        onclick: createLinkList(showDialog),
+        stateSelector: 'a[href]'
+    });
+
+    editor.addButton('unlink', {
+        icon: 'unlink',
+        tooltip: 'Remove link',
+        cmd: 'unlink',
+        stateSelector: 'a[href]'
+    });
+
+    editor.addShortcut('Meta+K', '', createLinkList(showDialog));
+    editor.addCommand('mceLink', createLinkList(showDialog));
+
+    this.showDialog = showDialog;
+
+    editor.addMenuItem('link', {
+        icon: 'link',
+        text: 'Insert/edit link',
+        shortcut: 'Meta+K',
+        onclick: createLinkList(showDialog),
+        stateSelector: 'a[href]',
+        context: 'insert',
+        prependToContext: true
+    });
+});

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/security/UserStore.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/security/UserStore.ts
@@ -23,6 +23,28 @@ module api.security {
             return this.permissions;
         }
 
+        isDeletable(): wemQ.Promise<boolean> {
+            var deferred = wemQ.defer<boolean>();
+            new GetPrincipalsByUserStoreRequest(this.key,
+                [PrincipalType.USER, PrincipalType.GROUP]).
+                sendAndParse().then((principals: Principal[]) => {
+                    if (principals.length > 0) {
+                        deferred.resolve(false);
+                    } else {
+                        deferred.resolve(true);
+                    }
+                }).catch((reason: any) => {
+                    api.DefaultErrorHandler.handle(reason);
+                    deferred.resolve(false);
+                }).done();
+            ;
+            return deferred.promise;
+        }
+
+        static checkOnDeletable(key: UserStoreKey): wemQ.Promise<boolean> {
+            return !!key ? UserStore.create().setKey(key.toString()).build().isDeletable() : null;
+        }
+
         equals(o: api.Equitable): boolean {
             if (!api.ObjectHelper.iFrameSafeInstanceOf(o, UserStore)) {
                 return false;

--- a/modules/admin-ui/src/main/resources/web/admin/common/lib/_module.js
+++ b/modules/admin-ui/src/main/resources/web/admin/common/lib/_module.js
@@ -27,7 +27,6 @@
 // @include tinymce/themes/modern/theme.js
 // @include tinymce/plugins/autoresize/plugin.js
 // @include tinymce/plugins/table/plugin.js
-// @include tinymce/plugins/link/plugin.js
 // @include tinymce/plugins/paste/plugin.js
 // @include tinymce/plugins/charmap/plugin.js
 // @include tinymce/plugins/code/plugin.js

--- a/modules/core-api/src/main/java/com/enonic/xp/content/PushContentRequests.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/content/PushContentRequests.java
@@ -15,11 +15,14 @@ public class PushContentRequests
 
     private final ImmutableSet<PushedBecauseParentOfPushed> pushedBecauseParentOfPusheds;
 
+    private final ImmutableSet<PushedBecauseChildOfPushed> pushedBecauseChildOfPusheds;
+
     private PushContentRequests( Builder builder )
     {
         pushBecauseRequested = ImmutableSet.copyOf( builder.pushBecauseRequested );
         pushedBecauseReferredTos = ImmutableSet.copyOf( builder.pushedBecauseReferredTo );
         pushedBecauseParentOfPusheds = ImmutableSet.copyOf( builder.pushedBecauseParentOf );
+        pushedBecauseChildOfPusheds = ImmutableSet.copyOf( builder.pushedBecauseChildOf );
     }
 
     public static Builder create()
@@ -66,6 +69,19 @@ public class PushContentRequests
         }
     }
 
+    public static class PushedBecauseChildOfPushed
+    {
+        private final ContentId contentId;
+
+        private final ContentId childOf;
+
+        public PushedBecauseChildOfPushed( final ContentId contentId, final ContentId childOf )
+        {
+            this.contentId = contentId;
+            this.childOf = childOf;
+        }
+    }
+
     public static class PushedBecauseReferredTo
     {
         private final ContentId contentId;
@@ -88,6 +104,8 @@ public class PushContentRequests
 
         private final Set<PushedBecauseParentOfPushed> pushedBecauseParentOf = Sets.newHashSet();
 
+        private final Set<PushedBecauseChildOfPushed> pushedBecauseChildOf = Sets.newHashSet();
+
         private Builder()
         {
         }
@@ -101,6 +119,12 @@ public class PushContentRequests
         public Builder addParentOf( final ContentId contentId, final ContentId parentOf )
         {
             this.pushedBecauseParentOf.add( new PushedBecauseParentOfPushed( contentId, parentOf ) );
+            return this;
+        }
+
+        public Builder addChildOf( final ContentId contentId, final ContentId childOf )
+        {
+            this.pushedBecauseChildOf.add( new PushedBecauseChildOfPushed( contentId, childOf ) );
             return this;
         }
 

--- a/modules/core-api/src/main/java/com/enonic/xp/media/ImageOrientation.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/media/ImageOrientation.java
@@ -1,0 +1,66 @@
+package com.enonic.xp.media;
+
+import java.util.HashMap;
+import java.util.Map;
+
+// Image orientation values from EXIF metadata
+// See http://www.impulseadventure.com/photo/exif-orientation.html
+public enum ImageOrientation
+{
+    TopLeft( 1 ), // 0th row at top, 0th column at left
+    TopRight( 2 ), // 0th row at top, 0th column at right
+    BottomRight( 3 ), // 0th row at bottom, 0th column at right
+    BottomLeft( 4 ), // 0th row at bottom, 0th column at left
+    LeftTop( 5 ), // 0th row at left, 0th column at top
+    RightTop( 6 ), // 0th row at right, 0th column at top
+    RightBottom( 7 ), // 0th row at right, 0th column at bottom
+    LeftBottom( 8 ); // 0th row at left, 0th column at bottom
+
+    private static final ImageOrientation DEFAULT = ImageOrientation.TopLeft; // no rotation needed
+
+    private static final Map<Integer, ImageOrientation> LOOKUP_TABLE = new HashMap<>();
+
+    static
+    {
+        for ( final ImageOrientation imageOrientation : ImageOrientation.values() )
+        {
+            LOOKUP_TABLE.put( imageOrientation.value, imageOrientation );
+        }
+    }
+
+    private final int value;
+
+    private ImageOrientation( final int value )
+    {
+        this.value = value;
+    }
+
+    public int getValue()
+    {
+        return value;
+    }
+
+    public static ImageOrientation valueOf( final int value )
+    {
+        final ImageOrientation orientation = LOOKUP_TABLE.get( value );
+        return orientation == null ? DEFAULT : orientation;
+    }
+
+    public static ImageOrientation from( final String value )
+    {
+        if ( value == null )
+        {
+            return null;
+        }
+        try
+        {
+            final Integer intValue = Integer.valueOf( value );
+            final ImageOrientation orientation = LOOKUP_TABLE.get( intValue );
+            return orientation == null ? DEFAULT : orientation;
+        }
+        catch ( NumberFormatException e )
+        {
+            return DEFAULT;
+        }
+    }
+}

--- a/modules/core-api/src/main/java/com/enonic/xp/media/MediaInfoService.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/media/MediaInfoService.java
@@ -8,5 +8,5 @@ public interface MediaInfoService
 {
     MediaInfo parseMediaInfo( ByteSource byteSource );
 
-    Integer getImageOrientation( ByteSource byteSource );
+    ImageOrientation getImageOrientation( ByteSource byteSource );
 }

--- a/modules/core-api/src/main/java/com/enonic/xp/media/MediaInfoService.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/media/MediaInfoService.java
@@ -8,5 +8,5 @@ public interface MediaInfoService
 {
     MediaInfo parseMediaInfo( ByteSource byteSource );
 
-    Integer getOrientation( ByteSource byteSource );
+    Integer getImageOrientation( ByteSource byteSource );
 }

--- a/modules/core-api/src/main/java/com/enonic/xp/node/NodePublishReasonIsChild.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/node/NodePublishReasonIsChild.java
@@ -1,0 +1,29 @@
+package com.enonic.xp.node;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public class NodePublishReasonIsChild
+    implements NodePublishReason
+{
+    private final String message = "Child of %s";
+
+    private final NodeId nodeId;
+
+    public NodePublishReasonIsChild( final NodeId nodeId )
+    {
+        this.nodeId = nodeId;
+    }
+
+    @Override
+    public NodeId getContextualNodeId()
+    {
+        return nodeId;
+    }
+
+    @Override
+    public String getMessage()
+    {
+        return String.format( message, nodeId.toString() );
+    }
+}

--- a/modules/core-api/src/main/java/com/enonic/xp/node/NodePublishRequest.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/node/NodePublishRequest.java
@@ -25,6 +25,11 @@ public class NodePublishRequest
         return ( this.reason instanceof NodePublishReasonIsParent );
     }
 
+    public boolean reasonRequested()
+    {
+        return ( this.reason instanceof NodePublishReasonRequested );
+    }
+
     public boolean reasonReferredFrom()
     {
         return ( this.reason instanceof NodePublishReasonIsReferred );

--- a/modules/core-api/src/main/java/com/enonic/xp/node/NodePublishRequest.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/node/NodePublishRequest.java
@@ -25,6 +25,11 @@ public class NodePublishRequest
         return ( this.reason instanceof NodePublishReasonIsParent );
     }
 
+    public boolean reasonChildOf()
+    {
+        return ( this.reason instanceof NodePublishReasonIsChild );
+    }
+
     public boolean reasonRequested()
     {
         return ( this.reason instanceof NodePublishReasonRequested );
@@ -48,6 +53,11 @@ public class NodePublishRequest
     public static NodePublishRequest parentFor( final NodeId nodeId, final NodeId parentOf )
     {
         return new NodePublishRequest( nodeId, new NodePublishReasonIsParent( parentOf ) );
+    }
+
+    public static NodePublishRequest childOf( final NodeId nodeId, final NodeId childOf )
+    {
+        return new NodePublishRequest( nodeId, new NodePublishReasonIsChild( childOf ) );
     }
 
     public static NodePublishRequest referredFrom( final NodeId nodeId, final NodeId referredFrom )

--- a/modules/core-api/src/main/java/com/enonic/xp/node/NodePublishRequests.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/node/NodePublishRequests.java
@@ -22,6 +22,8 @@ public class NodePublishRequests
 
     private final Set<NodePublishRequest> publishAsRequested = Sets.newHashSet();
 
+    private final Set<NodePublishRequest> publishAsChildOf = Sets.newHashSet();
+
     public int size()
     {
         return this.nodePublishRequests.size();
@@ -35,6 +37,11 @@ public class NodePublishRequests
     public Set<NodePublishRequest> getPublishAsParentFor()
     {
         return publishAsParentFor;
+    }
+
+    public Set<NodePublishRequest> getPublishAsChildOf()
+    {
+        return publishAsChildOf;
     }
 
     public Set<NodePublishRequest> getPublishAsReferredTo()
@@ -79,6 +86,10 @@ public class NodePublishRequests
         else if ( nodePublishRequest.reasonReferredFrom() )
         {
             publishAsReferredTo.add( nodePublishRequest );
+        }
+        else if ( nodePublishRequest.reasonChildOf() )
+        {
+            publishAsChildOf.add( nodePublishRequest );
         }
         else
         {

--- a/modules/core-api/src/main/java/com/enonic/xp/node/ResolveSyncWorkResult.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/node/ResolveSyncWorkResult.java
@@ -76,6 +76,12 @@ public class ResolveSyncWorkResult
             return this;
         }
 
+        public Builder publishChildOf( final NodeId nodeId, final NodeId childOf )
+        {
+            this.nodePublishRequests.add( NodePublishRequest.childOf( nodeId, childOf ) );
+            return this;
+        }
+
         public Builder publishReferredFrom( final NodeId nodeId, final NodeId referredFrom )
         {
             this.nodePublishRequests.add( NodePublishRequest.referredFrom( nodeId, referredFrom ) );

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/PushContentRequestsFactory.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/PushContentRequestsFactory.java
@@ -39,5 +39,11 @@ class PushContentRequestsFactory
         {
             builder.addRequested( ContentId.from( requested.getNodeId().toString() ) );
         }
+
+        for ( final NodePublishRequest childOf : nodePublishRequests.getPublishAsChildOf() )
+        {
+            builder.addChildOf( ContentId.from( childOf.getNodeId().toString() ),
+                                ContentId.from( childOf.getReason().getContextualNodeId().toString() ) );
+        }
     }
 }

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/media/MediaInfoServiceImpl.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/media/MediaInfoServiceImpl.java
@@ -17,6 +17,7 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import com.google.common.io.ByteSource;
 
+import com.enonic.xp.media.ImageOrientation;
 import com.enonic.xp.media.MediaInfo;
 import com.enonic.xp.media.MediaInfoService;
 import com.enonic.xp.util.Exceptions;
@@ -58,12 +59,11 @@ public final class MediaInfoServiceImpl
     }
 
     @Override
-    public Integer getImageOrientation( ByteSource byteSource )
+    public ImageOrientation getImageOrientation( ByteSource byteSource )
     {
-        Metadata metadata = this.parseMetadata( byteSource );
-        String orientation = metadata.get( Metadata.ORIENTATION );
-
-        return orientation == null ? 0 : Integer.valueOf( orientation );
+        final Metadata metadata = this.parseMetadata( byteSource );
+        final String orientation = metadata.get( Metadata.ORIENTATION );
+        return ImageOrientation.from( orientation );
     }
 
     private Metadata parseMetadata( final ByteSource byteSource )

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/media/MediaInfoServiceImpl.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/media/MediaInfoServiceImpl.java
@@ -58,7 +58,7 @@ public final class MediaInfoServiceImpl
     }
 
     @Override
-    public Integer getOrientation( ByteSource byteSource )
+    public Integer getImageOrientation( ByteSource byteSource )
     {
         Metadata metadata = this.parseMetadata( byteSource );
         String orientation = metadata.get( Metadata.ORIENTATION );

--- a/modules/core-repo/src/test/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommandTest.java
+++ b/modules/core-repo/src/test/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommandTest.java
@@ -878,6 +878,7 @@ public class ResolveSyncWorkCommandTest
         assertNode( nodePublishRequests, "b2" );
         assertNode( nodePublishRequests, "b2_1" );
 
+        assertTrue( nodePublishRequests.get( NodeId.from( "s1" ) ).reasonRequested() );
         assertTrue( nodePublishRequests.get( NodeId.from( "b2_1" ) ).reasonReferredFrom() );
         assertTrue( nodePublishRequests.get( NodeId.from( "b2" ) ).reasonParentFor() );
         assertTrue( nodePublishRequests.get( NodeId.from( "s2" ) ).reasonParentFor() );
@@ -886,6 +887,50 @@ public class ResolveSyncWorkCommandTest
         //assertTrue( nodePublishRequests.get( NodeId.from( "a2" ) ).reasonChildOf() );
         //assertTrue( nodePublishRequests.get( NodeId.from( "a2_1" ) ).reasonChildOf() );
     }
+
+
+    /*
+    - S1 (New)
+     - A1 (New)
+     - A2 (New)
+         - A2_1 - Ref:B2_1 (New)
+    - S2 (New)
+     - B1 (New)
+     - B2 (New)
+         - B2_1 (New)
+    - S1d (New)
+    - A1d (New)
+    - A2d (New)
+         - A2_1d - Ref:B2_1 (New)
+
+    Publish A2 with children, should publish S1, A1, A2, A2_1, B2_1, B2, S2
+    */
+    @Test
+    public void resolve_with_include_children_2()
+        throws Exception
+    {
+        createS1S2Tree();
+
+        final ResolveSyncWorkResult result = getResolveSyncWorkResult( NodeId.from( "a2" ), true );
+
+        final NodePublishRequests nodePublishRequests = result.getNodePublishRequests();
+
+        assertEquals( 6, nodePublishRequests.size() );
+
+        assertNode( nodePublishRequests, "s1" );
+        assertNode( nodePublishRequests, "a2" );
+        assertNode( nodePublishRequests, "a2_1" );
+        assertNode( nodePublishRequests, "s2" );
+        assertNode( nodePublishRequests, "b2" );
+        assertNode( nodePublishRequests, "b2_1" );
+
+        assertTrue( nodePublishRequests.get( NodeId.from( "a2" ) ).reasonRequested() );
+        assertTrue( nodePublishRequests.get( NodeId.from( "b2_1" ) ).reasonReferredFrom() );
+        assertTrue( nodePublishRequests.get( NodeId.from( "b2" ) ).reasonParentFor() );
+        assertTrue( nodePublishRequests.get( NodeId.from( "s2" ) ).reasonParentFor() );
+        //assertTrue( nodePublishRequests.get( NodeId.from( "a2_1" ) ).reasonChildOf() );
+    }
+
 
 
     @Test

--- a/modules/core-repo/src/test/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommandTest.java
+++ b/modules/core-repo/src/test/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommandTest.java
@@ -924,6 +924,7 @@ public class ResolveSyncWorkCommandTest
         assertNode( nodePublishRequests, "b2" );
         assertNode( nodePublishRequests, "b2_1" );
 
+        assertTrue( nodePublishRequests.get( NodeId.from( "s1" ) ).reasonParentFor() );
         assertTrue( nodePublishRequests.get( NodeId.from( "a2" ) ).reasonRequested() );
         assertTrue( nodePublishRequests.get( NodeId.from( "b2_1" ) ).reasonReferredFrom() );
         assertTrue( nodePublishRequests.get( NodeId.from( "b2" ) ).reasonParentFor() );

--- a/modules/core-repo/src/test/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommandTest.java
+++ b/modules/core-repo/src/test/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommandTest.java
@@ -310,7 +310,7 @@ public class ResolveSyncWorkCommandTest
             name( "node2_1" ).
             build() );
 
-        final ResolveSyncWorkResult result = getResolveSyncWorkResult( node1.id(), false );
+        final ResolveSyncWorkResult result = getResolveSyncWorkResult( node1_1.id(), false );
 
         final NodePublishRequests nodePublishRequests = result.getNodePublishRequests();
         assertEquals( 3, nodePublishRequests.size() );
@@ -381,11 +381,11 @@ public class ResolveSyncWorkCommandTest
 
         final NodePublishRequest node2PublishRequest = nodePublishRequests.get( node2.id() );
         assertNotNull( node2PublishRequest );
-        assertTrue( node2PublishRequest.reasonParentFor() );
+        assertTrue( node2PublishRequest.reasonReferredFrom() );
 
         final NodePublishRequest node2_1PublishRequest = nodePublishRequests.get( node2_1.id() );
         assertNotNull( node2_1PublishRequest );
-        assertTrue( node2_1PublishRequest.reasonParentFor() );
+        assertTrue( node2_1PublishRequest.reasonReferredFrom() );
     }
 
     @Test
@@ -802,7 +802,6 @@ public class ResolveSyncWorkCommandTest
         assertNode( nodePublishRequests, "b2_1" );
     }
 
-
     /*
  - S1 (New)
      - A1 (New)
@@ -828,7 +827,7 @@ public class ResolveSyncWorkCommandTest
 
         duplicateNode( getNodeById( NodeId.from( "s1" ) ) );
 
-        final ResolveSyncWorkResult result = getResolveSyncWorkResult( "s1" );
+        final ResolveSyncWorkResult result = getResolveSyncWorkResult( NodeId.from( "s1" ), true );
 
         final NodePublishRequests nodePublishRequests = result.getNodePublishRequests();
 
@@ -880,12 +879,12 @@ public class ResolveSyncWorkCommandTest
 
         assertTrue( nodePublishRequests.get( NodeId.from( "s1" ) ).reasonRequested() );
         assertTrue( nodePublishRequests.get( NodeId.from( "b2_1" ) ).reasonReferredFrom() );
-        assertTrue( nodePublishRequests.get( NodeId.from( "b2" ) ).reasonParentFor() );
-        assertTrue( nodePublishRequests.get( NodeId.from( "s2" ) ).reasonParentFor() );
+        assertTrue( nodePublishRequests.get( NodeId.from( "b2" ) ).reasonReferredFrom() );
+        assertTrue( nodePublishRequests.get( NodeId.from( "s2" ) ).reasonReferredFrom() );
 
-        //assertTrue( nodePublishRequests.get( NodeId.from( "a1" ) ).reasonChildOf() );
-        //assertTrue( nodePublishRequests.get( NodeId.from( "a2" ) ).reasonChildOf() );
-        //assertTrue( nodePublishRequests.get( NodeId.from( "a2_1" ) ).reasonChildOf() );
+        assertTrue( nodePublishRequests.get( NodeId.from( "a1" ) ).reasonChildOf() );
+        assertTrue( nodePublishRequests.get( NodeId.from( "a2" ) ).reasonChildOf() );
+        assertTrue( nodePublishRequests.get( NodeId.from( "a2_1" ) ).reasonChildOf() );
     }
 
 
@@ -927,12 +926,10 @@ public class ResolveSyncWorkCommandTest
         assertTrue( nodePublishRequests.get( NodeId.from( "s1" ) ).reasonParentFor() );
         assertTrue( nodePublishRequests.get( NodeId.from( "a2" ) ).reasonRequested() );
         assertTrue( nodePublishRequests.get( NodeId.from( "b2_1" ) ).reasonReferredFrom() );
-        assertTrue( nodePublishRequests.get( NodeId.from( "b2" ) ).reasonParentFor() );
-        assertTrue( nodePublishRequests.get( NodeId.from( "s2" ) ).reasonParentFor() );
-        //assertTrue( nodePublishRequests.get( NodeId.from( "a2_1" ) ).reasonChildOf() );
+        assertTrue( nodePublishRequests.get( NodeId.from( "b2" ) ).reasonReferredFrom() );
+        assertTrue( nodePublishRequests.get( NodeId.from( "s2" ) ).reasonReferredFrom() );
+        assertTrue( nodePublishRequests.get( NodeId.from( "a2_1" ) ).reasonChildOf() );
     }
-
-
 
     @Test
     public void publish_duplicate_of_original_do_not_publish_original()
@@ -942,7 +939,7 @@ public class ResolveSyncWorkCommandTest
 
         final Node s1d = duplicateNode( getNodeById( NodeId.from( "s1" ) ) );
 
-        final ResolveSyncWorkResult result = getResolveSyncWorkResult( s1d.id(), false );
+        final ResolveSyncWorkResult result = getResolveSyncWorkResult( s1d.id(), true );
 
         final NodePublishRequests nodePublishRequests = result.getNodePublishRequests();
 


### PR DESCRIPTION
- Added NodePublishReasonIsChild class to refer nodes that were published as a child of initially published node (includeChildren parameter should be true)
- Modified logic of usage of ResolveContext objects in ResolveSyncWorkCommand - now all resolved nodes ResolveContext is based on their relation to initially published node instead of resolving against node that triggered publishing of each node
- Modified ResolveSyncWorkCommand to adhere to new logic of ResolveContext
- Modified tests
- Merged with Master