### PR TITLE
XP-1534 Detail Panel - Background color missing from mobile toolbar

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/mobile-content-item-statistics-panel.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/mobile-content-item-statistics-panel.less
@@ -169,7 +169,7 @@
     width: 100%;
     border-top: 1px solid @admin-bg-light-gray;
     background-color: @admin-white;
-    opacity: 0.99;
+    opacity: 0.95;
 
     .fold-button {
       border: 0px;


### PR DESCRIPTION
- Issue has already been fixed - I only adjusted the opacity a bit.