### PR TITLE
XP-1085 Responsive Admin - Search panel fills entire screen in "mobil…

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/app/browse/BrowsePanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/app/browse/BrowsePanel.ts
@@ -40,6 +40,8 @@ module api.app.browse {
 
         private filterPanelForcedHidden: boolean = false;
 
+        private filterPanelToBeShownFullScreen: boolean = false;
+
         private toggleFilterPanelAction: api.ui.Action;
 
         constructor(params: BrowsePanelParams<M>) {
@@ -62,15 +64,7 @@ module api.app.browse {
                 .setAlignmentTreshold(BrowsePanel.SPLIT_PANEL_ALIGNMENT_TRESHOLD).build();
 
             if (this.filterPanel) {
-                this.filterAndGridAndDetailSplitPanel = new api.ui.panel.SplitPanelBuilder(this.filterPanel, this.gridAndDetailSplitPanel)
-                    .setFirstPanelSize(200,
-                    api.ui.panel.SplitPanelUnit.PIXEL).setAlignment(api.ui.panel.SplitPanelAlignment.VERTICAL).build();
-
-                this.filterPanel.onHideFilterPanelButtonClicked(() => {
-                    this.toggleFilterPanel();
-                });
-
-                this.addToggleFilterPanelButtonInToolbar();
+                this.setupFilterPanel();
             } else {
                 this.filterAndGridAndDetailSplitPanel = this.gridAndDetailSplitPanel;
             }
@@ -92,21 +86,10 @@ module api.app.browse {
             });
 
             ResponsiveManager.onAvailableSizeChanged(this, (item: ResponsiveItem) => {
-                if (item.isInRangeOrSmaller(ResponsiveRanges._360_540)) {
-                    if (this.filterPanel && !this.filterAndGridAndDetailSplitPanel.isPanelHidden(1) && !this.filterPanelForcedShown) {
-                        this.filterAndGridAndDetailSplitPanel.hidePanel(1);
-                    }
-                    if (!this.gridAndDetailSplitPanel.isPanelHidden(2)) {
-                        this.gridAndDetailSplitPanel.hidePanel(2);
-                    }
-                } else if (item.isInRangeOrBigger(ResponsiveRanges._540_720)) {
-                    if (this.filterPanel && this.filterAndGridAndDetailSplitPanel.isPanelHidden(1) && !this.filterPanelForcedHidden) {
-                        this.filterAndGridAndDetailSplitPanel.showPanel(1);
-                    }
-                    if (this.gridAndDetailSplitPanel.isPanelHidden(2)) {
-                        this.gridAndDetailSplitPanel.showPanel(2);
-                    }
-                }
+                this.checkFilterPanelToBeShownFullScreen(item);
+
+                this.toggleFilterPanelDependingOnScreenSize(item);
+                this.togglePreviewPanelDependingOnScreenSize(item);
             });
         }
 
@@ -145,17 +128,56 @@ module api.app.browse {
         }
 
         toggleFilterPanel() {
-            this.filterPanelForcedShown = !this.filterPanelForcedShown;
-            this.filterPanelForcedHidden = !this.filterPanelForcedHidden;
-            if(this.filterAndGridAndDetailSplitPanel.isPanelHidden(1)) {
-                this.filterAndGridAndDetailSplitPanel.showPanel(1);
-                this.filterPanel.giveFocusToSearch();
-                this.toggleFilterPanelAction.setVisible(false);
+            this.filterAndGridAndDetailSplitPanel.setFirstPanelIsFullScreen(this.filterPanelToBeShownFullScreen);
+
+            if(this.filterPanelIsHidden()) {
+                this.showFilterPanel();
             }
             else {
-                this.filterAndGridAndDetailSplitPanel.hidePanel(1);
-                this.toggleFilterPanelAction.setVisible(true);
+                this.hideFilterPanel();
             }
+        }
+
+        private filterPanelIsHidden(): boolean {
+            return this.filterAndGridAndDetailSplitPanel.isFirstPanelHidden();
+        }
+
+        private showFilterPanel() {
+            this.filterPanelForcedShown = true;
+            this.filterPanelForcedHidden = false;
+
+            if(this.filterPanelToBeShownFullScreen) {
+                this.filterAndGridAndDetailSplitPanel.hideSecondPanel();
+            }
+
+            this.filterAndGridAndDetailSplitPanel.showFirstPanel();
+            this.filterPanel.giveFocusToSearch();
+            this.toggleFilterPanelAction.setVisible(false);
+        }
+
+        private hideFilterPanel() {
+            this.filterPanelForcedShown = false;
+            this.filterPanelForcedHidden = true;
+            this.filterAndGridAndDetailSplitPanel.showSecondPanel();
+            this.filterAndGridAndDetailSplitPanel.hideFirstPanel();
+
+            this.toggleFilterPanelAction.setVisible(true);
+        }
+
+        private setupFilterPanel() {
+            this.filterAndGridAndDetailSplitPanel = new api.ui.panel.SplitPanelBuilder(this.filterPanel, this.gridAndDetailSplitPanel)
+                .setFirstPanelSize(200,
+                api.ui.panel.SplitPanelUnit.PIXEL).setAlignment(api.ui.panel.SplitPanelAlignment.VERTICAL).build();
+
+            this.filterPanel.onHideFilterPanelButtonClicked(() => {
+                this.toggleFilterPanel();
+            });
+
+            this.filterPanel.onShowResultsButtonClicked(() => {
+                this.toggleFilterPanel();
+            });
+
+            this.addToggleFilterPanelButtonInToolbar();
         }
 
         private addToggleFilterPanelButtonInToolbar() {
@@ -165,6 +187,41 @@ module api.app.browse {
             this.browseToolbar.addAction(this.toggleFilterPanelAction);
             this.browseToolbar.addActions(existingActions);
             this.toggleFilterPanelAction.setVisible(false);
+        }
+
+        private checkFilterPanelToBeShownFullScreen(item: ResponsiveItem) {
+            if (item.isInRangeOrSmaller(ResponsiveRanges._360_540)) {
+                this.filterPanelToBeShownFullScreen = true;
+            }
+            else {
+                this.filterPanelToBeShownFullScreen = false;
+            }
+        }
+
+        private toggleFilterPanelDependingOnScreenSize(item: ResponsiveItem) {
+            if (item.isInRangeOrSmaller(ResponsiveRanges._1380_1620)) {
+                if (this.filterPanel && !this.filterAndGridAndDetailSplitPanel.isFirstPanelHidden() && !this.filterPanelForcedShown) {
+                    this.filterAndGridAndDetailSplitPanel.hideFirstPanel();
+                    this.toggleFilterPanelAction.setVisible(true);
+                }
+            } else if (item.isInRangeOrBigger(ResponsiveRanges._1620_1920)) {
+                if (this.filterPanel && this.filterAndGridAndDetailSplitPanel.isFirstPanelHidden() && !this.filterPanelForcedHidden) {
+                    this.filterAndGridAndDetailSplitPanel.showFirstPanel();
+                    this.toggleFilterPanelAction.setVisible(false);
+                }
+            }
+        }
+
+        private togglePreviewPanelDependingOnScreenSize(item: ResponsiveItem) {
+            if (item.isInRangeOrSmaller(ResponsiveRanges._360_540)) {
+                if (!this.gridAndDetailSplitPanel.isSecondPanelHidden()) {
+                    this.gridAndDetailSplitPanel.hideSecondPanel();
+                }
+            } else if (item.isInRangeOrBigger(ResponsiveRanges._540_720)) {
+                if (this.gridAndDetailSplitPanel.isSecondPanelHidden()) {
+                    this.gridAndDetailSplitPanel.showSecondPanel();
+                }
+            }
         }
 
     }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/app/browse/filter/BrowseFilterPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/app/browse/filter/BrowseFilterPanel.ts
@@ -10,6 +10,8 @@ module api.app.browse.filter {
 
         private hideFilterPanelButtonClickedListeners: {():void}[] = [];
 
+        private showResultsButtonClickedListeners: {():void}[] = [];
+
         private aggregationContainer: api.aggregation.AggregationContainer;
 
         private searchField: api.app.browse.filter.TextSearchField;
@@ -20,12 +22,20 @@ module api.app.browse.filter {
 
         private hideFilterPanelButton: api.dom.SpanEl;
 
+        private showResultsButton: api.dom.SpanEl;
+
         constructor(aggregations?: api.aggregation.Aggregation[], groupViews?: api.aggregation.AggregationGroupView[]) {
             super();
             this.addClass('filter-panel');
 
             this.hideFilterPanelButton = new api.dom.SpanEl("hide-filter-panel-button icon-search");
             this.hideFilterPanelButton.onClicked(() => this.notifyHidePanelButtonPressed());
+
+            var showResultsButtonWrapper = new api.dom.DivEl("show-filter-results");
+            this.showResultsButton = new api.dom.SpanEl("show-filter-results-button");
+            this.showResultsButton.setHtml("Show results");
+            this.showResultsButton.onClicked(() => this.notifyShowResultsButtonPressed());
+            showResultsButtonWrapper.appendChild(this.showResultsButton);
 
             this.searchField = new TextSearchField('Search');
             this.searchField.onValueChanged(() => {
@@ -62,6 +72,9 @@ module api.app.browse.filter {
                 this.appendChild(this.searchField);
                 this.appendChild(hitsCounterAndClearButtonWrapper);
                 this.appendChild(this.aggregationContainer);
+                this.appendChild(showResultsButtonWrapper);
+
+                this.showResultsButton.hide();
 
                 api.ui.KeyBindings.get().bindKey(new api.ui.KeyBinding("/", (e: ExtendedKeyboardEvent) => {
                     setTimeout(this.giveFocusToSearch.bind(this), 100);
@@ -143,6 +156,10 @@ module api.app.browse.filter {
             this.hideFilterPanelButtonClickedListeners.push(listener);
         }
 
+        onShowResultsButtonClicked(listener: ()=>void) {
+            this.showResultsButtonClickedListeners.push(listener);
+        }
+
         private notifySearch(searchInputValues: api.query.SearchInputValues, elementChanged?: api.dom.Element) {
             this.searchListeners.forEach((listener: (event: SearchEvent)=>void) => {
                 listener.call(this, new SearchEvent(searchInputValues, elementChanged));
@@ -167,6 +184,12 @@ module api.app.browse.filter {
             });
         }
 
+        private notifyShowResultsButtonPressed() {
+            this.showResultsButtonClickedListeners.forEach((listener: ()=>void) => {
+                listener.call(this);
+            });
+        }
+
         updateHitsCounter(hits: number) {
             if(hits != 1) {
                 this.hitsCounterEl.setHtml(hits + " hits");
@@ -175,6 +198,12 @@ module api.app.browse.filter {
                 this.hitsCounterEl.setHtml(hits + " hit");
             }
 
+            if(hits != 0) {
+                this.showResultsButton.show();
+            }
+            else {
+                this.showResultsButton.hide();
+            }
         }
     }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/app/browse/browse-filter-panel.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/app/browse/browse-filter-panel.less
@@ -60,4 +60,23 @@
     top: 6px;
   }
 
+  .show-filter-results {
+    color: @admin-button-blue1;
+    text-align: center;
+    font-size: 14px;
+
+
+    @media screen and (min-width: 541px) {
+      display: none;
+    }
+
+    .show-filter-results-button {
+      color: @admin-button-blue1;
+      cursor: pointer;
+      &:hover {
+        color: @admin-button-blue3;
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
…e mode"

- Change, so that search panel is automatically hidden/default hidden for resolutions lower than 1620 (current is < 540px)
- For resolutions lower than 540, the search panel will (when displayed) fill the entire screen
- Clicking on "Show results" at the bottom will open the list of found items. When there are 0 hits, "Show results" should be hidden