### PR TITLE
XP-1428 Tab not closed, but content was deleted

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -380,11 +380,12 @@ public final class ContentResource
                 contents.forEach( ( content ) -> {
                     if ( ContentState.PENDING_DELETE.equals( content.getContentState() ) )
                     {
-                        jsonResult.addPending( content.getId().toString(), content.getDisplayName() );
+                        jsonResult.addPending( content.getId().toString(), content.getPath().toString(), content.getDisplayName() );
                     }
                     else
                     {
-                        jsonResult.addSuccess( content.getId().toString(), content.getDisplayName(), content.getType().getLocalName() );
+                        jsonResult.addSuccess( content.getId().toString(), content.getPath().toString(), content.getDisplayName(),
+                                               content.getType().getLocalName() );
                     }
 
                 } );
@@ -397,13 +398,15 @@ public final class ContentResource
                     Content content = contentService.getByPath( contentToDelete );
                     if ( content != null )
                     {
-                        jsonResult.addFailure( content.getId().toString(), content.getDisplayName(), content.getType().getLocalName(),
+                        jsonResult.addFailure( content.getId().toString(), content.getPath().toString(), content.getDisplayName(),
+                                               content.getType().getLocalName(),
                                                e.getMessage() );
                     }
                 }
                 catch ( final Exception e2 )
                 {
-                    jsonResult.addFailure( null, deleteContent.getContentPath().toString(), null, e2.getMessage() );
+                    jsonResult.addFailure( null, deleteContent.getContentPath().toString(), deleteContent.getContentPath().toString(), null,
+                                           e2.getMessage() );
                 }
 
             }

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/DeleteContentResultJson.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/DeleteContentResultJson.java
@@ -27,19 +27,19 @@ public class DeleteContentResultJson
         return failures;
     }
 
-    public void addSuccess( final String id, final String contentName, final String type )
+    public void addSuccess( final String id, final String path, final String contentName, final String type )
     {
-        successes.add( new Success( id, contentName, type ) );
+        successes.add( new Success( id, path, contentName, type ) );
     }
 
-    public void addPending( final String id, final String contentName )
+    public void addPending( final String id, final String path, final String contentName )
     {
-        pendings.add( new Pending( id, contentName ) );
+        pendings.add( new Pending( id, path, contentName ) );
     }
 
-    public void addFailure( final String id, final String contentName, final String type, final String reason )
+    public void addFailure( final String id, final String path, final String contentName, final String type, final String reason )
     {
-        failures.add( new Failure( id, contentName, type, reason ) );
+        failures.add( new Failure( id, path, contentName, type, reason ) );
     }
 
     public class Success
@@ -47,15 +47,18 @@ public class DeleteContentResultJson
 
         private String id;
 
+        private String path;
+
         private String name;
 
         private String type;
 
-        public Success( final String id, final String contentName, final String type )
+        public Success( final String id, final String path, final String contentName, final String type )
         {
             this.id = id;
             this.name = contentName;
             this.type = type;
+            this.path = path;
         }
 
         public String getId()
@@ -72,6 +75,11 @@ public class DeleteContentResultJson
         {
             return type;
         }
+
+        public String getPath()
+        {
+            return path;
+        }
     }
 
     public class Pending
@@ -80,10 +88,13 @@ public class DeleteContentResultJson
 
         private String name;
 
-        public Pending( final String id, final String contentName )
+        private String path;
+
+        public Pending( final String id, final String path, final String contentName )
         {
             this.id = id;
             this.name = contentName;
+            this.path = path;
         }
 
         public String getId()
@@ -95,6 +106,11 @@ public class DeleteContentResultJson
         {
             return name;
         }
+
+        public String getPath()
+        {
+            return path;
+        }
     }
 
     public class Failure
@@ -103,9 +119,9 @@ public class DeleteContentResultJson
 
         private String reason;
 
-        public Failure( final String id, final String contentName, final String type, final String reason )
+        public Failure( final String id, final String path, final String contentName, final String type, final String reason )
         {
-            super( id, contentName, type );
+            super( id, path, contentName, type );
             this.reason = reason;
         }
 

--- a/modules/admin/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/delete_content_both.json
+++ b/modules/admin/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/delete_content_both.json
@@ -3,6 +3,7 @@
     {
       "id": "aaa",
       "name": "My Content",
+      "path": "/my_a_content2",
       "reason": "Not able to delete content with path [/two]: Some reason",
       "type": "my_type"
     }
@@ -12,6 +13,7 @@
     {
       "id": "123",
       "name": "one",
+      "path": "/one",
       "type": "unstructured"
     }
   ]

--- a/modules/admin/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/delete_content_failure.json
+++ b/modules/admin/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/delete_content_failure.json
@@ -3,12 +3,14 @@
     {
       "id": "aaa",
       "name": "My Content",
+      "path": "/my_a_content",
       "reason": "Content with path [/one] was not found in branch [draft]",
       "type": "my_type"
     },
     {
       "id": "aaa",
       "name": "My Content",
+      "path": "/my_a_content",
       "reason": "Not able to delete content with path [/two]: Some reason",
       "type": "my_type"
     }

--- a/modules/admin/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/delete_content_success.json
+++ b/modules/admin/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/delete_content_success.json
@@ -5,11 +5,13 @@
     {
       "id": "123",
       "name": "one",
+      "path": "/one",
       "type": "folder"
     },
     {
       "id": "123",
       "name": "one",
+      "path": "/one",
       "type": "folder"
     }
   ]

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
@@ -11,6 +11,7 @@ module app {
     import AppBarTabMenuItem = api.app.bar.AppBarTabMenuItem;
     import AppBarTabMenuItemBuilder = api.app.bar.AppBarTabMenuItemBuilder;
     import ShowBrowsePanelEvent = api.app.ShowBrowsePanelEvent;
+    import ContentDeletedEvent = api.content.ContentDeletedEvent;
 
     export class ContentAppPanel extends api.app.BrowseAndWizardBasedAppPanel<ContentSummaryAndCompareStatus> {
 
@@ -104,14 +105,13 @@ module app {
                 this.handleMove(event);
             });
 
-            api.content.ContentDeletedEvent.on((event: api.content.ContentDeletedEvent) => {
-                if (!event.isPending()) {
-                    var item = this.getNavigator().getNavigationItemByIdValue(event.getContentId().toString());
-                    if (item) {
-                        item.getCloseAction().execute(true);
-                    }
-                }
+            ContentDeletedEvent.on((event: ContentDeletedEvent) => {
+
             });
+        }
+
+        private handleDeleted(event: ContentDeletedEvent) {
+            // do something when content is deleted
         }
 
         private handleUpdated(event: ContentUpdatedEvent) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
@@ -454,13 +454,16 @@ module app.browse {
                 // merge array of nodes arrays
                 merged = merged.concat.apply(merged, nodes);
 
+                var contentDeletedEvent = new api.content.ContentDeletedEvent();
                 merged.forEach((node: TreeNode<ContentSummaryAndCompareStatus>) => {
-                    if (node.getData() && node.getData().getContentSummary()) {
+                    var contentSummary = node.getData().getContentSummary();
+                    if (node.getData() && !!contentSummary) {
 
                         this.updateDetailsPanel(null);
-                        new api.content.ContentDeletedEvent(node.getData().getContentSummary().getContentId()).fire();
+                        contentDeletedEvent.addItem(contentSummary.getContentId(), contentSummary.getPath());
                     }
                 });
+                contentDeletedEvent.fireIfNotEmpty();
 
                 this.contentTreeGrid.xDeleteContentNodes(merged);
 
@@ -495,6 +498,7 @@ module app.browse {
                             return el !== null;
                         })
                 ).then((data: ContentSummaryAndCompareStatus[]) => {
+                        var contentDeletedEvent = new api.content.ContentDeletedEvent();
                         data.forEach((el) => {
                             for (var i = 0; i < pendingResult.length; i++) {
                                 if (pendingResult[i].getId() === el.getId()) {
@@ -502,11 +506,12 @@ module app.browse {
 
                                     this.updateItemInDetailsPanelIfNeeded(el);
 
-                                    new api.content.ContentDeletedEvent(el.getContentId(), true).fire();
+                                    contentDeletedEvent.addPendingItem(el.getContentId(), el.getPath());
                                     break;
                                 }
                             }
                         });
+                        contentDeletedEvent.fireIfNotEmpty();
                         this.contentTreeGrid.invalidate();
                     });
             });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
@@ -465,11 +465,12 @@ module app.browse {
                     }
                 } else {
                     for (var j = 0; j < all.length; j++) {
-                        var path = (all[j].getData() && all[j].getData().getContentSummary())
-                            ? all[j].getData().getContentSummary().getPath()
+                        var treeNode = all[j],
+                            path = (treeNode.getData() && treeNode.getData().getContentSummary())
+                                ? treeNode.getData().getContentSummary().getPath()
                             : null;
                         if (path && path.equals(node.getPath())) {
-                            node.getNodes().push(all[j]);
+                            node.getNodes().push(treeNode);
                         }
                     }
                 }
@@ -480,7 +481,6 @@ module app.browse {
 
             return result;
         }
-
 
         xAppendContentNode(relationship: TreeNodeParentOfContent,
                            update: boolean = true): wemQ.Promise<TreeNode<ContentSummaryAndCompareStatus>> {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/action/DeleteContentAction.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/action/DeleteContentAction.ts
@@ -1,6 +1,7 @@
 module app.wizard.action {
 
     import ContentId = api.content.ContentId;
+    import ContentPath = api.content.ContentPath;
 
     export class DeleteContentAction extends api.ui.Action {
 
@@ -15,13 +16,16 @@ module app.wizard.action {
                             .addContentPath(wizardPanel.getPersistedItem().getPath())
                             .sendAndParse()
                             .then((result: api.content.DeleteContentResult) => {
+                                var contentDeletedEvent = new api.content.ContentDeletedEvent();
                                 app.view.DeleteAction.showDeleteResult(result);
                                 result.getDeleted().forEach((deleted) => {
-                                    new api.content.ContentDeletedEvent(new ContentId(deleted.getId())).fire();
+                                    contentDeletedEvent.addItem(new ContentId(deleted.getId()), ContentPath.fromString(deleted.getPath()));
                                 });
                                 result.getPendings().forEach((pending) => {
-                                    new api.content.ContentDeletedEvent(new ContentId(pending.getId()), true).fire();
+                                    contentDeletedEvent.addPendingItem(new ContentId(pending.getId()),
+                                        ContentPath.fromString(pending.getPath()));
                                 });
+                                contentDeletedEvent.fireIfNotEmpty();
                             }).catch((reason: any) => {
                                 if (reason && reason.message) {
                                     api.notify.showError(reason.message);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentDeletedEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentDeletedEvent.ts
@@ -1,27 +1,35 @@
 module api.content {
 
-    export interface ContentDeletedEventJson {
-        contentId: string;
-    }
-
     export class ContentDeletedEvent extends api.event.Event {
 
-        private contentId: api.content.ContentId;
+        private contentDeletedItems: ContentDeletedItem[] = [];
 
-        private pending: boolean;
-
-        constructor(contentId: api.content.ContentId, pending: boolean = false) {
+        constructor() {
             super();
-            this.contentId = contentId;
-            this.pending = pending;
         }
 
-        public getContentId(): api.content.ContentId {
-            return this.contentId;
+        addItem(contentId: ContentId, contentPath: api.content.ContentPath): ContentDeletedEvent {
+            this.contentDeletedItems.push(new ContentDeletedItem(contentId, contentPath, false));
+            return this;
         }
 
-        public isPending(): boolean {
-            return this.pending;
+        addPendingItem(contentId: ContentId, contentPath: api.content.ContentPath): ContentDeletedEvent {
+            this.contentDeletedItems.push(new ContentDeletedItem(contentId, contentPath, true));
+            return this;
+        }
+
+        getDeleteditems(): ContentDeletedItem[] {
+            return this.contentDeletedItems;
+        }
+
+        isEmpty(): boolean {
+            return this.contentDeletedItems.length == 0;
+        }
+
+        fireIfNotEmpty() {
+            if (!this.isEmpty()) {
+                this.fire();
+            }
         }
 
         static on(handler: (event: ContentDeletedEvent) => void) {
@@ -31,9 +39,32 @@ module api.content {
         static un(handler?: (event: ContentDeletedEvent) => void) {
             api.event.Event.unbind(api.ClassHelper.getFullName(this), handler);
         }
+    }
 
-        static fromJson(json: ContentDeletedEventJson): ContentDeletedEvent {
-            return new ContentDeletedEvent(new ContentId(json.contentId));
+    export class ContentDeletedItem {
+
+        private contentPath: api.content.ContentPath;
+
+        private pending: boolean;
+
+        private contentId: ContentId
+
+        constructor(contentId: ContentId, contentPath: api.content.ContentPath, pending: boolean = false) {
+            this.contentPath = contentPath;
+            this.pending = pending;
+            this.contentId = contentId;
+        }
+
+        public getContentPath(): ContentPath {
+            return this.contentPath;
+        }
+
+        public getContentId(): ContentId {
+            return this.contentId;
+        }
+
+        public isPending(): boolean {
+            return this.pending;
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/DeleteContentResult.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/DeleteContentResult.ts
@@ -28,15 +28,15 @@ module api.content {
         static fromJson(json: DeleteContentResultJson): DeleteContentResult {
             if (json.successes) {
                 var success: DeleteContentResultSuccess[] = json.successes.
-                    map((success) => new DeleteContentResultSuccess(success.id, success.name, success.type));
+                    map((success) => new DeleteContentResultSuccess(success.id, success.path, success.name, success.type));
             }
             if (json.pendings) {
                 var pending: DeleteContentResultPending[] = json.pendings.
-                    map((pending) => new DeleteContentResultPending(pending.id, pending.name));
+                    map((pending) => new DeleteContentResultPending(pending.id, pending.path, pending.name));
             }
             if (json.failures) {
                 var failure: DeleteContentResultFailure[] = json.failures.
-                    map((failure) => new DeleteContentResultFailure(failure.id, failure.name, failure.type, failure.reason));
+                    map((failure) => new DeleteContentResultFailure(failure.id, failure.path, failure.name, failure.type, failure.reason));
             }
             return new DeleteContentResult(success, pending, failure);
         }
@@ -46,17 +46,23 @@ module api.content {
     export class DeleteContentResultSuccess {
 
         private id: string;
+        private path: string;
         private name: string;
         private type: string;
 
-        constructor(id: string, name: string, type: string) {
+        constructor(id: string, path: string, name: string, type: string) {
             this.id = id;
             this.name = name;
             this.type = type;
+            this.path = path;
         }
 
         getId(): string {
             return this.id;
+        }
+
+        getPath(): string {
+            return this.path;
         }
 
         getName(): string {
@@ -71,15 +77,21 @@ module api.content {
     export class DeleteContentResultPending {
 
         private id: string;
+        private path: string;
         private name: string;
 
-        constructor(id: string, name: string) {
+        constructor(id: string, path: string, name: string) {
             this.id = id;
             this.name = name;
+            this.path = path;
         }
 
         getId(): string {
             return this.id;
+        }
+
+        getPath(): string {
+            return this.path;
         }
 
         getName(): string {
@@ -91,8 +103,8 @@ module api.content {
 
         private reason: string;
 
-        constructor(id: string, name: string, type: string, reason: string) {
-            super(id, name, type);
+        constructor(id: string, path: string, name: string, type: string, reason: string) {
+            super(id, path, name, type);
             this.reason = reason;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/DeleteContentResultJson.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/DeleteContentResultJson.ts
@@ -2,10 +2,10 @@ module api.content {
 
     export interface DeleteContentResultJson {
 
-        successes: {id:string; name:string; type:string}[];
+        successes: {id:string; path: string; name:string; type:string}[];
 
-        pendings: {id:string; name:string}[];
+        pendings: {id:string; path: string; name:string}[];
 
-        failures: {id:string; name:string; type:string; reason:string}[];
+        failures: {id:string; path: string; name:string; type:string; reason:string}[];
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -27,10 +27,6 @@ module api.content.form.inputtype.image {
     import FileUploadCompleteEvent = api.ui.uploader.FileUploadCompleteEvent;
     import FileUploadFailedEvent = api.ui.uploader.FileUploadFailedEvent;
 
-    export interface ImageSelectorConfig {
-        relationshipType: string
-    }
-
     export class ImageSelector extends api.form.inputtype.support.BaseInputTypeManagingAdd<ContentId> {
 
         private config: api.content.form.inputtype.ContentInputTypeViewContext;
@@ -76,11 +72,15 @@ module api.content.form.inputtype.image {
             });
 
             api.content.ContentDeletedEvent.on((event) => {
-                var deleted = event.getContentId();
-                var option = this.selectedOptionsView.getById(deleted.toString());
-                if (option != null) {
-                    this.selectedOptionsView.removeSelectedOptions([option]);
-                }
+                event.getDeleteditems().filter((deletedItem) => {
+                    return !!deletedItem;
+                }).forEach((deletedItem) => {
+
+                    var option = this.selectedOptionsView.getById(deletedItem.getContentId().toString());
+                    if (option != null) {
+                        this.selectedOptionsView.removeSelectedOptions([option]);
+                    }
+                });
             });
 
         }


### PR DESCRIPTION
- Adjusted ContentDeletedEvent to contain an array of ContentDeletedItems. ContentDeletedItem contains both id and path of deleted item to satisfy whoever handles this event.
- Adjusted DeleteContentResultJson to contain path.
- Made ContentWizardPanel to close itself on receiving ContentDeleteEvent after check for being equal or descendant of deleted item