### PR TITLE
XP-1961 LiveEdit panel must be shown by default when opening content …

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
@@ -273,6 +273,10 @@ module app.wizard {
                         }
                     });
 
+                    if (this.liveEditModel && this.liveEditModel.getPageModel() && this.liveEditModel.getPageModel().hasController()) {
+                        this.wizardActions.getShowSplitEditAction().execute();
+                    }
+
                     responsiveItem.update();
                 });
 


### PR DESCRIPTION
…for edit
Added check for existence of page controller that will enable live editor if true