### PR TITLE
XP-2325 Simplify server events handling  code in ContentBrowsePanel

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/ServerEventAggregator.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/ServerEventAggregator.ts
@@ -1,7 +1,5 @@
 module api.app {
 
-    import BatchContentServerEvent = api.content.BatchContentServerEvent;
-
     export class ServerEventAggregator {
 
         private static AGGREGATION_TIMEOUT: number = 500;
@@ -13,7 +11,6 @@ module api.app {
         private batchReadyListeners: {(event):void}[] = [];
 
         private debounced;
-
 
         constructor() {
             this.debounced = api.util.AppHelper.debounce(() => {
@@ -48,10 +45,9 @@ module api.app {
         }
 
         private isTheSameTypeEvent(event: api.content.ContentServerEvent) {
-            var changes = event.getContentChanges();
-            var types = changes.map(change =>  change.getChangeType());
+            var change = event.getContentChange();
 
-            if (types.some(type => this.type != type)) {
+            if (this.type != change.getChangeType()) {
                 return false;
             }
 
@@ -60,8 +56,7 @@ module api.app {
 
         private init(event: api.content.ContentServerEvent) {
             this.events = [event];
-            this.type = event.getContentChanges().length > 0 ?
-                        event.getContentChanges()[0].getChangeType() : null;
+            this.type = !!event.getContentChange() ? event.getContentChange().getChangeType() : null;
         }
 
         onBatchIsReady(listener: (event)=>void) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/ServerEventsConnection.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/ServerEventsConnection.ts
@@ -133,10 +133,10 @@ module api.app {
             }
             if (eventType.indexOf('node.') === 0) {
                 var event = api.content.ContentServerEvent.fromJson(<api.content.NodeEventJson>eventJson);
-                if (event.getContentChanges().length === 0) {
-                    return null;
-                } else {
+                if (!!event.getContentChange()) {
                     return event;
+                } else {
+                    return null;
                 }
             }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentDeletedEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentDeletedEvent.ts
@@ -26,6 +26,12 @@ module api.content {
             return this.contentDeletedItems.length == 0;
         }
 
+        fire() {
+            if (!this.isEmpty()) {
+                super.fire();
+            }
+        }
+
         static on(handler: (event: ContentDeletedEvent) => void) {
             api.event.Event.bind(api.ClassHelper.getFullName(this), handler);
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentServerEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentServerEvent.ts
@@ -16,21 +16,19 @@ module api.content {
 
     export class ContentServerEvent extends api.event.Event {
 
-        private changes: ContentServerChange[];
+        private change: ContentServerChange;
 
-        constructor(changes: ContentServerChange[]) {
+        constructor(change: ContentServerChange) {
             super();
-            this.changes = changes || [];
+            this.change = change;
         }
 
-        getContentChanges(): ContentServerChange[] {
-            return this.changes;
+        getContentChange(): ContentServerChange {
+            return this.change;
         }
 
         toString(): string {
-            return "ContentServerEvent: [" +
-                   this.changes.map((change) => change.toString()).join(", ") +
-                   "]";
+            return "ContentServerEvent: [" + this.change.toString() + "]";
         }
 
         static on(handler: (event: ContentServerEvent) => void) {
@@ -42,8 +40,8 @@ module api.content {
         }
 
         static fromJson(nodeEventJson: NodeEventJson): ContentServerEvent {
-            var changes = ContentServerChange.fromJson(nodeEventJson);
-            return new ContentServerEvent(changes);
+            var change = ContentServerChange.fromJson(nodeEventJson);
+            return new ContentServerEvent(change);
         }
     }
 }


### PR DESCRIPTION
- Optimized handling of server events on front-end
- Simplified parsing result of websocket event data - now it generates exactly one ContentServerChange per event
- Removed promises chaining in the ServerEventsHandler
- Added Move ContentServerChangeType and added appropriate handler