### PR TITLE
XP-478 Tiny MCE, Content Wizard page: button 'Add' does not work, whe…

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/TinyMCE.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/TinyMCE.ts
@@ -35,6 +35,7 @@ module api.form.inputtype.text {
             var clazz = textAreaEl.getId().replace(/\./g, '_');
             textAreaEl.addClass(clazz);
             var baseUrl = CONFIG.assetsUri;
+            var textAreaWrapper = new api.dom.DivEl();
 
             textAreaEl.onRendered(() => {
                 tinymce.init({
@@ -64,9 +65,11 @@ module api.form.inputtype.text {
                             property.setValue(value);
                         });
                         editor.on('focus', (e) => {
+                            this.resetInputHeight();
                             textAreaWrapper.addClass(focusedEditorCls);
                         });
                         editor.on('blur', (e) => {
+                            this.setStaticInputHeight();
                             textAreaWrapper.removeClass(focusedEditorCls);
                         });
                         editor.on('keydown', (e) => {
@@ -91,35 +94,43 @@ module api.form.inputtype.text {
                     },
                     init_instance_callback: (editor) => {
                         this.editor = this.getEditor(textAreaEl.getId(), property);
-                        editor.execCommand('mceAutoResize');
+                        this.setupStickyEditorToolbarForInputOccurence(textAreaWrapper);
                     }
                 });
 
-                this.setupStickyEditorToolbar();
             });
 
-            var textAreaWrapper = new api.dom.DivEl();
             textAreaWrapper.appendChild(textAreaEl);
             return textAreaWrapper;
         }
 
-        private setupStickyEditorToolbar() {
-            wemjq(this.getHTMLElement()).closest(".form-panel").on("scroll", () => this.updateStickyEditorToolbar());
+        private setupStickyEditorToolbarForInputOccurence(inputOccurence: Element) {
+            wemjq(this.getHTMLElement()).closest(".form-panel").on("scroll", () => this.updateStickyEditorToolbar(inputOccurence));
 
             api.ui.responsive.ResponsiveManager.onAvailableSizeChanged(this, () => {
                 this.updateEditorToolbarWidth();
-                this.updateEditorToolbarPos();
+                this.updateEditorToolbarPos(inputOccurence);
+            });
+
+            this.onOccurrenceAdded(() => {
+                this.resetInputHeight();
+                this.updateEditorToolbarWidth();
+            });
+
+            this.onOccurrenceRemoved(() => {
+                this.resetInputHeight();
+                this.updateEditorToolbarWidth();
             });
         }
 
-        private updateStickyEditorToolbar() {
-            if (!this.editorTopEdgeIsVisible() && this.editorLowerEdgeIsVisible()) {
-                this.addClass("sticky-toolbar");
+        private updateStickyEditorToolbar(inputOccurence: Element) {
+            if (!this.editorTopEdgeIsVisible(inputOccurence) && this.editorLowerEdgeIsVisible(inputOccurence)) {
+                inputOccurence.addClass("sticky-toolbar");
                 this.updateEditorToolbarWidth();
-                this.updateEditorToolbarPos();
+                this.updateEditorToolbarPos(inputOccurence);
             }
             else {
-                this.removeClass("sticky-toolbar")
+                inputOccurence.removeClass("sticky-toolbar")
             }
         }
 
@@ -127,23 +138,22 @@ module api.form.inputtype.text {
             wemjq(this.getHTMLElement()).find(".mce-toolbar-grp").width(wemjq(this.getHTMLElement()).find(".mce-edit-area").innerWidth());
         }
 
-        private updateEditorToolbarPos() {
-            wemjq(this.getHTMLElement()).find(".mce-toolbar-grp").css({top: this.getToolbarOffsetTop(10)});
+        private updateEditorToolbarPos(inputOccurence: Element) {
+            wemjq(inputOccurence.getHTMLElement()).find(".mce-toolbar-grp").css({top: this.getToolbarOffsetTop(1)});
         }
 
-        private editorTopEdgeIsVisible(): boolean {
-            return this.calcDistToTopOfScrlbleArea() > 0;
+        private editorTopEdgeIsVisible(inputOccurence: Element): boolean {
+            return this.calcDistToTopOfScrlbleArea(inputOccurence) > 0;
         }
 
-        private editorLowerEdgeIsVisible(): boolean {
-            var distToTopOfScrlblArea = this.calcDistToTopOfScrlbleArea();
-            var editorToolbarHeight = wemjq(this.getHTMLElement()).find(".mce-toolbar-grp").outerHeight(true);
-
-            return (this.getEl().getHeightWithoutPadding() - editorToolbarHeight + distToTopOfScrlblArea) > 0;
+        private editorLowerEdgeIsVisible(inputOccurence: Element): boolean {
+            var distToTopOfScrlblArea = this.calcDistToTopOfScrlbleArea(inputOccurence);
+            var editorToolbarHeight = wemjq(inputOccurence.getHTMLElement()).find(".mce-toolbar-grp").outerHeight(true);
+            return (inputOccurence.getEl().getHeightWithoutPadding() - editorToolbarHeight + distToTopOfScrlblArea) > 0;
         }
 
-        private calcDistToTopOfScrlbleArea(): number {
-            return this.getEl().getOffsetTop() - this.getToolbarOffsetTop();
+        private calcDistToTopOfScrlbleArea(inputOccurence: Element): number {
+            return inputOccurence.getEl().getOffsetTop() - this.getToolbarOffsetTop();
         }
 
         private getToolbarOffsetTop(delta: number = 0): number {
@@ -152,6 +162,14 @@ module api.form.inputtype.text {
                 stickyToolbarOffset = toolbar.offset().top;
 
             return stickyToolbarOffset + stickyToolbarHeight + delta;
+        }
+
+        private resetInputHeight() {
+            wemjq(this.getHTMLElement()).height("auto");
+        }
+
+        private setStaticInputHeight() {
+            wemjq(this.getHTMLElement()).height(wemjq(this.getHTMLElement()).height());
         }
 
         private getEditor(editorId: string, property: Property): TinyMceEditor {

--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/form/inputtype/text/tinymce.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/form/inputtype/text/tinymce.less
@@ -64,9 +64,12 @@
     }
   }
 
-  &.sticky-toolbar {
+  .sticky-toolbar {
     .mce-toolbar-grp {
       position: fixed;
+      .box-shadow(2px 2px 10px @admin-dark-gray);
+      z-index: 1000;
+      border-top: 1px solid @admin-dark-gray-border;
     }
   }
 }


### PR DESCRIPTION
…n 'mce-toolbar' showed in the text area

-Updated tinymce editor to preserve size when losing focus (When losing focus tinymce editor was reducing size so all elements were shifting and 'Add' button was moving right on the time when you try to click it.)
-Updated handling of sticky toolbar to correctly behave with multiple input occurences (Issue occured because previously didn't take into account multiple input occurences )

XP-482 TinyMCE - Adjustments to floating toolbar design
-Add a clearly visible drop shadow (similar as used other places in wizard)
-Drop the margin above the toolbar - so it is close to the wizardStepNavigator
-Should be 1px thin border separating it from the navbar.