### PR TITLE
XP-588 TinyMCE - Remove big tooltip for help text etc

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/TinyMCE.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/TinyMCE.ts
@@ -93,6 +93,7 @@ module api.form.inputtype.text {
                     init_instance_callback: (editor) => {
                         this.setEditorContent(textAreaEl.getId(), property);
                         this.setupStickyEditorToolbarForInputOccurence(textAreaWrapper);
+                        this.removeTooltipFromEditorArea(textAreaWrapper);
                     }
                 });
 
@@ -258,6 +259,10 @@ module api.form.inputtype.text {
             if (focusEl) {
                 focusEl.focus();
             }
+        }
+
+        private removeTooltipFromEditorArea(inputOccurence: Element) {
+            wemjq(inputOccurence.getHTMLElement()).find("iframe").removeAttr("title");
         }
     }
 


### PR DESCRIPTION
[Fixed]  Removed 'title' attribute from editor area -> tooltip won't be shown