### PR TITLE
XP-2351 ContentWizard: Name and DisplayName cleared, when permissions…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardHeaderWithDisplayNameAndName.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardHeaderWithDisplayNameAndName.ts
@@ -106,7 +106,14 @@ module api.app.wizard {
                    name.toLowerCase() === this.generateName(displayName).toLowerCase();
         }
 
-        initNames(displayName: string, name: string, forceDisplayNameProgrammaticallySet: boolean) {
+        initNames(displayName: string, name: string, forceDisplayNameProgrammaticallySet: boolean, ignoreDirtyFlag: boolean = true) {
+
+            if (!ignoreDirtyFlag) {
+                if (this.displayNameEl.isDirty()) {
+                    displayName = this.displayNameEl.getValue();
+                    name = this.nameEl.getValue();
+                }
+            }
 
             this.autoGenerateName = this.checkAutoGenerateName(name, displayName);
 


### PR DESCRIPTION
… applied

- Added check to initNames() method of WizardHeaderWithDisplayNameAndName.ts that will not reset name and display name of wizard panel if displayName input has dirty flag
- Fixed incorrect behaviour of layoutPersistedItem() method that used to subscribe on events each time method executed
- Moved some handlers from ContentWizardPanel's constructor