### PR TITLE
XP-1156 Move some form json classes to admin

### DIFF
--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/application/ApplicationJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/application/ApplicationJson.java
@@ -6,8 +6,8 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 
 import com.enonic.xp.admin.impl.json.ItemJson;
+import com.enonic.xp.admin.impl.json.form.FormJson;
 import com.enonic.xp.app.Application;
-import com.enonic.xp.form.FormJson;
 import com.enonic.xp.schema.mixin.MixinName;
 import com.enonic.xp.site.SiteDescriptor;
 

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/page/DescriptorJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/page/DescriptorJson.java
@@ -3,7 +3,7 @@ package com.enonic.xp.admin.impl.json.content.page;
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.admin.impl.json.ItemJson;
-import com.enonic.xp.form.FormJson;
+import com.enonic.xp.admin.impl.json.form.FormJson;
 import com.enonic.xp.region.Descriptor;
 
 

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/page/PageDescriptorJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/page/PageDescriptorJson.java
@@ -7,7 +7,7 @@ import com.google.common.base.Preconditions;
 
 import com.enonic.xp.admin.impl.json.ItemJson;
 import com.enonic.xp.admin.impl.json.content.page.region.RegionDescriptorJson;
-import com.enonic.xp.form.FormJson;
+import com.enonic.xp.admin.impl.json.form.FormJson;
 import com.enonic.xp.page.PageDescriptor;
 import com.enonic.xp.region.RegionDescriptor;
 import com.enonic.xp.region.RegionDescriptors;

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/FieldSetJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/FieldSetJson.java
@@ -1,10 +1,14 @@
-package com.enonic.xp.form;
+package com.enonic.xp.admin.impl.json.form;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.annotations.Beta;
+
+import com.enonic.xp.form.FieldSet;
+import com.enonic.xp.form.FormItem;
+import com.enonic.xp.form.FormItems;
 
 @Beta
 @SuppressWarnings("UnusedDeclaration")

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/FormItemJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/FormItemJson.java
@@ -1,9 +1,11 @@
-package com.enonic.xp.form;
+package com.enonic.xp.admin.impl.json.form;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.annotations.Beta;
+
+import com.enonic.xp.form.FormItem;
 
 @Beta
 @SuppressWarnings("UnusedDeclaration")

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/FormItemJsonFactory.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/FormItemJsonFactory.java
@@ -1,6 +1,12 @@
-package com.enonic.xp.form;
+package com.enonic.xp.admin.impl.json.form;
 
 import com.google.common.annotations.Beta;
+
+import com.enonic.xp.form.FormItem;
+import com.enonic.xp.form.FormItemSet;
+import com.enonic.xp.form.InlineMixin;
+import com.enonic.xp.form.Input;
+import com.enonic.xp.form.Layout;
 
 @Beta
 public class FormItemJsonFactory

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/FormItemSetJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/FormItemSetJson.java
@@ -1,10 +1,14 @@
-package com.enonic.xp.form;
+package com.enonic.xp.admin.impl.json.form;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.annotations.Beta;
+
+import com.enonic.xp.form.FormItem;
+import com.enonic.xp.form.FormItemSet;
+import com.enonic.xp.form.FormItems;
 
 @Beta
 @SuppressWarnings("UnusedDeclaration")

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/FormJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/FormJson.java
@@ -1,4 +1,4 @@
-package com.enonic.xp.form;
+package com.enonic.xp.admin.impl.json.form;
 
 
 import java.util.ArrayList;
@@ -6,6 +6,10 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.annotations.Beta;
+
+import com.enonic.xp.form.Form;
+import com.enonic.xp.form.FormItem;
+import com.enonic.xp.form.InlineMixinsToFormItemsTransformer;
 
 @Beta
 @SuppressWarnings("UnusedDeclaration")

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/InlineMixinJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/InlineMixinJson.java
@@ -1,7 +1,10 @@
-package com.enonic.xp.form;
+package com.enonic.xp.admin.impl.json.form;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.annotations.Beta;
+
+import com.enonic.xp.form.FormItem;
+import com.enonic.xp.form.InlineMixin;
 
 @Beta
 @SuppressWarnings("UnusedDeclaration")

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/InputJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/InputJson.java
@@ -1,10 +1,11 @@
-package com.enonic.xp.form;
+package com.enonic.xp.admin.impl.json.form;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.Beta;
 
+import com.enonic.xp.form.Input;
 import com.enonic.xp.form.inputtype.InputType;
 import com.enonic.xp.form.inputtype.InputTypeConfig;
 

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/LayoutJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/LayoutJson.java
@@ -1,7 +1,9 @@
-package com.enonic.xp.form;
+package com.enonic.xp.admin.impl.json.form;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.annotations.Beta;
+
+import com.enonic.xp.form.Layout;
 
 @Beta
 @SuppressWarnings("UnusedDeclaration")

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/LayoutJsonFactory.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/LayoutJsonFactory.java
@@ -1,6 +1,9 @@
-package com.enonic.xp.form;
+package com.enonic.xp.admin.impl.json.form;
 
 import com.google.common.annotations.Beta;
+
+import com.enonic.xp.form.FieldSet;
+import com.enonic.xp.form.Layout;
 
 @Beta
 @SuppressWarnings("UnusedDeclaration")

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/OccurrencesJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/form/OccurrencesJson.java
@@ -1,7 +1,9 @@
-package com.enonic.xp.form;
+package com.enonic.xp.admin.impl.json.form;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.annotations.Beta;
+
+import com.enonic.xp.form.Occurrences;
 
 @Beta
 @SuppressWarnings("UnusedDeclaration")

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/schema/content/ContentTypeJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/schema/content/ContentTypeJson.java
@@ -1,7 +1,7 @@
 package com.enonic.xp.admin.impl.json.schema.content;
 
+import com.enonic.xp.admin.impl.json.form.FormJson;
 import com.enonic.xp.admin.impl.rest.resource.schema.content.ContentTypeIconUrlResolver;
-import com.enonic.xp.form.FormJson;
 import com.enonic.xp.schema.content.ContentType;
 
 @SuppressWarnings("UnusedDeclaration")

--- a/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/schema/mixin/MixinJson.java
+++ b/modules/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/schema/mixin/MixinJson.java
@@ -6,10 +6,10 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 
 import com.enonic.xp.admin.impl.json.ItemJson;
+import com.enonic.xp.admin.impl.json.form.FormItemJson;
+import com.enonic.xp.admin.impl.json.form.FormItemJsonFactory;
 import com.enonic.xp.admin.impl.rest.resource.schema.mixin.MixinIconUrlResolver;
 import com.enonic.xp.form.FormItem;
-import com.enonic.xp.form.FormItemJson;
-import com.enonic.xp.form.FormItemJsonFactory;
 import com.enonic.xp.schema.mixin.Mixin;
 
 public class MixinJson

--- a/modules/admin-impl/src/test/java/com/enonic/xp/admin/impl/json/form/FormItemJsonTest.java
+++ b/modules/admin-impl/src/test/java/com/enonic/xp/admin/impl/json/form/FormItemJsonTest.java
@@ -8,11 +8,8 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import com.enonic.xp.form.FieldSet;
-import com.enonic.xp.form.FieldSetJson;
 import com.enonic.xp.form.FormItemSet;
-import com.enonic.xp.form.FormItemSetJson;
 import com.enonic.xp.form.Input;
-import com.enonic.xp.form.InputJson;
 import com.enonic.xp.form.inputtype.InputTypes;
 import com.enonic.xp.support.JsonTestHelper;
 


### PR DESCRIPTION
- Moved json classes to com.enonic.xp.admin.impl.json.form" in admin-impl module
- There were no tests to move
- Seems like all-input-types input type should be removed from features module