### PR TITLE
XP-1328 'Confirm Navigation' dialog appears when a site without a tem…

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveFormPanel.ts
@@ -129,11 +129,12 @@ module app.wizard.page {
             this.partInspectionPanel = new PartInspectionPanel();
             this.layoutInspectionPanel = new LayoutInspectionPanel();
 
-            api.dom.WindowDOM.get().asWindow().onbeforeunload = (event) => {
+            api.dom.WindowDOM.get().onBeforeUnload((event) => {
+                console.log("onbeforeunload " + this.liveEditModel.getContent().getDisplayName())
                 // the reload is triggered by the main frame,
                 // so let the live edit know it to skip the popup
                 this.liveEditPageProxy.skipNextReloadConfirmation(true);
-            };
+            });
 
             var saveAction = new api.ui.Action('Apply');
             saveAction.onExecuted(() => {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/dom/WindowDOM.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/dom/WindowDOM.ts
@@ -6,12 +6,24 @@ module api.dom {
 
         private static instance: WindowDOM = new WindowDOM();
 
+        private onBeforeUnloadListeners: {(event): void;}[] = [];
+
+        private onUnloadListeners: {(event): void;}[] = [];
+
         static get(): WindowDOM {
             return WindowDOM.instance;
         }
 
         constructor() {
             this.el = window;
+
+            this.el.onbeforeunload = (event) => {
+                this.onBeforeUnloadListeners.forEach((listener) => listener(event));
+            }
+
+            this.el.onunload = (event) => {
+                this.onUnloadListeners.forEach((listener) => listener(event));
+            }
         }
 
         asWindow(): Window {
@@ -84,6 +96,14 @@ module api.dom {
 
         unScroll(listener: (event: UIEvent) => void) {
             this.el.removeEventListener('scroll', listener);
+        }
+
+        onBeforeUnload(listener: (event) => void) {
+            this.onBeforeUnloadListeners.push(listener);
+        }
+
+        onUnload(listener: (event) => void) {
+            this.onUnloadListeners.push(listener);
         }
     }
 

--- a/modules/admin-ui/src/main/resources/web/admin/live-edit/js/LiveEditPage.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/live-edit/js/LiveEditPage.ts
@@ -38,7 +38,7 @@ module LiveEdit {
 
         constructor() {
 
-            api.liveedit.SkipLiveEditReloadConfirmationEvent.on((event: api.liveedit.SkipLiveEditReloadConfirmationEvent) => {
+            api.liveedit.SkipLiveEditReloadConfirmationEvent.on((event: api.liveedit.SkipLiveEditReloadConfirmationEvent) => {debugger;
                 this.skipNextReloadConfirmation = event.isSkip();
             });
 
@@ -67,7 +67,7 @@ module LiveEdit {
                 DragAndDrop.init(this.pageView);
 
                 api.ui.Tooltip.allowMultipleInstances(false);
-
+debugger;
                 this.registerGlobalListeners();
 
                 new api.liveedit.LiveEditPageViewReadyEvent(this.pageView).fire();
@@ -77,15 +77,16 @@ module LiveEdit {
 
         private registerGlobalListeners(): void {
 
-            api.dom.WindowDOM.get().asWindow().onbeforeunload = (event) => {
+            api.dom.WindowDOM.get().onBeforeUnload((event) => {
                 if (!this.skipNextReloadConfirmation) {
                     var message = "This will close this wizard!";
                     (event || window.event)['returnValue'] = message;
                     return message;
                 }
-            };
+            });
 
-            api.dom.WindowDOM.get().asWindow().onunload = (event) => {
+            api.dom.WindowDOM.get().onUnload((event) => {
+
                 if (!this.skipNextReloadConfirmation) {
                     new api.liveedit.PageUnloadedEvent(this.pageView).fire();
                     // do remove to trigger model unbinding
@@ -93,7 +94,7 @@ module LiveEdit {
                     this.skipNextReloadConfirmation = false;
                 }
                 this.pageView.remove();
-            };
+            });
 
             api.liveedit.ComponentLoadedEvent.on((event: api.liveedit.ComponentLoadedEvent) => {
 


### PR DESCRIPTION
…plate opened for edit

- WindowDOM onbeforeunload event was handled improperly - each time event was overriden by calling "WindowDOM.get().asWiindow().onbeforeunload = (event) => {...}" instead of maintaining array of listeners of event