### PR TITLE
XP-1332 Rendering without Template - Save before close dialog prompte…

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageTemplateSelector.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageTemplateSelector.ts
@@ -80,6 +80,10 @@ module app.wizard.page.contextwindow.inspect.page {
                         }
                     });
 
+                    this.pageModel.onReset(() => {
+                        this.selectOption(pageTemplateOptions.getDefault(), true);
+                    });
+
                 }).catch((reason: any) => {
                     api.DefaultErrorHandler.handle(reason);
                 }).done();

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/PageModel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/PageModel.ts
@@ -396,7 +396,14 @@ module api.content.page {
                     build();
             }
             else if (this.mode == PageMode.NO_CONTROLLER) {
-                return null;
+                if(this.contentHasNonRenderableTemplateSet()) {
+                    return new PageBuilder().
+                        setTemplate(this.liveEditModel.getContent().getPage().getTemplate()).
+                        build();
+                }
+                else {
+                    return null;
+                }
             }
             else {
                 throw new Error("Page mode not supported: " + this.mode);
@@ -458,6 +465,12 @@ module api.content.page {
 
         isCustomized(): boolean {
             return this.customized;
+        }
+
+        private contentHasNonRenderableTemplateSet() {
+           return !this.isPageTemplate() && (this.mode == PageMode.NO_CONTROLLER) &&
+                                 this.liveEditModel.getContent().getPage() &&
+                                 this.liveEditModel.getContent().getPage().getTemplate();
         }
 
         private registerRegionsListeners(regions: api.content.page.region.Regions) {


### PR DESCRIPTION
…d when not supposed to

-  if non renderable template was set for content then page assembled from edited page was not equal to persisted content (solved)
 - also when resetting content with controller set and no templates available - page template selector was not set to 'auto'