### PR TITLE
XP-837 Select text in Text component leaves focus onmouseup

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
@@ -388,6 +388,22 @@ module api.liveedit {
             }
         }
 
+        hasTargetWithinTextComponent(target: HTMLElement) {
+            var textItemViews = this.getItemViewsByType(api.liveedit.text.TextItemType.get());
+            var result: boolean = false;
+
+            var textView: api.liveedit.text.TextComponentView;
+            textItemViews.forEach((view: ItemView) => {
+                textView = <api.liveedit.text.TextComponentView> view;
+                if (textView.getEl().contains(target)) {
+                    result = true;
+                    return;
+                }
+            });
+
+            return result;
+        }
+
         isEmpty(): boolean {
             return !this.pageModel || this.pageModel.getMode() == PageMode.NO_CONTROLLER;
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/RegionView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/RegionView.ts
@@ -65,6 +65,8 @@ module api.liveedit {
 
         private componentRemovedListener: (event: api.content.page.region.ComponentRemovedEvent) => void;
 
+        private mouseDownLastTarget: HTMLElement;
+
         public static debug: boolean;
 
         constructor(builder: RegionViewBuilder) {
@@ -128,6 +130,12 @@ module api.liveedit {
             //this.onDragEnter(this.handleDragEnter.bind(this));
             //this.onDragLeave(this.handleDragLeave.bind(this));
             //this.onDrop(this.handleDrop.bind(this));
+
+            this.onMouseDown(this.memorizeLastMouseDownTarget.bind(this));
+        }
+
+        memorizeLastMouseDownTarget(event: MouseEvent) {
+            this.mouseDownLastTarget = <HTMLElement> event.target;
         }
 
         private createRegionContextMenuActions() {
@@ -212,7 +220,9 @@ module api.liveedit {
 
             var pageView = this.getPageView();
             if (pageView.isTextEditMode()) {
-                pageView.setTextEditMode(false);
+                if (!pageView.hasTargetWithinTextComponent(this.mouseDownLastTarget)) {
+                    pageView.setTextEditMode(false);
+                }
             } else {
                 super.handleClick(event);
             }


### PR DESCRIPTION
- Fixed. Made Region view to remember its mousedown target and check if it belongs to one of the TextComponents elements on mouse up.