### PR TITLE
XP-531 Users App: browse panel not refreshed, when user was filtered …

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
@@ -17,6 +17,7 @@ module app.browse {
     import BatchContentRequest = api.content.BatchContentRequest;
     import TreeNodesOfContentPath = api.content.TreeNodesOfContentPath;
     import ContentChangeResult = api.content.ContentChangeResult;
+    import ContentId = api.content.ContentId;
 
     export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummary> {
 


### PR DESCRIPTION
…and deleted

-Issue was in handling principal delete : fact that content can be filtered was not taken into account when deleting principal so delete was performed only in filtered TreeNode and not in default one
-Updated treegrid to handle delete in both default and filtered TreeNodes