### PR TITLE
XP-2248 Need to click twice for selecting a application in a site-wizard

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/page/PageDescriptorDropdown.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/page/PageDescriptorDropdown.ts
@@ -27,23 +27,33 @@ module api.content.page {
 
             this.initLoader();
 
+
             this.onOptionSelected((event: api.ui.selector.OptionSelectedEvent<api.content.page.PageDescriptor>) => {
                 var pageDescriptor = event.getOption().displayValue;
                 var setController = new SetController(this).setDescriptor(pageDescriptor);
                 model.getPageModel().setController(setController);
             });
 
-            this.siteModel.onApplicationAdded((event: api.content.site.ApplicationAddedEvent) => {
+            var onApplicationAddedHandler = () => {
                 this.getPageDescriptorsByApplicationsRequest.setApplicationKeys(this.siteModel.getApplicationKeys());
                 this.removeAllOptions();
                 this.load();
-            });
+            }
 
-            this.siteModel.onApplicationRemoved((event: api.content.site.ApplicationRemovedEvent) => {
+            var onApplicationRemovedHandler = () => {
                 this.getPageDescriptorsByApplicationsRequest.setApplicationKeys(this.siteModel.getApplicationKeys());
                 this.removeAllOptions();
                 this.load();
-            });
+            }
+
+            this.siteModel.onApplicationAdded(onApplicationAddedHandler);
+
+            this.siteModel.onApplicationRemoved(onApplicationRemovedHandler);
+
+            this.onRemoved(() => {
+                this.siteModel.unApplicationAdded(onApplicationAddedHandler);
+                this.siteModel.unApplicationRemoved(onApplicationRemovedHandler);
+            })
         }
 
         private initLoader() {


### PR DESCRIPTION
-PageDescriptorDropdown is created on live edit page and binds some handlers (onApplicationAdded and onApplicationRemoved) on siteModel during construction. When we press 'save' on content -  live edit page is reloaded, PageDescriptorDropdown is recreated but siteModel is not, so sitemodel keeps some listeners that no longer relevant (created in other iframe). Usually it is not a problem for FF and Chrome to call such a listener that was released by window (but IE will complain and throw error) but not this time: from my observations there was error when creating XMLHttpRequest in JsonRequest in those 'window released' handlers. Small fix - remove those handlers when dropdown removed.