### PR TITLE
XP-1781 Version History panel: grid not updated, when a 'modified' co…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
@@ -189,7 +189,6 @@ module app.browse {
                         then((renderable: boolean) => {
                             var item: api.app.view.ViewItem<ContentSummary> = browseItems[0].toViewItem();
                             item.setRenderable(renderable);
-                            this.mobileContentItemStatisticsPanel.setItem(item);
                             this.mobileBrowseActions.updateActionsEnabledState(browseItems);
                         });
                 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/publish/ContentPublishItem.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/publish/ContentPublishItem.ts
@@ -5,7 +5,6 @@ module app.publish {
     import ContentPath = api.content.ContentPath;
     import ContentSummary = api.content.ContentSummary;
     import DialogButton = api.ui.dialog.DialogButton;
-    import PublishContentRequest = api.content.PublishContentRequest;
     import CompareStatus = api.content.CompareStatus;
     import ContentPublishItemJson = api.content.json.ContentPublishItemJson;
     import ContentName = api.content.ContentName;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/ContentItemVersionsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/ContentItemVersionsPanel.ts
@@ -35,6 +35,10 @@ module app.view {
             }
         }
 
+        public reloadActivePanel() {
+            this.allGrid.reload();
+        }
+
         public getItem(): ViewItem<ContentSummary> {
             return this.item;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/DetailsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/DetailsPanel.ts
@@ -72,9 +72,17 @@ module app.view.detail {
                 this.versionsPanel.reRenderActivePanel();
             });
 
-            ResponsiveManager.onAvailableSizeChanged(this, (item: ResponsiveItem) => {
-                if (this.item) {
-                    this.resetItem();
+            var delayedReset = api.util.AppHelper.debounce(this.resetItem.bind(this), 300, false);
+            ResponsiveManager.onAvailableSizeChanged(this, delayedReset);
+
+            api.content.ContentsPublishedEvent.on((event: api.content.ContentsPublishedEvent) => {
+                var itemId = (<ContentSummary>this.getItem().getModel()).getId();
+                var idPublished = event.getContentIds().some((id, index, array) => {
+                    return itemId === id.toString();
+                });
+
+                if (idPublished) {
+                    this.versionsPanel.reloadActivePanel();
                 }
             });
 
@@ -86,7 +94,7 @@ module app.view.detail {
             this.getAndInitCustomWidgetsViews().done(() => {
                 this.initWidgetsSelectionRow();
             });
-            this.appendChild(this.detailsContainer)
+            this.appendChild(this.detailsContainer);
             this.appendChild(this.divForNoSelection);
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/action/PublishAction.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/action/PublishAction.ts
@@ -2,7 +2,6 @@ module app.wizard.action {
 
     import Content = api.content.Content;
     import ContentId = api.content.ContentId;
-    import PublishContentRequest = api.content.PublishContentRequest;
 
     export class PublishAction extends api.ui.Action {
 


### PR DESCRIPTION
…ntent was published, two 'online' badges present in the grid

Added published event listener to update the DetailPanel when it's triggered.
Optimized DetailPanel update and reRender, using the `debounce` function.
Removed unnecessary DetailPanel update from the ContentBrowsePanel, when TreeGrid item clicked (since the selection event will be triggered anyway).