### PR TITLE
XP-2121 IE 11 - HTTP requests caching issues

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/BrowserHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/BrowserHelper.ts
@@ -12,6 +12,8 @@ module api {
 
         private static BROWSER_VERSION: string;
 
+        private static IS_IE: boolean = false;
+
         static isAvailableBrowser(): boolean {
             if (!BrowserHelper.BROWSER_NAME) {
                 this.init();
@@ -46,9 +48,7 @@ module api {
                 this.init();
             }
 
-            return BrowserHelper.BROWSER_NAME === BrowserName.TRIDENT ||
-                   BrowserHelper.BROWSER_NAME === BrowserName.MSIE ||
-                   navigator.userAgent.indexOf('Edge/') > 0;
+            return BrowserHelper.IS_IE;
         }
 
         private static init() {
@@ -58,6 +58,10 @@ module api {
 
             BrowserHelper.AVAILABLE_VERSIONS[BrowserName.CHROME] = "39";
             BrowserHelper.AVAILABLE_VERSIONS[BrowserName.FIREFOX] = "27";
+
+            BrowserHelper.IS_IE = BrowserHelper.BROWSER_NAME === BrowserName.TRIDENT ||
+                                  BrowserHelper.BROWSER_NAME === BrowserName.MSIE ||
+                                  navigator.userAgent.indexOf('Edge/') > 0;
 
         }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/rest/JsonRequest.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/rest/JsonRequest.ts
@@ -81,6 +81,10 @@ module api.rest {
             request.open(this.method, api.util.UriHelper.getUri(this.path.toString()) + '?' + paramString, true);
             request.timeout = this.timeoutMillis;
             request.setRequestHeader("Accept", "application/json");
+            if (api.BrowserHelper.isIE()) {
+                request.setRequestHeader("Pragma", "no-cache");
+                request.setRequestHeader("Cache-Control", "no-cache");
+            }
             return request;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/system/StatusRequest.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/system/StatusRequest.ts
@@ -7,7 +7,7 @@ module api.system {
         }
 
         getParams(): Object {
-            return {"cb": Date.now()}; //adding cache breaker for ie
+            return {};
         }
 
         sendAndParse(): wemQ.Promise<StatusResult> {


### PR DESCRIPTION
- Added 'Cache-Control' and 'Pragma' headers with 'no-cache' value for IE requests to prevent caching http GET requests ( not cached by default  in FF and Chrome)
- Removed changes made in XP-2046 as no-cache headers will cover XP-2046 specific case
- Updated browser helper to store static boolean variable indicating if browser is IE or not to not evaluate each time