### PR TITLE
XP-1321 Rendering without Template - Non-renderable page is shown in …

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
@@ -437,13 +437,16 @@ module app.browse {
             var previewItemPath = previewItem.getPath();
 
             if (!!content && content.getPath().toString() === previewItemPath) {
-                var item = new BrowseItem<ContentSummary>(content).
-                    setId(content.getId()).
-                    setDisplayName(content.getDisplayName()).
-                    setPath(content.getPath().toString()).
-                    setIconUrl(new ContentIconUrlResolver().setContent(content).resolve()).
-                    setRenderable(previewItem.isRenderable());
-                this.getBrowseItemPanel().setStatisticsItem(item);
+                new api.content.page.IsRenderableRequest(el.getContentId()).sendAndParse().
+                    then((renderable: boolean) => {
+                        var item = new BrowseItem<ContentSummary>(content).
+                            setId(content.getId()).
+                            setDisplayName(content.getDisplayName()).
+                            setPath(content.getPath().toString()).
+                            setIconUrl(new ContentIconUrlResolver().setContent(content).resolve()).
+                            setRenderable(renderable);
+                        this.getBrowseItemPanel().setStatisticsItem(item);
+                    });
             }
         }
     }


### PR DESCRIPTION
…CM preview

-issue was: when content updated it's statistics/preview panels get updated and renderable parameter is used in process, but renderable parameter itself updated already after it is being set in ViewItem in preview panel -> invalid renderable used -> preview panel attempted to be loaded -> error