### PR TITLE
XP-715 Tooltip - Remove unnessesary tooltips

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/ContextWindow.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/ContextWindow.ts
@@ -73,9 +73,9 @@ module app.wizard.page.contextwindow {
             });
 
             this.appendChild(this.splitter);
-            this.addItem("Insert", this.insertablesPanel);
-            this.addItem("Inspect", this.inspectionsPanel);
-            this.addItem("Emulator", this.emulatorPanel);
+            this.addItem("Insert", false, this.insertablesPanel);
+            this.addItem("Inspect", false, this.inspectionsPanel);
+            this.addItem("Emulator", false, this.emulatorPanel);
 
             this.onRendered(() => this.onRenderedHandler());
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/app/NamesAndIconView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/app/NamesAndIconView.ts
@@ -4,7 +4,7 @@ module api.app {
 
         size: NamesAndIconViewSize;
 
-        addTitleAttribute: boolean = true;
+        addTitleAttribute: boolean = false;
 
         appendIcon: boolean = true;
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/app/bar/AppBarTabMenuItem.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/app/bar/AppBarTabMenuItem.ts
@@ -9,6 +9,7 @@ module api.app.bar {
         private editing: boolean;
 
         constructor(builder : AppBarTabMenuItemBuilder) {
+            builder.setAddLabelTitleAttribute(false);
             super(builder);
 
             this.addClass("appbar-tab-menu-item");

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardHeaderWithDisplayNameAndName.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardHeaderWithDisplayNameAndName.ts
@@ -149,7 +149,6 @@ module api.app.wizard {
 
         setPath(value: string) {
             this.pathEl.getEl().setText(value);
-            this.pathEl.getEl().setAttribute('title', value);
             if (value) {
                 this.pathEl.show();
             } else {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardStep.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardStep.ts
@@ -7,7 +7,7 @@ module api.app.wizard {
         private stepForm: WizardStepForm;
 
         constructor(label: string, stepForm: WizardStepForm) {
-            this.tabBarItem = new api.ui.tab.TabBarItemBuilder().setLabel(label).build();
+            this.tabBarItem = new api.ui.tab.TabBarItemBuilder().setAddLabelTitleAttribute(false).setLabel(label).build();
             this.stepForm = stepForm;
         }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/form/InputLabel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/form/InputLabel.ts
@@ -12,7 +12,6 @@ module api.form {
             var wrapper = new api.dom.DivEl("wrapper");
             var label = new api.dom.DivEl("label");
             label.getEl().setInnerHtml(input.getLabel());
-            label.getEl().setAttribute('title', input.getLabel());
             wrapper.getEl().appendChild(label.getHTMLElement());
 
             if( input.getOccurrences().required() ) {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/tiny/LinkModalDialog.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/tiny/LinkModalDialog.ts
@@ -164,10 +164,10 @@ module api.form.inputtype.text.tiny {
 
         private createDockedPanel(): DockedPanel {
             var dockedPanel = new DockedPanel();
-            dockedPanel.addItem(LinkModalDialog.tabNames.content, this.createContentPanel());
-            dockedPanel.addItem(LinkModalDialog.tabNames.url, this.createUrlPanel(), this.isUrl());
-            dockedPanel.addItem(LinkModalDialog.tabNames.download, this.createDownloadPanel(), this.isDownloadLink());
-            dockedPanel.addItem(LinkModalDialog.tabNames.email, this.createEmailPanel(), this.isEmail());
+            dockedPanel.addItem(LinkModalDialog.tabNames.content, true, this.createContentPanel());
+            dockedPanel.addItem(LinkModalDialog.tabNames.url, true, this.createUrlPanel(), this.isUrl());
+            dockedPanel.addItem(LinkModalDialog.tabNames.download, true, this.createDownloadPanel(), this.isDownloadLink());
+            dockedPanel.addItem(LinkModalDialog.tabNames.email, true, this.createEmailPanel(), this.isEmail());
 
             return dockedPanel;
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/panel/DockedPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/panel/DockedPanel.ts
@@ -20,8 +20,8 @@ module api.ui.panel {
             this.setDoOffset(false);
         }
 
-        addItem<T extends Panel>(label: string, panel: T, select?: boolean): number {
-            var item = new api.ui.tab.TabBarItemBuilder().setLabel(label).build();
+        addItem<T extends Panel>(label: string, addLabelTitleAttribute: boolean, panel: T, select?: boolean): number {
+            var item = new api.ui.tab.TabBarItemBuilder().setLabel(label).setAddLabelTitleAttribute(addLabelTitleAttribute).build();
             this.addItemArray(item);
 
             this.deck.addNavigablePanel(item, panel, select || this.items.length == 1);

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabItem.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabItem.ts
@@ -29,7 +29,7 @@ module api.ui.tab {
             this.labelEl = new api.dom.SpanEl('label');
             this.appendChild(this.labelEl);
 
-            this.setLabel(builder.label, builder.markUnnamed);
+            this.setLabel(builder.label, builder.markUnnamed, builder.addLabelTitleAttribute);
 
             this.markInvalid(builder.markInvalid);
 
@@ -65,7 +65,7 @@ module api.ui.tab {
             return this.index;
         }
 
-        setLabel(newValue: string, markUnnamed: boolean = false) {
+        setLabel(newValue: string, markUnnamed: boolean = false, addLabelTitleAttribute: boolean = true) {
             if (this.label == newValue) {
                 return;
             }
@@ -73,7 +73,11 @@ module api.ui.tab {
             var oldValue = this.label;
             this.label = newValue;
             this.labelEl.setHtml(newValue, true);
-            this.labelEl.getEl().setAttribute('title', newValue);
+
+            if (addLabelTitleAttribute) {
+                this.labelEl.getEl().setAttribute('title', newValue);
+            }
+
             this.labelEl.toggleClass("unnamed", markUnnamed);
 
             this.notifyLabelChangedListeners(newValue, oldValue);
@@ -163,6 +167,8 @@ module api.ui.tab {
 
         label: string;
 
+        addLabelTitleAttribute: boolean = true;
+
         closeAction: api.ui.Action;
 
         closeButtonEnabled: boolean;
@@ -193,6 +199,11 @@ module api.ui.tab {
 
         setMarkInvalid(markInvalid: boolean): TabItemBuilder {
             this.markInvalid = markInvalid;
+            return this;
+        }
+
+        setAddLabelTitleAttribute(addLabelTitleAttribute: boolean): TabItemBuilder {
+            this.addLabelTitleAttribute = addLabelTitleAttribute;
             return this;
         }
 


### PR DESCRIPTION
Removed tooltips from the following places:

Content Grid:

Over displayname and path)
Content Wizard
-Tab (at top of view)

WizardStepPanels
Every "label" in the form
Live Edit

Context window tabs
All forms in "inspect" panel