### PR TITLE
XP-1174 Page Controller dropdown missing options when editing page-te…

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/GetPageDescriptorByKeyRequest.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/GetPageDescriptorByKeyRequest.ts
@@ -28,7 +28,7 @@ module api.content.page {
             }
             else {
                 return this.send().then((response: api.rest.JsonResponse<PageDescriptorJson>) => {
-                    pageDescriptor = this.fromJsonToPageDescriptor(response.getResult());
+                    pageDescriptor = this.fromJsonToPageDescriptor(response.getResult(), true);
                     return pageDescriptor;
                 });
             }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/PageDescriptorResourceRequest.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/PageDescriptorResourceRequest.ts
@@ -16,9 +16,13 @@ module api.content.page {
             return this.resourcePath;
         }
 
-        fromJsonToPageDescriptor(json: api.content.page.PageDescriptorJson): PageDescriptor {
+        fromJsonToPageDescriptor(json: api.content.page.PageDescriptorJson, ignoreCache: boolean = false): PageDescriptor {
+
             var pageDescriptor = new api.content.page.PageDescriptorBuilder().fromJson(json).build();
-            this.cache.put(pageDescriptor);
+            if(!ignoreCache) {
+                this.cache.put(pageDescriptor);
+            }
+
             return  pageDescriptor;
         }
 


### PR DESCRIPTION
…mplate

-GetPageDescriptorByKeyRequest and GetPageDescriptorsByApplicationRequest use same cache which lead to issue:
 If GetPageDescriptorByKeyRequest is called before GetPageDescriptorsByApplicationRequest it fecthes specific (single one) PageDescriptor and puts it into cache; When after that
 GetPageDescriptorsByApplicationRequest is used it is first checks cache and sees that entry related to application presents (single entry) and returns it instead of
 fetching all application related page descriptors.
 Updated GetPageDescriptorByKeyRequest to not put it's result to cache