### PR TITLE
XP-671 Live Edit - Have to press "Customize" twice

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveFormPanel.ts
@@ -225,17 +225,18 @@ module app.wizard.page {
 
                 // NB: To make the event.getSource() check work, all calls from this to PageModel that changes a property must done with this as eventSource argument.
 
-                if (event.getPropertyName() == "controller" && this !== event.getSource()) {
+                if (event.getPropertyName() == PageModel.PROPERTY_CONTROLLER && this !== event.getSource()) {
                     this.saveAndReloadPage(true);
                 }
-                else if (event.getPropertyName() == "template" && this !== event.getSource()) {
+                else if (event.getPropertyName() == PageModel.PROPERTY_TEMPLATE && this !== event.getSource()) {
 
-                    //if ((this.pageModel.getMode() == PageMode.AUTOMATIC) || event.getOldValue()) {
+                    // do not reload page if there was no template in pageModel before and if new template is the default one - case when switching automatic template to default
+                    if (!(this.pageModel.getTemplate() == this.pageModel.getDefaultPageTemplate() && !event.getOldValue())) {
 
-                    this.pageInspectionPanel.refreshInspectionHandler(liveEditModel);
-                    this.lockPageAfterProxyLoad = true;
-                    this.saveAndReloadPage(false);
-                    //}
+                        this.pageInspectionPanel.refreshInspectionHandler(liveEditModel);
+                        this.lockPageAfterProxyLoad = true;
+                        this.saveAndReloadPage(false);
+                    }
                 }
             });
 

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageControllerSelector.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageControllerSelector.ts
@@ -59,7 +59,7 @@ module app.wizard.page.contextwindow.inspect.page {
             });
 
             this.pageModel.onPropertyChanged((event: PropertyChangedEvent) => {
-                if (event.getPropertyName() == "controller" && this !== event.getSource()) {
+                if (event.getPropertyName() == PageModel.PROPERTY_CONTROLLER && this !== event.getSource()) {
                     var descriptorKey = <DescriptorKey>event.getNewValue();
                     if (descriptorKey) {
                         this.selectController(descriptorKey);

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageInspectionPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageInspectionPanel.ts
@@ -171,13 +171,13 @@ module app.wizard.page.contextwindow.inspect.page {
 
 
             pageModel.onPropertyChanged((event: PropertyChangedEvent) => {
-                if (event.getPropertyName() == "controller" && this !== event.getSource()) {
+                if (event.getPropertyName() == PageModel.PROPERTY_CONTROLLER && this !== event.getSource()) {
 
                     this.pageControllerForm.show();
 
                     this.refreshConfigForm(pageModel.getController(), pageModel.getConfig());
                 }
-                else if (event.getPropertyName() == "config" && this !== event.getSource()) {
+                else if (event.getPropertyName() == PageModel.PROPERTY_CONFIG && this !== event.getSource()) {
 
                     this.pageControllerForm.show();
 
@@ -248,7 +248,7 @@ module app.wizard.page.contextwindow.inspect.page {
                         this.refreshConfigForm(controller, pageModel.getConfig());
                     }
                 }
-                else if (event.getPropertyName() == "config" && this !== event.getSource()) {
+                else if (event.getPropertyName() == PageModel.PROPERTY_CONFIG && this !== event.getSource()) {
 
                     this.pageTemplateForm.show();
 

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageTemplateSelector.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageTemplateSelector.ts
@@ -50,7 +50,7 @@ module app.wizard.page.contextwindow.inspect.page {
                     });
 
                     this.pageModel.onPropertyChanged((event: PropertyChangedEvent) => {
-                        if (event.getPropertyName() == "template" && this !== event.getSource()) {
+                        if (event.getPropertyName() == PageModel.PROPERTY_TEMPLATE && this !== event.getSource()) {
                             var pageTemplateKey = <PageTemplateKey>event.getNewValue();
                             if (pageTemplateKey) {
                                 this.selectTemplate(pageTemplateKey);

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/PageModel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/PageModel.ts
@@ -72,6 +72,10 @@ module api.content.page {
 
         public static PROPERTY_TEMPLATE = 'template';
 
+        public static PROPERTY_CONTROLLER = 'controller';
+
+        public static PROPERTY_CONFIG = 'config';
+
         private liveEditModel: api.liveedit.LiveEditModel;
 
         private defaultTemplate: PageTemplate;
@@ -212,7 +216,7 @@ module api.content.page {
             var newControllerKey = this.controller ? this.controller.getKey() : null;
             if (!api.ObjectHelper.equals(oldControllerKey, newControllerKey)) {
                 this.setIgnorePropertyChanges(true);
-                this.notifyPropertyChanged("controller", oldControllerKey, newControllerKey, setController.eventSource);
+                this.notifyPropertyChanged(PageModel.PROPERTY_CONTROLLER, oldControllerKey, newControllerKey, setController.eventSource);
                 this.setIgnorePropertyChanges(false);
             }
 
@@ -302,7 +306,7 @@ module api.content.page {
             this.config.onChanged(this.configPropertyChangedHandler);
 
             this.setIgnorePropertyChanges(true);
-            this.notifyPropertyChanged("config", oldValue, value, eventOrigin);
+            this.notifyPropertyChanged(PageModel.PROPERTY_CONFIG, oldValue, value, eventOrigin);
             this.setIgnorePropertyChanges(false);
             return this;
         }


### PR DESCRIPTION
- [Fixed]. Added check that skips page reload for case when automatic template is switched to the default one upon page unlock
- Replaced hardcoded strings in a few places.