### PR TITLE
XP-2154 Wrong behavior in Details Panel: DropdownHandle button appear…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/WidgetsSelectionRow.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/detail/WidgetsSelectionRow.ts
@@ -93,8 +93,9 @@ module app.view.detail {
         }
 
         private isDefaultOptionDisplayValueViewer(object: Object) {
-            if (object && object["id"] && object["id"].toString().indexOf("DefaultOptionDisplayValueViewer") > 0) {
-                return true;
+            if (object && object["id"]) {
+                var id = object["id"].toString();
+                return id.indexOf("DropdownHandle") < 0 && id.indexOf("InfoWidgetToggleButton") < 0;
             }
             return false;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/SelectedOptionView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/SelectedOptionView.ts
@@ -2,7 +2,7 @@ module api.ui.selector.dropdown {
 
     import DropdownHandle = api.ui.selector.DropdownHandle;
 
-    export class SelectedOptionView<T> extends api.dom.ButtonEl {
+    export class SelectedOptionView<T> extends api.dom.FormItemEl {
 
         private objectViewer:Viewer<T>;
 
@@ -15,7 +15,7 @@ module api.ui.selector.dropdown {
         private openDropdownListeners: {(): void;}[] = [];
 
         constructor(objectViewer:Viewer<T>) {
-            super("selected-option");
+            super("div", "selected-option");
             this.objectViewer = objectViewer;
             this.dropdownHandle = new DropdownHandle();
             this.optionValueEl = new api.dom.DivEl('option-value');

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/detail/details-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/detail/details-panel.less
@@ -447,6 +447,14 @@
         max-height: 35px;
         display: inline-block;
         border: 0px;
+
+        .option-value {
+          margin: 0px 37px 0px 0px;
+
+          .viewer {
+            line-height: 35px;
+          }
+        }
       }
 
       .viewer {


### PR DESCRIPTION
…s when user clicks on the bottom of the "Version History" option value

- Fixed styling
- Adjusted check for default option clicked
- Made SelectedOptionView to extend FormItemEl instead of ButtonEl as button element blocks child level events, which caused bug with incorrect dropdown behaviour in FF and IE.  No functionality seems affected with this change.