### PR TITLE
XP-826 Bug: Parts info/context menu never goes away

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemView.ts
@@ -256,6 +256,8 @@ module api.liveedit {
                 }
             };
             this.onMouseLeaveView(this.mouseLeaveViewListener);
+
+            this.getPageView().onItemViewAdded(this.shaderClickedListener);
         }
 
         private unbindMouseListeners() {
@@ -269,6 +271,7 @@ module api.liveedit {
             Shader.get().unClicked(this.shaderClickedListener);
             this.unMouseOverView(this.mouseOverViewListener);
             this.unMouseLeaveView(this.mouseLeaveViewListener);
+            this.getPageView().unItemViewAdded(this.shaderClickedListener);
         }
 
         highlight() {
@@ -471,6 +474,7 @@ module api.liveedit {
                 // it won't receive mouse event and won't be deselected
                 // therefore we deselect it manually
                 this.deselectParent();
+                this.getPageView().deselectChildViews();
 
                 this.select(!this.isEmpty() ? {x: event.pageX, y: event.pageY} : null);
             } else {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
@@ -607,6 +607,15 @@ module api.liveedit {
             });
         }
 
+        deselectChildViews() {
+            for (var itemView in this.viewsById) {
+                var view = this.viewsById[itemView];
+                if (api.ObjectHelper.iFrameSafeInstanceOf(view, ItemView) && view.isSelected()) {
+                    view.deselect();
+                }
+            }
+        }
+
         private doParseItemViews(parentElement?: api.dom.Element) {
 
             var pageRegions = this.liveEditModel.getPageModel().getRegions();


### PR DESCRIPTION
* Deselect context item in LiveEdit whenever a new content is inserted
* Deselect all context items whenever a new one is selected