### PR TITLE
XP-836 Bug: Copy Pasting text into Text component

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
@@ -44,6 +44,17 @@ module api.liveedit.text {
             this.onKeyDown(this.handleKey.bind(this));
             this.onKeyUp(this.handleKey.bind(this));
 
+            this.rootElement.getHTMLElement().onpaste = this.handlePasteEvent.bind(this);
+        }
+
+        private isAllTextSelected(): boolean {
+            return this.rootElement.getHTMLElement().innerText.trim() == window['getSelection']().toString();
+        }
+
+        private handlePasteEvent(event) {
+            if (this.isAllTextSelected()) {
+                this.rootElement.getHTMLElement().innerHTML = "";
+            }
         }
 
         showTooltip() {


### PR DESCRIPTION
- Actual problem seemed to occur only when inserting while all text in component was selected. In case of such insert - replaced text was removed, but its tags, such like "\<h2>" were not removed completely. Fixed via manual emptying of component onpaste event for such case.