### PR TITLE
XP-801 Publishing Wizard - Misc fixes of the dependencies list

### DIFF
--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ResolvedContent.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ResolvedContent.java
@@ -220,4 +220,70 @@ public class ResolvedContent
         }
     }
 
+    public static class ResolvedDependencyContent
+        extends ResolvedContent
+    {
+
+        private final boolean child;
+
+        public ResolvedDependencyContent( Builder builder )
+        {
+            super( builder );
+            this.child = builder.child;
+        }
+
+        public static Builder create()
+        {
+            return new Builder();
+        }
+
+        @SuppressWarnings("unused")
+        public boolean isChild()
+        {
+            return child;
+        }
+
+        public static final class Builder
+            extends ResolvedContent.Builder
+        {
+            private boolean child;
+
+            public Builder isChild( final boolean child )
+            {
+                this.child = child;
+                return this;
+            }
+
+            public Builder content( final Content content )
+            {
+                this.content = content;
+                return this;
+            }
+
+            public Builder compareStatus( final String compareStatus )
+            {
+                this.compareStatus = compareStatus;
+                return this;
+            }
+
+            public Builder iconUrl( final String iconUrl )
+            {
+                this.iconUrl = iconUrl;
+                return this;
+            }
+
+            public ResolvedDependencyContent build()
+            {
+                this.id = content.getId().toString();
+                this.path = content.getPath().toString();
+                this.displayName = content.getDisplayName();
+                this.name = content.getName().toString();
+                this.type = content.getType().toString();
+                this.isValid = content.isValid();
+
+                return new ResolvedDependencyContent( this );
+            }
+        }
+    }
+
 }

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/ResolvePublishDependenciesResultJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/ResolvePublishDependenciesResultJson.java
@@ -3,30 +3,20 @@ package com.enonic.xp.admin.impl.rest.resource.content.json;
 
 import java.util.List;
 
-import com.enonic.xp.admin.impl.rest.resource.content.ResolvedContent;
+import com.enonic.xp.admin.impl.rest.resource.content.ResolvedContent.ResolvedDependencyContent;
 
 public class ResolvePublishDependenciesResultJson
 {
-    private final List<ResolvedContent> dependantContents;
+    private final List<ResolvedDependencyContent> dependenciesContents;
 
-    private final List<ResolvedContent> childrenContents;
-
-    public ResolvePublishDependenciesResultJson( final List<ResolvedContent> dependantContents,
-                                                 final List<ResolvedContent> childrenContents )
+    public ResolvePublishDependenciesResultJson( List<ResolvedDependencyContent> dependenciesContents )
     {
-        this.dependantContents = dependantContents;
-        this.childrenContents = childrenContents;
+        this.dependenciesContents = dependenciesContents;
     }
 
     @SuppressWarnings("unused")
-    public List<ResolvedContent> getDependantContents()
+    public List<ResolvedDependencyContent> getDependenciesContents()
     {
-        return dependantContents;
-    }
-
-    @SuppressWarnings("unused")
-    public List<ResolvedContent> getChildrenContents()
-    {
-        return childrenContents;
+        return dependenciesContents;
     }
 }

--- a/modules/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/content/ResolvePublishDependenciesResultJsonFactoryTest.java
+++ b/modules/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/content/ResolvePublishDependenciesResultJsonFactoryTest.java
@@ -49,16 +49,17 @@ public class ResolvePublishDependenciesResultJsonFactoryTest
 
         final ResolvePublishDependenciesResultJson result = createDependantsResultJson( resolvedDependencies, resolved, compareResults );
 
-        assertEquals( 0, result.getDependantContents().size() );
-        assertEquals( 2, result.getChildrenContents().size() );
+        assertEquals( 2, result.getDependenciesContents().size() );
 
-        assertNotNull( result.getChildrenContents().get( 0 ).getCompareStatus() );
-        assertNotNull( result.getChildrenContents().get( 0 ).getName() );
-        assertNotNull( result.getChildrenContents().get( 0 ).getDisplayName() );
-        assertNotNull( result.getChildrenContents().get( 0 ).getIconUrl() );
-        assertNotNull( result.getChildrenContents().get( 0 ).getId() );
-        assertNotNull( result.getChildrenContents().get( 0 ).getPath() );
-        assertNotNull( result.getChildrenContents().get( 0 ).getType() );
+        assertEquals( result.getDependenciesContents().get( 0 ).isChild(), true );
+
+        assertNotNull( result.getDependenciesContents().get( 0 ).getCompareStatus() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getName() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getDisplayName() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getIconUrl() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getId() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getPath() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getType() );
     }
 
     @Test
@@ -80,16 +81,17 @@ public class ResolvePublishDependenciesResultJsonFactoryTest
 
         final ResolvePublishDependenciesResultJson result = createDependantsResultJson( resolvedDependencies, resolved, compareResults );
 
-        assertEquals( 2, result.getDependantContents().size() );
-        assertEquals( 0, result.getChildrenContents().size() );
+        assertEquals( 2, result.getDependenciesContents().size() );
 
-        assertNotNull( result.getDependantContents().get( 0 ).getCompareStatus() );
-        assertNotNull( result.getDependantContents().get( 0 ).getName() );
-        assertNotNull( result.getDependantContents().get( 0 ).getDisplayName() );
-        assertNotNull( result.getDependantContents().get( 0 ).getIconUrl() );
-        assertNotNull( result.getDependantContents().get( 0 ).getId() );
-        assertNotNull( result.getDependantContents().get( 0 ).getPath() );
-        assertNotNull( result.getDependantContents().get( 0 ).getType() );
+        assertEquals( result.getDependenciesContents().get( 0 ).isChild(), false );
+
+        assertNotNull( result.getDependenciesContents().get( 0 ).getCompareStatus() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getName() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getDisplayName() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getIconUrl() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getId() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getPath() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getType() );
     }
 
     @Test
@@ -113,16 +115,15 @@ public class ResolvePublishDependenciesResultJsonFactoryTest
 
         final ResolvePublishDependenciesResultJson result = createDependantsResultJson( resolvedDependencies, resolved, compareResults );
 
-        assertEquals( 2, result.getDependantContents().size() );
-        assertEquals( 2, result.getChildrenContents().size() );
+        assertEquals( 4, result.getDependenciesContents().size() );
 
-        assertNotNull( result.getDependantContents().get( 0 ).getCompareStatus() );
-        assertNotNull( result.getDependantContents().get( 0 ).getName() );
-        assertNotNull( result.getDependantContents().get( 0 ).getDisplayName() );
-        assertNotNull( result.getDependantContents().get( 0 ).getIconUrl() );
-        assertNotNull( result.getDependantContents().get( 0 ).getId() );
-        assertNotNull( result.getDependantContents().get( 0 ).getPath() );
-        assertNotNull( result.getDependantContents().get( 0 ).getType() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getCompareStatus() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getName() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getDisplayName() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getIconUrl() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getId() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getPath() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getType() );
     }
 
     @Test
@@ -150,19 +151,19 @@ public class ResolvePublishDependenciesResultJsonFactoryTest
 
         final ResolvePublishDependenciesResultJson result = createDependantsResultJson( resolvedDependencies, resolved, compareResults );
 
-        assertEquals( 3, result.getDependantContents().size() );
+        assertEquals( 3, result.getDependenciesContents().size() );
 
-        assertEquals( result.getDependantContents().get( 0 ).getId(), "s2" );
-        assertEquals( result.getDependantContents().get( 1 ).getId(), "s1" );
-        assertEquals( result.getDependantContents().get( 2 ).getId(), "s3" );
+        assertEquals( result.getDependenciesContents().get( 0 ).getId(), "s2" );
+        assertEquals( result.getDependenciesContents().get( 1 ).getId(), "s1" );
+        assertEquals( result.getDependenciesContents().get( 2 ).getId(), "s3" );
 
-        assertNotNull( result.getDependantContents().get( 0 ).getCompareStatus() );
-        assertNotNull( result.getDependantContents().get( 0 ).getName() );
-        assertNotNull( result.getDependantContents().get( 0 ).getDisplayName() );
-        assertNotNull( result.getDependantContents().get( 0 ).getIconUrl() );
-        assertNotNull( result.getDependantContents().get( 0 ).getId() );
-        assertNotNull( result.getDependantContents().get( 0 ).getPath() );
-        assertNotNull( result.getDependantContents().get( 0 ).getType() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getCompareStatus() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getName() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getDisplayName() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getIconUrl() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getId() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getPath() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getType() );
     }
 
     @Test
@@ -184,15 +185,15 @@ public class ResolvePublishDependenciesResultJsonFactoryTest
 
         final ResolvePublishDependenciesResultJson result = createDependantsResultJson( resolvedDependencies, resolved, compareResults );
 
-        assertEquals( 2, result.getDependantContents().size() );
+        assertEquals( 2, result.getDependenciesContents().size() );
 
-        assertNull( result.getDependantContents().get( 0 ).getCompareStatus() );
-        assertNotNull( result.getDependantContents().get( 0 ).getName() );
-        assertNotNull( result.getDependantContents().get( 0 ).getDisplayName() );
-        assertNotNull( result.getDependantContents().get( 0 ).getIconUrl() );
-        assertNotNull( result.getDependantContents().get( 0 ).getId() );
-        assertNotNull( result.getDependantContents().get( 0 ).getPath() );
-        assertNotNull( result.getDependantContents().get( 0 ).getType() );
+        assertNull( result.getDependenciesContents().get( 0 ).getCompareStatus() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getName() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getDisplayName() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getIconUrl() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getId() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getPath() );
+        assertNotNull( result.getDependenciesContents().get( 0 ).getType() );
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/modules/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/resolve_publish_dependencies.json
+++ b/modules/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/resolve_publish_dependencies.json
@@ -1,6 +1,7 @@
 {
-  "childrenContents": [
+  "dependenciesContents": [
     {
+      "child": true,
       "compareStatus": "NEW",
       "displayName": "My Content",
       "iconUrl": "/admin/rest/schema/content/icon/mymodule:my_type?hash=f95b70fdc3088560732a5ac135644506",
@@ -9,10 +10,9 @@
       "path": "/node1_1_1_content",
       "type": "mymodule:my_type",
       "valid": true
-    }
-  ],
-  "dependantContents": [
+    },
     {
+      "child": false,
       "compareStatus": "NEW",
       "displayName": "My Content",
       "iconUrl": "/admin/rest/schema/content/icon/mymodule:my_type?hash=f95b70fdc3088560732a5ac135644506",

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/publish/ContentPublishItem.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/publish/ContentPublishItem.ts
@@ -8,7 +8,7 @@ module app.publish {
     import PublishContentRequest = api.content.PublishContentRequest;
     import CompareStatus = api.content.CompareStatus;
     import ResolvePublishDependenciesResultJson = api.content.json.ResolvePublishRequestedContentsResultJson;
-    import ResolvedPublishDependencyJson = api.content.json.ResolvedPublishDependencyJson;
+    import ResolvedPublishContentJson = api.content.json.ResolvedPublishContentJson;
     import ContentName = api.content.ContentName;
     import ContentTypeName = api.schema.content.ContentTypeName;
 
@@ -120,9 +120,9 @@ module app.publish {
         /**
          * Builds array of ContentPublishItem[] from resolved contents.
          */
-        static getResolvedContents(jsonItems: ResolvedPublishDependencyJson[]): ContentPublishItem[] {
+        static getResolvedContents(jsonItems: ResolvedPublishContentJson[]): ContentPublishItem[] {
             var array: ContentPublishItem[] = [];
-            jsonItems.forEach((obj: ResolvedPublishDependencyJson) => {
+            jsonItems.forEach((obj: ResolvedPublishContentJson) => {
                 array.push(new ContentPublishItemBuilder().fromJson(obj).build());
             });
             return array;
@@ -161,7 +161,7 @@ module app.publish {
             }
         }
 
-        fromJson(json: ResolvedPublishDependencyJson): ContentPublishItemBuilder {
+        fromJson(json: ResolvedPublishContentJson): ContentPublishItemBuilder {
             this.id = json.id;
             this.path = ContentPath.fromString(json.path);
             this.compareStatus = <CompareStatus>CompareStatus[json.compareStatus];

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/publish/ContentPublishRequestedItem.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/publish/ContentPublishRequestedItem.ts
@@ -7,8 +7,8 @@ module app.publish {
     import DialogButton = api.ui.dialog.DialogButton;
     import PublishContentRequest = api.content.PublishContentRequest;
     import CompareStatus = api.content.CompareStatus;
-    import ResolvePublishDependenciesResultJson = api.content.json.ResolvePublishRequestedContentsResultJson;
     import ResolvedPublishRequestedContentJson = api.content.json.ResolvedPublishRequestedContentJson;
+    import ResolvedPublishDependencyContentJson = api.content.json.ResolvedPublishDependencyContentJson;
     import ContentName = api.content.ContentName;
     import ContentTypeName = api.schema.content.ContentTypeName;
 
@@ -96,6 +96,66 @@ module app.publish {
 
         build(): ContentPublishRequestedItem {
             return new ContentPublishRequestedItem(this);
+        }
+    }
+
+    export class ContentPublishDependencyItem extends ContentPublishItem {
+
+        private child: boolean;
+
+        constructor(builder: ContentPublishDependencyItemBuilder) {
+            super(builder);
+
+            this.child = builder.child;
+        }
+
+        isChild(): boolean {
+            return this.child;
+        }
+
+        equals(o: api.Equitable): boolean {
+
+            if (!api.ObjectHelper.iFrameSafeInstanceOf(o, ContentPublishRequestedItem)) {
+                return false;
+            }
+
+            var other = <ContentPublishRequestedItem>o;
+
+            if (!super.equals(o)) {
+                return false;
+            }
+
+            if (!api.ObjectHelper.booleanEquals(this.child, other.child)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        static getPushDependenciesContents(jsonItems: ResolvedPublishDependencyContentJson[]): ContentPublishDependencyItem[] {
+            var array: ContentPublishDependencyItem[] = [];
+            jsonItems.forEach((obj: ResolvedPublishDependencyContentJson) => {
+                array.push(new ContentPublishDependencyItemBuilder().fromJson(obj).build());
+            });
+            return array;
+        }
+
+    }
+
+    export class ContentPublishDependencyItemBuilder extends ContentPublishItemBuilder {
+
+        child: boolean;
+
+        fromJson(json: ResolvedPublishDependencyContentJson): ContentPublishDependencyItemBuilder {
+            super.fromJson(json);
+
+            this.child = json.child;
+
+            return this;
+        }
+
+        build(): ContentPublishDependencyItem {
+            return new ContentPublishDependencyItem(this);
         }
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/publish/ResolvedPublishContentViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/publish/ResolvedPublishContentViewer.ts
@@ -45,7 +45,7 @@ module app.publish {
         }
     }
 
-    export class ResolvedDependantContentViewer<M extends ContentPublishItem>extends api.ui.Viewer<M> {
+    export class ResolvedDependantContentViewer<M extends ContentPublishItem> extends api.ui.Viewer<M> {
 
         private namesAndIconView: DependantNamesAndIconView;
 
@@ -58,7 +58,7 @@ module app.publish {
         setObject(object: M, relativePath: boolean = false) {
             super.setObject(object);
 
-            var displayName = this.resolveDisplayName(object) || this.normalizeDisplayName(this.resolveUnnamedDisplayName(object)),
+            var displayName = this.resolveDisplayName(object),
                 iconUrl = this.resolveIconUrl(object);
 
             this.namesAndIconView.setMainName(displayName);
@@ -71,30 +71,16 @@ module app.publish {
         }
 
         resolveDisplayName(object: M): string {
-            var contentName = object.getName(),
-                invalid = !object.isValid() || !object.getDisplayName() || contentName.isUnnamed(),
+            var invalid = !object.isValid(),
                 pendingDelete = CompareStatus.PENDING_DELETE == object.getCompareStatus() ? true : false;
             this.toggleClass("invalid", invalid);
             this.toggleClass("pending-delete", pendingDelete);
 
-            return object.getDisplayName();
-        }
-
-        resolveUnnamedDisplayName(object: M): string {
-            return object.getType() ? object.getType().getLocalName() : "";
+            return object.getPath().toString();
         }
 
         resolveIconUrl(object: any): string {
             return new ContentIconUrlResolver().setContent(object).resolve();
-        }
-
-        private normalizeDisplayName(displayName: string): string {
-            if (api.util.StringHelper.isEmpty(displayName)) {
-                return "";
-            } else {
-                displayName = api.util.StringHelper.capitalizeAll(displayName.replace(/-/g, " ").trim());
-                return "<Unnamed " + displayName + ">";
-            }
         }
 
         getPreferredHeight(): number {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/json/ResolvePublishDependenciesResultJson.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/json/ResolvePublishDependenciesResultJson.ts
@@ -2,8 +2,6 @@ module api.content.json {
 
     export interface ResolvePublishDependenciesResultJson {
 
-        dependantContents: ResolvedPublishDependencyJson[];
-
-        childrenContents: ResolvedPublishDependencyJson[];
+        dependenciesContents: ResolvedPublishDependencyContentJson[];
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/json/ResolvedPublishContentJson.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/json/ResolvedPublishContentJson.ts
@@ -1,6 +1,6 @@
 module api.content.json {
 
-    export interface ResolvedPublishDependencyJson {
+    export interface ResolvedPublishContentJson {
 
         id: string;
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/json/ResolvedPublishRequestedContentJson.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/json/ResolvedPublishRequestedContentJson.ts
@@ -1,10 +1,15 @@
 module api.content.json {
 
-    export interface ResolvedPublishRequestedContentJson extends ResolvedPublishDependencyJson {
+    export interface ResolvedPublishRequestedContentJson extends ResolvedPublishContentJson {
 
         childrenCount: number;
 
         dependantsCount: number;
 
+    }
+
+    export interface ResolvedPublishDependencyContentJson extends ResolvedPublishContentJson {
+
+        child: boolean;
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/json/_module.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/json/_module.ts
@@ -19,7 +19,7 @@
 ///<reference path='SetOrderUpdateJson.ts' />
 ///<reference path='SetChildOrderAndReorderJson.ts' />
 ///<reference path='ResolvePublishRequestedContentsResultJson.ts' />
-///<reference path='ResolvedPublishDependencyJson.ts' />
+///<reference path='ResolvedPublishContentJson.ts' />
 ///<reference path='ResolvePublishDependenciesResultJson.ts' />
 ///<reference path='ResolvedPublishRequestedContentJson.ts' />
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/app/publish/publish-dialog.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/app/publish/publish-dialog.less
@@ -1,19 +1,32 @@
 .publish-dialog {
 
   .dialog-content {
+
+    max-height: 400px;
+    overflow-y: auto;
+
+    @media screen and (max-height: 720px) {
+      max-height: 250px;
+    }
+
+    @media screen and (max-height: 540px) {
+      max-height: 150px;
+    }
+
     @media screen and (max-height: 360px) {
-      height: 60%;
+      max-height: 80px;
     }
   }
 
   .item-list {
     padding: 0px;
-    max-height: 280px;
-    overflow-y: auto;
   }
 
   .dependencies-toggle-label {
     color: @admin-blue;
+    &:hover {
+      cursor: pointer;
+    }
   }
 
   .dialog-buttons {
@@ -50,6 +63,10 @@
 
     input[type="checkbox"] + label {
       color: @admin-blue !important;
+
+      &:hover {
+        cursor: pointer;
+      }
     }
 
     @media screen and (max-height: 360px) {
@@ -79,24 +96,9 @@
   .initial-items {
 
     &.item-list {
-      padding-bottom: 10px;
 
-      min-height: 150px;
+      min-height: 40px;
 
-      @media screen and (max-height: 720px) {
-        max-height: 350px;
-        min-height: 100px;
-      }
-
-      @media screen and (max-height: 540px) {
-        max-height: 170px;
-        min-height: 80px;
-      }
-
-      @media screen and (max-height: 360px) {
-        max-height: 80px;
-        min-height: 40px;
-      }
     }
 
     .browse-selection-publish-item {
@@ -186,23 +188,9 @@
 
   .dependant-items {
 
-    &.item-list {
-      padding-top: 10px;
-    }
-
-    @media screen and (max-height: 720px) {
-      max-height: 160px;
-    }
-
-    @media screen and (max-height: 540px) {
-      max-height: 80px;
-    }
-
-    @media screen and (max-height: 360px) {
-      max-height: 40px;
-    }
-
     .browse-selection-publish-item {
+
+      display: block;
 
       .content-resolved-dependant-viewer {
         padding: 4px 0px 4px 0px;
@@ -221,17 +209,18 @@
         .names-and-icon-view {
           .wrapper {
             margin: 0px;
+            height: 16px;
+            width: 16px;
+            line-height: 16px;
           }
 
           .name-span {
             margin: 0px 15px 0px 8px;
-            line-height: 32px;
+            line-height: 16px;
           }
 
         }
       }
-
-      display: inline;
 
       &.disabled {
         .checkbox {


### PR DESCRIPTION
- Made dependencies list to be shown as one per line
- Show full content path instead of display name
- Sort alphabetically by full path
- No empty space between the "Show/hide dependents and child items" link and its contents
- Hide "Show/hide dependents and child items" if there are no dependencies
- Cursor must change to "hand" when hovered over "Show/hide dependents and child items" and "Include child items" so that it's obvious that they are clickable
- Rename "Show/hide dependents and child items" to "Show/hide dependencies and child items to be published"
- Move the main section inside scrollable area - when the list of dependencies is being scroller the main section should scroll as well