### PR TITLE
XP-504 Moved content behaves strange in ResolveSyncWorkCommand

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/publish/ContentPublishDialog.ts
@@ -10,7 +10,7 @@ module app.publish {
     import CompareStatus = api.content.CompareStatus;
 
     /**
-     * ContentPublishDialog manages list of items resolved via ResolvePublishDependenceies command.
+     * ContentPublishDialog manages list of items resolved via ResolvePublishDependencies command.
      * Resolved items are converted into array of SelectionPublishItem<ContentPublishItem> items and stored in selectionItems property.
      * SelectionPublishItem has checked/unchecked state which determines if item's id will be included into a list of contentIds of Publish request.
      * Items displayed in dialog and selectionItems property will change depending on includeChildren checkbox state as
@@ -322,8 +322,10 @@ module app.publish {
             var childrenEligibleForPublish = this.getChildrenEligibleForPublishCount();
             if (childrenEligibleForPublish > 0) {
                 this.includeChildItemsCheck.setLabel('Include child items (+' + childrenEligibleForPublish + ')');
+                this.includeChildItemsCheck.setDisabled(false);
             } else {
                 this.includeChildItemsCheck.setLabel('Include child items');
+                this.includeChildItemsCheck.setDisabled(true);
             }
         }
 

--- a/modules/core-repo/src/main/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommand.java
+++ b/modules/core-repo/src/main/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommand.java
@@ -240,6 +240,10 @@ public class ResolveSyncWorkCommand
                     resultBuilder.deleteRequested( comparison.getNodeId() );
                 }
             }
+            else if ( comparison.getNodeId().equals( this.publishRootNode.id() ) )
+            {
+                this.resultBuilder.publishRequested( nodeId );
+            }
             else if ( resolveContext.becauseReferredTo )
             {
                 resultBuilder.publishReferredFrom( comparison.getNodeId(), resolveContext.contextNodeId );
@@ -250,28 +254,23 @@ public class ResolveSyncWorkCommand
             }
             else
             {
-                addRequestedOrChild( comparison.getNodeId() );
+                addChild( comparison.getNodeId() );
             }
         }
     }
 
 
-    public void addRequestedOrChild( final NodeId nodeId )
+    public void addChild( final NodeId nodeId )
     {
-        if ( nodeId.equals( this.publishRootNode.id() ) )
-        {
-            this.resultBuilder.publishRequested( nodeId );
-        }
-        else
-        {
-            final Node node = doGetById( nodeId, false );
 
-            final NodePath parentPath = node.parentPath();
+        final Node node = doGetById( nodeId, false );
 
-            final Node parentNode = doGetByPath( parentPath, false );
+        final NodePath parentPath = node.parentPath();
 
-            this.resultBuilder.publishChildOf( nodeId, parentNode.id() );
-        }
+        final Node parentNode = doGetByPath( parentPath, false );
+
+        this.resultBuilder.publishChildOf( nodeId, parentNode.id() );
+
     }
 
     public static class ResolveContext

--- a/modules/core-repo/src/test/java/com/enonic/wem/repo/internal/entity/FindNodesWithVersionDifferenceCommandTest.java
+++ b/modules/core-repo/src/test/java/com/enonic/wem/repo/internal/entity/FindNodesWithVersionDifferenceCommandTest.java
@@ -285,6 +285,59 @@ public class FindNodesWithVersionDifferenceCommandTest
     }
 
     @Test
+    public void assure_correct_diff_order_when_there_are_children2()
+    {
+        final Node node1 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node1" ) ).
+            parent( NodePath.ROOT ).
+            name( "node1" ).
+            build() );
+
+        final Node node1_1 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node1_1" ) ).
+            parent( node1.path() ).
+            name( "node1_1" ).
+            build() );
+
+        final Node node1_1_1 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node1_1_1" ) ).
+            parent( node1_1.path() ).
+            name( "node1_1_1" ).
+            build() );
+
+        final Node node1_1_1_1 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node1_1_1_1" ) ).
+            parent( node1_1_1.path() ).
+            name( "node1_1_1_1" ).
+            build() );
+
+        pushNodes( WS_OTHER, node1.id() );
+
+        NodeVersionDiffResult result = getDiff( WS_DEFAULT, WS_OTHER, node1_1.path() );
+
+        assertEquals( 3, result.getNodesWithDifferences().getSize() );
+
+        int counter = 0;
+        for ( final NodeId nodeId : result.getNodesWithDifferences() )
+        {
+            if ( counter == 0 )
+            {
+                assertEquals( node1_1.id().toString(), nodeId.toString() );
+            }
+            else if ( counter == 1 )
+            {
+                assertEquals( node1_1_1.id().toString(), nodeId.toString() );
+            }
+            else if ( counter == 2 )
+            {
+                assertEquals( node1_1_1_1.id().toString(), nodeId.toString() );
+            }
+
+            counter++;
+        }
+    }
+
+    @Test
     public void deleted_in_target()
         throws Exception
     {

--- a/modules/core-repo/src/test/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommandTest.java
+++ b/modules/core-repo/src/test/java/com/enonic/wem/repo/internal/entity/ResolveSyncWorkCommandTest.java
@@ -174,6 +174,23 @@ public class ResolveSyncWorkCommandTest
         assertNotNull( nodePublishRequests.get( rootNode.id() ) );
     }
 
+    /**
+     * node1                                   (Moved)
+     * .....|
+     * .....node1_1                            (New)
+     * ............|
+     * .............node1_1_1                  (New)
+     * ......................|
+     * .......................node1_1_1_1      (New)
+     * <p>
+     * Contents created below look like pic above.
+     * ResolveSyncWorkCommand will return empty set for node1_1_1_1.id() when called with includeChildren=true,
+     * and will return all four when called with includeChildren=false, because:
+     * 1) FindNodesWithVersionDifferenceCommand will returns only actual nodes that have Moved status (such like node1)...
+     * 2) ... though CompareContentCommand will return status Moved for all children of Moved content.
+     * 3) When includeChildren=false ResolveSyncWorkCommand will resolve all parents against the passed node.
+     * So ResolveSyncWorkCommand will return only "Moved" parents of passed node and passed node itself when includeChildren=false
+     */
     @Test
     public void resolveDependenciesOfMovedNodes()
     {
@@ -214,7 +231,129 @@ public class ResolveSyncWorkCommandTest
         final ResolveSyncWorkResult resultChildrenIncluded = resolveSyncWorkResult( node1_1_1_1.id(), true );
         final ResolveSyncWorkResult resultChildrenNotIncluded = resolveSyncWorkResult( node1_1_1_1.id(), false );
 
-        // assertEquals( resultChildrenIncluded.getNodePublishRequests().size(), resultChildrenNotIncluded.getNodePublishRequests().size());
+        assertEquals( resultChildrenIncluded.getNodePublishRequests().size(), 0 );
+        assertEquals( resultChildrenNotIncluded.getNodePublishRequests().size(), 4 );
+    }
+
+    /**
+     * node1                                   (Moved)
+     * .....|
+     * .....node1_1                            (New)
+     * ............|
+     * .............node1_1_1                  (New)
+     * ......................|
+     * .......................node1_1_1_1      (New)
+     * <p>
+     * Contents created below look like pic above.
+     * ResolveSyncWorkCommand will return empty set for node1_1_1.id() when called with includeChildren=true,
+     * and will return node1_1_1 and two of its parents when called with includeChildren=false, because:
+     * 1) FindNodesWithVersionDifferenceCommand will returns only actual nodes that have Moved status (such like node1)...
+     * 2) ... though CompareContentCommand will return status Moved for all children of Moved content.
+     * 3) When includeChildren=false ResolveSyncWorkCommand will resolve all parents against the passed node.
+     * So ResolveSyncWorkCommand will return only "Moved" parents of passed node and passed node itself when includeChildren=false
+     */
+    @Test
+    public void resolveDependenciesOfMovedNodes2()
+    {
+        final Node node1 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node1" ) ).
+            parent( NodePath.ROOT ).
+            name( "node1" ).
+            build() );
+
+        final Node node1_1 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node1_1" ) ).
+            parent( node1.path() ).
+            name( "node1_1" ).
+            build() );
+
+        final Node node1_1_1 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node1_1_1" ) ).
+            parent( node1_1.path() ).
+            name( "node1_1_1" ).
+            build() );
+
+        final Node node1_1_1_1 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node1_1_1_1" ) ).
+            parent( node1_1_1.path() ).
+            name( "node1_1_1_1" ).
+            build() );
+
+        final Node node2 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node2" ) ).
+            parent( NodePath.ROOT ).
+            name( "node2" ).
+            build() );
+
+        pushNodes( WS_OTHER, node1.id(), node2.id(), node1_1.id(), node1_1_1.id(), node1_1_1_1.id() );
+
+        moveNode( node1, node2.path() );
+
+        final ResolveSyncWorkResult resultChildrenIncluded = resolveSyncWorkResult( node1_1_1.id(), true );
+        final ResolveSyncWorkResult resultChildrenNotIncluded = resolveSyncWorkResult( node1_1_1.id(), false );
+
+        assertEquals( resultChildrenIncluded.getNodePublishRequests().size(), 0 );
+        assertEquals( resultChildrenNotIncluded.getNodePublishRequests().size(), 3 );
+    }
+
+    /**
+     * node1                                   (New)
+     * .....|
+     * .....node1_1                            (New)
+     * ............|
+     * .............node1_1_1                  (Moved)
+     * ......................|
+     * .......................node1_1_1_1      (New)
+     * <p>
+     * Contents created below look like pic above.
+     * ResolveSyncWorkCommand will return node1_1_1 for node1_1_1.id() when called both with includeChildren=true and with includeChildren=false
+     * 1) FindNodesWithVersionDifferenceCommand will returns only actual nodes that have Moved status (such like node1)...
+     * 2) ... though CompareContentCommand will return status Moved for all children of Moved content.
+     * 3) When includeChildren=false ResolveSyncWorkCommand will resolve all parents against the passed node.
+     * So ResolveSyncWorkCommand will return only "Moved" parents of passed node and passed node itself when includeChildren=false
+     */
+    @Test
+    public void resolveDependenciesOfMovedNodes3()
+    {
+        final Node node1 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node1" ) ).
+            parent( NodePath.ROOT ).
+            name( "node1" ).
+            build() );
+
+        final Node node1_1 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node1_1" ) ).
+            parent( node1.path() ).
+            name( "node1_1" ).
+            build() );
+
+        final Node node1_1_1 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node1_1_1" ) ).
+            parent( node1_1.path() ).
+            name( "node1_1_1" ).
+            build() );
+
+        final Node node1_1_1_1 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node1_1_1_1" ) ).
+            parent( node1_1_1.path() ).
+            name( "node1_1_1_1" ).
+            build() );
+
+        final Node node2 = createNode( CreateNodeParams.create().
+            setNodeId( NodeId.from( "node2" ) ).
+            parent( NodePath.ROOT ).
+            name( "node2" ).
+            build() );
+
+        pushNodes( WS_OTHER, node1.id(), node2.id(), node1_1.id(), node1_1_1.id(), node1_1_1_1.id() );
+
+        moveNode( node1_1_1, node2.path() );
+
+        final ResolveSyncWorkResult resultChildrenIncluded = resolveSyncWorkResult( node1_1_1.id(), true );
+        final ResolveSyncWorkResult resultChildrenNotIncluded = resolveSyncWorkResult( node1_1_1.id(), false );
+
+        assertEquals( resultChildrenIncluded.getNodePublishRequests().size(), 1 );
+        assertEquals( resultChildrenNotIncluded.getNodePublishRequests().size(), 1 );
     }
 
     private void moveNode( Node moveMe, NodePath to )


### PR DESCRIPTION
- [Modified] ResolveSyncWorkCommand to handle rare case of incorrect order of returned result of FindNodesWithVersionDifferenceCommand which resulted in incorrect ResolveContext of publishRootNode
- [Modified] ResolvePublishDependenciesCommand to set includeChildren=false for ResolveSyncWorkCommand when passed node has status "Moved" in order to make it resolve at least passed Moved node and its parents
- [Modified] PublishDialog to disable includeChildren checkbox when there are no children available
- [Modified] tests to reflect current behaviour