### PR TITLE
XP-1299 Two contents with the same name appears in the Grid when cont…

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
@@ -116,10 +116,6 @@ module app.browse {
 
         private handleGlobalEvents() {
 
-            api.content.ContentMovedEvent.on((event) => {
-                this.contentTreeGrid.reload();
-            });
-
             api.content.ContentChildOrderUpdatedEvent.on((event) => {
                 //this.handleChildOrderUpdated(event);
             });

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/MoveContentDialog.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/MoveContentDialog.ts
@@ -96,7 +96,6 @@ module app.browse {
                     this.contentMoveMask.hide();
 
                     if (response.getMoved().length > 0) {
-                        new api.content.ContentMovedEvent(response.getMoved()).fire();
                         if (response.getMoved().length > 1) {
                             api.notify.showFeedback(response.getMoved().length + ' items moved');
                         } else {


### PR DESCRIPTION
…ent moved to the ROOT

- moving of content is done via deleting and creating of content, all necessary events are triggered as supposed to, just in MoveContentDialog   extra event ContentMovedEvent was fired what is not needed anymore