### PR TITLE
XP-494 Publish parent of modified content broken wizard

### DIFF
--- a/modules/core-api/src/main/java/com/enonic/xp/node/NodePublishRequest.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/node/NodePublishRequest.java
@@ -9,10 +9,13 @@ public class NodePublishRequest
 
     private final NodePublishReason reason;
 
-    private NodePublishRequest( final NodeId nodeId, final NodePublishReason reason )
+    private final NodeId initialReasonNodeId;
+
+    private NodePublishRequest( final NodeId nodeId, final NodePublishReason reason, final NodeId initialReasonNodeId )
     {
         this.nodeId = nodeId;
         this.reason = reason;
+        this.initialReasonNodeId = initialReasonNodeId;
     }
 
     public NodeId getNodeId()
@@ -45,23 +48,28 @@ public class NodePublishRequest
         return reason;
     }
 
-    public static NodePublishRequest requested( final NodeId nodeId )
+    public NodeId getInitialReasonNodeId()
     {
-        return new NodePublishRequest( nodeId, new NodePublishReasonRequested() );
+        return initialReasonNodeId;
     }
 
-    public static NodePublishRequest parentFor( final NodeId nodeId, final NodeId parentOf )
+    public static NodePublishRequest requested( final NodeId nodeId, final NodeId initialReasonNodeId )
     {
-        return new NodePublishRequest( nodeId, new NodePublishReasonIsParent( parentOf ) );
+        return new NodePublishRequest( nodeId, new NodePublishReasonRequested(), initialReasonNodeId );
     }
 
-    public static NodePublishRequest childOf( final NodeId nodeId, final NodeId childOf )
+    public static NodePublishRequest parentFor( final NodeId nodeId, final NodeId parentOf, final NodeId initialReasonNodeId )
     {
-        return new NodePublishRequest( nodeId, new NodePublishReasonIsChild( childOf ) );
+        return new NodePublishRequest( nodeId, new NodePublishReasonIsParent( parentOf ), initialReasonNodeId );
     }
 
-    public static NodePublishRequest referredFrom( final NodeId nodeId, final NodeId referredFrom )
+    public static NodePublishRequest childOf( final NodeId nodeId, final NodeId childOf, final NodeId initialReasonNodeId )
     {
-        return new NodePublishRequest( nodeId, new NodePublishReasonIsReferred( referredFrom ) );
+        return new NodePublishRequest( nodeId, new NodePublishReasonIsChild( childOf ), initialReasonNodeId );
+    }
+
+    public static NodePublishRequest referredFrom( final NodeId nodeId, final NodeId referredFrom, final NodeId initialReasonNodeId )
+    {
+        return new NodePublishRequest( nodeId, new NodePublishReasonIsReferred( referredFrom ), initialReasonNodeId );
     }
 }

--- a/modules/core-api/src/main/java/com/enonic/xp/node/ResolveSyncWorkResult.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/node/ResolveSyncWorkResult.java
@@ -74,55 +74,55 @@ public class ResolveSyncWorkResult
         {
         }
 
-        public Builder publishRequested( final NodeId nodeId )
+        public Builder publishRequested( final NodeId nodeId, final NodeId initialReasonNodeId )
         {
-            this.nodePublishRequests.add( NodePublishRequest.requested( nodeId ) );
+            this.nodePublishRequests.add( NodePublishRequest.requested( nodeId, initialReasonNodeId ) );
             return this;
         }
 
-        public Builder publishParentFor( final NodeId nodeId, final NodeId parentOf )
+        public Builder publishParentFor( final NodeId nodeId, final NodeId parentOf, final NodeId initialReasonNodeId )
         {
-            this.nodePublishRequests.add( NodePublishRequest.parentFor( nodeId, parentOf ) );
+            this.nodePublishRequests.add( NodePublishRequest.parentFor( nodeId, parentOf, initialReasonNodeId ) );
             return this;
         }
 
-        public Builder publishChildOf( final NodeId nodeId, final NodeId childOf )
+        public Builder publishChildOf( final NodeId nodeId, final NodeId childOf, final NodeId initialReasonNodeId )
         {
-            this.nodePublishRequests.add( NodePublishRequest.childOf( nodeId, childOf ) );
+            this.nodePublishRequests.add( NodePublishRequest.childOf( nodeId, childOf, initialReasonNodeId ) );
             return this;
         }
 
-        public Builder publishReferredFrom( final NodeId nodeId, final NodeId referredFrom )
+        public Builder publishReferredFrom( final NodeId nodeId, final NodeId referredFrom, final NodeId initialReasonNodeId )
         {
-            this.nodePublishRequests.add( NodePublishRequest.referredFrom( nodeId, referredFrom ) );
+            this.nodePublishRequests.add( NodePublishRequest.referredFrom( nodeId, referredFrom, initialReasonNodeId ) );
             return this;
         }
 
-        public Builder deleteRequested( final NodeId nodeId )
+        public Builder deleteRequested( final NodeId nodeId, final NodeId initialReasonNodeId )
         {
             this.delete.add( nodeId );
-            this.nodeDeleteRequests.add( NodePublishRequest.requested( nodeId ) );
+            this.nodeDeleteRequests.add( NodePublishRequest.requested( nodeId, initialReasonNodeId ) );
             return this;
         }
 
-        public Builder deleteParentFor( final NodeId nodeId, final NodeId parentOf )
+        public Builder deleteParentFor( final NodeId nodeId, final NodeId parentOf, final NodeId initialReasonNodeId )
         {
             this.delete.add( nodeId );
-            this.nodeDeleteRequests.add( NodePublishRequest.parentFor( nodeId, parentOf ) );
+            this.nodeDeleteRequests.add( NodePublishRequest.parentFor( nodeId, parentOf, initialReasonNodeId ) );
             return this;
         }
 
-        public Builder deleteChildOf( final NodeId nodeId, final NodeId childOf )
+        public Builder deleteChildOf( final NodeId nodeId, final NodeId childOf, final NodeId initialReasonNodeId )
         {
             this.delete.add( nodeId );
-            this.nodeDeleteRequests.add( NodePublishRequest.childOf( nodeId, childOf ) );
+            this.nodeDeleteRequests.add( NodePublishRequest.childOf( nodeId, childOf, initialReasonNodeId ) );
             return this;
         }
 
-        public Builder deleteReferredFrom( final NodeId nodeId, final NodeId referredFrom )
+        public Builder deleteReferredFrom( final NodeId nodeId, final NodeId referredFrom, final NodeId initialReasonNodeId )
         {
             this.delete.add( nodeId );
-            this.nodeDeleteRequests.add( NodePublishRequest.referredFrom( nodeId, referredFrom ) );
+            this.nodeDeleteRequests.add( NodePublishRequest.referredFrom( nodeId, referredFrom, initialReasonNodeId ) );
             return this;
         }
 

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/PushContentRequestsFactory.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/PushContentRequestsFactory.java
@@ -27,24 +27,28 @@ class PushContentRequestsFactory
         for ( final NodePublishRequest parentOf : nodePublishRequests.getPublishAsParentFor() )
         {
             builder.addParentOf( ContentId.from( parentOf.getNodeId().toString() ),
-                                 ContentId.from( parentOf.getReason().getContextualNodeId().toString() ) );
+                                 ContentId.from( parentOf.getReason().getContextualNodeId().toString() ),
+                                 ContentId.from( parentOf.getInitialReasonNodeId().toString() ) );
         }
 
         for ( final NodePublishRequest referredTo : nodePublishRequests.getPublishAsReferredTo() )
         {
             builder.addReferredTo( ContentId.from( referredTo.getNodeId().toString() ),
-                                   ContentId.from( referredTo.getReason().getContextualNodeId().toString() ) );
+                                   ContentId.from( referredTo.getReason().getContextualNodeId().toString() ),
+                                   ContentId.from( referredTo.getInitialReasonNodeId().toString() ) );
         }
 
         for ( final NodePublishRequest requested : nodePublishRequests.getPublishAsRequested() )
         {
-            builder.addRequested( ContentId.from( requested.getNodeId().toString() ) );
+            builder.addRequested( ContentId.from( requested.getNodeId().toString() ),
+                                  ContentId.from( requested.getInitialReasonNodeId().toString() ) );
         }
 
         for ( final NodePublishRequest childOf : nodePublishRequests.getPublishAsChildOf() )
         {
             builder.addChildOf( ContentId.from( childOf.getNodeId().toString() ),
-                                ContentId.from( childOf.getReason().getContextualNodeId().toString() ) );
+                                ContentId.from( childOf.getReason().getContextualNodeId().toString() ),
+                                ContentId.from( childOf.getInitialReasonNodeId().toString() ) );
         }
     }
 
@@ -53,24 +57,28 @@ class PushContentRequestsFactory
         for ( final NodePublishRequest parentOf : nodePublishRequests.getPublishAsParentFor() )
         {
             builder.addDeleteBecauseParentOf( ContentId.from( parentOf.getNodeId().toString() ),
-                                              ContentId.from( parentOf.getReason().getContextualNodeId().toString() ) );
+                                              ContentId.from( parentOf.getReason().getContextualNodeId().toString() ),
+                                              ContentId.from( parentOf.getInitialReasonNodeId().toString() ) );
         }
 
         for ( final NodePublishRequest referredTo : nodePublishRequests.getPublishAsReferredTo() )
         {
             builder.addDeleteBecauseReferredTo( ContentId.from( referredTo.getNodeId().toString() ),
-                                                ContentId.from( referredTo.getReason().getContextualNodeId().toString() ) );
+                                                ContentId.from( referredTo.getReason().getContextualNodeId().toString() ),
+                                                ContentId.from( referredTo.getInitialReasonNodeId().toString() ) );
         }
 
         for ( final NodePublishRequest requested : nodePublishRequests.getPublishAsRequested() )
         {
-            builder.addDeleteRequested( ContentId.from( requested.getNodeId().toString() ) );
+            builder.addDeleteRequested( ContentId.from( requested.getNodeId().toString() ),
+                                        ContentId.from( requested.getInitialReasonNodeId().toString() ) );
         }
 
         for ( final NodePublishRequest childOf : nodePublishRequests.getPublishAsChildOf() )
         {
             builder.addDeleteBecauseChildOf( ContentId.from( childOf.getNodeId().toString() ),
-                                ContentId.from( childOf.getReason().getContextualNodeId().toString() ) );
+                                             ContentId.from( childOf.getReason().getContextualNodeId().toString() ),
+                                             ContentId.from( childOf.getInitialReasonNodeId().toString() ) );
         }
     }
 }

--- a/modules/core-impl/src/test/java/com/enonic/xp/core/impl/content/PushContentCommandTest.java
+++ b/modules/core-impl/src/test/java/com/enonic/xp/core/impl/content/PushContentCommandTest.java
@@ -51,8 +51,8 @@ public class PushContentCommandTest
     {
         Mockito.when( nodeService.resolveSyncWork( Mockito.isA( SyncWorkResolverParams.class ) ) ).
             thenReturn( ResolveSyncWorkResult.create().
-                publishRequested( NodeId.from( "s1" ) ).
-                publishRequested( NodeId.from( "s2" ) ).
+                publishRequested( NodeId.from( "s1" ), NodeId.from( "s1" ) ).
+                publishRequested( NodeId.from( "s2" ), NodeId.from( "s2" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -88,8 +88,8 @@ public class PushContentCommandTest
     {
         Mockito.when( nodeService.resolveSyncWork( Mockito.isA( SyncWorkResolverParams.class ) ) ).
             thenReturn( ResolveSyncWorkResult.create().
-                publishRequested( NodeId.from( "s1" ) ).
-                publishReferredFrom( NodeId.from( "s1" ), NodeId.from( "s2" ) ).
+                publishRequested( NodeId.from( "s1" ), NodeId.from( "s1" ) ).
+                publishReferredFrom( NodeId.from( "s1" ), NodeId.from( "s2" ), NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -127,8 +127,8 @@ public class PushContentCommandTest
     {
         Mockito.when( nodeService.resolveSyncWork( Mockito.isA( SyncWorkResolverParams.class ) ) ).
             thenReturn( ResolveSyncWorkResult.create().
-                publishRequested( NodeId.from( "s1" ) ).
-                publishReferredFrom( NodeId.from( "s1" ), NodeId.from( "s2" ) ).
+                publishRequested( NodeId.from( "s1" ), NodeId.from( "s1" ) ).
+                publishReferredFrom( NodeId.from( "s1" ), NodeId.from( "s2" ), NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -208,8 +208,8 @@ public class PushContentCommandTest
     {
         Mockito.when( nodeService.resolveSyncWork( Mockito.isA( SyncWorkResolverParams.class ) ) ).
             thenReturn( ResolveSyncWorkResult.create().
-                publishRequested( NodeId.from( "s1" ) ).
-                publishReferredFrom( NodeId.from( "s1" ), NodeId.from( "s2" ) ).
+                publishRequested( NodeId.from( "s1" ), NodeId.from( "s1" ) ).
+                publishReferredFrom( NodeId.from( "s1" ), NodeId.from( "s2" ), NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).

--- a/modules/core-impl/src/test/java/com/enonic/xp/core/impl/content/ResolvePublishDependenciesCommandTest.java
+++ b/modules/core-impl/src/test/java/com/enonic/xp/core/impl/content/ResolvePublishDependenciesCommandTest.java
@@ -56,8 +56,8 @@ public class ResolvePublishDependenciesCommandTest
     {
         Mockito.when( nodeService.resolveSyncWork( Mockito.isA( SyncWorkResolverParams.class ) ) ).
             thenReturn( ResolveSyncWorkResult.create().
-                publishRequested( NodeId.from( "s1" ) ).
-                publishRequested( NodeId.from( "s2" ) ).
+                publishRequested( NodeId.from( "s1" ), NodeId.from( "s1" ) ).
+                publishRequested( NodeId.from( "s2" ), NodeId.from( "s2" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -90,8 +90,8 @@ public class ResolvePublishDependenciesCommandTest
     {
         Mockito.when( nodeService.resolveSyncWork( Mockito.isA( SyncWorkResolverParams.class ) ) ).
             thenReturn( ResolveSyncWorkResult.create().
-                publishRequested( NodeId.from( "s1" ) ).
-                publishReferredFrom( NodeId.from( "s2" ), NodeId.from( "s1" ) ).
+                publishRequested( NodeId.from( "s1" ), NodeId.from( "s1" ) ).
+                publishReferredFrom( NodeId.from( "s2" ), NodeId.from( "s1" ), NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -125,9 +125,9 @@ public class ResolvePublishDependenciesCommandTest
     {
         Mockito.when( nodeService.resolveSyncWork( Mockito.isA( SyncWorkResolverParams.class ) ) ).
             thenReturn( ResolveSyncWorkResult.create().
-                publishRequested( NodeId.from( "s1" ) ).
-                publishReferredFrom( NodeId.from( "s2" ), NodeId.from( "s1" ) ).
-                publishParentFor( NodeId.from( "s3" ), NodeId.from( "s1" ) ).
+                publishRequested( NodeId.from( "s1" ), NodeId.from( "s1" ) ).
+                publishReferredFrom( NodeId.from( "s2" ), NodeId.from( "s1" ), NodeId.from( "s1" ) ).
+                publishParentFor( NodeId.from( "s3" ), NodeId.from( "s1" ), NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -165,9 +165,9 @@ public class ResolvePublishDependenciesCommandTest
     {
         Mockito.when( nodeService.resolveSyncWork( Mockito.isA( SyncWorkResolverParams.class ) ) ).
             thenReturn( ResolveSyncWorkResult.create().
-                publishRequested( NodeId.from( "s1" ) ).
-                deleteRequested( NodeId.from( "s2" ) ).
-                deleteRequested( NodeId.from( "s3" ) ).
+                publishRequested( NodeId.from( "s1" ), NodeId.from( "s1" ) ).
+                deleteRequested( NodeId.from( "s2" ), NodeId.from( "s1" ) ).
+                deleteRequested( NodeId.from( "s3" ), NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).

--- a/modules/core-repo/src/main/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommand.java
+++ b/modules/core-repo/src/main/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommand.java
@@ -219,34 +219,38 @@ public class ResolveSyncWorkCommand
         {
             resultBuilder.conflict( nodeId );
         }
+        else if ( nodeId.equals( this.publishRootNode.id() ) )
+        {
+            addRequestedOrChild( nodeId );
+        }
         else
         {
             if ( comparison.getCompareStatus() == CompareStatus.PENDING_DELETE )
             {
                 if ( resolveContext.becauseReferredTo )
                 {
-                    resultBuilder.deleteReferredFrom( comparison.getNodeId(), resolveContext.contextNodeId );
+                    resultBuilder.deleteReferredFrom( comparison.getNodeId(), resolveContext.contextNodeId, this.publishRootNode.id() );
                 }
                 else if ( resolveContext.becauseParent )
                 {
-                    resultBuilder.deleteParentFor( comparison.getNodeId(), resolveContext.contextNodeId );
+                    resultBuilder.deleteParentFor( comparison.getNodeId(), resolveContext.contextNodeId, this.publishRootNode.id() );
                 }
                 else if ( resolveContext.becauseChild )
                 {
-                    resultBuilder.deleteChildOf( comparison.getNodeId(), resolveContext.contextNodeId );
+                    resultBuilder.deleteChildOf( comparison.getNodeId(), resolveContext.contextNodeId, this.publishRootNode.id() );
                 }
                 else
                 {
-                    resultBuilder.deleteRequested( comparison.getNodeId() );
+                    resultBuilder.deleteRequested( comparison.getNodeId(), this.publishRootNode.id() );
                 }
             }
             else if ( resolveContext.becauseReferredTo )
             {
-                resultBuilder.publishReferredFrom( comparison.getNodeId(), resolveContext.contextNodeId );
+                resultBuilder.publishReferredFrom( comparison.getNodeId(), resolveContext.contextNodeId, this.publishRootNode.id() );
             }
             else if ( resolveContext.becauseParent )
             {
-                resultBuilder.publishParentFor( comparison.getNodeId(), resolveContext.contextNodeId );
+                resultBuilder.publishParentFor( comparison.getNodeId(), resolveContext.contextNodeId, this.publishRootNode.id() );
             }
             else
             {
@@ -260,7 +264,7 @@ public class ResolveSyncWorkCommand
     {
         if ( nodeId.equals( this.publishRootNode.id() ) )
         {
-            this.resultBuilder.publishRequested( nodeId );
+            this.resultBuilder.publishRequested( nodeId, this.publishRootNode.id() );
         }
         else
         {
@@ -270,7 +274,7 @@ public class ResolveSyncWorkCommand
 
             final Node parentNode = doGetByPath( parentPath, false );
 
-            this.resultBuilder.publishChildOf( nodeId, parentNode.id() );
+            this.resultBuilder.publishChildOf( nodeId, parentNode.id(), this.publishRootNode.id() );
         }
     }
 


### PR DESCRIPTION
- [Modified] Push Node/Content requests and ResolveSyncWorkCommand to manage initially published node more correctly via adding initialNodeId field to NodePublishRequest
- [Modified] tests