### PR TITLE
XP-2091 IE 11 - Error when closing and saving content with unsaved ch…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/PageComponentsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/PageComponentsView.ts
@@ -27,6 +27,8 @@ module app.wizard {
         private liveEditPage: LiveEditPageProxy;
         private contextMenu: api.liveedit.ItemViewContextMenu;
 
+        private responsiveItem: ResponsiveItem;
+
         private tree: PageComponentsTreeGrid;
         private header: api.dom.H3El;
         private modal: boolean;
@@ -67,7 +69,7 @@ module app.wizard {
                 this.constrainToParent();
             });
 
-            ResponsiveManager.onAvailableSizeChanged(api.dom.Body.get(), (item: ResponsiveItem) => {
+            this.responsiveItem = ResponsiveManager.onAvailableSizeChanged(api.dom.Body.get(), (item: ResponsiveItem) => {
                 var smallSize = item.isInRangeOrSmaller(ResponsiveRanges._360_540);
                 if (!smallSize && this.isVisible()) {
                     this.constrainToParent();
@@ -85,6 +87,10 @@ module app.wizard {
             } else if (this.tree) {
                 this.tree.setPageView(pageView);
             }
+
+            this.pageView.onRemoved(() => {
+                ResponsiveManager.unAvailableSizeChangedByItem(this.responsiveItem);
+            })
         }
 
         setContent(content: Content) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/responsive/ResponsiveManager.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/responsive/ResponsiveManager.ts
@@ -37,6 +37,20 @@ module api.ui.responsive {
             });
         }
 
+        static unAvailableSizeChangedByItem(item: ResponsiveItem) {
+
+            ResponsiveManager.responsiveListeners =
+            ResponsiveManager.responsiveListeners.filter((curr) => {
+                if (curr.getItem() === item) {
+                    ResponsiveManager.window.getHTMLElement().removeEventListener('availablesizechange', curr.getListener());
+                    ResponsiveManager.window.unResized(curr.getListener());
+                    return false;
+                } else {
+                    return true;
+                }
+            });
+        }
+
         // Manual event triggering
         static fireResizeEvent() {
             var customEvent = document.createEvent('Event');


### PR DESCRIPTION
…anges

- Each time content edit was open new PageComponentsView was created and  onAvaialbleSizeChanged listener added but old ones were not removed. Chrome and FF were OK about that but IE could not reach objects created in removed iframe. Removed onAvaialbleSizeChanged listener that was redundant after content edit tab is closed.