### PR TITLE
XP-2222 NamesView: character 'g' not fully displayed

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/treegrid/tree-grid.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/treegrid/tree-grid.less
@@ -138,7 +138,11 @@
             line-height: 36px;
           }
           .names-view {
-            margin-top: 3px;
+            margin-top: 1px;
+            .main-name {
+              height: 18px;
+              line-height: 18px;
+            }
           }
 
         }


### PR DESCRIPTION
Fixed the `names-view` styling in grid.