### PR TITLE
XP-519 Live Edit - Reset button no longer working

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/insert/InsertablesPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/insert/InsertablesPanel.ts
@@ -27,7 +27,7 @@ module app.wizard.page.contextwindow.insert {
 
         private contextWindowDraggable: JQuery;
 
-        public static debug = true;
+        public static debug = false;
 
         constructor(config: ComponentTypesPanelConfig) {
             super("insertables-panel");

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageInspectionPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageInspectionPanel.ts
@@ -82,7 +82,7 @@ module app.wizard.page.contextwindow.inspect.page {
                         }).done();
                 }
                 else {
-                    this.pageModel.setAutomaticTemplate(this);
+                    this.pageModel.setAutomaticTemplate(this, true);
                 }
             });
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/PageModel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/PageModel.ts
@@ -219,7 +219,7 @@ module api.content.page {
             return this;
         }
 
-        setAutomaticTemplate(eventSource?: any): PageModel {
+        setAutomaticTemplate(eventSource?: any, ignoreRegionChanges: boolean = false): PageModel {
 
             var config = this.defaultTemplate.hasConfig() ?
                          this.defaultTemplate.getConfig().copy() :
@@ -230,11 +230,11 @@ module api.content.page {
                           api.content.page.region.Regions.create().build();
 
             var setTemplate = new SetTemplate(eventSource).
-                setTemplate(this.defaultTemplate, this.defaultTemplateDescriptor).
+                setTemplate(null, this.defaultTemplateDescriptor).
                 setRegions(regions).
                 setConfig(config);
 
-            this.setTemplate(setTemplate);
+            this.setTemplate(setTemplate, ignoreRegionChanges);
             return this;
         }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/dom/Element.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/dom/Element.ts
@@ -595,30 +595,51 @@ module api.dom {
         /*
          *      Event listeners
          */
+        private mouseEnterByHandler = {};
 
-        onMouseEnter(handler: (e: MouseEvent)=>any) {
+        onMouseEnter(handler: (e: MouseEvent) => any) {
             if (typeof this.getHTMLElement().onmouseenter != "undefined") {
                 this.getEl().addEventListener('mouseenter', handler);
             } else {
-                this.getEl().addEventListener('mouseover', (e: MouseEvent) => {
+                this.mouseEnterByHandler[<any> handler] = (e: MouseEvent) => {
                     // execute handler only if mouse came from outside
                     if (!this.getEl().contains(<HTMLElement> (e.relatedTarget || e.fromElement))) {
                         handler(e);
                     }
-                });
+                };
+                this.getEl().addEventListener('mouseover', this.mouseEnterByHandler[<any> handler]);
             }
         }
 
-        onMouseLeave(handler: (e: MouseEvent)=>any) {
+        unMouseEnter(handler: (e: MouseEvent) => any) {
+            if (typeof this.getHTMLElement().onmouseenter != "undefined") {
+                this.getEl().removeEventListener('mouseenter', handler);
+            } else {
+                this.getEl().removeEventListener('mouseover', this.mouseEnterByHandler[<any> handler]);
+            }
+        }
+
+        private mouseLeaveByHandler = {};
+
+        onMouseLeave(handler: (e: MouseEvent) => any) {
             if (typeof this.getHTMLElement().onmouseleave != "undefined") {
                 this.getEl().addEventListener('mouseleave', handler);
             } else {
-                this.getEl().addEventListener('mouseout', (e: MouseEvent) => {
+                this.mouseLeaveByHandler[<any> handler] = (e: MouseEvent) => {
                     // execute handler only if mouse moves outside
                     if (!this.getEl().contains(<HTMLElement> (e.relatedTarget || e.toElement))) {
                         handler(e);
                     }
-                });
+                };
+                this.getEl().addEventListener('mouseout', this.mouseLeaveByHandler[<any> handler]);
+            }
+        }
+
+        unMouseLeave(handler: (e: MouseEvent) => any) {
+            if (typeof this.getHTMLElement().onmouseleave != "undefined") {
+                this.getEl().removeEventListener('mouseleave', handler);
+            } else {
+                this.getEl().removeEventListener('mouseout', this.mouseLeaveByHandler[<any> handler]);
             }
         }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/ComponentView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/ComponentView.ts
@@ -196,9 +196,10 @@ module api.liveedit {
             var parentView = this.getParentItemView();
             if (parentView) {
                 parentView.removeComponentView(this);
-            } else {
-                super.remove();
             }
+
+            super.remove();
+
             return this;
         }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
@@ -78,10 +78,6 @@ module api.liveedit {
             this.propertyChangedListener = (event: api.PropertyChangedEvent) => {
                 // don't parse on regions change during reset, because it'll be done when page is loaded later
                 if (event.getPropertyName() === PageModel.PROPERTY_REGIONS && !this.ignorePropertyChanges) {
-                    this.regionViews.forEach((regionView)=> {
-                        this.unregisterRegionView(regionView)
-                    });
-
                     this.parseItemViews();
                 }
                 this.refreshEmptyState();
@@ -89,7 +85,10 @@ module api.liveedit {
             pageModel.onPropertyChanged(this.propertyChangedListener);
 
             this.pageModeChangedListener = (event: PageModeChangedEvent) => {
-                var resetEnabled = !(event.getNewMode() != PageMode.AUTOMATIC && event.getNewMode() != PageMode.NO_CONTROLLER);
+                var resetEnabled = event.getNewMode() != PageMode.AUTOMATIC && event.getNewMode() != PageMode.NO_CONTROLLER;
+                if (PageView.debug) {
+                    console.log('PageView.pageModeChangedListener setting reset enabled', resetEnabled);
+                }
                 resetAction.setEnabled(resetEnabled);
             };
             pageModel.onPageModeChanged(this.pageModeChangedListener);
@@ -544,6 +543,18 @@ module api.liveedit {
         }
 
         private parseItemViews() {
+            // unregister existing views
+            for (var itemView in this.viewsById) {
+                if (this.viewsById.hasOwnProperty(itemView)) {
+                    this.unregisterItemView(this.viewsById[itemView]);
+                }
+            }
+
+            // unregister existing regions
+            this.regionViews.forEach((regionView: RegionView)=> {
+                this.unregisterRegionView(regionView)
+            });
+
             this.regionViews = [];
             this.regionIndex = 0;
             this.viewsById = {};

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/RegionView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/RegionView.ts
@@ -418,6 +418,10 @@ module api.liveedit {
         }
 
         private parseComponentViews() {
+            this.componentViews.forEach((componentView) => {
+                this.unregisterComponentView(componentView);
+            });
+
             this.componentViews = [];
             this.componentIndex = 0;
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/layout/LayoutComponentView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/layout/LayoutComponentView.ts
@@ -109,6 +109,10 @@ module api.liveedit.layout {
         }
 
         private parseRegions() {
+            this.regionViews.forEach((regionView) => {
+                this.unregisterRegionView(regionView);
+            });
+
             this.regionViews = [];
             this.regionIndex = 0;
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/part/PartItemType.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/part/PartItemType.ts
@@ -33,7 +33,6 @@ module api.liveedit.part {
         }
 
         createView(config: CreateItemViewConfig<RegionView,PartComponent>): PartComponentView {
-            console.log('PartItemType.createView', config);
 
             return new PartComponentView(new PartComponentViewBuilder().
                 setItemViewProducer(config.itemViewProducer).


### PR DESCRIPTION
- turned off debug in InsertablesPanel and PartItemType
- turned off live edit page parsing when selecting auto template because the page will be reloaded and parsed anyways
- added unMouseEnter and unMouseLeave to Element.ts
- did unregistering of children before parsing in PageView, RegionView and LayoutComponentView
- made sure super.remove() is called in ComponentView.remove
- made sure all listeners are unboud on remove in ItemView