### PR TITLE
XP-1826 Attachment type for the same attachment differs depending if …

### DIFF
--- a/modules/core/core-impl/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
+++ b/modules/core/core-impl/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
@@ -47,11 +47,10 @@ final class UpdateMediaCommand
             params.mimeType( mediaInfo.getMediaType() );
         }
 
-        final ContentTypeName type = ContentTypeFromMimeTypeResolver.resolve( params.getMimeType() );
-        if ( type == null )
-        {
-            throw new IllegalArgumentException( "Could not resolve a ContentType from MIME type: " + params.getMimeType() );
-        }
+        Preconditions.checkNotNull( params.getMimeType(), "Unable to resolve media type" );
+
+        final ContentTypeName resolvedTypeFromMimeType = ContentTypeFromMimeTypeResolver.resolve( params.getMimeType() );
+        final ContentTypeName type = resolvedTypeFromMimeType != null ? resolvedTypeFromMimeType : ContentTypeName.unknownMedia();
 
         final CreateAttachment mediaAttachment = CreateAttachment.create().
             name( params.getName() ).


### PR DESCRIPTION
…you are uploading it from new content dialog or from content wizard

- Made content type to be set during media update the same way as during creation