### PR TITLE
XP-1899 Fire pushed event from node layer

### DIFF
--- a/modules/core/core-event/src/main/java/com/enonic/xp/core/impl/event/EventPublisherImpl.java
+++ b/modules/core/core-event/src/main/java/com/enonic/xp/core/impl/event/EventPublisherImpl.java
@@ -35,8 +35,11 @@ public final class EventPublisherImpl
     @Override
     public void publish( final Event event )
     {
-        this.queue.add( event );
-        dispatchEvents();
+        if ( event != null )
+        {
+            this.queue.add( event );
+            dispatchEvents();
+        }
     }
 
     private void dispatchEvents()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/NodeEvents.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/NodeEvents.java
@@ -2,6 +2,7 @@ package com.enonic.xp.repo.impl;
 
 import com.enonic.xp.event.Event2;
 import com.enonic.xp.node.Node;
+import com.enonic.xp.node.Nodes;
 
 public class NodeEvents
 {
@@ -12,7 +13,9 @@ public class NodeEvents
 
     public static final String NODE_DELETED_EVENT = "node.deleted";
 
-    public static Event2 moved( Node from, Node to )
+    public static final String NODE_PUSHED_EVENT = "node.pushed";
+
+    public static Event2 moved( final Node from, final Node to )
     {
         if ( from != null && to != null )
         {
@@ -27,7 +30,7 @@ public class NodeEvents
         return null;
     }
 
-    public static Event2 created( Node created )
+    public static Event2 created( final Node created )
     {
         if ( created != null )
         {
@@ -40,7 +43,33 @@ public class NodeEvents
         return null;
     }
 
-    public static Event2 deleted( Node deleted )
+    public static Event2 pushed( final Nodes pushedNodes )
+    {
+        if ( pushedNodes != null && pushedNodes.getSize() > 0 )
+        {
+            final Event2.Builder builder = Event2.create( NODE_PUSHED_EVENT ).distributed( true );
+
+            addNodeValuesToEventData( builder, pushedNodes );
+
+            return builder.build();
+        }
+        return null;
+    }
+
+    private static void addNodeValuesToEventData( final Event2.Builder builder, final Nodes nodes )
+    {
+
+        final StringBuilder pushedNodesAsString = new StringBuilder();
+
+        for ( final Node node : nodes )
+        {
+            pushedNodesAsString.append( node.id() ).append( ":" ).append( node.path() ).append( ";" );
+        }
+
+        builder.value( "nodes", pushedNodesAsString.toString() );
+    }
+
+    public static Event2 deleted( final Node deleted )
     {
         if ( deleted != null )
         {

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/NodeServiceImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/NodeServiceImpl.java
@@ -256,6 +256,7 @@ public class NodeServiceImpl
             indexServiceInternal( this.indexServiceInternal ).
             storageService( this.storageService ).
             searchService( this.searchService ).
+            eventPublisher( this.eventPublisher ).
             ids( ids ).
             target( target ).
             build().

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/PushNodesCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/PushNodesCommand.java
@@ -23,6 +23,7 @@ import com.enonic.xp.query.expr.FieldOrderExpr;
 import com.enonic.xp.query.expr.OrderExpr;
 import com.enonic.xp.query.expr.OrderExpressions;
 import com.enonic.xp.repo.impl.InternalContext;
+import com.enonic.xp.repo.impl.NodeEvents;
 import com.enonic.xp.repo.impl.repository.IndexNameResolver;
 import com.enonic.xp.repo.impl.storage.MoveNodeParams;
 import com.enonic.xp.security.acl.Permission;
@@ -109,7 +110,11 @@ public class PushNodesCommand
 
         indexServiceInternal.refresh( IndexNameResolver.resolveSearchIndexName( ContextAccessor.current().getRepositoryId() ) );
 
-        return builder.build();
+        final PushNodesResult result = builder.build();
+
+        this.eventPublisher.publish( NodeEvents.pushed( result.getSuccessful() ) );
+
+        return result;
     }
 
     private void updateTargetChildrenMetaData( final Node node, PushNodesResult.Builder resultBuilder )

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/NodeEventsTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/NodeEventsTest.java
@@ -4,8 +4,10 @@ import org.junit.Test;
 
 import com.enonic.xp.event.Event2;
 import com.enonic.xp.node.Node;
+import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeName;
 import com.enonic.xp.node.NodePath;
+import com.enonic.xp.node.Nodes;
 
 import static org.junit.Assert.*;
 
@@ -42,6 +44,24 @@ public class NodeEventsTest
     }
 
     @Test
+    public void testPushed()
+    {
+        final Node pushed1 = createNode( "pushed1", NodePath.create( "/mynode1/pushed1" ).build(), "id1" );
+        final Node pushed2 = createNode( "pushed2", NodePath.create( "/mynode1/pushed2" ).build(), "id2" );
+        final Node pushed3 = createNode( "pushed3", NodePath.create( "/mynode1/pushed3" ).build(), "id3" );
+        final Nodes nodes = Nodes.from( pushed1, pushed2, pushed3 );
+
+        Event2 event = NodeEvents.pushed( nodes );
+
+        assertNotNull( event );
+        assertTrue( event.isDistributed() );
+        assertTrue( event.hasValue( "nodes" ) );
+        assertEquals( NodeEvents.NODE_PUSHED_EVENT, event.getType() );
+        assertEquals( "id1:/mynode1/pushed1/pushed1;id2:/mynode1/pushed2/pushed2;id3:/mynode1/pushed3/pushed3;",
+                      event.getValue( "nodes" ).get() );
+    }
+
+    @Test
     public void testDeleted()
     {
         final Node deleted = createNode( "deleted", NodePath.create( "/mynode1/child1" ).build() );
@@ -73,4 +93,14 @@ public class NodeEventsTest
             parentPath( root ).
             build();
     }
+
+    private Node createNode( final String name, final NodePath root, String id )
+    {
+        return Node.create().
+            name( NodeName.from( name ) ).
+            parentPath( root ).
+            id( NodeId.from( id ) ).
+            build();
+    }
+
 }

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/index/IndexServiceImplTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/index/IndexServiceImplTest.java
@@ -136,6 +136,7 @@ public class IndexServiceImplTest
             indexServiceInternal( this.indexServiceInternal ).
             storageService( this.storageService ).
             searchService( this.searchService ).
+            eventPublisher( this.eventPublisher ).
             build().
             execute();
 

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/AbstractNodeTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/AbstractNodeTest.java
@@ -312,6 +312,7 @@ public abstract class AbstractNodeTest
             indexServiceInternal( this.indexServiceInternal ).
             storageService( this.storageService ).
             searchService( this.searchService ).
+            eventPublisher( this.eventPublisher ).
             build().
             execute();
     }

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/CompareNodeCommandTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/CompareNodeCommandTest.java
@@ -222,6 +222,7 @@ public class CompareNodeCommandTest
             indexServiceInternal( this.indexServiceInternal ).
             storageService( this.storageService ).
             searchService( this.searchService ).
+            eventPublisher( this.eventPublisher ).
             build().
             execute();
     }

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/FindNodesWithVersionDifferenceCommandTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/FindNodesWithVersionDifferenceCommandTest.java
@@ -376,6 +376,7 @@ public class FindNodesWithVersionDifferenceCommandTest
             indexServiceInternal( this.indexServiceInternal ).
             storageService( this.storageService ).
             searchService( this.searchService ).
+            eventPublisher( this.eventPublisher ).
             build().
             execute();
     }


### PR DESCRIPTION
- Added appropriate method to NodeEvents
- Pushed nodes' ids and paths are stored in Event2 data as a String
- Added check for null event into EventPublisherImpl.publish(..) method
- Adjusted tests