### PR TITLE
XP-2112 Not possible to delete published content when application is …

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -76,6 +76,7 @@ import com.enonic.xp.admin.impl.rest.resource.content.json.ResolvePublishContent
 import com.enonic.xp.admin.impl.rest.resource.content.json.ResolvePublishDependenciesJson;
 import com.enonic.xp.admin.impl.rest.resource.content.json.SetChildOrderJson;
 import com.enonic.xp.admin.impl.rest.resource.content.json.UpdateContentJson;
+import com.enonic.xp.app.ApplicationNotFoundException;
 import com.enonic.xp.attachment.Attachment;
 import com.enonic.xp.attachment.AttachmentNames;
 import com.enonic.xp.attachment.CreateAttachment;
@@ -487,10 +488,23 @@ public final class ContentResource
                 return ContentPublishItemJson.create().
                     content( content ).
                     compareStatus( compareContentResult.getCompareStatus().name() ).
-                    iconUrl( contentIconUrlResolver.resolve( content ) ).
+                    iconUrl( getIconUrl( contentIconUrlResolver, content ) ).
                     build();
             } ).
             collect( Collectors.toList() );
+    }
+
+    private String getIconUrl( final ContentIconUrlResolver contentIconUrlResolver, final Content content )
+    {
+        try
+        {
+            return contentIconUrlResolver.resolve( content );
+        }
+        catch ( final ApplicationNotFoundException exception )
+        {
+            // do nothing - we resolve content of an application that was removed
+        }
+        return null;
     }
 
     @POST


### PR DESCRIPTION
…missing

- During publish of Pending delete item that belongs to an application that was removed - ApplicationNotFoundException occurs during resolving icon url. Wrapped call to resolve() method with try catch.