### PR TITLE
XP-2148 Cannot edit links or view source in HtmlAreas in site config.

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
@@ -225,7 +225,8 @@ module api.form.inputtype.text {
         private getToolbarOffsetTop(delta: number = 0): number {
             var toolbar = wemjq(this.getHTMLElement()).closest(".form-panel").find(".wizard-step-navigator-and-toolbar"),
                 stickyToolbarHeight = toolbar.outerHeight(true),
-                stickyToolbarOffset = toolbar.offset().top;
+                offset = toolbar.offset(),
+                stickyToolbarOffset = offset ? offset.top : 0;
 
             return stickyToolbarOffset + stickyToolbarHeight + delta;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/htmlarea/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/htmlarea/ModalDialog.ts
@@ -191,6 +191,7 @@ module api.form.inputtype.text.htmlarea {
             super.close();
             api.dom.Body.get().unKeyDown(this.keyDownListener);
             this.editor.focus();
+            this.remove();
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
@@ -24,6 +24,8 @@ module api.ui.dialog {
 
         private cancelButton: api.ui.button.ActionButton;
 
+        private static openDialogsCounter: number = 0;
+
         constructor(config: ModalDialogConfig) {
             super("modal-dialog");
 
@@ -55,7 +57,7 @@ module api.ui.dialog {
             this.mouseClickListener = (event: MouseEvent) => {
                 if (this.isVisible()) {
                     for (var element = event.target; element; element = (<any>element).parentNode) {
-                        if (element == this.getHTMLElement()) {
+                        if (element == this.getHTMLElement() || this.clickedTinyMceElementThatCanBeIgnored(<any>element)) {
                             return;
                         }
                     }
@@ -77,6 +79,13 @@ module api.ui.dialog {
                     this.centerMyself();
                 }
             });
+        }
+
+        private clickedTinyMceElementThatCanBeIgnored(element: HTMLElement): boolean {
+            if (!!element && !!element.className) {
+                return element.className.indexOf("mce-") > -1 || element.className.indexOf("html-area-modal-dialog") > -1;
+            }
+            return false;
         }
 
         private createDefaultCancelAction() {
@@ -165,11 +174,15 @@ module api.ui.dialog {
 
         close() {
 
-            api.ui.mask.BodyMask.get().hide();
+            if (ModalDialog.openDialogsCounter == 1) {
+                api.ui.mask.BodyMask.get().hide();
+            }
 
             this.hide();
 
             api.ui.KeyBindings.get().unshelveBindings();
+
+            ModalDialog.openDialogsCounter--;
         }
 
         open() {
@@ -181,6 +194,8 @@ module api.ui.dialog {
             this.show();
 
             api.ui.KeyBindings.get().bindKeys(api.ui.Action.getKeyBindings(this.actions));
+
+            ModalDialog.openDialogsCounter++;
         }
     }
 


### PR DESCRIPTION
- Added additional check to Modal Dialog that checks if tinymce element was clicked while dialog is open
- Added counter for number of open dialogs so that we don't hide mask when any of the open dialogs closed
- Added remove() call to HtmlArea.ModalDialog in order to remove HtmlArea dialogs on close - it creates new dialog each time on open anyway, so we do not pollute dom tree with redundant dialog elements (other option would be to init and use single dialog once for each html area option that requires dialog - see openXxxDialog() methods in HtmlArea)