### PR TITLE
XP-693 Move XmlRelationshipTypeParser to core-schema module

### DIFF
--- a/modules/core-schema/src/main/java/com/enonic/xp/core/impl/schema/relationship/RelationshipTypeLoader.java
+++ b/modules/core-schema/src/main/java/com/enonic/xp/core/impl/schema/relationship/RelationshipTypeLoader.java
@@ -20,7 +20,6 @@ import com.enonic.xp.module.ModuleKey;
 import com.enonic.xp.schema.relationship.RelationshipType;
 import com.enonic.xp.schema.relationship.RelationshipTypeName;
 import com.enonic.xp.schema.relationship.RelationshipTypes;
-import com.enonic.xp.xml.parser.XmlRelationshipTypeParser;
 
 final class RelationshipTypeLoader
 {

--- a/modules/core-schema/src/main/java/com/enonic/xp/core/impl/schema/relationship/XmlRelationshipTypeParser.java
+++ b/modules/core-schema/src/main/java/com/enonic/xp/core/impl/schema/relationship/XmlRelationshipTypeParser.java
@@ -1,4 +1,4 @@
-package com.enonic.xp.xml.parser;
+package com.enonic.xp.core.impl.schema.relationship;
 
 import java.util.Collections;
 import java.util.List;
@@ -10,6 +10,7 @@ import com.enonic.xp.module.ModuleRelativeResolver;
 import com.enonic.xp.schema.content.ContentTypeName;
 import com.enonic.xp.schema.relationship.RelationshipType;
 import com.enonic.xp.xml.DomElement;
+import com.enonic.xp.xml.parser.XmlModelParser;
 
 @Beta
 public final class XmlRelationshipTypeParser

--- a/modules/core-schema/src/test/java/com/enonic/xp/core/impl/schema/relationship/XmlRelationshipTypeParserTest.java
+++ b/modules/core-schema/src/test/java/com/enonic/xp/core/impl/schema/relationship/XmlRelationshipTypeParserTest.java
@@ -1,10 +1,11 @@
-package com.enonic.xp.xml.parser;
+package com.enonic.xp.core.impl.schema.relationship;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import com.enonic.xp.module.ModuleKey;
 import com.enonic.xp.schema.relationship.RelationshipType;
+import com.enonic.xp.xml.parser.XmlModelParserTest;
 
 import static org.junit.Assert.*;
 


### PR DESCRIPTION
-Moved XmlRelationshipTypeParser to core-schema module. Moved it under com.enonic.xp.core.impl.schema.relationship package. Also moved the associated tests.