### PR TITLE
XP-2000 Detail panel - Remove delay when switching between content items

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/AttachmentsWidgetItemView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/AttachmentsWidgetItemView.ts
@@ -20,11 +20,11 @@ module app.view.detail {
             this.content = content;
         }
 
-        public layout() {
+        public layout(): wemQ.Promise<any> {
             this.removeChildren();
             if (this.content != undefined) {
 
-                new api.content.GetContentAttachmentsRequest(this.content.getContentId()).sendAndParse().then((attachments: Attachments) => {
+                return new api.content.GetContentAttachmentsRequest(this.content.getContentId()).sendAndParse().then((attachments: Attachments) => {
                     if (attachments) {
 
                         var uploaderList = new api.dom.UlEl("uploader-list");
@@ -59,9 +59,13 @@ module app.view.detail {
                         this.appendChild(new api.dom.SpanEl("att-placeholder").setHtml("This item has no attachments"));
                     }
 
-                }).done();
+                    super.layout();
+
+                });
+            } else {
+                return super.layout();
             }
-            super.layout();
+
         }
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/DetailsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/DetailsPanel.ts
@@ -294,19 +294,18 @@ module app.view.detail {
                         setName(DetailsPanel.DEFAULT_WIDGET_NAME).
                         setDetailsPanel(this).
                         setUseToggleButton(false).
+                        setLayoutCallbackFunction(() => {
+                            if (DetailsPanel.DEFAULT_WIDGET_NAME == this.activeWidget.getWidgetName()) {
+                                this.setActiveWidget(this.defaultWidgetView);
+                            }
+                            this.updateWidgetsHeights();
+                        }).
                         addWidgetItemView(widgetItemView).
                         addWidgetItemView(propWidgetItemView).
                         addWidgetItemView(attachmentsWidgetItemView).
                         build();
 
                     this.detailsContainer.appendChild(this.defaultWidgetView);
-
-                    if (DetailsPanel.DEFAULT_WIDGET_NAME == this.activeWidget.getWidgetName()) {
-                        this.setActiveWidget(this.defaultWidgetView);
-                    }
-                    setTimeout(() => {
-                        this.updateWidgetsHeights();
-                    }, 1000);
 
                 }).done();
             }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/PropertiesWidgetItemView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/PropertiesWidgetItemView.ts
@@ -18,21 +18,23 @@ module app.view.detail {
             this.content = content;
         }
 
-        public layout() {
+        public layout(): wemQ.Promise<any> {
             this.removeChildren();
             if (this.content != undefined) {
 
                 if (!this.content.getType().getApplicationKey().isSystemReserved()) {
-                    new api.application.GetApplicationRequest(this.content.getType().getApplicationKey()).sendAndParse().then((application: Application) => {
+                    return new api.application.GetApplicationRequest(this.content.getType().getApplicationKey()).sendAndParse().then((application: Application) => {
                         this.doLayout(application);
                     }).catch(() => {
                         this.doLayout();
-                    }).done();
+                    });
                 } else {
                     this.doLayout();
+                    return super.layout();
                 }
+            } else {
+                return super.layout();
             }
-            super.layout();
         }
 
         private doLayout(application?: Application) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/StatusWidgetItemView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/StatusWidgetItemView.ts
@@ -15,14 +15,14 @@ module app.view.detail {
             this.status = status;
         }
 
-        public layout() {
+        public layout(): wemQ.Promise<any> {
             this.removeChildren();
             if (this.status != undefined) {
                 var statusEl = new api.dom.SpanEl().setHtml(CompareStatusFormatter.formatStatus(this.status).toLocaleUpperCase());
                 statusEl.addClass(CompareStatus[this.status].toLowerCase().replace("_", "-") || "unknown");
                 this.appendChild(statusEl);
             }
-            super.layout();
+            return super.layout();
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/WidgetItemView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/WidgetItemView.ts
@@ -15,10 +15,11 @@ module app.view.detail {
             this.item = item;
         }
 
-        public layout() {
+        public layout(): wemQ.Promise<any> {
             if (this.item) {
                 this.appendChild(this.item);
             }
+            return wemQ<any>(null);
         }
 
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/WidgetView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/WidgetView.ts
@@ -16,6 +16,7 @@ module app.view.detail {
 
         private normalHeightOfContent: number;
 
+        private layoutCallbackFunction: () => void;
 
         constructor(builder: WidgetViewBuilder) {
             super("widget-view");
@@ -23,23 +24,33 @@ module app.view.detail {
             this.detailsPanel = builder.detailsPanel;
             this.widgetName = builder.name;
             this.widgetItemViews = builder.widgetItemViews;
+            this.layoutCallbackFunction = builder.layoutCallbackFunction;
 
             if (builder.useToggleButton) {
                 this.initWidgetToggleButton();
             }
-            this.layout();
+
+            this.layout().done(() => {
+                if (this.layoutCallbackFunction) {
+                    this.layoutCallbackFunction();
+                }
+            });
         }
 
-        public layout() {
+        public layout(): wemQ.Promise<any> {
 
             this.slideOut();
+
+            var layoutTasks: wemQ.Promise<any>[] = [];
 
             if (this.widgetItemViews) {
                 this.widgetItemViews.forEach((itemView: WidgetItemView) => {
                     this.appendChild(itemView);
-                    itemView.layout();
+                    layoutTasks.push(itemView.layout());
                 })
             }
+
+            return wemQ.all(layoutTasks);
         }
 
         private initWidgetToggleButton() {
@@ -106,6 +117,8 @@ module app.view.detail {
 
         widgetItemViews: WidgetItemView[] = [];
 
+        layoutCallbackFunction: () => void;
+
         public setName(name: string): WidgetViewBuilder {
             this.name = name;
             return this;
@@ -128,6 +141,11 @@ module app.view.detail {
 
         public setWidgetItemViews(widgetItemViews: WidgetItemView[]): WidgetViewBuilder {
             this.widgetItemViews = widgetItemViews;
+            return this;
+        }
+
+        public setLayoutCallbackFunction(layoutCallbackFunction: () => void): WidgetViewBuilder {
+            this.layoutCallbackFunction = layoutCallbackFunction;
             return this;
         }
 


### PR DESCRIPTION
- Added wemQ chaining of layout calls for each WidgetItemView to allow WidgetView track ending of all its children' layout methods. WidgetItemView layout method might take a while due to need to make a back-end request.
- Added layoutCallbackFunction to WidgetView that will fire when all children Layout() methods will end up completely