### PR TITLE
XP-2133 IE 11 - Styling/appearance issue when pressing launcher butto…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/app-launcher/js/app/home/HomeMainContainer.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/app-launcher/js/app/home/HomeMainContainer.ts
@@ -43,8 +43,7 @@ module app.home {
             this.appendChild(this.centerPanel);
 
             this.onAdded(() => {
-                // See `.home-main-container .lazy-image` content property
-                lazyImage.setSrc(lazyImage.getEl().getComputedProperty("content").slice(1, -1));
+                lazyImage.setSrc("/admin/common/images/background-1920.jpg");
             });
 
             LogOutEvent.on(() => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/launcher/launcher.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/launcher/launcher.less
@@ -34,10 +34,6 @@ html, body {
   -o-background-size: cover;
   background-size: cover;
 
-  .lazy-image {
-    content: "/admin/common/images/background-1920.jpg";
-  }
-
   a {
     color: @admin-white;
     text-decoration: none;


### PR DESCRIPTION
…n that brings you to choosing app (Content Manager, Users Applications )

-Background image is set on element only when it has finished loading; to not hardcode appearance related values in ui code image's address was previously saved in css in content attribute (see launcher.less) and that was ok for Chrome and FF, but not for IE. Had to move image's address to code to make work in IE also.