### PR TITLE
XP-2112 Not possible to delete published content when application is …

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentIconUrlResolver.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentIconUrlResolver.java
@@ -40,4 +40,35 @@ public final class ContentIconUrlResolver
         }
         return this.contentTypeIconUrlResolver.resolve( content.getType() );
     }
+
+    public String resolveOrReturnNull( final Content content )
+    {
+        try
+        {
+            if ( content.hasThumbnail() )
+            {
+                return ServletRequestUrlHelper.createUri(
+                    "/admin/rest/content/icon/" + content.getId() + "?ts=" + content.getModifiedTime().toEpochMilli() );
+            }
+            else if ( content instanceof Media )
+            {
+                final Media media = (Media) content;
+                if ( media.isImage() )
+                {
+                    final Attachment attachment = ( (Media) content ).getMediaAttachment();
+                    if ( attachment != null )
+                    {
+                        return ServletRequestUrlHelper.createUri(
+                            "/admin/rest/content/icon/" + content.getId() + "?ts=" + content.getModifiedTime().toEpochMilli() );
+                    }
+                }
+            }
+            return this.contentTypeIconUrlResolver.resolve( content.getType() );
+        }
+        catch ( final Exception e )
+        {
+            e.printStackTrace();
+        }
+        return null;
+    }
 }

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -487,7 +487,7 @@ public final class ContentResource
                 return ContentPublishItemJson.create().
                     content( content ).
                     compareStatus( compareContentResult.getCompareStatus().name() ).
-                    iconUrl( contentIconUrlResolver.resolve( content ) ).
+                    iconUrl( contentIconUrlResolver.resolveOrReturnNull( content ) ).
                     build();
             } ).
             collect( Collectors.toList() );


### PR DESCRIPTION
…missing

- During publish of Pending delete item that belongs to an application that was removed - ApplicationNotFoundException occurred during resolving icon url. Added method to IconUrlResolver that returns null if its not possible to resolve content icon.