### PR TITLE
XP-963 Incomplete json passed back when a few items initially selecte…

### DIFF
--- a/modules/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResourceTest.java
+++ b/modules/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResourceTest.java
@@ -725,7 +725,7 @@ public class ContentResourceTest
         throws Exception
     {
         Mockito.when( contentService.push( Mockito.isA( PushContentParams.class ) ) ).thenReturn( PushContentsResult.create().
-            setPushedContent( Contents.from( newContent().
+            addPushedContent( Contents.from( newContent().
                 id( ContentId.from( "my-content" ) ).
                 parentPath( ContentPath.ROOT ).
                 name( "content" ).
@@ -747,11 +747,43 @@ public class ContentResourceTest
     }
 
     @Test
+    public void publish_content_success2()
+        throws Exception
+    {
+        Mockito.when( contentService.push( Mockito.isA( PushContentParams.class ) ) ).thenReturn( PushContentsResult.create().
+            addPushedContent( Contents.from( newContent().
+                id( ContentId.from( "my-content" ) ).
+                parentPath( ContentPath.ROOT ).
+                name( "content" ).
+                displayName( "My Content" ).
+                build() ) ).
+            addPushedContent( Contents.from( newContent().
+                id( ContentId.from( "my-content2" ) ).
+                parentPath( ContentPath.ROOT ).
+                name( "content" ).
+                displayName( "My Content 2" ).
+                build() ) ).
+            addFailed( newContent().
+                id( ContentId.from( "my-content3" ) ).
+                parentPath( ContentPath.ROOT ).
+                name( "content" ).
+                displayName( "My Content" ).
+                build(), PushContentsResult.FailedReason.PARENT_NOT_EXISTS ).
+            build() );
+
+        String jsonString = request().path( "content/publish" ).
+            entity( readFromFile( "publish_content_params.json" ), MediaType.APPLICATION_JSON_TYPE ).
+            post().getAsString();
+
+        assertJson( "publish_content_a few_success.json", jsonString );
+    }
+
+    @Test
     public void publish_content_deleted()
         throws Exception
     {
         Mockito.when( contentService.push( Mockito.isA( PushContentParams.class ) ) ).thenReturn( PushContentsResult.create().
-            setPushedContent( Contents.from( newContent().
+            addPushedContent( Contents.from( newContent().
                 id( ContentId.from( "my-content" ) ).
                 parentPath( ContentPath.ROOT ).
                 name( "content" ).

--- a/modules/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/publish_content_a few_success.json
+++ b/modules/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/publish_content_a few_success.json
@@ -1,0 +1,19 @@
+{
+  "deleted": [],
+  "failures": [
+    {
+      "path": "/content",
+      "reason": "Parent content does not exist"
+    }
+  ],
+  "successes": [
+    {
+      "id": "my-content2",
+      "name": "My Content 2"
+    },
+    {
+      "id": "my-content",
+      "name": "My Content"
+    }
+  ]
+}

--- a/modules/core-api/src/main/java/com/enonic/xp/content/PushContentsResult.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/content/PushContentsResult.java
@@ -21,8 +21,8 @@ public class PushContentsResult
 
     private PushContentsResult( final Builder builder )
     {
-        this.pushedContent = builder.pushedContent;
-        this.childrenPushedContent = builder.childrenPushedContent;
+        this.pushedContent = Contents.from( builder.pushedContent );
+        this.childrenPushedContent = Contents.from( builder.childrenPushedContent );
         this.failed = ImmutableSet.copyOf( builder.failed );
         this.pushContentRequests = builder.pushContentRequests;
         this.deleted = ContentIds.from( builder.deleted );
@@ -103,9 +103,10 @@ public class PushContentsResult
 
     public static final class Builder
     {
-        private Contents pushedContent = Contents.empty();
 
-        private Contents childrenPushedContent = Contents.empty();
+        private final Set<Content> pushedContent = Sets.newHashSet();
+
+        private final Set<Content> childrenPushedContent = Sets.newHashSet();
 
         private final Set<Failed> failed = Sets.newHashSet();
 
@@ -117,15 +118,15 @@ public class PushContentsResult
         {
         }
 
-        public Builder setPushedContent( final Contents pushedContent )
+        public Builder addPushedContent( final Contents pushedContent )
         {
-            this.pushedContent = pushedContent;
+            this.pushedContent.addAll( pushedContent.getSet() );
             return this;
         }
 
-        public Builder setChildrenPushedContent( final Contents childrenPushedContent )
+        public Builder addChildrenPushedContent( final Contents childrenPushedContent )
         {
-            this.childrenPushedContent = childrenPushedContent;
+            this.childrenPushedContent.addAll( childrenPushedContent.getSet() );
             return this;
         }
 

--- a/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/PushContentCommand.java
+++ b/modules/core-impl/src/main/java/com/enonic/xp/core/impl/content/PushContentCommand.java
@@ -275,9 +275,9 @@ public class PushContentCommand
 
     private void appendPushNodesResult( final PushNodesResult pushNodesResult )
     {
-        this.resultBuilder.setPushedContent( translator.fromNodes( pushNodesResult.getSuccessfull() ) );
+        this.resultBuilder.addPushedContent( translator.fromNodes( pushNodesResult.getSuccessfull() ) );
 
-        this.resultBuilder.setChildrenPushedContent( translator.fromNodes( pushNodesResult.getChildrenSuccessfull() ) );
+        this.resultBuilder.addChildrenPushedContent( translator.fromNodes( pushNodesResult.getChildrenSuccessfull() ) );
 
         for ( final PushNodesResult.Failed failedNode : pushNodesResult.getFailed() )
         {


### PR DESCRIPTION
…d for publish.

- Adjusted PushContentResult to store result of push node command in Sets, that enables correct storage of pushed items when a few initial items are passed for publishing