### PR TITLE
XP-2124 Settings step form: incorrect option - (und) present in  "Loc…

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -862,7 +862,15 @@ public final class ContentResource
                     containsIgnoreCase( locale.getDisplayVariant( locale ), trimmedQuery ) ||
                     containsIgnoreCase( locale.getCountry(), trimmedQuery ) ||
                     containsIgnoreCase( locale.getDisplayCountry( locale ), trimmedQuery ) ||
-                    containsIgnoreCase( getFormattedDisplayName( locale ), trimmedQuery ) ).
+                    containsIgnoreCase( getFormattedDisplayName( locale ), trimmedQuery ) &&
+                        StringUtils.isNotEmpty( locale.toLanguageTag() ) && StringUtils.isNotEmpty( locale.getDisplayName() ) ).
+                toArray( Locale[]::new );
+        }
+        else
+        {
+            locales = Arrays.stream( locales ).
+                filter(
+                    ( locale ) -> StringUtils.isNotEmpty( locale.toLanguageTag() ) && StringUtils.isNotEmpty( locale.getDisplayName() ) ).
                 toArray( Locale[]::new );
         }
         return new LocaleListJson( locales );


### PR DESCRIPTION
…aleComboBox"

- Adjusted filter predicate to check if fetched locale values contain tag and display name which are used on front end.