### PR TITLE
XP-992 Remove use of Module.getClassLoader

### DIFF
--- a/modules/core-api/src/main/java/com/enonic/xp/module/Module.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/module/Module.java
@@ -36,8 +36,6 @@ public interface Module
 
     boolean isStarted();
 
-    ClassLoader getClassLoader();
-
     void checkIfStarted();
 
     boolean isApplication();

--- a/modules/core-api/src/main/java/com/enonic/xp/module/ModuleService.java
+++ b/modules/core-api/src/main/java/com/enonic/xp/module/ModuleService.java
@@ -12,6 +12,8 @@ public interface ModuleService
 
     Modules getAllModules();
 
+    ClassLoader getClassLoader(Module module);
+
     void startModule( ModuleKey key );
 
     void stopModule( ModuleKey key );

--- a/modules/core-module/src/main/java/com/enonic/xp/core/impl/module/ModuleBuilder.java
+++ b/modules/core-module/src/main/java/com/enonic/xp/core/impl/module/ModuleBuilder.java
@@ -41,7 +41,6 @@ final class ModuleBuilder
         module.vendorName = getHeader( this.bundle, X_VENDOR_NAME, null );
         module.vendorUrl = getHeader( this.bundle, X_VENDOR_URL, null );
         module.systemVersion = getHeader( this.bundle, X_SYSTEM_VERSION, null );
-        module.classLoader = new BundleClassLoader( this.bundle );
 
         return module;
     }

--- a/modules/core-module/src/main/java/com/enonic/xp/core/impl/module/ModuleImpl.java
+++ b/modules/core-module/src/main/java/com/enonic/xp/core/impl/module/ModuleImpl.java
@@ -34,8 +34,6 @@ final class ModuleImpl
 
     protected Bundle bundle;
 
-    protected ClassLoader classLoader;
-
     @Override
     public ModuleKey getKey()
     {

--- a/modules/core-module/src/main/java/com/enonic/xp/core/impl/module/ModuleImpl.java
+++ b/modules/core-module/src/main/java/com/enonic/xp/core/impl/module/ModuleImpl.java
@@ -122,12 +122,6 @@ final class ModuleImpl
         return this.bundle.getState() == Bundle.ACTIVE;
     }
 
-    @Override
-    public ClassLoader getClassLoader()
-    {
-        return this.classLoader;
-    }
-
     private void findResourcePaths( final Set<String> set, final Bundle bundle, final String parentPath )
     {
         final Enumeration<URL> paths = bundle.findEntries( parentPath, "*", true );

--- a/modules/core-module/src/main/java/com/enonic/xp/core/impl/module/ModuleServiceImpl.java
+++ b/modules/core-module/src/main/java/com/enonic/xp/core/impl/module/ModuleServiceImpl.java
@@ -53,6 +53,12 @@ public final class ModuleServiceImpl
     }
 
     @Override
+    public ClassLoader getClassLoader( final Module module )
+    {
+        return new BundleClassLoader( module.getBundle() );
+    }
+
+    @Override
     public void startModule( final ModuleKey key )
     {
         startModule( getModule( key ) );

--- a/modules/core-module/src/test/java/com/enonic/xp/core/impl/module/ModuleBuilderTest.java
+++ b/modules/core-module/src/test/java/com/enonic/xp/core/impl/module/ModuleBuilderTest.java
@@ -59,7 +59,6 @@ public class ModuleBuilderTest
         assertEquals( "Enonic AS", module.getVendorName() );
         assertEquals( "http://enonic.com", module.getVendorUrl() );
         assertEquals( "[5.0,6.0)", module.getSystemVersion() );
-        assertNotNull( module.getClassLoader() );
     }
 
     private Bundle newBundle( final String name, final Map<String, String> headers )

--- a/modules/portal-impl/src/test/java/com/enonic/xp/portal/impl/controller/AbstractControllerTest.java
+++ b/modules/portal-impl/src/test/java/com/enonic/xp/portal/impl/controller/AbstractControllerTest.java
@@ -61,11 +61,11 @@ public abstract class AbstractControllerTest
         Mockito.when( bundle.getBundleContext() ).thenReturn( bundleContext );
 
         final Module module = Mockito.mock( Module.class );
-        Mockito.when( module.getClassLoader() ).thenReturn( getClass().getClassLoader() );
         Mockito.when( module.getBundle() ).thenReturn( bundle );
 
         final ModuleService moduleService = Mockito.mock( ModuleService.class );
         Mockito.when( moduleService.getModule( ModuleKey.from( "mymodule" ) ) ).thenReturn( module );
+        Mockito.when( moduleService.getClassLoader( Mockito.any() ) ).thenReturn( getClass().getClassLoader() );
 
         final ScriptServiceImpl scriptService = new ScriptServiceImpl();
         scriptService.setModuleService( moduleService );

--- a/modules/portal-script/src/main/java/com/enonic/xp/portal/impl/script/ScriptServiceImpl.java
+++ b/modules/portal-script/src/main/java/com/enonic/xp/portal/impl/script/ScriptServiceImpl.java
@@ -62,12 +62,13 @@ public final class ScriptServiceImpl
     private ScriptExecutor createExecutor( final ModuleKey key )
     {
         final Module module = this.moduleService.getModule( key );
-        final ScriptEngine engine = NashornHelper.getScriptEngine( module.getClassLoader(), "-strict" );
+        ClassLoader classLoader = moduleService.getClassLoader( module );
+        final ScriptEngine engine = NashornHelper.getScriptEngine( classLoader, "-strict" );
 
         final ScriptExecutorImpl executor = new ScriptExecutorImpl();
         executor.setEngine( engine );
         executor.setGlobalMap( this.globalMap );
-        executor.setClassLoader( module.getClassLoader() );
+        executor.setClassLoader( classLoader );
         executor.setServiceRegistry( new ServiceRegistryImpl( module.getBundle().getBundleContext() ) );
         executor.initialize();
         return executor;

--- a/modules/portal-script/src/test/java/com/enonic/xp/portal/impl/script/AbstractScriptTest.java
+++ b/modules/portal-script/src/test/java/com/enonic/xp/portal/impl/script/AbstractScriptTest.java
@@ -32,11 +32,11 @@ public abstract class AbstractScriptTest
         Mockito.when( bundle.getBundleContext() ).thenReturn( bundleContext );
 
         final Module module = Mockito.mock( Module.class );
-        Mockito.when( module.getClassLoader() ).thenReturn( getClass().getClassLoader() );
         Mockito.when( module.getBundle() ).thenReturn( bundle );
 
         final ModuleService moduleService = Mockito.mock( ModuleService.class );
         Mockito.when( moduleService.getModule( MYMODULE_KEY ) ).thenReturn( module );
+        Mockito.when( moduleService.getClassLoader( Mockito.any() ) ).thenReturn( getClass().getClassLoader() );
 
         this.scriptService.setModuleService( moduleService );
     }

--- a/modules/testing/src/main/java/com/enonic/xp/testing/script/ScriptTestSupport.java
+++ b/modules/testing/src/main/java/com/enonic/xp/testing/script/ScriptTestSupport.java
@@ -45,11 +45,11 @@ public abstract class ScriptTestSupport
         Mockito.when( bundle.getBundleContext() ).thenReturn( this.bundleContext );
 
         final Module module = Mockito.mock( Module.class );
-        Mockito.when( module.getClassLoader() ).thenReturn( getClass().getClassLoader() );
         Mockito.when( module.getBundle() ).thenReturn( bundle );
 
         final ModuleService moduleService = Mockito.mock( ModuleService.class );
         Mockito.when( moduleService.getModule( getModuleKey() ) ).thenReturn( module );
+        Mockito.when( moduleService.getClassLoader( Mockito.any() ) ).thenReturn( getClass().getClassLoader() );
 
         this.scriptService.setModuleService( moduleService );
         this.portalRequest = new PortalRequest();

--- a/modules/upgrade/src/test/java/com/enonic/xp/upgrade/PathHelperTest.java
+++ b/modules/upgrade/src/test/java/com/enonic/xp/upgrade/PathHelperTest.java
@@ -12,7 +12,7 @@ public class PathHelperTest
     public void subtractPath()
         throws Exception
     {
-        assertEquals( "b/c", PathHelper.subtractPath( Paths.get( "a", "b", "c" ), Paths.get( "a" ) ).toString() );
+        assertEquals( "b\\c", PathHelper.subtractPath( Paths.get( "a", "b", "c" ), Paths.get( "a" ) ).toString() );
 
         assertEquals( "c", PathHelper.subtractPath( Paths.get( "a", "b", "c" ), Paths.get( "a", "b" ) ).toString() );
 

--- a/modules/upgrade/src/test/java/com/enonic/xp/upgrade/PathHelperTest.java
+++ b/modules/upgrade/src/test/java/com/enonic/xp/upgrade/PathHelperTest.java
@@ -12,7 +12,7 @@ public class PathHelperTest
     public void subtractPath()
         throws Exception
     {
-        assertEquals( "b\\c", PathHelper.subtractPath( Paths.get( "a", "b", "c" ), Paths.get( "a" ) ).toString() );
+        assertEquals( "b/c", PathHelper.subtractPath( Paths.get( "a", "b", "c" ), Paths.get( "a" ) ).toString() );
 
         assertEquals( "c", PathHelper.subtractPath( Paths.get( "a", "b", "c" ), Paths.get( "a", "b" ) ).toString() );
 


### PR DESCRIPTION
 -Added a method "ClassLoader getClassLoader(Module)" on ModuleService. This will just create a new BundleClassLoader.
 -Used ModuleService.getClassLoader(..) every place we use Module.getClassLoader
 -Removed Module.getClassLoader and implementation.