### PR TITLE
XP-1226 Live edit Context Window - Show page config if no components …

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/InspectionsPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/InspectionsPanel.ts
@@ -74,7 +74,7 @@ module app.wizard.page.contextwindow.inspect {
         }
 
         public clearInspection() {
-            this.showInspectionPanel(this.noSelectionPanel);
+            this.showInspectionPanel(this.pageInspectionPanel);
         }
 
         public isInspecting(): boolean {


### PR DESCRIPTION
…are selected

- Made page inspection panel to be shown by default when there is nothing to show in inspection panel