### PR TITLE
XP-1530 Bad notification message, when content saved with a name, tha…

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -17,6 +17,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang.StringUtils;
 import org.osgi.service.component.annotations.Component;
@@ -73,6 +74,7 @@ import com.enonic.xp.content.CompareContentResult;
 import com.enonic.xp.content.CompareContentResults;
 import com.enonic.xp.content.CompareContentsParams;
 import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ContentAlreadyExistException;
 import com.enonic.xp.content.ContentConstants;
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentIds;
@@ -301,6 +303,11 @@ public final class ContentResource
     @Path("update")
     public ContentJson update( final UpdateContentJson json )
     {
+        if ( contentNameIsOccupied( json.getRenameContentParams() ) ) {
+            throw JaxRsExceptions.newException( Response.Status.CONFLICT , String.format( "Content [%s] could not be updated. A content with that name already exists",
+                                                                     json.getRenameContentParams().getNewName().toString() ) );
+        }
+
         final UpdateContentParams updateParams = json.getUpdateContentParams();
 
         final Content updatedContent = contentService.update( updateParams );
@@ -309,9 +316,15 @@ public final class ContentResource
             return new ContentJson( updatedContent, newContentIconUrlResolver(), principalsResolver );
         }
 
-        final RenameContentParams renameParams = json.getRenameContentParams();
-        final Content renamedContent = contentService.rename( renameParams );
-        return new ContentJson( renamedContent, newContentIconUrlResolver(), principalsResolver );
+        try {  // in case content with same name and path was created in between content updated and renamed
+            final RenameContentParams renameParams = json.getRenameContentParams();
+            final Content renamedContent = contentService.rename( renameParams );
+            return new ContentJson( renamedContent, newContentIconUrlResolver(), principalsResolver );
+        }
+        catch ( ContentAlreadyExistException e ) { // catching to throw exception with better message and other error code
+            throw JaxRsExceptions.newException( Response.Status.CONFLICT , String.format( "Content could not be renamed to [%s]. A content with that name already exists",
+                                                                                          json.getRenameContentParams().getNewName().toString() ) );
+        }
     }
 
     @POST
@@ -886,6 +899,23 @@ public final class ContentResource
         }
 
         return QueryExpr.from( expr );
+    }
+
+    private boolean contentNameIsOccupied( final RenameContentParams renameParams ) {
+        Content content = contentService.getById( renameParams.getContentId() );
+        if ( content.getName().equals( renameParams.getNewName() ) ) {
+            return false;
+        }
+
+        ContentPath newPath = ContentPath.from( content.getParentPath(), renameParams.getNewName().toString() );
+        try {
+            contentService.getByPath( newPath );
+        }
+        catch ( ContentNotFoundException e ) {
+            return false;
+        }
+
+        return true;
     }
 
     @Reference


### PR DESCRIPTION
…t already in use

-Updated ContentResource.update() behaviour to check first if content name changes and if it is not occupied by some other content. Throwing error in that case, content is not updated at all. (before content form was saved first and then rename attempt was made so changes on form saved but name change is not)