### PR TITLE
XP-2134 BrowsePanel: not all context-menu items displayed if menu ope…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGridContextMenu.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGridContextMenu.ts
@@ -16,5 +16,34 @@ module api.ui.treegrid {
         getActions(): TreeGridActions<any> {
             return this.actions;
         }
+
+        showAt(x: number, y: number) {
+            TreeGridContextMenu.prototype.doMoveTo(this, this.restrainX(x), this.restrainY(y));
+            this.show();
+        }
+
+        private restrainX(x: number): number {
+            let posX = x;
+            let width = this.getEl().getWidthWithBorder();
+            let right = this.getParentElement().getEl().getWidthWithMargin();
+
+            if (posX + width > right) {
+                posX = posX - width;
+            }
+
+            return posX;
+        }
+
+        private restrainY(y: number): number {
+            let posY = y;
+            let height = this.getEl().getHeightWithBorder();
+            let bottom = this.getParentElement().getEl().getHeightWithBorder();
+
+            if (posY + height > bottom) {
+                posY = posY - height;
+            }
+
+            return posY;
+        }
     }
 }


### PR DESCRIPTION
…ned in the bottom of grid

Updated the `TreeGridContextMenu` positioning.