### PR TITLE
XP-2403 LiveEdit - Image Selector is no longer filtered

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverter.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverter.java
@@ -76,7 +76,8 @@ public class ContentSelectorQueryJsonToContentQueryConverter
             from( this.contentQueryJson.getFrom() ).
             size( this.contentQueryJson.getSize() ).
             queryExpr( this.createQueryExpr( contentSelectorInput ) ).
-            addContentTypeNames( this.getContentTypeNames( contentSelectorInput ) );
+            addContentTypeNames( this.getContentTypeNamesFromConfig( contentSelectorInput ) ).
+            addContentTypeNames( this.contentQueryJson.getContentTypeNames() );
 
         return builder.build();
     }
@@ -181,7 +182,7 @@ public class ContentSelectorQueryJsonToContentQueryConverter
         return ValueExpr.string( "/" + ContentConstants.CONTENT_ROOT_NAME + resolvedPath );
     }
 
-    private ContentTypeNames getContentTypeNames( final Input contentSelectorInput )
+    private ContentTypeNames getContentTypeNamesFromConfig( final Input contentSelectorInput )
     {
         if ( contentSelectorInput == null )
         {

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/ContentSelectorQueryJson.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/ContentSelectorQueryJson.java
@@ -1,10 +1,13 @@
 package com.enonic.xp.admin.impl.rest.resource.content.json;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.enonic.xp.content.ContentId;
+import com.enonic.xp.schema.content.ContentTypeNames;
 
 public class ContentSelectorQueryJson
 {
@@ -20,12 +23,15 @@ public class ContentSelectorQueryJson
 
     private final String inputName;
 
+    private final ContentTypeNames contentTypeNames;
+
     @JsonCreator
     public ContentSelectorQueryJson( @JsonProperty("queryExpr") final String queryExprString, //
                                      @JsonProperty("from") final Integer from, //
                                      @JsonProperty("size") final Integer size, //
                                      @JsonProperty("expand") final String expand, @JsonProperty("contentId") final String contentId,
-                                     @JsonProperty("inputName") final String inputName )
+                                     @JsonProperty("inputName") final String inputName,
+                                     @JsonProperty("contentTypeNames") final List<String> contentTypeNamesString )
     {
 
         this.from = from;
@@ -34,6 +40,7 @@ public class ContentSelectorQueryJson
         this.contentId = ContentId.from( contentId );
         this.expand = expand != null ? expand : "none";
         this.inputName = inputName;
+        this.contentTypeNames = ContentTypeNames.from( contentTypeNamesString );
     }
 
     @JsonIgnore
@@ -66,9 +73,15 @@ public class ContentSelectorQueryJson
         return expand;
     }
 
-    @JsonIgnore
+
     public String getInputName()
     {
         return inputName;
+    }
+
+    @JsonIgnore
+    public ContentTypeNames getContentTypeNames()
+    {
+        return contentTypeNames;
     }
 }

--- a/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverterTest.java
+++ b/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverterTest.java
@@ -1,6 +1,9 @@
 package com.enonic.xp.admin.impl.rest.resource.content;
 
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import org.junit.Before;
@@ -73,7 +76,8 @@ public class ContentSelectorQueryJsonToContentQueryConverterTest
         Mockito.when( contentService.getById( Mockito.isA( ContentId.class ) ) ).
             thenReturn( content );
 
-        ContentSelectorQueryJson contentQueryJson = new ContentSelectorQueryJson( "", 0, 100, "summary", "contentId", "inputName" );
+        ContentSelectorQueryJson contentQueryJson =
+            new ContentSelectorQueryJson( "", 0, 100, "summary", "contentId", "inputName", Collections.emptyList() );
         ContentSelectorQueryJsonToContentQueryConverter processor = ContentSelectorQueryJsonToContentQueryConverter.create().
             contentQueryJson( contentQueryJson ).
             contentService( contentService ).
@@ -115,7 +119,8 @@ public class ContentSelectorQueryJsonToContentQueryConverterTest
         Mockito.when( contentService.getNearestSite( Mockito.isA( ContentId.class ) ) ).
             thenReturn( site );
 
-        ContentSelectorQueryJson contentQueryJson = new ContentSelectorQueryJson( "", 0, 100, "summary", "contentId", "inputName" );
+        ContentSelectorQueryJson contentQueryJson =
+            new ContentSelectorQueryJson( "", 0, 100, "summary", "contentId", "inputName", Collections.emptyList() );
         ContentSelectorQueryJsonToContentQueryConverter processor = ContentSelectorQueryJsonToContentQueryConverter.create().
             contentQueryJson( contentQueryJson ).
             contentService( contentService ).
@@ -131,6 +136,45 @@ public class ContentSelectorQueryJsonToContentQueryConverterTest
         assertEquals(
             "((_path LIKE '/content/my-site/path1*' OR _path LIKE '/content/my-site/path2/path3*') OR _path LIKE '/content/parent-path/child-path*')",
             contentQuery.getQueryExpr().toString() );
+    }
+
+    @Test
+    public void testPathWithAllowTypePassedFromJson()
+    {
+        final InputTypeConfig config = InputTypeConfig.create().
+            property( InputTypeProperty.create( "relationship", "system:reference" ).build() ).
+            property( InputTypeProperty.create( "allowContentType", "myApplication:comment" ).build() ).
+            property( InputTypeProperty.create( "allowPath", "parent-path/child-path" ).build() ).
+            build();
+
+        final ContentType contentType = createContentTypeWithSelectorInput( "inputName", config );
+
+        final Content content = createContent( "content-id", "my-content", contentType.getName() );
+
+        Mockito.when( contentTypeService.getByName( Mockito.isA( GetContentTypeParams.class ) ) ).
+            thenReturn( contentType );
+
+        Mockito.when( contentService.getById( Mockito.isA( ContentId.class ) ) ).
+            thenReturn( content );
+
+        final List<String> allowTypesFromJson = Arrays.asList( "myApplication:type1", "myApplication:type2", "myApplication:type2" );
+
+        ContentSelectorQueryJson contentQueryJson =
+            new ContentSelectorQueryJson( "", 0, 100, "summary", "contentId", "inputName", allowTypesFromJson );
+        ContentSelectorQueryJsonToContentQueryConverter processor = ContentSelectorQueryJsonToContentQueryConverter.create().
+            contentQueryJson( contentQueryJson ).
+            contentService( contentService ).
+            contentTypeService( contentTypeService ).
+            relationshipTypeService( relationshipTypeService ).
+            build();
+
+        final ContentQuery contentQuery = processor.createQuery();
+
+        assertEquals( 0, contentQuery.getFrom() );
+        assertEquals( 100, contentQuery.getSize() );
+        assertEquals( ContentTypeNames.from( "myApplication:comment", "myApplication:type1", "myApplication:type2" ),
+                      contentQuery.getContentTypes() );
+        assertEquals( "_path LIKE '/content/parent-path/child-path*'", contentQuery.getQueryExpr().toString() );
     }
 
     @Test(expected = RuntimeException.class)
@@ -155,7 +199,8 @@ public class ContentSelectorQueryJsonToContentQueryConverterTest
         Mockito.when( contentService.getNearestSite( Mockito.isA( ContentId.class ) ) ).
             thenReturn( null );
 
-        ContentSelectorQueryJson contentQueryJson = new ContentSelectorQueryJson( "", 0, 100, "summary", "contentId", "inputName" );
+        ContentSelectorQueryJson contentQueryJson =
+            new ContentSelectorQueryJson( "", 0, 100, "summary", "contentId", "inputName", Collections.emptyList() );
         ContentSelectorQueryJsonToContentQueryConverter processor = ContentSelectorQueryJsonToContentQueryConverter.create().
             contentQueryJson( contentQueryJson ).
             contentService( contentService ).
@@ -186,7 +231,7 @@ public class ContentSelectorQueryJsonToContentQueryConverterTest
 
         ContentSelectorQueryJson contentQueryJson = new ContentSelectorQueryJson(
             "(fulltext('displayName^5,_name^3,_alltext', 'check', 'AND') OR ngram('displayName^5,_name^3,_alltext', 'check', 'AND')) " +
-                "ORDER BY _modifiedTime DESC", 0, 100, "summary", "contentId", "inputName" );
+                "ORDER BY _modifiedTime DESC", 0, 100, "summary", "contentId", "inputName", Collections.emptyList() );
         ContentSelectorQueryJsonToContentQueryConverter processor = getProcessor( contentQueryJson );
 
         final ContentQuery contentQuery = processor.createQuery();
@@ -220,7 +265,7 @@ public class ContentSelectorQueryJsonToContentQueryConverterTest
 
         ContentSelectorQueryJson contentQueryJson = new ContentSelectorQueryJson(
             "(fulltext('displayName^5,_name^3,_alltext', 'check', 'AND') OR ngram('displayName^5,_name^3,_alltext', 'check', 'AND')) " +
-                "ORDER BY _modifiedTime DESC", 0, 100, "summary", "contentId", "inputName" );
+                "ORDER BY _modifiedTime DESC", 0, 100, "summary", "contentId", "inputName", Collections.emptyList() );
         ContentSelectorQueryJsonToContentQueryConverter processor = getProcessor( contentQueryJson );
 
         final ContentQuery contentQuery = processor.createQuery();
@@ -254,7 +299,7 @@ public class ContentSelectorQueryJsonToContentQueryConverterTest
 
         ContentSelectorQueryJson contentQueryJson = new ContentSelectorQueryJson(
             "(fulltext('displayName^5,_name^3,_alltext', 'check', 'AND') OR ngram('displayName^5,_name^3,_alltext', 'check', 'AND')) " +
-                "ORDER BY _modifiedTime DESC", 0, 100, "summary", "contentId", "inputName" );
+                "ORDER BY _modifiedTime DESC", 0, 100, "summary", "contentId", "inputName", Collections.emptyList() );
         ContentSelectorQueryJsonToContentQueryConverter processor = getProcessor( contentQueryJson );
 
         final ContentQuery contentQuery = processor.createQuery();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/region/ImageInspectionPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/region/ImageInspectionPanel.ts
@@ -33,10 +33,11 @@ module app.wizard.page.contextwindow.inspect.region {
             super(<ComponentInspectionPanelConfig>{
                 iconClass: api.liveedit.ItemViewIconClassResolver.resolveByType("image", "icon-xlarge")
             });
+            var loader = new api.content.ContentSummaryLoader();
+            loader.setAllowedContentTypeNames([ContentTypeName.IMAGE]);
             this.imageSelector = ContentComboBox.create().
                 setMaximumOccurrences(1).
-                setAllowedContentTypes([ContentTypeName.IMAGE.toString()]).
-                setLoader(new api.content.ContentSummaryLoader()).
+                setLoader(loader).
                 build();
 
             this.imageSelectorForm = new ImageSelectorForm(this.imageSelector, "Image");

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentComboBox.ts
@@ -9,7 +9,7 @@ module api.content {
 
         constructor(builder: ContentComboBoxBuilder) {
 
-            var loader = builder.loader ? builder.loader : new ContentSummaryLoader(builder.allowedContentTypes);
+            var loader = builder.loader ? builder.loader : new ContentSummaryLoader();
 
             var richComboBoxBuilder = new RichComboBoxBuilder<ContentSummary>().
                 setComboBoxName(builder.name ? builder.name : 'contentSelector').
@@ -105,8 +105,6 @@ module api.content {
 
         loader: api.util.loader.BaseLoader<json.ContentQueryResultJson<json.ContentSummaryJson>, ContentSummary>;
 
-        allowedContentTypes: string[];
-
         minWidth: number;
 
         setName(value: string): ContentComboBoxBuilder {
@@ -121,11 +119,6 @@ module api.content {
 
         setLoader(loader: api.util.loader.BaseLoader<json.ContentQueryResultJson<json.ContentSummaryJson>, ContentSummary>): ContentComboBoxBuilder {
             this.loader = loader;
-            return this;
-        }
-
-        setAllowedContentTypes(allowedTypes: string[]): ContentComboBoxBuilder {
-            this.allowedContentTypes = allowedTypes;
             return this;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSelectorQueryRequest.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSelectorQueryRequest.ts
@@ -32,6 +32,8 @@ module api.content {
 
         private inputName: string;
 
+        private contentTypeNames: string[] = [];
+
         constructor() {
             super();
             super.setMethod("POST");
@@ -69,6 +71,10 @@ module api.content {
             return this.size;
         }
 
+        setContentTypeNames(contentTypeNames: string[]) {
+            this.contentTypeNames = contentTypeNames
+        }
+
         setQueryExpr(searchString: string) {
 
             var fulltextExpression: Expression = new api.query.FulltextSearchExpressionBuilder().
@@ -99,7 +105,8 @@ module api.content {
                 size: this.getSize(),
                 expand: this.expandAsString(),
                 contentId: this.getId().toString(),
-                inputName: this.getInputName()
+                inputName: this.getInputName(),
+                contentTypeNames: this.contentTypeNames,
             };
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryLoader.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryLoader.ts
@@ -15,12 +15,8 @@ module api.content {
 
         private order: OrderExpr[];
 
-        constructor(allowedContentTypes?: string[]) {
+        constructor() {
             this.contentSummaryRequest = new ContentSummaryRequest();
-
-            if (!!allowedContentTypes) {
-                this.setAllowedContentTypes(allowedContentTypes);
-            }
 
             // Setting default order
             this.order = ContentSummaryLoader.ORDER_BY_MODIFIED_TIME_DESC;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelectorLoader.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelectorLoader.ts
@@ -1,14 +1,6 @@
 module api.content.form.inputtype.contentselector {
 
-    /**
-     * Extends ContentSummaryLoader to restrict requests before allowed content types are set.
-     * If search() method was called before allowed content types are set
-     * then search string is preserved and request postponed.
-     * After content types are set, search request is made with latest preserved search string.
-     */
     export class ContentSelectorLoader extends api.util.loader.BaseLoader<json.ContentQueryResultJson<json.ContentSummaryJson>, ContentSummary> {
-
-        private postponedSearchString: string;
 
         private contentSelectorQueryRequest: ContentSelectorQueryRequest;
 
@@ -24,6 +16,10 @@ module api.content.form.inputtype.contentselector {
             this.contentSelectorQueryRequest.setQueryExpr(searchString);
 
             return this.load();
+        }
+
+        setContentTypeNames(contentTypeNames: string[]) {
+            this.contentSelectorQueryRequest.setContentTypeNames(contentTypeNames);
         }
 
         sendRequest(): wemQ.Promise<ContentSummary[]> {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageContentComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageContentComboBox.ts
@@ -13,7 +13,7 @@ module api.content.form.inputtype.image {
 
         constructor(builder: ImageContentComboBoxBuilder) {
 
-            var loader = builder.loader ? builder.loader : new ContentSummaryLoader(builder.allowedContentTypes);
+            var loader = builder.loader ? builder.loader : new ContentSummaryLoader();
 
             var richComboBoxBuilder = new RichComboBoxBuilder().
                 setComboBoxName(builder.name ? builder.name : 'imageContentSelector').
@@ -49,8 +49,6 @@ module api.content.form.inputtype.image {
 
         loader: api.util.loader.BaseLoader<json.ContentQueryResultJson<json.ContentSummaryJson>, ContentSummary>;
 
-        allowedContentTypes: string[];
-
         minWidth: number;
 
         selectedOptionsView: ImageSelectorSelectedOptionsView;
@@ -69,11 +67,6 @@ module api.content.form.inputtype.image {
 
         setLoader(loader: api.util.loader.BaseLoader<json.ContentQueryResultJson<json.ContentSummaryJson>, ContentSummary>): ImageContentComboBoxBuilder {
             this.loader = loader;
-            return this;
-        }
-
-        setAllowedContentTypes(allowedTypes: string[]): ImageContentComboBoxBuilder {
-            this.allowedContentTypes = allowedTypes;
             return this;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -158,11 +158,13 @@ module api.content.form.inputtype.image {
 
         createContentComboBox(maximumOccurrences: number, inputIconUrl: string, allowedContentTypes: string[],
                               inputName: string): ContentComboBox {
+            var loader = new ContentSelectorLoader(this.config.contentId, inputName);
+            loader.setContentTypeNames(allowedContentTypes.length ? allowedContentTypes : [ContentTypeName.IMAGE.toString()]);
+
             var contentComboBox: ImageContentComboBox
                     = ImageContentComboBox.create().
                     setMaximumOccurrences(maximumOccurrences).
-                    setAllowedContentTypes(allowedContentTypes.length ? allowedContentTypes : [ContentTypeName.IMAGE.toString()]).
-                    setLoader(new ContentSelectorLoader(this.config.contentId, inputName)).
+                    setLoader(loader).
                     setSelectedOptionsView(this.selectedOptionsView = this.createSelectedOptionsView()).
                     build(),
                 comboBox: ComboBox<ImageSelectorDisplayValue> = contentComboBox.getComboBox();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/image/ImagePlaceholder.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/image/ImagePlaceholder.ts
@@ -42,10 +42,12 @@ module api.liveedit.image {
                 new ImageOpenUploadDialogEvent(this).fire();
             });
 
+            var loader = new api.content.ContentSummaryLoader();
+            loader.setAllowedContentTypeNames([ContentTypeName.IMAGE]);
+
             this.comboBox = api.content.ContentComboBox.create().
                 setMaximumOccurrences(1).
-                setAllowedContentTypes([ContentTypeName.IMAGE.toString()]).
-                setLoader(new api.content.ContentSummaryLoader()).
+                setLoader(loader).
                 setMinWidth(270).
                 build();
 


### PR DESCRIPTION
- Removed setAllowedContentTypes() method of ContentCombobox builder to exclude ambiguities with setting content types that are actually required for loader
- Fixed problem with not setting Image content type into ContentSummaryLoader
- Added possibility to pass ContentTypes for ContentSelector query as a parameter - this allows to programmatically set allow types, not only by config
- Added test for that