### PR TITLE
XP-1987 Content still is selected when 'icon-remove' clicked in the C…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/BrowseItemPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/BrowseItemPanel.ts
@@ -55,5 +55,9 @@ module api.app.browse {
         getStatisticsItem(): api.app.view.ViewItem<M> {
             return this.itemStatisticsPanel.getItem();
         }
+
+        onDeselected(listener: (event: ItemDeselectedEvent<M>)=>void) {
+            this.itemsSelectionPanel.onDeselected(listener);
+        }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/BrowseItemsSelectionPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/BrowseItemsSelectionPanel.ts
@@ -31,6 +31,7 @@ module api.app.browse {
 
             var removeCallback = () => {
                 this.removeItem(item);
+                this.notifyDeselected(item);
             };
             var selectionItem = new SelectionItem(this.createItemViewer(item), item, removeCallback);
 
@@ -52,8 +53,6 @@ module api.app.browse {
             if (this.items.length === 0) {
                 this.getEl().addClass('no-selection').setInnerHtml(this.messageForNoSelection);
             }
-
-            // this.notifyDeselected(item);
         }
 
         getItems(): BrowseItem<M>[] {
@@ -114,6 +113,16 @@ module api.app.browse {
                 }
             }
             return -1;
+        }
+
+        onDeselected(listener: (event: ItemDeselectedEvent<M>)=>void) {
+            this.deselectedListeners.push(listener);
+        }
+
+        private notifyDeselected(item: BrowseItem<M>) {
+            this.deselectedListeners.forEach((listener: (event: ItemDeselectedEvent<M>)=>void) => {
+                listener.call(this, new ItemDeselectedEvent(item));
+            });
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/BrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/BrowsePanel.ts
@@ -56,6 +56,10 @@ module api.app.browse {
             this.browseItemPanel = params.browseItemPanel;
             this.filterPanel = params.filterPanel;
 
+            this.browseItemPanel.onDeselected((event: ItemDeselectedEvent<M>) => {
+                this.treeGrid.deselectNode(event.getBrowseItem().getId());
+            });
+
             this.gridAndToolbarContainer = new api.ui.panel.Panel();
 
             var gridPanel = new api.ui.panel.Panel();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/SelectionItem.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/SelectionItem.ts
@@ -17,7 +17,7 @@ module api.app.browse {
 
         private initRemoveButton(callback?: () => void) {
             this.removeEl = new api.dom.DivEl("icon remove");
-            this.removeEl.onClicked((event: MouseEvent) => {
+            this.removeEl.onClicked(() => {
                 if (callback) {
                     callback();
                 }


### PR DESCRIPTION
…ontentBrowseItemsSelectionPanel

Restore the deselection listeners, that were removed in "XP-342 Content info shown in the ContentItemStatisticsPanel, when when grid item not selected".
Move `notifyDeselected` call from `BrowseItemsSelectionPanel.removeItem()` to remove callback.