### PR TITLE
XP-1428 Tab not closed, but content was deleted

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
@@ -459,6 +459,7 @@ module app.browse {
 
                         this.updateDetailsPanel(null);
                         new api.content.ContentDeletedEvent(node.getData().getContentSummary().getContentId()).fire();
+                        this.notifyChildrenDeleted(node);
                     }
                 });
 
@@ -476,6 +477,18 @@ module app.browse {
                 return new ContentChangeResult(ContentServerChangeType.DELETE, deleteResult);
             });
             return promise;
+        }
+
+        // this will fire ContentDeletedEvent for children of passed node that were loaded in the grid.
+        private notifyChildrenDeleted(node: TreeNode<ContentSummaryAndCompareStatus>) {
+            var nodeChildren: TreeNode<ContentSummaryAndCompareStatus>[] = node.getChildren();
+            for (var j = 0; j < nodeChildren.length; j++) {
+                var childNode: TreeNode<ContentSummaryAndCompareStatus> = nodeChildren[j];
+                if (childNode.getData() && childNode.getData().getContentSummary()) {
+                    new api.content.ContentDeletedEvent(childNode.getData().getContentSummary().getContentId()).fire();
+                }
+                this.notifyChildrenDeleted(childNode);
+            }
         }
 
         private handleContentPending(change: ContentServerChange, promise: wemQ.Promise<any>,

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
@@ -465,11 +465,12 @@ module app.browse {
                     }
                 } else {
                     for (var j = 0; j < all.length; j++) {
-                        var path = (all[j].getData() && all[j].getData().getContentSummary())
-                            ? all[j].getData().getContentSummary().getPath()
+                        var treeNode = all[j],
+                            path = (treeNode.getData() && treeNode.getData().getContentSummary())
+                                ? treeNode.getData().getContentSummary().getPath()
                             : null;
                         if (path && path.equals(node.getPath())) {
-                            node.getNodes().push(all[j]);
+                            node.getNodes().push(treeNode);
                         }
                     }
                 }
@@ -480,7 +481,6 @@ module app.browse {
 
             return result;
         }
-
 
         xAppendContentNode(relationship: TreeNodeParentOfContent,
                            update: boolean = true): wemQ.Promise<TreeNode<ContentSummaryAndCompareStatus>> {


### PR DESCRIPTION
- Added method to ContentBrowsePanel that will fire DeletedEvent for all child nodes of deleted node that were loaded into the grid.
- For cases when node was not loaded yet into the grid (when you reload browser page with editor tab open), added additional check for all open tabs to identify tabs that are open for non-existent content. That check fires with delay to ensure that deleted nodes that were loaded into grid will triiger tab close before this check.