### PR TITLE
XP-509 TinyMCE - set focus inside editor after adding a new instance

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/TinyMCE.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/TinyMCE.ts
@@ -101,6 +101,18 @@ module api.form.inputtype.text {
             });
 
             textAreaWrapper.appendChild(textAreaEl);
+
+            textAreaWrapper.giveFocus = () => {
+                try {
+                    this.editor.focus();
+                    return true;
+                }
+                catch (e) {
+                    console.log("Element.giveFocus(): Failed to give focus to TinyMCE element: id = " + this.getId());
+                    return false;
+                }
+            };
+
             return textAreaWrapper;
         }
 


### PR DESCRIPTION
-[Fixed] Fixed TinyMCE to correctly react on InputOccurence's giveFocus() event. In createInputOccurrenceElement() DivEL wrapper for tinymce was returned, and calling giveFocus() on it was not setting focus on editor area.