### PR TITLE
XP-1997 Detail panel unexpectedly goes to floating mode

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/NonMobileDetailsPanelsManager.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/NonMobileDetailsPanelsManager.ts
@@ -37,7 +37,7 @@ module app.view.detail {
         }
 
         private doHandleResizeEvent() {
-            if (!this.resizeEventMonitorLocked && this.nonMobileDetailsPanelIsActive()) {
+            if (!this.resizeEventMonitorLocked && this.nonMobileDetailsPanelIsActive() && this.contentBrowsePanelIsVisible()) {
                 this.resizeEventMonitorLocked = true;
                 if (this.needsSwitchToFloatingMode() || this.needsSwitchToDockedMode()) {
                     this.doPanelAnimation();
@@ -50,6 +50,10 @@ module app.view.detail {
             } else {
                 return;
             }
+        }
+
+        private contentBrowsePanelIsVisible(): boolean {
+            return this.splitPanelWithGridAndDetails.getParentElement().isVisible();
         }
 
         private nonMobileDetailsPanelIsActive(): boolean {


### PR DESCRIPTION
- Added additional check to non-mobile details panel manager, that checks if content browse panel is visible. If not true - there is no sense to do animations/calculations on non-mobile details panels