### PR TITLE
XP-494 Publish parent of modified content broken wizard

### DIFF
--- a/modules/core-api/src/main/java/com/enonic/xp/node/ResolveSyncWorkResult.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/node/ResolveSyncWorkResult.java
@@ -12,7 +12,7 @@ public class ResolveSyncWorkResult
 
     private final NodePublishRequests nodeDeleteRequests;
 
-    private final NodeIds delete;
+    private final NodeId initialReasonNodeId;
 
     private final NodeIds conflict;
 
@@ -20,8 +20,8 @@ public class ResolveSyncWorkResult
     {
         this.nodePublishRequests = builder.nodePublishRequests;
         this.nodeDeleteRequests = builder.nodeDeleteRequests;
-        this.delete = NodeIds.from( builder.delete );
         this.conflict = NodeIds.from( builder.conflict );
+        this.initialReasonNodeId = builder.initialReasonNodeId;
     }
 
     public boolean hasConflicts()
@@ -44,16 +44,15 @@ public class ResolveSyncWorkResult
         return nodeDeleteRequests;
     }
 
-    public NodeIds getDelete()
-    {
-        return delete;
-    }
-
     NodeIds getConflict()
     {
         return conflict;
     }
 
+    public NodeId getInitialReasonNodeId()
+    {
+        return initialReasonNodeId;
+    }
 
     public static Builder create()
     {
@@ -66,9 +65,9 @@ public class ResolveSyncWorkResult
 
         private final NodePublishRequests nodeDeleteRequests = new NodePublishRequests();
 
-        private final Set<NodeId> delete = Sets.newHashSet();
-
         private final Set<NodeId> conflict = Sets.newHashSet();
+
+        private NodeId initialReasonNodeId;
 
         private Builder()
         {
@@ -100,41 +99,37 @@ public class ResolveSyncWorkResult
 
         public Builder deleteRequested( final NodeId nodeId )
         {
-            this.delete.add( nodeId );
             this.nodeDeleteRequests.add( NodePublishRequest.requested( nodeId ) );
             return this;
         }
 
         public Builder deleteParentFor( final NodeId nodeId, final NodeId parentOf )
         {
-            this.delete.add( nodeId );
             this.nodeDeleteRequests.add( NodePublishRequest.parentFor( nodeId, parentOf ) );
             return this;
         }
 
         public Builder deleteChildOf( final NodeId nodeId, final NodeId childOf )
         {
-            this.delete.add( nodeId );
             this.nodeDeleteRequests.add( NodePublishRequest.childOf( nodeId, childOf ) );
             return this;
         }
 
         public Builder deleteReferredFrom( final NodeId nodeId, final NodeId referredFrom )
         {
-            this.delete.add( nodeId );
             this.nodeDeleteRequests.add( NodePublishRequest.referredFrom( nodeId, referredFrom ) );
-            return this;
-        }
-
-        public Builder addDelete( final NodeId delete )
-        {
-            this.delete.add( delete );
             return this;
         }
 
         public Builder conflict( final NodeId nodeId )
         {
             this.conflict.add( nodeId );
+            return this;
+        }
+
+        public Builder setInitialReasonNodeId( final NodeId initialReasonNodeId )
+        {
+            this.initialReasonNodeId = initialReasonNodeId;
             return this;
         }
 

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/PushContentCommand.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/PushContentCommand.java
@@ -21,6 +21,7 @@ import com.enonic.xp.context.ContextBuilder;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeIds;
+import com.enonic.xp.node.NodePublishRequest;
 import com.enonic.xp.node.PushNodesResult;
 import com.enonic.xp.node.ResolveSyncWorkResult;
 import com.enonic.xp.node.ResolveSyncWorkResults;
@@ -169,9 +170,9 @@ public class PushContentCommand
             branch( target ).
             build() ) );
 
-        for ( final NodeId nodeId : result.getDelete() )
+        for ( final NodePublishRequest publishRequest : result.getNodeDeleteRequests() )
         {
-            this.resultBuilder.addDeleted( ContentId.from( nodeId.toString() ) );
+            this.resultBuilder.addDeleted( ContentId.from( publishRequest.getNodeId().toString() ) );
         }
 
         if ( !deletedContents.isEmpty() )
@@ -185,9 +186,9 @@ public class PushContentCommand
     {
         return context.callWith( () -> {
             final List<ContentPath> deletedNodes = new ArrayList<>();
-            for ( final NodeId nodeId : result.getDelete() )
+            for ( final NodePublishRequest publishRequest : result.getNodeDeleteRequests() )
             {
-                final Node node = nodeService.deleteById( nodeId );
+                final Node node = nodeService.deleteById( publishRequest.getNodeId() );
                 if ( node != null )
                 {
                     deletedNodes.add( translateNodePathToContentPath( node.path() ) );

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/PushContentRequestsFactory.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/PushContentRequestsFactory.java
@@ -2,6 +2,7 @@ package com.enonic.xp.core.impl.content;
 
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.PushContentRequests;
+import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodePublishRequest;
 import com.enonic.xp.node.NodePublishRequests;
 import com.enonic.xp.node.ResolveSyncWorkResult;
@@ -15,62 +16,71 @@ class PushContentRequestsFactory
 
         for ( final ResolveSyncWorkResult syncWorkResult : syncWorkResults )
         {
-            doCreate( builder, syncWorkResult.getNodePublishRequests() );
-            doCreateDeleted( builder, syncWorkResult.getNodeDeleteRequests() );
+            doCreate( builder, syncWorkResult.getNodePublishRequests(), syncWorkResult.getInitialReasonNodeId() );
+            doCreateDeleted( builder, syncWorkResult.getNodeDeleteRequests(), syncWorkResult.getInitialReasonNodeId() );
         }
 
         return builder.build();
     }
 
-    private static void doCreate( final PushContentRequests.Builder builder, final NodePublishRequests nodePublishRequests )
+    private static void doCreate( final PushContentRequests.Builder builder, final NodePublishRequests nodePublishRequests,
+                                  final NodeId initialReasonNodeId )
     {
         for ( final NodePublishRequest parentOf : nodePublishRequests.getPublishAsParentFor() )
         {
             builder.addParentOf( ContentId.from( parentOf.getNodeId().toString() ),
-                                 ContentId.from( parentOf.getReason().getContextualNodeId().toString() ) );
+                                 ContentId.from( parentOf.getReason().getContextualNodeId().toString() ),
+                                 ContentId.from( initialReasonNodeId.toString() ) );
         }
 
         for ( final NodePublishRequest referredTo : nodePublishRequests.getPublishAsReferredTo() )
         {
             builder.addReferredTo( ContentId.from( referredTo.getNodeId().toString() ),
-                                   ContentId.from( referredTo.getReason().getContextualNodeId().toString() ) );
+                                   ContentId.from( referredTo.getReason().getContextualNodeId().toString() ),
+                                   ContentId.from( initialReasonNodeId.toString() ) );
         }
 
         for ( final NodePublishRequest requested : nodePublishRequests.getPublishAsRequested() )
         {
-            builder.addRequested( ContentId.from( requested.getNodeId().toString() ) );
+            builder.addRequested( ContentId.from( requested.getNodeId().toString() ), ContentId.from( initialReasonNodeId.toString() ) );
         }
 
         for ( final NodePublishRequest childOf : nodePublishRequests.getPublishAsChildOf() )
         {
             builder.addChildOf( ContentId.from( childOf.getNodeId().toString() ),
-                                ContentId.from( childOf.getReason().getContextualNodeId().toString() ) );
+                                ContentId.from( childOf.getReason().getContextualNodeId().toString() ),
+                                ContentId.from( initialReasonNodeId.toString() ) );
         }
     }
 
-    private static void doCreateDeleted( final PushContentRequests.Builder builder, final NodePublishRequests nodePublishRequests )
+    private static void doCreateDeleted( final PushContentRequests.Builder builder, final NodePublishRequests nodePublishRequests,
+                                         final NodeId initialReasonNodeId )
     {
         for ( final NodePublishRequest parentOf : nodePublishRequests.getPublishAsParentFor() )
         {
             builder.addDeleteBecauseParentOf( ContentId.from( parentOf.getNodeId().toString() ),
-                                              ContentId.from( parentOf.getReason().getContextualNodeId().toString() ) );
+                                              ContentId.from( parentOf.getReason().getContextualNodeId().toString() ),
+                                              ContentId.from( initialReasonNodeId.toString() ) );
         }
 
         for ( final NodePublishRequest referredTo : nodePublishRequests.getPublishAsReferredTo() )
         {
             builder.addDeleteBecauseReferredTo( ContentId.from( referredTo.getNodeId().toString() ),
-                                                ContentId.from( referredTo.getReason().getContextualNodeId().toString() ) );
+                                                ContentId.from( referredTo.getReason().getContextualNodeId().toString() ),
+                                                ContentId.from( initialReasonNodeId.toString() ) );
         }
 
         for ( final NodePublishRequest requested : nodePublishRequests.getPublishAsRequested() )
         {
-            builder.addDeleteRequested( ContentId.from( requested.getNodeId().toString() ) );
+            builder.addDeleteRequested( ContentId.from( requested.getNodeId().toString() ),
+                                        ContentId.from( initialReasonNodeId.toString() ) );
         }
 
         for ( final NodePublishRequest childOf : nodePublishRequests.getPublishAsChildOf() )
         {
             builder.addDeleteBecauseChildOf( ContentId.from( childOf.getNodeId().toString() ),
-                                ContentId.from( childOf.getReason().getContextualNodeId().toString() ) );
+                                             ContentId.from( childOf.getReason().getContextualNodeId().toString() ),
+                                             ContentId.from( initialReasonNodeId.toString() ) );
         }
     }
 }

--- a/modules/core-impl/src/test/java/com/enonic/xp/core/impl/content/PushContentCommandTest.java
+++ b/modules/core-impl/src/test/java/com/enonic/xp/core/impl/content/PushContentCommandTest.java
@@ -53,6 +53,7 @@ public class PushContentCommandTest
             thenReturn( ResolveSyncWorkResult.create().
                 publishRequested( NodeId.from( "s1" ) ).
                 publishRequested( NodeId.from( "s2" ) ).
+                setInitialReasonNodeId( NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -90,6 +91,7 @@ public class PushContentCommandTest
             thenReturn( ResolveSyncWorkResult.create().
                 publishRequested( NodeId.from( "s1" ) ).
                 publishReferredFrom( NodeId.from( "s1" ), NodeId.from( "s2" ) ).
+                setInitialReasonNodeId( NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -129,6 +131,7 @@ public class PushContentCommandTest
             thenReturn( ResolveSyncWorkResult.create().
                 publishRequested( NodeId.from( "s1" ) ).
                 publishReferredFrom( NodeId.from( "s1" ), NodeId.from( "s2" ) ).
+                setInitialReasonNodeId( NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -160,15 +163,15 @@ public class PushContentCommandTest
         assertEquals( 1, result.getPushContentRequests().getPushedBecauseReferredTos().size() );
     }
 
-
     @Test
     public void pending_deleted()
         throws Exception
     {
         Mockito.when( nodeService.resolveSyncWork( Mockito.isA( SyncWorkResolverParams.class ) ) ).
             thenReturn( ResolveSyncWorkResult.create().
-                addDelete( NodeId.from( "s3" ) ).
-                addDelete( NodeId.from( "s4" ) ).
+                deleteRequested( NodeId.from( "s3" ) ).
+                deleteRequested( NodeId.from( "s4" ) ).
+                setInitialReasonNodeId( NodeId.from( "s3" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -210,6 +213,7 @@ public class PushContentCommandTest
             thenReturn( ResolveSyncWorkResult.create().
                 publishRequested( NodeId.from( "s1" ) ).
                 publishReferredFrom( NodeId.from( "s1" ), NodeId.from( "s2" ) ).
+                setInitialReasonNodeId( NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).

--- a/modules/core-impl/src/test/java/com/enonic/xp/core/impl/content/ResolvePublishDependenciesCommandTest.java
+++ b/modules/core-impl/src/test/java/com/enonic/xp/core/impl/content/ResolvePublishDependenciesCommandTest.java
@@ -57,7 +57,8 @@ public class ResolvePublishDependenciesCommandTest
         Mockito.when( nodeService.resolveSyncWork( Mockito.isA( SyncWorkResolverParams.class ) ) ).
             thenReturn( ResolveSyncWorkResult.create().
                 publishRequested( NodeId.from( "s1" ) ).
-                publishRequested( NodeId.from( "s2" ) ).
+                publishParentFor( NodeId.from( "s2" ), NodeId.from( "s1" ) ).
+                setInitialReasonNodeId( NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -81,7 +82,8 @@ public class ResolvePublishDependenciesCommandTest
             build().
             execute();
 
-        assertEquals( 2, result.getPushRequestedIds().getSize() );
+        assertEquals( 1, result.getPushRequestedIds().getSize() );
+        assertEquals( 1, result.getDependantsIdsResolvedWithChildrenIncluded().getSize() );
     }
 
     @Test
@@ -92,6 +94,7 @@ public class ResolvePublishDependenciesCommandTest
             thenReturn( ResolveSyncWorkResult.create().
                 publishRequested( NodeId.from( "s1" ) ).
                 publishReferredFrom( NodeId.from( "s2" ), NodeId.from( "s1" ) ).
+                setInitialReasonNodeId( NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -128,6 +131,7 @@ public class ResolvePublishDependenciesCommandTest
                 publishRequested( NodeId.from( "s1" ) ).
                 publishReferredFrom( NodeId.from( "s2" ), NodeId.from( "s1" ) ).
                 publishParentFor( NodeId.from( "s3" ), NodeId.from( "s1" ) ).
+                setInitialReasonNodeId( NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -166,8 +170,9 @@ public class ResolvePublishDependenciesCommandTest
         Mockito.when( nodeService.resolveSyncWork( Mockito.isA( SyncWorkResolverParams.class ) ) ).
             thenReturn( ResolveSyncWorkResult.create().
                 publishRequested( NodeId.from( "s1" ) ).
-                deleteRequested( NodeId.from( "s2" ) ).
-                deleteRequested( NodeId.from( "s3" ) ).
+                deleteChildOf( NodeId.from( "s2" ), NodeId.from( "s1" ) ).
+                deleteChildOf( NodeId.from( "s3" ), NodeId.from( "s1" ) ).
+                setInitialReasonNodeId( NodeId.from( "s1" ) ).
                 build() );
 
         Mockito.when( nodeService.getByIds( Mockito.isA( NodeIds.class ) ) ).
@@ -194,7 +199,8 @@ public class ResolvePublishDependenciesCommandTest
             build().
             execute();
 
-        assertEquals( 3, result.getPushRequestedIds().getSize() );
+        assertEquals( 1, result.getPushRequestedIds().getSize() );
+        assertEquals( 2, result.getChildrenContentsIds().getSize() );
     }
 
     private Content createContent( final String id, final String name, final ContentPath path, boolean valid )

--- a/modules/core-repo/src/main/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommand.java
+++ b/modules/core-repo/src/main/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommand.java
@@ -77,7 +77,7 @@ public class ResolveSyncWorkCommand
             resolveDiffWithNodeIdAsInput( nodeId, ResolveContext.requested() );
         }
 
-        return resultBuilder.build();
+        return resultBuilder.setInitialReasonNodeId( this.publishRootNode.id() ).build();
     }
 
     private NodeVersionDiffResult getInitialDiff()

--- a/modules/core-repo/src/test/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommandTest.java
+++ b/modules/core-repo/src/test/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommandTest.java
@@ -1,5 +1,8 @@
 package com.enonic.wem.repo.internal.entity;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -91,8 +94,12 @@ public class ResolveSyncWorkCommandTest
         assertEquals( 1, nodePublishRequests.size() );
         assertNotNull( nodePublishRequests.get( rootNode.id() ) );
 
-        final NodeIds deleted = result.getDelete();
-        assertEquals( 2, deleted.getSize() );
+        Set<NodeId> deleted = new HashSet<>();
+        for ( NodePublishRequest deleteRequest : result.getNodeDeleteRequests() )
+        {
+            deleted.add( deleteRequest.getNodeId() );
+        }
+        assertEquals( 2, deleted.size() );
         assertTrue( deleted.contains( node2_1.id() ) );
         assertTrue( deleted.contains( node3.id() ) );
     }


### PR DESCRIPTION
- [Modified] Push Content request and ResolveSyncWorkCommand to manage initially published node more correctly via adding initialNodeId field to ResolveSyncWorkResult
- [Modified] tests