### PR TITLE
XP-964 Disable publish button when there is invalid content

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/app/publish/publish-dialog.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/app/publish/publish-dialog.less
@@ -78,6 +78,9 @@
 
   .publish-dialog-subheader {
     margin-top: 20px;
+    &.invalid {
+      color: @admin-red;
+    }
   }
 
   .content-resolved-publish-viewer, .content-resolved-dependant-viewer {


### PR DESCRIPTION
- Adjusted publish dialog to disable publish button when there is a invalid item among the resolved items. Note, that if there are invalid children items - publish button will not be disabled until children items get resolved, otherwise we would break the laziness of publish dialog loading.