### PR TITLE
XP-1428 Tab not closed, but content was deleted

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
@@ -11,6 +11,7 @@ module app {
     import AppBarTabMenuItem = api.app.bar.AppBarTabMenuItem;
     import AppBarTabMenuItemBuilder = api.app.bar.AppBarTabMenuItemBuilder;
     import ShowBrowsePanelEvent = api.app.ShowBrowsePanelEvent;
+    import ContentDeletedEvent = api.content.ContentDeletedEvent;
 
     export class ContentAppPanel extends api.app.BrowseAndWizardBasedAppPanel<ContentSummaryAndCompareStatus> {
 
@@ -104,14 +105,13 @@ module app {
                 this.handleMove(event);
             });
 
-            api.content.ContentDeletedEvent.on((event: api.content.ContentDeletedEvent) => {
-                if (!event.isPending()) {
-                    var item = this.getNavigator().getNavigationItemByIdValue(event.getContentId().toString());
-                    if (item) {
-                        item.getCloseAction().execute(true);
-                    }
-                }
+            ContentDeletedEvent.on((event: ContentDeletedEvent) => {
+
             });
+        }
+
+        private handleDeleted(event: ContentDeletedEvent) {
+            // do something when content is deleted
         }
 
         private handleUpdated(event: ContentUpdatedEvent) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentBrowsePanel.ts
@@ -454,13 +454,16 @@ module app.browse {
                 // merge array of nodes arrays
                 merged = merged.concat.apply(merged, nodes);
 
+                var contentDeletedEvent = new api.content.ContentDeletedEvent();
                 merged.forEach((node: TreeNode<ContentSummaryAndCompareStatus>) => {
-                    if (node.getData() && node.getData().getContentSummary()) {
+                    var contentSummary = node.getData().getContentSummary();
+                    if (node.getData() && !!contentSummary) {
 
                         this.updateDetailsPanel(null);
-                        new api.content.ContentDeletedEvent(node.getData().getContentSummary().getContentId()).fire();
+                        contentDeletedEvent.addItem(contentSummary.getContentId(), contentSummary.getPath());
                     }
                 });
+                contentDeletedEvent.fireIfNotEmpty();
 
                 this.contentTreeGrid.xDeleteContentNodes(merged);
 
@@ -495,6 +498,7 @@ module app.browse {
                             return el !== null;
                         })
                 ).then((data: ContentSummaryAndCompareStatus[]) => {
+                        var contentDeletedEvent = new api.content.ContentDeletedEvent();
                         data.forEach((el) => {
                             for (var i = 0; i < pendingResult.length; i++) {
                                 if (pendingResult[i].getId() === el.getId()) {
@@ -502,11 +506,12 @@ module app.browse {
 
                                     this.updateItemInDetailsPanelIfNeeded(el);
 
-                                    new api.content.ContentDeletedEvent(el.getContentId(), true).fire();
+                                    contentDeletedEvent.addPendingItem(el.getContentId(), el.getPath());
                                     break;
                                 }
                             }
                         });
+                        contentDeletedEvent.fireIfNotEmpty();
                         this.contentTreeGrid.invalidate();
                     });
             });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
@@ -465,11 +465,12 @@ module app.browse {
                     }
                 } else {
                     for (var j = 0; j < all.length; j++) {
-                        var path = (all[j].getData() && all[j].getData().getContentSummary())
-                            ? all[j].getData().getContentSummary().getPath()
+                        var treeNode = all[j],
+                            path = (treeNode.getData() && treeNode.getData().getContentSummary())
+                                ? treeNode.getData().getContentSummary().getPath()
                             : null;
                         if (path && path.equals(node.getPath())) {
-                            node.getNodes().push(all[j]);
+                            node.getNodes().push(treeNode);
                         }
                     }
                 }
@@ -480,7 +481,6 @@ module app.browse {
 
             return result;
         }
-
 
         xAppendContentNode(relationship: TreeNodeParentOfContent,
                            update: boolean = true): wemQ.Promise<TreeNode<ContentSummaryAndCompareStatus>> {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/action/DeleteContentAction.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/action/DeleteContentAction.ts
@@ -1,6 +1,7 @@
 module app.wizard.action {
 
     import ContentId = api.content.ContentId;
+    import ContentPath = api.content.ContentPath;
 
     export class DeleteContentAction extends api.ui.Action {
 
@@ -14,15 +15,7 @@ module app.wizard.action {
                         new api.content.DeleteContentRequest()
                             .addContentPath(wizardPanel.getPersistedItem().getPath())
                             .sendAndParse()
-                            .then((result: api.content.DeleteContentResult) => {
-                                app.view.DeleteAction.showDeleteResult(result);
-                                result.getDeleted().forEach((deleted) => {
-                                    new api.content.ContentDeletedEvent(new ContentId(deleted.getId())).fire();
-                                });
-                                result.getPendings().forEach((pending) => {
-                                    new api.content.ContentDeletedEvent(new ContentId(pending.getId()), true).fire();
-                                });
-                            }).catch((reason: any) => {
+                            .catch((reason: any) => {
                                 if (reason && reason.message) {
                                     api.notify.showError(reason.message);
                                 } else {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentDeletedEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentDeletedEvent.ts
@@ -1,27 +1,35 @@
 module api.content {
 
-    export interface ContentDeletedEventJson {
-        contentId: string;
-    }
-
     export class ContentDeletedEvent extends api.event.Event {
 
-        private contentId: api.content.ContentId;
+        private contentDeletedItems: ContentDeletedItem[] = [];
 
-        private pending: boolean;
-
-        constructor(contentId: api.content.ContentId, pending: boolean = false) {
+        constructor() {
             super();
-            this.contentId = contentId;
-            this.pending = pending;
         }
 
-        public getContentId(): api.content.ContentId {
-            return this.contentId;
+        addItem(contentId: ContentId, contentPath: api.content.ContentPath): ContentDeletedEvent {
+            this.contentDeletedItems.push(new ContentDeletedItem(contentId, contentPath, false));
+            return this;
         }
 
-        public isPending(): boolean {
-            return this.pending;
+        addPendingItem(contentId: ContentId, contentPath: api.content.ContentPath): ContentDeletedEvent {
+            this.contentDeletedItems.push(new ContentDeletedItem(contentId, contentPath, true));
+            return this;
+        }
+
+        getDeleteditems(): ContentDeletedItem[] {
+            return this.contentDeletedItems;
+        }
+
+        isEmpty(): boolean {
+            return this.contentDeletedItems.length == 0;
+        }
+
+        fireIfNotEmpty() {
+            if (!this.isEmpty()) {
+                this.fire();
+            }
         }
 
         static on(handler: (event: ContentDeletedEvent) => void) {
@@ -31,9 +39,32 @@ module api.content {
         static un(handler?: (event: ContentDeletedEvent) => void) {
             api.event.Event.unbind(api.ClassHelper.getFullName(this), handler);
         }
+    }
 
-        static fromJson(json: ContentDeletedEventJson): ContentDeletedEvent {
-            return new ContentDeletedEvent(new ContentId(json.contentId));
+    export class ContentDeletedItem {
+
+        private contentPath: api.content.ContentPath;
+
+        private pending: boolean;
+
+        private contentId: ContentId
+
+        constructor(contentId: ContentId, contentPath: api.content.ContentPath, pending: boolean = false) {
+            this.contentPath = contentPath;
+            this.pending = pending;
+            this.contentId = contentId;
+        }
+
+        public getContentPath(): ContentPath {
+            return this.contentPath;
+        }
+
+        public getContentId(): ContentId {
+            return this.contentId;
+        }
+
+        public isPending(): boolean {
+            return this.pending;
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -27,10 +27,6 @@ module api.content.form.inputtype.image {
     import FileUploadCompleteEvent = api.ui.uploader.FileUploadCompleteEvent;
     import FileUploadFailedEvent = api.ui.uploader.FileUploadFailedEvent;
 
-    export interface ImageSelectorConfig {
-        relationshipType: string
-    }
-
     export class ImageSelector extends api.form.inputtype.support.BaseInputTypeManagingAdd<ContentId> {
 
         private config: api.content.form.inputtype.ContentInputTypeViewContext;
@@ -76,11 +72,15 @@ module api.content.form.inputtype.image {
             });
 
             api.content.ContentDeletedEvent.on((event) => {
-                var deleted = event.getContentId();
-                var option = this.selectedOptionsView.getById(deleted.toString());
-                if (option != null) {
-                    this.selectedOptionsView.removeSelectedOptions([option]);
-                }
+                event.getDeleteditems().filter((deletedItem) => {
+                    return !!deletedItem;
+                }).forEach((deletedItem) => {
+
+                    var option = this.selectedOptionsView.getById(deletedItem.getContentId().toString());
+                    if (option != null) {
+                        this.selectedOptionsView.removeSelectedOptions([option]);
+                    }
+                });
             });
 
         }


### PR DESCRIPTION
- Adjusted ContentDeletedEvent to contain an array of ContentDeletedItems. ContentDeletedItem contains both id and path of deleted item to satisfy whoever handles this event.
- Made ContentWizardPanel to close itself on receiving ContentDeleteEvent after check for being equal or descendant of deleted item