### PR TITLE
XP-1488 Content Manager - Tuning design of Search Panel

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/app/browse/browse-filter-panel.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/app/browse/browse-filter-panel.less
@@ -14,6 +14,33 @@
     &:hover {
       color: @admin-button-blue3;
     }
+    font-size: 14px;
+  }
+
+  .aggregation-bucket-view {
+    padding: 1px 0px;
+
+    .checkbox {
+      input[type="checkbox"] {
+
+        &:checked + label {
+          color: @admin-black !important;
+          &:before {
+            top: 2px;
+            left: 1px;
+          }
+        }
+
+        & + label {
+          color: @admin-font-gray2 !important;
+          &:before {
+            top: 2px;
+            left: 1px;
+          }
+        }
+      }
+    }
+
   }
 
   input.text-search-field {
@@ -36,7 +63,7 @@
 
   h2 {
     color: #000000 !important;
-    font-size: 15px !important;
+    font-size: 14px !important;
     padding: 0 !important;
     text-transform: capitalize;
     white-space: nowrap;


### PR DESCRIPTION
 - Indent result count: did not change indent as currently it looks ok and differs from attached images
 - Indent facet headers: did not change indent as currently it looks ok and differs from attached images
 - Reduce size of facet fonts + add more padding: reduced size of facet headers font from 15px to 14px, did not reduce size of facet font as 12px seem to be correct, added 1px top and bottom padding for facets
 - Make facet lists "grey" when not selected, and black when selected: added gray color for unchecked facets
 - Reduce font size for "clear": reduced size from 16px to 14px
 - Adjust alignment between facet font and checkbox (should be vertically centered): set 2px to top attribute and 1px to left attribute of label:before selector