### PR TITLE
XP-2185 Handle relationship and allowType alliases

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/xml/alias/ContentSelectorAliasConverter.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/xml/alias/ContentSelectorAliasConverter.java
@@ -1,0 +1,29 @@
+package com.enonic.xp.xml.alias;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public final class ContentSelectorAliasConverter
+    implements XmlAliasConverter
+{
+
+    public final static ContentSelectorAliasConverter INSTANCE = new ContentSelectorAliasConverter();
+
+    private ContentSelectorAliasConverter()
+    {
+    }
+
+    @Override
+    public String convert( final String alias )
+    {
+        if ( alias.equals( "relationship" ) )
+        {
+            return "relationship-type";
+        }
+        else if ( alias.equals( "allowType" ) )
+        {
+            return "allow-content-type";
+        }
+        return alias;
+    }
+}

--- a/modules/core/core-api/src/main/java/com/enonic/xp/xml/alias/XmlAliasConverter.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/xml/alias/XmlAliasConverter.java
@@ -1,0 +1,9 @@
+package com.enonic.xp.xml.alias;
+
+import com.google.common.annotations.Beta;
+
+@Beta
+public interface XmlAliasConverter
+{
+    String convert( final String alias );
+}

--- a/modules/core/core-api/src/main/java/com/enonic/xp/xml/alias/XmlAliasConverters.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/xml/alias/XmlAliasConverters.java
@@ -1,0 +1,37 @@
+package com.enonic.xp.xml.alias;
+
+import java.util.Map;
+
+import com.google.common.annotations.Beta;
+import com.google.common.collect.Maps;
+
+import com.enonic.xp.inputtype.InputTypeName;
+
+@Beta
+public final class XmlAliasConverters
+{
+    public static XmlAliasConverter DEFAULT_CONVERTER = ( s ) -> s;
+
+    private final Map<InputTypeName, XmlAliasConverter> map;
+
+    private final static XmlAliasConverters INSTANCE = new XmlAliasConverters();
+
+    private XmlAliasConverters()
+    {
+        this.map = Maps.newConcurrentMap();
+        this.map.put( InputTypeName.CONTENT_SELECTOR, ContentSelectorAliasConverter.INSTANCE );
+        this.map.put( InputTypeName.IMAGE_SELECTOR, ContentSelectorAliasConverter.INSTANCE );
+    }
+
+    public static XmlAliasConverter getConverter( final InputTypeName inputTypeName )
+    {
+        XmlAliasConverter result = INSTANCE.map.get( inputTypeName );
+        return result != null ? result : DEFAULT_CONVERTER;
+    }
+
+    public static String convert( final InputTypeName inputTypeName, final String alias )
+    {
+        return getConverter( inputTypeName ).convert( alias );
+    }
+
+}

--- a/modules/core/core-api/src/main/java/com/enonic/xp/xml/parser/XmlFormMapper.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/xml/parser/XmlFormMapper.java
@@ -84,8 +84,9 @@ public final class XmlFormMapper
     private Input buildInputItem( final DomElement root )
     {
         final Input.Builder builder = Input.create();
+        final InputTypeName inputTypeName = InputTypeName.from( root.getAttribute( "type" ) );
 
-        builder.inputType( InputTypeName.from( root.getAttribute( "type" ) ) );
+        builder.inputType( inputTypeName );
         builder.name( root.getAttribute( "name" ) );
         builder.label( root.getChildValue( "label" ) );
         builder.customText( root.getChildValue( "custom-text" ) );
@@ -96,7 +97,7 @@ public final class XmlFormMapper
         builder.validationRegexp( root.getChildValue( "validation-regexp" ) );
         builder.maximizeUIInputWidth( root.getChildValueAs( "maximize", Boolean.class, false ) );
 
-        buildConfig( builder, root.getChild( "config" ) );
+        buildConfig( builder, root.getChild( "config" ), inputTypeName );
 
         return builder.build();
     }
@@ -137,8 +138,11 @@ public final class XmlFormMapper
         return Occurrences.create( min, max );
     }
 
-    private void buildConfig( final Input.Builder builder, final DomElement root )
+    private void buildConfig( final Input.Builder builder, final DomElement root, final InputTypeName inputTypeName )
     {
-        builder.inputTypeConfig( new XmlInputTypeConfigMapper( this.currentApplication ).build( root ) );
+        if ( inputTypeName.equals( InputTypeName.CONTENT_SELECTOR ) || inputTypeName.equals( InputTypeName.IMAGE_SELECTOR ) )
+        {
+            builder.inputTypeConfig( new XmlInputTypeConfigMapper( this.currentApplication, inputTypeName ).build( root ) );
+        }
     }
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/xml/parser/XmlInputTypeConfigMapper.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/xml/parser/XmlInputTypeConfigMapper.java
@@ -8,16 +8,21 @@ import com.google.common.base.Strings;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.app.ApplicationRelativeResolver;
 import com.enonic.xp.inputtype.InputTypeConfig;
+import com.enonic.xp.inputtype.InputTypeName;
 import com.enonic.xp.inputtype.InputTypeProperty;
 import com.enonic.xp.xml.DomElement;
+import com.enonic.xp.xml.alias.XmlAliasConverters;
 
 final class XmlInputTypeConfigMapper
 {
     private final ApplicationRelativeResolver relativeResolver;
 
-    public XmlInputTypeConfigMapper( final ApplicationKey currentApplication )
+    private final InputTypeName inputTypeName;
+
+    public XmlInputTypeConfigMapper( final ApplicationKey currentApplication, final InputTypeName inputTypeName )
     {
         this.relativeResolver = new ApplicationRelativeResolver( currentApplication );
+        this.inputTypeName = inputTypeName;
     }
 
     public InputTypeConfig build( final DomElement root )
@@ -63,12 +68,14 @@ final class XmlInputTypeConfigMapper
 
     private String resolveName( final String name )
     {
-        if ( name.contains( "-" ) )
+        final String result = XmlAliasConverters.convert( this.inputTypeName, name );
+
+        if ( result.contains( "-" ) )
         {
-            return CaseFormat.LOWER_HYPHEN.to( CaseFormat.LOWER_CAMEL, name );
+            return CaseFormat.LOWER_HYPHEN.to( CaseFormat.LOWER_CAMEL, result );
         }
 
-        return name;
+        return result;
     }
 
     private String resolveValue( final String name, final String value )

--- a/modules/core/core-api/src/test/java/com/enonic/xp/xml/alias/XmlAliasConvertersTest.java
+++ b/modules/core/core-api/src/test/java/com/enonic/xp/xml/alias/XmlAliasConvertersTest.java
@@ -1,0 +1,42 @@
+package com.enonic.xp.xml.alias;
+
+
+import org.junit.Test;
+
+import com.enonic.xp.inputtype.InputTypeName;
+
+import static org.junit.Assert.*;
+
+public class XmlAliasConvertersTest
+{
+    @Test
+    public void testConvertersExist()
+    {
+        assertNotNull( XmlAliasConverters.getConverter( InputTypeName.CONTENT_SELECTOR ) );
+        assertNotNull( XmlAliasConverters.getConverter( InputTypeName.from( "some-name" ) ) );
+    }
+
+    @Test
+    public void testContentSelectorConverters()
+    {
+        final String contentType = "allowType";
+        final String relationshipType = "relationship";
+        final String shouldBeUnchanged = "relationshipX";
+        final String result1 = XmlAliasConverters.convert( InputTypeName.CONTENT_SELECTOR, contentType );
+        final String result2 = XmlAliasConverters.convert( InputTypeName.CONTENT_SELECTOR, relationshipType );
+        final String result3 = XmlAliasConverters.convert( InputTypeName.CONTENT_SELECTOR, shouldBeUnchanged );
+
+        assertEquals( "allow-content-type", result1 );
+        assertEquals( "relationship-type", result2 );
+        assertEquals( shouldBeUnchanged, result3 );
+    }
+
+    @Test
+    public void testDefaultConverter()
+    {
+        final String type = "some-type";
+        final String result = XmlAliasConverters.convert( InputTypeName.CONTENT_SELECTOR, type );
+
+        assertEquals( type, result );
+    }
+}

--- a/modules/core/core-api/src/test/java/com/enonic/xp/xml/parser/XmlContentTypeParserTest.java
+++ b/modules/core/core-api/src/test/java/com/enonic/xp/xml/parser/XmlContentTypeParserTest.java
@@ -60,7 +60,7 @@ public class XmlContentTypeParserTest
         assertEquals( false, result.isAbstract() );
         assertEquals( true, result.isFinal() );
 
-        assertEquals( 2, result.getForm().size() );
+        assertEquals( 3, result.getForm().size() );
         assertEquals( "[myapplication:metadata]", result.getMetadata().toString() );
 
         final FormItem item = result.getForm().getFormItem( "myDate" );
@@ -68,6 +68,15 @@ public class XmlContentTypeParserTest
 
         final Input input = (Input) item;
         assertEquals( InputTypeName.DATE.toString(), input.getInputType().toString() );
+
+        final FormItem contentSelectorItem = result.getForm().getFormItem( "someonesParent" );
+        assertNotNull( contentSelectorItem );
+
+        final Input contentSelectorInput = (Input) contentSelectorItem;
+        assertEquals( InputTypeName.CONTENT_SELECTOR.toString(), contentSelectorInput.getInputType().toString() );
+
+        assertEquals( "myapplication:mytype", contentSelectorInput.getInputTypeConfig().getProperty( "allowContentType" ).getValue() );
+        assertEquals( "system:reference", contentSelectorInput.getInputTypeConfig().getProperty( "relationshipType" ).getValue() );
 
         final InputTypeConfig config = input.getInputTypeConfig();
         assertNotNull( config );

--- a/modules/core/core-api/src/test/java/com/enonic/xp/xml/parser/XmlInputTypeConfigMapperTest.java
+++ b/modules/core/core-api/src/test/java/com/enonic/xp/xml/parser/XmlInputTypeConfigMapperTest.java
@@ -10,6 +10,7 @@ import com.google.common.base.Joiner;
 
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.inputtype.InputTypeConfig;
+import com.enonic.xp.inputtype.InputTypeName;
 import com.enonic.xp.inputtype.InputTypeProperty;
 import com.enonic.xp.xml.DomElement;
 import com.enonic.xp.xml.DomHelper;
@@ -41,7 +42,12 @@ public class XmlInputTypeConfigMapperTest
 
     private InputTypeConfig build( final String suffix )
     {
-        final XmlInputTypeConfigMapper mapper = new XmlInputTypeConfigMapper( APP_KEY );
+        return build( suffix, InputTypeName.from( "some-input-type" ) );
+    }
+
+    private InputTypeConfig build( final String suffix, final InputTypeName inputTypeName )
+    {
+        final XmlInputTypeConfigMapper mapper = new XmlInputTypeConfigMapper( APP_KEY, inputTypeName );
         return mapper.build( parse( suffix ) );
     }
 
@@ -96,6 +102,17 @@ public class XmlInputTypeConfigMapperTest
         assertEquals( "other4=[myMixinType=myapp:test]", toString( config.getProperties( "other4" ) ) );
         assertEquals( "other5=[myContentType=myapp:test]", toString( config.getProperties( "other5" ) ) );
         assertEquals( "other6=[myRelationshipType=myapp:test]", toString( config.getProperties( "other6" ) ) );
+    }
+
+    @Test
+    public void parseAliased()
+    {
+        final InputTypeConfig config = build( "aliased.xml", InputTypeName.CONTENT_SELECTOR );
+        assertNotNull( config );
+        assertEquals( 2, config.getSize() );
+
+        assertEquals( "allowContentType=myapp:contentTypeTest[]", toString( config.getProperties( "allowContentType" ) ) );
+        assertEquals( "relationshipType=myapp:relationshipTypeTest[]", toString( config.getProperties( "relationshipType" ) ) );
     }
 
     @Test

--- a/modules/core/core-api/src/test/resources/com/enonic/xp/xml/parser/XmlContentTypeParserTest.xml
+++ b/modules/core/core-api/src/test/resources/com/enonic/xp/xml/parser/XmlContentTypeParserTest.xml
@@ -15,6 +15,14 @@
       <indexed>false</indexed>
       <occurrences minimum="0" maximum="1"/>
     </input>
+    <input type="ContentSelector" name="someonesParent">
+      <label>Someones parent</label>
+      <occurrences minimum="0" maximum="1"/>
+      <config>
+        <relationship>system:reference</relationship>
+        <allowType>mytype</allowType>
+      </config>
+    </input>
     <item-set name="mySet">
       <immutable>false</immutable>
       <occurrences minimum="0" maximum="1"/>

--- a/modules/core/core-api/src/test/resources/com/enonic/xp/xml/parser/XmlInputTypeConfigMapperTest-aliased.xml
+++ b/modules/core/core-api/src/test/resources/com/enonic/xp/xml/parser/XmlInputTypeConfigMapperTest-aliased.xml
@@ -1,0 +1,4 @@
+<config>
+  <allowType>contentTypeTest</allowType>
+  <relationship>relationshipTypeTest</relationship>
+</config>


### PR DESCRIPTION
- For input types of type ContentSelector and ImageSelector made possible to use aliased names for some filter entries.
- Added XmlAliasConverters functionality for converting alias names into basic ones
- Created and adjusted tests