### PR TITLE
XP-617 Remove PortalResponse parameter in Renderer interface

### DIFF
--- a/modules/portal-api/src/main/java/com/enonic/xp/portal/rendering/Renderer.java
+++ b/modules/portal-api/src/main/java/com/enonic/xp/portal/rendering/Renderer.java
@@ -11,5 +11,5 @@ public interface Renderer<R extends Renderable>
 {
     Class<R> getType();
 
-    RenderResult render( R component, PortalRequest portalRequest, PortalResponse portalResponse );
+    RenderResult render( R component, PortalRequest portalRequest );
 }

--- a/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/postprocess/instruction/ComponentInstruction.java
+++ b/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/postprocess/instruction/ComponentInstruction.java
@@ -91,7 +91,7 @@ public final class ComponentInstruction
             throw new RenderException( "No Renderer found for: " + component.getClass().getSimpleName() );
         }
 
-        final RenderResult result = renderer.render( component, portalRequest, portalResponse );
+        final RenderResult result = renderer.render( component, portalRequest );
         return result.getAsString();
     }
 

--- a/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/rendering/DescriptorBasedComponentRenderer.java
+++ b/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/rendering/DescriptorBasedComponentRenderer.java
@@ -34,7 +34,7 @@ public abstract class DescriptorBasedComponentRenderer<R extends DescriptorBased
     protected ControllerScriptFactory controllerScriptFactory;
 
     @Override
-    public final RenderResult render( final R component, final PortalRequest portalRequest, final PortalResponse portalResponse )
+    public final RenderResult render( final R component, final PortalRequest portalRequest )
     {
         final Descriptor descriptor = resolveDescriptor( component );
         if ( descriptor == null )
@@ -47,6 +47,8 @@ public abstract class DescriptorBasedComponentRenderer<R extends DescriptorBased
 
         // render
         final Component previousComponent = portalRequest.getComponent();
+        final PortalResponse portalResponse = new PortalResponse();
+
         try
         {
             portalRequest.setComponent( component );

--- a/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/rendering/ImageRenderer.java
+++ b/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/rendering/ImageRenderer.java
@@ -31,9 +31,11 @@ public final class ImageRenderer
     }
 
     @Override
-    public RenderResult render( final ImageComponent component, final PortalRequest portalRequest, final PortalResponse portalResponse )
+    public RenderResult render( final ImageComponent component, final PortalRequest portalRequest )
     {
         final RenderMode renderMode = getRenderingMode( portalRequest );
+        final PortalResponse portalResponse = new PortalResponse();
+
         portalResponse.setContentType( "text/html" );
         portalResponse.setPostProcess( false );
 

--- a/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/rendering/PageRenderer.java
+++ b/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/rendering/PageRenderer.java
@@ -30,9 +30,10 @@ public final class PageRenderer
     }
 
     @Override
-    public RenderResult render( final Content content, final PortalRequest portalRequest, final PortalResponse portalResponse )
+    public RenderResult render( final Content content, final PortalRequest portalRequest )
     {
         final PageDescriptor pageDescriptor = portalRequest.getPageDescriptor();
+        final PortalResponse portalResponse = new PortalResponse();
 
         if ( pageDescriptor != null )
         {

--- a/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/rendering/TextRenderer.java
+++ b/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/rendering/TextRenderer.java
@@ -35,9 +35,11 @@ public final class TextRenderer
     }
 
     @Override
-    public RenderResult render( final TextComponent textComponent, final PortalRequest portalRequest, final PortalResponse portalResponse )
+    public RenderResult render( final TextComponent textComponent, final PortalRequest portalRequest )
     {
         final RenderMode renderMode = getRenderingMode( portalRequest );
+        final PortalResponse portalResponse = new PortalResponse();
+
         portalResponse.setContentType( "text/html" );
         portalResponse.setPostProcess( false );
 

--- a/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/resource/render/ComponentControllerResource.java
+++ b/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/resource/render/ComponentControllerResource.java
@@ -15,6 +15,6 @@ public final class ComponentControllerResource
     protected RenderResult execute( final PortalRequest portalRequest, final PortalResponse portalResponse )
         throws Exception
     {
-        return this.renderer.render( this.component, portalRequest, portalResponse );
+        return this.renderer.render( this.component, portalRequest );
     }
 }

--- a/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/resource/render/PageControllerResource.java
+++ b/modules/portal-impl/src/main/java/com/enonic/xp/portal/impl/resource/render/PageControllerResource.java
@@ -15,6 +15,6 @@ public final class PageControllerResource
     protected RenderResult execute( final PortalRequest portalRequest, final PortalResponse portalResponse )
         throws Exception
     {
-        return this.renderer.render( this.content, portalRequest, portalResponse );
+        return this.renderer.render( this.content, portalRequest );
     }
 }

--- a/modules/portal-impl/src/test/java/com/enonic/xp/portal/impl/postprocess/instruction/ComponentInstructionTest.java
+++ b/modules/portal-impl/src/test/java/com/enonic/xp/portal/impl/postprocess/instruction/ComponentInstructionTest.java
@@ -168,7 +168,7 @@ public class ComponentInstructionTest
             }
 
             @Override
-            public RenderResult render( final Renderable component, final PortalRequest portalRequest, final PortalResponse portalResponse )
+            public RenderResult render( final Renderable component, final PortalRequest portalRequest )
             {
                 return RenderResult.newRenderResult().entity( renderResult ).build();
             }

--- a/modules/portal-impl/src/test/java/com/enonic/xp/portal/impl/rendering/RendererFactoryImplTest.java
+++ b/modules/portal-impl/src/test/java/com/enonic/xp/portal/impl/rendering/RendererFactoryImplTest.java
@@ -74,7 +74,7 @@ public class RendererFactoryImplTest
             }
 
             @Override
-            public RenderResult render( final Renderable component, final PortalRequest portalRequest, final PortalResponse portalResponse )
+            public RenderResult render( final Renderable component, final PortalRequest portalRequest )
             {
                 return null;
             }

--- a/modules/portal-impl/src/test/java/com/enonic/xp/portal/impl/rendering/TextRendererTest.java
+++ b/modules/portal-impl/src/test/java/com/enonic/xp/portal/impl/rendering/TextRendererTest.java
@@ -37,7 +37,7 @@ public class TextRendererTest
         renderer = new TextRenderer();
 
         // exercise
-        RenderResult result = renderer.render( textComponent, portalRequest, portalResponse );
+        RenderResult result = renderer.render( textComponent, portalRequest );
 
         // verify
         assertEquals( "", result.getAsString() );
@@ -52,7 +52,7 @@ public class TextRendererTest
         renderer = new TextRenderer();
 
         // exercise
-        RenderResult result = renderer.render( textComponent, portalRequest, portalResponse );
+        RenderResult result = renderer.render( textComponent, portalRequest );
 
         // verify
         assertEquals( "<div data-portal-component-type=\"text\"><section></section></div>", result.getAsString() );
@@ -67,7 +67,7 @@ public class TextRendererTest
         renderer = new TextRenderer();
 
         // exercise
-        RenderResult result = renderer.render( textComponent, portalRequest, portalResponse );
+        RenderResult result = renderer.render( textComponent, portalRequest );
 
         // verify
         assertEquals( "<section data-portal-component-type=\"text\"></section>", result.getAsString() );
@@ -83,7 +83,7 @@ public class TextRendererTest
         renderer = new TextRenderer();
 
         // exercise
-        RenderResult result = renderer.render( textComponent, portalRequest, portalResponse );
+        RenderResult result = renderer.render( textComponent, portalRequest );
 
         // verify
         assertEquals( "<section data-portal-component-type=\"text\">" + text + "</section>", result.getAsString() );
@@ -99,7 +99,7 @@ public class TextRendererTest
         renderer = new TextRenderer();
 
         // exercise
-        RenderResult result = renderer.render( textComponent, portalRequest, portalResponse );
+        RenderResult result = renderer.render( textComponent, portalRequest );
 
         // verify
         assertEquals( "<div data-portal-component-type=\"text\"><section>" + text + "</section></div>", result.getAsString() );

--- a/modules/portal-impl/src/test/java/com/enonic/xp/portal/impl/resource/render/ComponentResourceTest.java
+++ b/modules/portal-impl/src/test/java/com/enonic/xp/portal/impl/resource/render/ComponentResourceTest.java
@@ -45,15 +45,14 @@ public class ComponentResourceTest
             header( "some-heaer", "some-value" ).
             status( 200 ).
             build();
-        Mockito.when( this.renderer.render( Mockito.any(), Mockito.any(), Mockito.any() ) ).thenReturn( result );
+        Mockito.when( this.renderer.render( Mockito.any(), Mockito.any() ) ).thenReturn( result );
 
         final MockHttpServletRequest request = newGetRequest( "/master/site/somepath/content/_/component/main-region/0" );
         final MockHttpServletResponse response = executeRequest( request );
 
         final ArgumentCaptor<PortalRequest> jsRequest = ArgumentCaptor.forClass( PortalRequest.class );
-        final ArgumentCaptor<PortalResponse> jsResponse = ArgumentCaptor.forClass( PortalResponse.class );
         final ArgumentCaptor<Renderable> renderable = ArgumentCaptor.forClass( Renderable.class );
-        Mockito.verify( this.renderer ).render( renderable.capture(), jsRequest.capture(), jsResponse.capture() );
+        Mockito.verify( this.renderer ).render( renderable.capture(), jsRequest.capture() );
 
         assertEquals( 200, response.getStatus() );
         assertEquals( "text/plain", response.getContentType() );
@@ -96,15 +95,14 @@ public class ComponentResourceTest
             header( "some-heaer", "some-value" ).
             status( 200 ).
             build();
-        Mockito.when( this.renderer.render( Mockito.any(), Mockito.any(), Mockito.any() ) ).thenReturn( result );
+        Mockito.when( this.renderer.render( Mockito.any(), Mockito.any() ) ).thenReturn( result );
 
         final MockHttpServletRequest request = newGetRequest( "/master/site/somepath/content/_/component/main-region/0" );
         final MockHttpServletResponse response = executeRequest( request );
 
         final ArgumentCaptor<PortalRequest> jsRequest = ArgumentCaptor.forClass( PortalRequest.class );
-        final ArgumentCaptor<PortalResponse> jsResponse = ArgumentCaptor.forClass( PortalResponse.class );
         final ArgumentCaptor<Renderable> renderable = ArgumentCaptor.forClass( Renderable.class );
-        Mockito.verify( this.renderer ).render( renderable.capture(), jsRequest.capture(), jsResponse.capture() );
+        Mockito.verify( this.renderer ).render( renderable.capture(), jsRequest.capture() );
 
         assertEquals( "http://localhost/portal/master/site/somepath/content/_/component/main-region/0", jsRequest.getValue().getUri() );
     }

--- a/modules/portal-impl/src/test/java/com/enonic/xp/portal/impl/resource/render/PageResourceTest.java
+++ b/modules/portal-impl/src/test/java/com/enonic/xp/portal/impl/resource/render/PageResourceTest.java
@@ -56,15 +56,14 @@ public class PageResourceTest
             header( "some-header", "some-value" ).
             status( 200 ).
             build();
-        Mockito.when( this.renderer.render( Mockito.any(), Mockito.any(), Mockito.any() ) ).thenReturn( result );
+        Mockito.when( this.renderer.render( Mockito.any(), Mockito.any() ) ).thenReturn( result );
 
         MockHttpServletRequest request = newGetRequest( "/master/site/somepath/content" );
         MockHttpServletResponse response = executeRequest( request );
 
         ArgumentCaptor<PortalRequest> jsRequest = ArgumentCaptor.forClass( PortalRequest.class );
-        ArgumentCaptor<PortalResponse> jsResponse = ArgumentCaptor.forClass( PortalResponse.class );
         ArgumentCaptor<Renderable> renderable = ArgumentCaptor.forClass( Renderable.class );
-        Mockito.verify( this.renderer ).render( renderable.capture(), jsRequest.capture(), jsResponse.capture() );
+        Mockito.verify( this.renderer ).render( renderable.capture(), jsRequest.capture() );
 
         assertEquals( 200, response.getStatus() );
         assertEquals( "text/plain", response.getContentType() );
@@ -82,15 +81,14 @@ public class PageResourceTest
             header( "some-header", "some-value" ).
             status( 200 ).
             build();
-        Mockito.when( this.renderer.render( Mockito.any(), Mockito.any(), Mockito.any() ) ).thenReturn( result );
+        Mockito.when( this.renderer.render( Mockito.any(), Mockito.any() ) ).thenReturn( result );
 
         MockHttpServletRequest request = newGetRequest( "/master/site/somepath/content" );
         MockHttpServletResponse response = executeRequest( request );
 
         ArgumentCaptor<PortalRequest> jsRequest = ArgumentCaptor.forClass( PortalRequest.class );
-        ArgumentCaptor<PortalResponse> jsResponse = ArgumentCaptor.forClass( PortalResponse.class );
         ArgumentCaptor<Renderable> renderable = ArgumentCaptor.forClass( Renderable.class );
-        Mockito.verify( this.renderer ).render( renderable.capture(), jsRequest.capture(), jsResponse.capture() );
+        Mockito.verify( this.renderer ).render( renderable.capture(), jsRequest.capture() );
 
         assertEquals( "http://localhost/portal/master/site/somepath/content", jsRequest.getValue().getUri() );
     }
@@ -131,7 +129,7 @@ public class PageResourceTest
             header( "some-header", "some-value" ).
             status( 200 ).
             build();
-        Mockito.when( this.renderer.render( Mockito.any(), Mockito.any(), Mockito.any() ) ).thenReturn( result );
+        Mockito.when( this.renderer.render( Mockito.any(), Mockito.any() ) ).thenReturn( result );
 
         final PortalRequest newPortalRequest = new PortalRequest();
         newPortalRequest.setMode( RenderMode.EDIT );


### PR DESCRIPTION
Refactor Renderer interface to remove PortalResponse parameter. All renderers should just new their own PortalResponse inside implementations.