### PR TITLE
XP-2364 Page Components view - Implement vertical scrolling

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/PageComponentsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/PageComponentsView.ts
@@ -71,6 +71,7 @@ module app.wizard {
 
             this.onShown((event) => {
                 this.constrainToParent();
+                this.getHTMLElement().style.display = "";
             });
 
             this.responsiveItem = ResponsiveManager.onAvailableSizeChanged(api.dom.Body.get(), (item: ResponsiveItem) => {


### PR DESCRIPTION
-PageComponentsView has a 'flex' set as a display option, but when it is being shown jquery sets display option to 'block' so styling breaks (PCV was already scrollable)