### PR TITLE
XP-1958 Page Components View, display name of site not present

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageTemplateOption.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageTemplateOption.ts
@@ -9,9 +9,6 @@ module app.wizard.page.contextwindow.inspect.page {
 
         private pageModel: PageModel;
 
-        static displayNameCustom = "Custom";
-        static displayNameAutomatic = "Automatic";
-
         constructor(template: PageTemplate, pageModel: PageModel) {
             this.template = template;
             this.pageModel = pageModel;
@@ -26,7 +23,9 @@ module app.wizard.page.contextwindow.inspect.page {
         }
 
         isCustom(): boolean {
-            return this.template && this.template.getDisplayName() == PageTemplateOption.displayNameCustom;
+            var pageTemplateDisplayName = api.content.page.PageTemplateDisplayName;
+
+            return this.template && this.template.getDisplayName() == pageTemplateDisplayName[pageTemplateDisplayName.Custom];
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageTemplateOptionViewer.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageTemplateOptionViewer.ts
@@ -7,7 +7,11 @@ module app.wizard.page.contextwindow.inspect.page {
         }
 
         resolveDisplayName(object: PageTemplateOption): string {
-            return !!object.getPageTemplate() ? (object.isCustom() ? PageTemplateOption.displayNameCustom : object.getPageTemplate().getDisplayName()) : PageTemplateOption.displayNameAutomatic;
+            var pageTemplateDisplayName = api.content.page.PageTemplateDisplayName;
+
+            return !!object.getPageTemplate() ?
+                        (object.isCustom() ? pageTemplateDisplayName[pageTemplateDisplayName.Custom] : object.getPageTemplate().getDisplayName())
+                    : pageTemplateDisplayName[pageTemplateDisplayName.Automatic];
         }
 
         resolveSubName(object: PageTemplateOption, relativePath: boolean = false): string {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageTemplateSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageTemplateSelector.ts
@@ -127,7 +127,11 @@ module app.wizard.page.contextwindow.inspect.page {
         }
 
         private createCustomizedOption(): Option<PageTemplateOption> {
-            var pageTemplate:PageTemplate = (<PageTemplateBuilder> new PageTemplateBuilder().setData(new api.data.PropertyTree()).setDisplayName(PageTemplateOption.displayNameCustom)).build();
+            var pageTemplateDisplayName = api.content.page.PageTemplateDisplayName;
+            var pageTemplate:PageTemplate = (<PageTemplateBuilder> new PageTemplateBuilder()
+                                                                    .setData(new api.data.PropertyTree())
+                                                                    .setDisplayName(pageTemplateDisplayName[pageTemplateDisplayName.Custom]))
+                                                                    .build();
             var option = {
                 value: "Customized",
                 displayValue: new PageTemplateOption(pageTemplate, this.pageModel)

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/page/PageMode.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/page/PageMode.ts
@@ -7,4 +7,9 @@ module api.content.page {
         FORCED_CONTROLLER,      // PageTemplate: when page.descriptor is not null
         NO_CONTROLLER,           // PageTemplate: when page.descriptor is null
     }
+
+    export enum PageTemplateDisplayName {
+        Automatic,
+        Custom
+    }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
@@ -425,17 +425,18 @@ module api.liveedit {
         }
 
         getName(): string {
+            var pageTemplateDisplayName = api.content.page.PageTemplateDisplayName;
             if (this.pageModel.hasTemplate()) {
                 return this.pageModel.getTemplate().getDisplayName();
             }
             if (this.pageModel.isCustomized()) {
-                return this.pageModel.hasController() ? this.pageModel.getController().getDisplayName() : "Custom";
+                return this.pageModel.hasController() ? this.pageModel.getController().getDisplayName() : pageTemplateDisplayName[pageTemplateDisplayName.Custom];
             }
             if (this.pageModel.getMode() == PageMode.AUTOMATIC) {
                 return this.pageModel.getDefaultPageTemplate().getDisplayName();
             }
 
-            return "[No name]";
+            return pageTemplateDisplayName[pageTemplateDisplayName.Automatic];
         }
 
         getIconUrl(content: api.content.Content): string {
@@ -451,11 +452,8 @@ module api.liveedit {
             if (this.pageModel.isCustomized()) {
                 return "icon-cog" + largeIconCls;
             }
-            if (this.pageModel.getMode() == PageMode.AUTOMATIC) {
-                return "icon-wand" + largeIconCls;
-            }
 
-            return super.getIconClass();
+            return "icon-wand" + largeIconCls;
         }
 
         getParentItemView(): ItemView {


### PR DESCRIPTION
* Show "Automatic" display name/icon in the root of page components tree when the page is in "forced controller" mode