### PR TITLE
XP-961 Bad notification messages are shown upon publish

### DIFF
--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/PublishContentResultJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/PublishContentResultJson.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentId;
-import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.content.PushContentsResult;
 
 public class PublishContentResultJson
@@ -17,16 +16,19 @@ public class PublishContentResultJson
 
     private final List<String> deleted = new ArrayList<>();
 
+    @SuppressWarnings("unused")
     public List<Success> getSuccesses()
     {
         return successes;
     }
 
+    @SuppressWarnings("unused")
     public List<Failure> getFailures()
     {
         return failures;
     }
 
+    @SuppressWarnings("unused")
     public List<String> getDeleted()
     {
         return deleted;
@@ -47,7 +49,7 @@ public class PublishContentResultJson
 
         for ( final PushContentsResult.Failed failed : pushContentsResult.getFailed() )
         {
-            json.failures.add( new Failure( failed.getContent().getPath(), failed.getFailedReason().getMessage() ) );
+            json.failures.add( new Failure( failed.getContent().getName().toString(), failed.getFailedReason().getMessage() ) );
         }
 
         for ( final ContentId deleted : pushContentsResult.getDeleted() )
@@ -83,21 +85,22 @@ public class PublishContentResultJson
 
     public static class Failure
     {
-        private final String path;
+        private final String name;
 
         private final String reason;
 
-        public Failure( final ContentPath contentPath, final String reason )
+        public Failure( final String name, final String reason )
         {
-            this.path = contentPath.toString();
+            this.name = name;
             this.reason = reason;
         }
 
-        public String getPath()
+        public String getName()
         {
-            return path;
+            return name;
         }
 
+        @SuppressWarnings("unused")
         public String getReason()
         {
             return reason;

--- a/modules/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/publish_content_success.json
+++ b/modules/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/publish_content_success.json
@@ -2,7 +2,7 @@
   "deleted": [],
   "failures": [
     {
-      "path": "/content",
+      "name": "content",
       "reason": "Parent content does not exist"
     }
   ],

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/PublishContentRequest.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/PublishContentRequest.ts
@@ -60,15 +60,15 @@ module api.content {
                 } else if (failed === 1) {
                     api.notify.showError('\"' + result.failures[0].name + '\" failed, reason: ' + result.failures[0].reason);
                 } else {
-                    api.notify.showSuccess('\"' + result.deleted[0].name + '\" deleted');
+                    api.notify.showSuccess('\"' + result.deleted[0] + '\" deleted');
                 }
                 break;
             default: // > 1
                 if (succeeded > 0) {
-                    api.notify.showSuccess('\"' + succeeded + '\" items published');
+                    api.notify.showSuccess('\"' + succeeded + '\" items were published');
                 }
                 if (deleted > 0) {
-                    api.notify.showSuccess('\"' + deleted + '\" items marked for deletion');
+                    api.notify.showSuccess('\"' + deleted + '\" pending items were deleted');
                 }
                 if (failed > 0) {
                     api.notify.showError('\"' + failed + '\" items failed to publish');


### PR DESCRIPTION
  - Adjusted resulting json to pass failed content's name instead of path
  - For now deleted items are passed back as list of ids - hence adjusted feedback() method to not reference deleted items name
  - Adjusted message for case when a few items were deleted