### PR TITLE
XP-2035 Detail panel - Contents disappear after modifying an item

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
@@ -114,6 +114,10 @@ module app.browse {
 
             this.subscribeDetailsPanelsOnEvents(nonMobileDetailsPanelsManager);
 
+            this.onShown(() => {
+                nonMobileDetailsPanelsManager.getActivePanel().updateWidgetsHeights();
+            });
+
             this.toolbar.appendChild(nonMobileDetailsPanelsManager.getToggleButton());
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/MobileContentItemStatisticsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/MobileContentItemStatisticsPanel.ts
@@ -89,6 +89,7 @@ module app.view {
                     this.setName(this.makeDisplayName(item));
                 }
             }
+            this.detailsPanel.updateWidgetsHeights();
             this.slideIn();
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/DetailsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/DetailsPanel.ts
@@ -236,7 +236,7 @@ module app.view.detail {
             this.updateCustomWidgets();
         }
 
-        private updateWidgetsHeights() {
+        updateWidgetsHeights() {
             this.widgetViews.forEach((widgetView: WidgetView) => {
                 this.updateWidgetHeight(widgetView);
             });


### PR DESCRIPTION
- Made non-mobile details panel to recalculate widgets heights on shown event and mobile panel to  recalculate widgets heights each time item is about to be shown