### PR TITLE
XP-1721 Spinner overkill - Remove redundant instances, optimize usage

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/ContentItemVersionsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/ContentItemVersionsPanel.ts
@@ -10,7 +10,6 @@ module app.view {
         private deckPanel: api.ui.panel.NavigatedDeckPanel;
         private activeGrid: ContentVersionsTreeGrid;
         private allGrid: ContentVersionsTreeGrid;
-        private mask: api.ui.mask.LoadMask;
 
         constructor() {
             super("content-item-versions-panel");
@@ -20,8 +19,6 @@ module app.view {
             this.deckPanel.setDoOffset(false);
             this.appendChild(navigator);
             this.appendChild(this.deckPanel);
-            this.mask = new api.ui.mask.LoadMask(this);
-            this.appendChild(this.mask);
 
             navigator.onNavigationItemSelected((event: api.ui.NavigatorEvent) => {
                 this.setItem(this.item);
@@ -29,16 +26,11 @@ module app.view {
 
 
             this.allGrid = new AllContentVersionsTreeGrid();
-            this.allGrid.onLoaded(() => {
-                this.mask.hide();
-            });
+
             this.deckPanel.addNavigablePanel(new api.ui.tab.TabBarItemBuilder().setLabel('All Versions').setAddLabelTitleAttribute(false).build(),
                 this.allGrid, true);
 
             this.activeGrid = new ActiveContentVersionsTreeGrid();
-            this.activeGrid.onLoaded(() => {
-                this.mask.hide();
-            });
 
             this.deckPanel.addNavigablePanel(new api.ui.tab.TabBarItemBuilder().setLabel('Active Versions').setAddLabelTitleAttribute(false).build(),
                 this.activeGrid);
@@ -50,7 +42,6 @@ module app.view {
             if (this.item) {
                 var panel = <ContentVersionsTreeGrid>this.deckPanel.getPanelShown();
                 if (panel.getContentId() != this.item.getModel().getContentId()) {
-                    this.mask.show();
                     (<ContentVersionsTreeGrid>this.deckPanel.getPanelShown()).setContentId(item.getModel().getContentId());
                 }
             }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
@@ -68,20 +68,34 @@ module api.ui.grid {
                 ResponsiveManager.unAvailableSizeChanged(this);
             });
 
-            this.loadMask = new api.ui.mask.LoadMask(this);
-
             // The only way to dataIdProperty before adding items
             this.dataView.setItems([], options.getDataIdProperty());
         }
 
         mask() {
             if (this.isVisible()) {
-                this.loadMask.show();
+                if (this.loadMask) {
+                    this.loadMask.show();
+                }
+                else { //lazy mask init
+                    if (this.getParentElement()) {
+                        this.createLoadMask();
+                        this.loadMask.show();
+                    }
+                    else {
+                        this.onAdded(() => {
+                            this.createLoadMask();
+                        });
+                    }
+                }
             }
         }
 
         unmask() {
-            this.loadMask.hide();
+            if (this.loadMask) {
+                this.loadMask.hide();
+            }
+
         }
 
         private autoRenderGridOnDataChanges(dataView: DataView<T>) {
@@ -95,6 +109,11 @@ module api.ui.grid {
                 this.invalidateRows(args.rows);
                 this.render();
             });
+        }
+
+        private createLoadMask() {
+            this.loadMask = new api.ui.mask.LoadMask(this);
+            this.getParentElement().appendChild(this.loadMask);
         }
 
         setSelectionModel(selectionModel: Slick.SelectionModel<T, any>) {


### PR DESCRIPTION
- Removed redundant spinner from ContentItemVersionsPanel as now spinner is handled directly in grid
- Updated grid to lazily create spinner on demand (when mask 'show' triggered)