### PR TITLE
XP-964 Disable publish button when there is invalid content

### DIFF
--- a/modules/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResourceTest.java
+++ b/modules/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResourceTest.java
@@ -747,38 +747,6 @@ public class ContentResourceTest
     }
 
     @Test
-    public void publish_content_success2()
-        throws Exception
-    {
-        Mockito.when( contentService.push( Mockito.isA( PushContentParams.class ) ) ).thenReturn( PushContentsResult.create().
-            addPushedContent( Contents.from( newContent().
-                id( ContentId.from( "my-content" ) ).
-                parentPath( ContentPath.ROOT ).
-                name( "content" ).
-                displayName( "My Content" ).
-                build() ) ).
-            addPushedContent( Contents.from( newContent().
-                id( ContentId.from( "my-content2" ) ).
-                parentPath( ContentPath.ROOT ).
-                name( "content" ).
-                displayName( "My Content 2" ).
-                build() ) ).
-            addFailed( newContent().
-                id( ContentId.from( "my-content3" ) ).
-                parentPath( ContentPath.ROOT ).
-                name( "content" ).
-                displayName( "My Content" ).
-                build(), PushContentsResult.FailedReason.PARENT_NOT_EXISTS ).
-            build() );
-
-        String jsonString = request().path( "content/publish" ).
-            entity( readFromFile( "publish_content_params.json" ), MediaType.APPLICATION_JSON_TYPE ).
-            post().getAsString();
-
-        assertJson( "publish_content_a few_success.json", jsonString );
-    }
-
-    @Test
     public void publish_content_deleted()
         throws Exception
     {


### PR DESCRIPTION
- Removed test, that might pass or fail on different machine due to unpredicted order of resulting items.