### PR TITLE
XP-1302 ContentWizard, 'Html Area' content type: button 'delete' does…

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/form/inputtype/text/html-area.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/form/inputtype/text/html-area.less
@@ -90,4 +90,11 @@
     }
   }
 
+  .input-occurrence-view {
+    a.remove-button {
+      padding-bottom: 26px;
+      margin-top: 26px;
+    }
+  }
+
 }


### PR DESCRIPTION
… not work, when area has a focus

- Adjusted margin and padding values for remove button of html-area in order to ensure that click on remove button actually reaches button after htmlarea's height changes. When clicking remove button on the html-area occurence: onblur event occurs before click event and adjusts htmlarea's height that moves remove link higher.