### PR TITLE
XP-1382 Component View - Fix keyboard navigation in the tree

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/PageComponentsTreeGrid.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/PageComponentsTreeGrid.ts
@@ -43,9 +43,16 @@ module app.wizard {
                     setHideColumnHeaders(true).
                     setForceFitColumns(true).
                     setFullWidthRows(true).
-                    setRowHeight(45).
+
+                    // It is necessary to turn off the library key handling. It may cause
+                    // the conflicts with Mousetrap, which leads to skipping the key events
+                    // Do not set to true, if you are not fully aware of the result
+                    setEnableCellNavigation(false).
+
                     setCheckableRows(false).
+                    disableMultipleSelection(true).
                     setMultiSelect(false).
+                    setRowHeight(45).
                     build()).
                 setShowToolbar(false).
                 setAutoLoad(true).

--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/PageComponentsView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/PageComponentsView.ts
@@ -56,7 +56,7 @@ module app.wizard {
 
             this.onShown((event) => {
                 this.constrainToParent();
-            })
+            });
 
             ResponsiveManager.onAvailableSizeChanged(api.dom.Body.get(), (item: ResponsiveItem) => {
                 var smallSize = item.isInRangeOrSmaller(ResponsiveRanges._360_540);
@@ -167,15 +167,24 @@ module app.wizard {
                     // do nothing if expand toggle is clicked
                     return;
                 }
-                var treeNode: TreeNode<ItemView> = this.tree.getGrid().getDataView().getItem(data.row);
-                treeNode.getData().select(null, api.liveedit.ItemViewContextMenuPosition.TOP);
-                treeNode.getData().scrollComponentIntoView();
+
+                this.tree.getGrid().selectRow(data.row);
 
                 if (this.isModal()) {
                     this.hide();
                 }
             };
             this.tree.getGrid().subscribeOnClick(this.clickListener);
+            this.tree.onSelectionChanged((data, nodes) => {
+                if (nodes.length > 0) {
+                    nodes[0].getData().select(null, api.liveedit.ItemViewContextMenuPosition.TOP);
+                    nodes[0].getData().scrollComponentIntoView();
+
+                    if (this.isModal()) {
+                        this.hide();
+                    }
+                }
+            });
             this.appendChild(this.tree);
 
             this.tree.onRemoved((event) => this.tree.getGrid().unsubscribeOnClick(this.clickListener));

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/MoveContentSummaryLoader.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/MoveContentSummaryLoader.ts
@@ -89,7 +89,6 @@ module api.content {
                        contentTypeAllowsChild[content.getType().toString()] &&
                        createContentFilter.isCreateContentAllowed(content, this.filterSourceContentType);
             });
-            return [];
         }
 
         sendRequest(): wemQ.Promise<ContentSummary[]> {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGridBuilder.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGridBuilder.ts
@@ -71,7 +71,12 @@ module api.ui.treegrid {
                 setAutoHeight(false).
                 setEnableAsyncPostRender(true).
                 setAutoRenderGridOnDataChanges(true).
+
+                // It is necessary to turn off the library key handling. It may cause
+                // the conflicts with Mousetrap, which leads to skipping the key events
+                // Do not set to true, if you are not fully aware of the result
                 setEnableCellNavigation(false).
+
                 setEnableColumnReorder(false).
                 setForceFitColumns(true).
                 setHideColumnHeaders(true).


### PR DESCRIPTION
The actual fix was the same, as in CMS-3733, which I've solved earlier. There was a conflict between the default slickgrid navigation and the KeyBinding. The new `PageComponentsTreeGrid` class is using the custom Options, so the `enableCellNavigation` was set to `true`, which is wrong. I've set it to `false` and added a comments about the conflict.