### PR TITLE
XP-1948 ContentDeleteDialog - Wrong number of items to delete

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
@@ -157,6 +157,10 @@ module app {
                     });
 
                     this.addWizardPanel(tabMenuItem, wizard);
+
+                    if (newContentEvent.getContentType().isSite() && this.getBrowsePanel()) {
+                        this.getBrowsePanel().getTreeGrid().reload(); // reload content grid to show that site has underlying folders
+                    }
                 }).catch((reason: any) => {
                     api.DefaultErrorHandler.handle(reason);
                 }).finally(() => {


### PR DESCRIPTION
- Made tree grid to reload on new content event, if content's type is Site