### PR TITLE
XP-478 Tiny MCE, Content Wizard page: button 'Add' does not work, whe…

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/form/inputtype/text/tinymce.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/form/inputtype/text/tinymce.less
@@ -64,7 +64,7 @@
     }
   }
 
-  &.sticky-toolbar {
+  .sticky-toolbar {
     .mce-toolbar-grp {
       position: fixed;
     }


### PR DESCRIPTION
…n 'mce-toolbar' showed in the text area

-Updated tinymce editor to preserve size when losing focus (When losing focus tinymce editor was reducing size so all elements were shifting and 'Add' button was moving right on the time when you try to click it.)
-Updated handling of sticky toolbar to correctly behave with multiple input occurences (Issue occured because previously didn't take into account multiple input occurences )