### PR TITLE
XP-522 TinyMCE - Remove gradient from "pressed" paste as text button

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/form/inputtype/text/tinymce.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/form/inputtype/text/tinymce.less
@@ -70,6 +70,16 @@
       border-top: 1px solid @admin-medium-gray-border;
     }
   }
+
+  div[aria-label="Paste as text"] {
+    &.mce-active {
+      background-image: none;
+      background-color: @admin-input-blue;
+      -webkit-box-shadow: none;
+      -moz-box-shadow: none;
+      box-shadow: none;
+    }
+  }
 }
 
 .mce-link-dialog {


### PR DESCRIPTION
-Updated according to design.
(Had to attach css selector to attribute because after pressing button on toolbar all it's classes are being reset so unable to set custom class to distinguish 'paste' button)