### PR TITLE
XP-2100 IE 11 - Links are clickable in Live Edit

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveEditPageProxy.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveEditPageProxy.ts
@@ -241,6 +241,7 @@ module app.wizard.page {
 
                 if (api.BrowserHelper.isIE()) {
                     this.resetObjectsAfterFrameReloadForIE();
+                    this.disableLinksInLiveEditForIE();
                 }
                 new api.liveedit.InitializeLiveEditEvent(this.liveEditModel).fire(this.liveEditWindow);
             }
@@ -704,6 +705,10 @@ module app.wizard.page {
                 var regions = api.content.page.region.Regions.create().fromJson(this.regionsCopyForIE, null).build();
                 this.liveEditModel.getPageModel().setRegions(regions);
             }
+        }
+
+        private disableLinksInLiveEditForIE() {
+            this.livejq("a").attr("disabled", "disabled"); // this works only in IE
         }
 
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/live-edit.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/live-edit.less
@@ -17,3 +17,6 @@ a {
     pointer-events: none;
 }
 
+a[disabled] {
+    cursor: move; //IE fix XP-2100
+}


### PR DESCRIPTION
- CSS pointer-events is supposed to work in IE 11 http://caniuse.com/#feat=pointer-events but as always there are issues - Does not work on links in IE11 unless display is set to block or inline-block. So our pointer-events: none not working in IE because of display css. Implemented workaround that disables links in Live Edit for IE only and adjusted styling a bit. One small thing that will remain is link's color change on hover.