### PR TITLE
XP-1428 Tab not closed, but content was deleted

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/remove/ContentDeleteDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/remove/ContentDeleteDialog.ts
@@ -7,6 +7,7 @@ module app.remove {
     import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
     import ContentPath = api.content.ContentPath;
     import DialogButton = api.ui.dialog.DialogButton;
+    import ContentId = api.content.ContentId;
 
     export class ContentDeleteDialog extends api.app.remove.DeleteDialog {
 
@@ -22,6 +23,12 @@ module app.remove {
             this.getDeleteAction().onExecuted(() => {
 
                 this.createDeleteRequest().sendAndParse().then((result: api.content.DeleteContentResult) => {
+                    result.getDeleted().forEach((deleted) => {
+                        new api.content.ContentDeletedEvent(new ContentId(deleted.getId())).fire();
+                    });
+                    result.getPendings().forEach((pending) => {
+                        new api.content.ContentDeletedEvent(new ContentId(pending.getId()), true).fire();
+                    });
                     this.close();
                     app.view.DeleteAction.showDeleteResult(result);
                 }).catch((reason: any) => {

--- a/modules/core/core-impl/src/test/java/com/enonic/xp/core/impl/content/DeleteContentCommandTest.java
+++ b/modules/core/core-impl/src/test/java/com/enonic/xp/core/impl/content/DeleteContentCommandTest.java
@@ -15,10 +15,12 @@ import com.enonic.xp.content.DeleteContentParams;
 import com.enonic.xp.event.EventPublisher;
 import com.enonic.xp.node.FindNodesByParentParams;
 import com.enonic.xp.node.FindNodesByParentResult;
+import com.enonic.xp.node.FindNodesByQueryResult;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeComparison;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodePath;
+import com.enonic.xp.node.NodeQuery;
 import com.enonic.xp.node.NodeService;
 import com.enonic.xp.node.NodeState;
 import com.enonic.xp.node.Nodes;
@@ -71,6 +73,8 @@ public class DeleteContentCommandTest
                 create().
                 addUpdatedNode( node ).
                 build() );
+
+        Mockito.when( this.nodeService.findByQuery( Mockito.isA( NodeQuery.class ) ) ).thenReturn( FindNodesByQueryResult.create().build() );
 
         Mockito.when( this.translator.fromNodes( Nodes.from( node ), false ) ).thenReturn( Contents.create().
             add( Content.create().

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/ContentServiceImplTest_delete.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/ContentServiceImplTest_delete.java
@@ -103,7 +103,7 @@ public class ContentServiceImplTest_delete
         final Contents deletedContents =
             this.contentService.delete( DeleteContentParams.create().contentPath( content.getPath() ).build() );
         assertNotNull( deletedContents );
-        assertEquals( Contents.from( content ), deletedContents );
+        assertEquals( Contents.from( content, child1Content, child2Content, subChildContent ), deletedContents );
 
         //Checks that the content and the children are deleted
         final GetContentByIdsParams getContentByIdsParams = new GetContentByIdsParams(
@@ -268,13 +268,23 @@ public class ContentServiceImplTest_delete
 
         refresh();
 
+        //Creates an child that we wont publish
+        final Content unpublishedChildContent2 = this.contentService.create( CreateContentParams.create().
+            contentData( new PropertyTree() ).
+            displayName( "Unpublished Child Content 2" ).
+            parent( unpublishedChildContent.getPath() ).
+            type( ContentTypeName.folder() ).
+            build() );
+
+        refresh();
+
         //Deletes the root content
         final Contents deletedContents = this.contentService.delete( DeleteContentParams.create().
             contentPath( parent.getPath() ).
             build() );
 
         assertNotNull( deletedContents );
-        assertEquals( 3, deletedContents.getSize() );
+        assertEquals( 4, deletedContents.getSize() );
 
         DeleteContentParams.create().
             contentPath( parent.getPath() ).
@@ -282,7 +292,8 @@ public class ContentServiceImplTest_delete
 
         for ( Content deletedContent : deletedContents )
         {
-            if ( unpublishedChildContent.getId().equals( deletedContent.getId() ) )
+            if ( unpublishedChildContent.getId().equals( deletedContent.getId() ) ||
+                unpublishedChildContent2.getId().equals( deletedContent.getId() ) )
             {
                 assertTrue( ContentState.DEFAULT == deletedContent.getContentState() );
             }


### PR DESCRIPTION
- Adjusted DeleteContentCommand to return info for all deleted nodes with status NEW, just like it does for nodes with other statuses.
- Adjusted tests.
- Made delete dialog to fire deleted event for each deleted node which enables closing of wizard editors for those nodes.