### PR TITLE
XP-2125 ContentWizard: button "Delete" should be disabled, when conte…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
@@ -149,11 +149,15 @@ module app {
                         return;
                     }
 
+                    var newTabId = AppBarTabId.forNew(wizard.getPersistedItem().getContentId().toString());
+
                     tabMenuItem = new AppBarTabMenuItemBuilder().
                         setLabel(api.content.ContentUnnamed.prettifyUnnamed(contentTypeSummary.getDisplayName())).
-                        setTabId(tabId).
+                        setTabId(newTabId).
                         setCloseAction(wizard.getCloseAction()).
                         build();
+
+                    wizard.setTabId(newTabId);
 
                     wizard.onContentNamed((event: ContentNamedEvent) => {
                         this.handleContentNamedEvent(event);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
@@ -277,7 +277,9 @@ module app.wizard {
                         this.wizardActions.getShowSplitEditAction().execute();
                     }
                     else {
-                        this.wizardActions.getShowFormAction().execute();
+                        if (!!this.getSplitPanel()) {
+                            this.wizardActions.getShowFormAction().execute();
+                        }
                     }
 
                     responsiveItem.update();


### PR DESCRIPTION
…nt not saved yet

- Adjusted content app panel to assign id of the newly created content to the wizard editor tab (like it made when pressing edit), which enables it to be found via ContentDeletedEvent handler.
- Fixed undefined problem in the ContentWizardPanel