### PR TITLE
XP-1946 Details panel has empty content on first open with selected item

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
@@ -142,7 +142,7 @@ module app.browse {
 
         }
 
-        private initSplitPanelWithDockedDetails(controlButtonBuilder: NonMobileDetailsPanelsManagerBuilder) {
+        private initSplitPanelWithDockedDetails(nonMobileDetailsPanelsManagerBuilder: NonMobileDetailsPanelsManagerBuilder) {
 
             var contentPanelsAndDetailPanel: api.ui.panel.SplitPanel = new api.ui.panel.SplitPanelBuilder(this.getFilterAndContentGridAndBrowseSplitPanel(),
                 this.defaultDockedDetailsPanel).
@@ -158,15 +158,15 @@ module app.browse {
 
             this.appendChild(contentPanelsAndDetailPanel);
 
-            controlButtonBuilder.setSplitPanelWithGridAndDetails(contentPanelsAndDetailPanel);
-            controlButtonBuilder.setDefaultDetailsPanel(this.defaultDockedDetailsPanel);
+            nonMobileDetailsPanelsManagerBuilder.setSplitPanelWithGridAndDetails(contentPanelsAndDetailPanel);
+            nonMobileDetailsPanelsManagerBuilder.setDefaultDetailsPanel(this.defaultDockedDetailsPanel);
         }
 
-        private initFloatingDetailsPanel(controlButtonBuilder: NonMobileDetailsPanelsManagerBuilder) {
+        private initFloatingDetailsPanel(nonMobileDetailsPanelsManagerBuilder: NonMobileDetailsPanelsManagerBuilder) {
 
             this.floatingDetailsPanel = DetailsPanel.create().build();
 
-            controlButtonBuilder.setFloatingDetailsPanel(this.floatingDetailsPanel);
+            nonMobileDetailsPanelsManagerBuilder.setFloatingDetailsPanel(this.floatingDetailsPanel);
 
             this.appendChild(this.floatingDetailsPanel);
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/DetailsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/DetailsPanel.ts
@@ -228,25 +228,22 @@ module app.view.detail {
 
             this.updateCommonWidgets();
             this.updateCustomWidgets();
-            setTimeout(() => {
-                this.updateWidgetsHeights();
-            }, 400);
         }
 
         private updateWidgetsHeights() {
             this.widgetViews.forEach((widgetView: WidgetView) => {
-                if (widgetView != this.activeWidget) {
-                    widgetView.updateNormalHeightSilently();
-                } else {
-                    widgetView.updateNormalHeight();
-                }
+                this.updateWidgetHeight(widgetView);
             });
             if (this.defaultWidgetView) {
-                if (this.defaultWidgetView != this.activeWidget) {
-                    this.defaultWidgetView.updateNormalHeightSilently();
-                } else {
-                    this.defaultWidgetView.updateNormalHeight();
-                }
+                this.updateWidgetHeight(this.defaultWidgetView);
+            }
+        }
+
+        private updateWidgetHeight(widgetView: WidgetView) {
+            if (widgetView != this.activeWidget) {
+                widgetView.updateNormalHeightSilently();
+            } else {
+                widgetView.updateNormalHeight();
             }
         }
 
@@ -304,7 +301,9 @@ module app.view.detail {
                     if (DetailsPanel.DEFAULT_WIDGET_NAME == this.activeWidget.getWidgetName()) {
                         this.setActiveWidget(this.defaultWidgetView);
                     }
-                    this.updateWidgetsHeights();
+                    setTimeout(() => {
+                        this.updateWidgetsHeights();
+                    }, 1000);
 
                 }).done();
             }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/NonMobileDetailsPanelsManager.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/NonMobileDetailsPanelsManager.ts
@@ -110,7 +110,7 @@ module app.view.detail {
         }
 
         hideDockedDetailsPanel() {
-            this.splitPanelWithGridAndDetails.hideSecondPanel();
+            this.splitPanelWithGridAndDetails.foldSecondPanel();
         }
 
         getToggleButton(): api.dom.DivEl {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/details/details.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/details/details.less
@@ -284,6 +284,7 @@
       }
     }
 
+    min-height: 100px;
   }
 
   .status-widget-item-view {


### PR DESCRIPTION
- Adjusted hiding of details panel
- Added min-height for properties widget view that assists in widget's height calculation as  properties widget view is rendered asynchronously after back-end request