### PR TITLE
XP-1537 Toolbar Overflow menu - Use white background color

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/ui/toolbar.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/ui/toolbar.less
@@ -1,7 +1,7 @@
 .toolbar {
   @toolbar-height: 41px;
 
-  background-color: transparent;
+  background-color: @admin-white;
   height: @toolbar-height;
   overflow: visible; // for the button glow
   .box-sizing(border-box);
@@ -52,7 +52,7 @@
       left: 0;
       z-index: @z-index-toolbar-element;
       padding: 0 10px;
-      background-color: @admin-bg-light-gray;
+      background-color: @admin-white;
       .box-shadow(-1px 1px 2px 0px rgba(0, 0, 0, 0.3));
 
       & > * {


### PR DESCRIPTION
Changed toolbar background from transparent to white.
Changed dropdown menu background from `#EEEEEE` to white.