### PR TITLE
XP-638 Live Edit - Selecting layout sometimes does not show context w…

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveFormPanel.ts
@@ -381,12 +381,14 @@ module app.wizard.page {
             this.liveEditPageProxy.onItemViewSelected((event: ItemViewSelectedEvent) => {
                 var itemView = event.getItemView();
                 if (itemView.isEmpty() || api.ObjectHelper.iFrameSafeInstanceOf(itemView, TextComponentView)) {
-                    if (this.contextWindow.canAutoSlide() && this.contextWindow.isFloating() && this.contextWindow.isShown()) {
+                    if (this.contextWindow.canAutoSlide() && this.contextWindow.isFloating() &&
+                        this.contextWindow.isShownOrAboutToBeShown()) {
                         this.contextWindow.slideOut();
                     }
                 }
                 else {
-                    if (this.contextWindow.canAutoSlide() && this.contextWindow.isFloating() && !this.contextWindow.isShown()) {
+                    if (this.contextWindow.canAutoSlide() && this.contextWindow.isFloating() &&
+                        !this.contextWindow.isShownOrAboutToBeShown()) {
                         this.contextWindow.slideIn();
                     }
                 }
@@ -398,9 +400,9 @@ module app.wizard.page {
 
             this.liveEditPageProxy.onItemViewDeselected((event: ItemViewDeselectEvent) => {
                 var toggler = this.contentWizardPanel.getContextWindowToggler();
-                if (!toggler.isActive() && this.contextWindow.isShown()) {
+                if (!toggler.isActive() && this.contextWindow.isShownOrAboutToBeShown()) {
                     this.contextWindow.slideOut();
-                } else if (toggler.isActive() && !this.contextWindow.isShown()) {
+                } else if (toggler.isActive() && !this.contextWindow.isShownOrAboutToBeShown()) {
                     this.contextWindow.slideIn();
                 }
                 this.contextWindow.clearSelection();

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/ContextWindow.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/ContextWindow.ts
@@ -35,7 +35,7 @@ module app.wizard.page.contextwindow {
 
         private liveFormPanel: LiveFormPanel;
 
-        private shown: boolean = false;
+        private contextWindowState: ContextWindowState = ContextWindowState.HIDDEN;
 
         private splitter: api.dom.DivEl;
 
@@ -135,8 +135,12 @@ module app.wizard.page.contextwindow {
             this.removeChild(this.ghostDragger);
         }
 
-        isShown() {
-            return this.shown;
+        isShown(): boolean {
+            return this.contextWindowState == ContextWindowState.SHOWN;
+        }
+
+        isShownOrAboutToBeShown(): boolean {
+            return this.contextWindowState == ContextWindowState.SHOWN || this.contextWindowState == ContextWindowState.SLIDING_IN;
         }
 
         slideOut() {
@@ -145,9 +149,10 @@ module app.wizard.page.contextwindow {
             if (this.animationTimer) {
                 clearTimeout(this.animationTimer);
             }
+            this.contextWindowState = ContextWindowState.SLIDING_OUT;
             this.animationTimer = setTimeout(() => {
                 this.getEl().addClass('hidden');
-                this.shown = false;
+                this.contextWindowState = ContextWindowState.HIDDEN;
                 this.updateFrameSize();
                 this.animationTimer = null;
             }, 100);
@@ -159,8 +164,9 @@ module app.wizard.page.contextwindow {
             if (this.animationTimer) {
                 clearTimeout(this.animationTimer);
             }
+            this.contextWindowState = ContextWindowState.SLIDING_IN;
             this.animationTimer = setTimeout(() => {
-                this.shown = true;
+                this.contextWindowState = ContextWindowState.SHOWN;
                 this.updateFrameSize();
                 this.animationTimer = null
             }, 100);
@@ -190,7 +196,7 @@ module app.wizard.page.contextwindow {
                 displayModeChanged = this.hasClass('floating') && !isFloating,
                 contextWindowWidth = this.actualWidth || this.getEl().getWidth();
 
-            this.liveFormPanel.updateFrameContainerSize(!isFloating && this.shown, contextWindowWidth);
+            this.liveFormPanel.updateFrameContainerSize(!isFloating && this.isShown(), contextWindowWidth);
 
             this.toggleClass("floating", isFloating);
 
@@ -219,5 +225,9 @@ module app.wizard.page.contextwindow {
             });
         }
 
+    }
+
+    enum ContextWindowState {
+        SHOWN, HIDDEN, SLIDING_IN, SLIDING_OUT
     }
 }


### PR DESCRIPTION
…indow

-[Modified] context window to use ContextWindowState enum instead of "shown: boolean" property which was sometimes in incorrect state due to slideIn/slideOut timeouts. Collisions occured when slideIn and slideOut were called in a time range shorter than timeout, during selecting component's parent for example.