### PR TITLE
XP-2403 LiveEdit - Image Selector is no longer filtered

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -802,7 +802,6 @@ public final class ContentResource
             ContentSelectorQueryJsonToContentQueryConverter.create().
                 contentQueryJson( contentQueryJson ).
                 contentService( this.contentService ).
-                contentTypeService( this.contentTypeService ).
                 relationshipTypeService( this.relationshipTypeService ).
                 build();
 

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverter.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentSelectorQueryJsonToContentQueryConverter.java
@@ -1,10 +1,8 @@
 package com.enonic.xp.admin.impl.rest.resource.content;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 
 import com.enonic.xp.admin.impl.rest.resource.content.json.ContentSelectorQueryJson;
 import com.enonic.xp.content.Content;
@@ -12,12 +10,6 @@ import com.enonic.xp.content.ContentConstants;
 import com.enonic.xp.content.ContentQuery;
 import com.enonic.xp.content.ContentRelativePathResolver;
 import com.enonic.xp.content.ContentService;
-import com.enonic.xp.form.FieldSet;
-import com.enonic.xp.form.FormItem;
-import com.enonic.xp.form.FormItemType;
-import com.enonic.xp.form.FormItems;
-import com.enonic.xp.form.Input;
-import com.enonic.xp.inputtype.InputTypeName;
 import com.enonic.xp.node.NodeIndexPath;
 import com.enonic.xp.query.expr.CompareExpr;
 import com.enonic.xp.query.expr.ConstraintExpr;
@@ -26,11 +18,7 @@ import com.enonic.xp.query.expr.LogicalExpr;
 import com.enonic.xp.query.expr.QueryExpr;
 import com.enonic.xp.query.expr.ValueExpr;
 import com.enonic.xp.query.parser.QueryParser;
-import com.enonic.xp.schema.content.ContentType;
-import com.enonic.xp.schema.content.ContentTypeName;
 import com.enonic.xp.schema.content.ContentTypeNames;
-import com.enonic.xp.schema.content.ContentTypeService;
-import com.enonic.xp.schema.content.GetContentTypeParams;
 import com.enonic.xp.schema.relationship.RelationshipType;
 import com.enonic.xp.schema.relationship.RelationshipTypeName;
 import com.enonic.xp.schema.relationship.RelationshipTypeService;
@@ -44,46 +32,56 @@ public class ContentSelectorQueryJsonToContentQueryConverter
 
     final private RelationshipTypeService relationshipTypeService;
 
-    final private ContentTypeService contentTypeService;
-
     final private Content content;
 
     private Site parentSite;
 
     private final static FieldExpr PATH_FIELD_EXPR = FieldExpr.from( NodeIndexPath.PATH );
 
-    private final static String ALLOW_PATH_CONFIG_ENTRY = "allowPath";
-
-    private final static String ALLOW_CONTENT_TYPE_CONFIG_ENTRY = "allowContentType";
-
-    private final static String RELATIONSHIP_TYPE_CONFIG_ENTRY = "relationshipType";
-
     private ContentSelectorQueryJsonToContentQueryConverter( final Builder builder )
     {
         this.contentQueryJson = builder.contentQueryJson;
         this.contentService = builder.contentService;
         this.relationshipTypeService = builder.relationshipTypeService;
-        this.contentTypeService = builder.contentTypeService;
         this.content = contentService.getById( contentQueryJson.getContentId() );
     }
 
     public ContentQuery createQuery()
     {
-        final Input contentSelectorInput =
-            this.getContentSelectorInputFromContentType( this.getContentType( content.getType() ), contentQueryJson.getInputName() );
-
         final ContentQuery.Builder builder = ContentQuery.create().
             from( this.contentQueryJson.getFrom() ).
             size( this.contentQueryJson.getSize() ).
-            queryExpr( this.createQueryExpr( contentSelectorInput ) ).
-            addContentTypeNames( this.getContentTypeNames( contentSelectorInput ) );
+            queryExpr( this.createQueryExpr() ).
+            addContentTypeNames( this.getContentTypeNamesFromJson() );
 
         return builder.build();
     }
 
-    private QueryExpr createQueryExpr( final Input contentSelectorInput )
+    private ContentTypeNames getContentTypeNamesFromJson()
     {
-        final List<String> allowedPaths = this.getAllowedPaths( contentSelectorInput );
+        if ( this.contentQueryJson.getContentTypeNames().getSize() == 0 )
+        {
+            return this.getContentTypeNamesFromRelationshipType();
+        }
+
+        return this.contentQueryJson.getContentTypeNames();
+    }
+
+    private ContentTypeNames getContentTypeNamesFromRelationshipType()
+    {
+        if ( this.contentQueryJson.getRelationshipType() == null )
+        {
+            return ContentTypeNames.empty();
+        }
+
+        final RelationshipType relationshipType =
+            relationshipTypeService.getByName( RelationshipTypeName.from( this.contentQueryJson.getRelationshipType() ) );
+        return getContentTypeNamesFromRelationship( relationshipType );
+    }
+
+    private QueryExpr createQueryExpr()
+    {
+        final List<String> allowedPaths = this.contentQueryJson.getAllowedContentPaths();
 
         if ( allowedPaths.size() == 0 )
         {
@@ -181,40 +179,6 @@ public class ContentSelectorQueryJsonToContentQueryConverter
         return ValueExpr.string( "/" + ContentConstants.CONTENT_ROOT_NAME + resolvedPath );
     }
 
-    private ContentTypeNames getContentTypeNames( final Input contentSelectorInput )
-    {
-        if ( contentSelectorInput == null )
-        {
-            return ContentTypeNames.empty();
-        }
-
-        final ContentTypeNames contentTypeNames =
-            ContentTypeNames.from( contentSelectorInput.getInputTypeConfig().getProperties( ALLOW_CONTENT_TYPE_CONFIG_ENTRY ).
-                stream().
-                map( ( prop ) -> ContentTypeName.from( prop.getValue() ) ).
-                collect( Collectors.toList() ) );
-
-        if ( contentTypeNames.getSize() == 0 )
-        {
-            return getContentTypeNamesFromRelationship( contentSelectorInput );
-        }
-
-        return contentTypeNames;
-    }
-
-    private ContentTypeNames getContentTypeNamesFromRelationship( final Input contentSelectorInput )
-    {
-        final String relationshipConfigEntry = contentSelectorInput.getInputTypeConfig().getValue( RELATIONSHIP_TYPE_CONFIG_ENTRY );
-
-        if ( relationshipConfigEntry == null )
-        {
-            return ContentTypeNames.empty();
-        }
-
-        final RelationshipType relationshipType = relationshipTypeService.getByName( RelationshipTypeName.from( relationshipConfigEntry ) );
-        return getContentTypeNamesFromRelationship( relationshipType );
-    }
-
     private ContentTypeNames getContentTypeNamesFromRelationship( final RelationshipType relationshipType )
     {
         if ( relationshipType == null )
@@ -222,76 +186,6 @@ public class ContentSelectorQueryJsonToContentQueryConverter
             return ContentTypeNames.empty();
         }
         return ContentTypeNames.from( relationshipType.getAllowedToTypes() );
-    }
-
-    private List<String> getAllowedPaths( final Input contentSelectorInput )
-    {
-        if ( contentSelectorInput == null )
-        {
-            return ImmutableList.of();
-        }
-
-        return contentSelectorInput.getInputTypeConfig().getProperties( ALLOW_PATH_CONFIG_ENTRY ).
-            stream().
-            map( ( prop ) -> prop.getValue() ).
-            collect( Collectors.toList() );
-    }
-
-    private Input getContentSelectorInputFromContentType( final ContentType contentType, final String inputName )
-    {
-        final FormItem formItem = getInputFormItem( contentType, inputName );
-
-        if ( formItem == null || !FormItemType.INPUT.equals( formItem.getType() ) || !isContentSelectorInput( (Input) formItem ) )
-        {
-            return null;
-        }
-
-        return (Input) formItem;
-    }
-
-    private FormItem getInputFormItem( final ContentType contentType, final String inputName )
-    {
-        if ( contentType == null )
-        {
-            return null;
-        }
-
-        final FormItems inputFormItems = getInputFormItemsOrBasicFormItemsIfPresent( contentType );
-        return getFormItemFromItems( inputFormItems, inputName );
-    }
-
-    private FormItem getFormItemFromItems( final FormItems inputFormItems, final String inputName )
-    {
-        if ( inputFormItems == null )
-        {
-            return null;
-        }
-        return inputFormItems.getItemByName( inputName );
-    }
-
-    private FormItems getInputFormItemsOrBasicFormItemsIfPresent( final ContentType contentType )
-    {
-        final FormItem basicFormItem = contentType.getForm().getFormItems().getItemByName( "basic" );
-        if ( basicFormItem != null && basicFormItem instanceof FieldSet )
-        {
-            return ( (FieldSet) basicFormItem ).getFormItems();
-        }
-        return contentType.getForm().getFormItems();
-    }
-
-    private boolean isContentSelectorInput( final Input input )
-    {
-        return InputTypeName.CONTENT_SELECTOR.equals( input.getInputType() ) || InputTypeName.IMAGE_SELECTOR.equals( input.getInputType() );
-    }
-
-    private ContentType getContentType( final ContentTypeName contentTypeName )
-    {
-        if ( contentTypeName == null )
-        {
-            return null;
-        }
-
-        return contentTypeService.getByName( new GetContentTypeParams().contentTypeName( contentTypeName ) );
     }
 
     public static Builder create()
@@ -307,17 +201,9 @@ public class ContentSelectorQueryJsonToContentQueryConverter
 
         private RelationshipTypeService relationshipTypeService;
 
-        private ContentTypeService contentTypeService;
-
         public Builder contentQueryJson( final ContentSelectorQueryJson contentQueryJson )
         {
             this.contentQueryJson = contentQueryJson;
-            return this;
-        }
-
-        public Builder contentTypeService( final ContentTypeService contentTypeService )
-        {
-            this.contentTypeService = contentTypeService;
             return this;
         }
 

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/ContentSelectorQueryJson.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/ContentSelectorQueryJson.java
@@ -1,10 +1,13 @@
 package com.enonic.xp.admin.impl.rest.resource.content.json;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.enonic.xp.content.ContentId;
+import com.enonic.xp.schema.content.ContentTypeNames;
 
 public class ContentSelectorQueryJson
 {
@@ -20,12 +23,21 @@ public class ContentSelectorQueryJson
 
     private final String inputName;
 
+    private final ContentTypeNames contentTypeNames;
+
+    private final List<String> allowedContentPaths;
+
+    private final String relationshipType;
+
     @JsonCreator
     public ContentSelectorQueryJson( @JsonProperty("queryExpr") final String queryExprString, //
                                      @JsonProperty("from") final Integer from, //
                                      @JsonProperty("size") final Integer size, //
                                      @JsonProperty("expand") final String expand, @JsonProperty("contentId") final String contentId,
-                                     @JsonProperty("inputName") final String inputName )
+                                     @JsonProperty("inputName") final String inputName,
+                                     @JsonProperty("contentTypeNames") final List<String> contentTypeNamesString,
+                                     @JsonProperty("allowedContentPaths") final List<String> allowedContentPaths,
+                                     @JsonProperty("relationshipType") final String relationshipType )
     {
 
         this.from = from;
@@ -34,6 +46,9 @@ public class ContentSelectorQueryJson
         this.contentId = ContentId.from( contentId );
         this.expand = expand != null ? expand : "none";
         this.inputName = inputName;
+        this.contentTypeNames = ContentTypeNames.from( contentTypeNamesString );
+        this.allowedContentPaths = allowedContentPaths;
+        this.relationshipType = relationshipType;
     }
 
     @JsonIgnore
@@ -66,9 +81,27 @@ public class ContentSelectorQueryJson
         return expand;
     }
 
-    @JsonIgnore
+
     public String getInputName()
     {
         return inputName;
+    }
+
+    @JsonIgnore
+    public ContentTypeNames getContentTypeNames()
+    {
+        return contentTypeNames;
+    }
+
+    @JsonIgnore
+    public List<String> getAllowedContentPaths()
+    {
+        return allowedContentPaths;
+    }
+
+    @JsonIgnore
+    public String getRelationshipType()
+    {
+        return relationshipType;
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/region/ImageInspectionPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/region/ImageInspectionPanel.ts
@@ -33,10 +33,11 @@ module app.wizard.page.contextwindow.inspect.region {
             super(<ComponentInspectionPanelConfig>{
                 iconClass: api.liveedit.ItemViewIconClassResolver.resolveByType("image", "icon-xlarge")
             });
+            var loader = new api.content.ContentSummaryLoader();
+            loader.setAllowedContentTypeNames([ContentTypeName.IMAGE]);
             this.imageSelector = ContentComboBox.create().
                 setMaximumOccurrences(1).
-                setAllowedContentTypes([ContentTypeName.IMAGE.toString()]).
-                setLoader(new api.content.ContentSummaryLoader()).
+                setLoader(loader).
                 build();
 
             this.imageSelectorForm = new ImageSelectorForm(this.imageSelector, "Image");

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentComboBox.ts
@@ -9,7 +9,7 @@ module api.content {
 
         constructor(builder: ContentComboBoxBuilder) {
 
-            var loader = builder.loader ? builder.loader : new ContentSummaryLoader(builder.allowedContentTypes);
+            var loader = builder.loader ? builder.loader : new ContentSummaryLoader();
 
             var richComboBoxBuilder = new RichComboBoxBuilder<ContentSummary>().
                 setComboBoxName(builder.name ? builder.name : 'contentSelector').
@@ -105,8 +105,6 @@ module api.content {
 
         loader: api.util.loader.BaseLoader<json.ContentQueryResultJson<json.ContentSummaryJson>, ContentSummary>;
 
-        allowedContentTypes: string[];
-
         minWidth: number;
 
         setName(value: string): ContentComboBoxBuilder {
@@ -121,11 +119,6 @@ module api.content {
 
         setLoader(loader: api.util.loader.BaseLoader<json.ContentQueryResultJson<json.ContentSummaryJson>, ContentSummary>): ContentComboBoxBuilder {
             this.loader = loader;
-            return this;
-        }
-
-        setAllowedContentTypes(allowedTypes: string[]): ContentComboBoxBuilder {
-            this.allowedContentTypes = allowedTypes;
             return this;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSelectorQueryRequest.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSelectorQueryRequest.ts
@@ -32,6 +32,12 @@ module api.content {
 
         private inputName: string;
 
+        private contentTypeNames: string[] = [];
+
+        private allowedContentPaths: string[] = [];
+
+        private relationshipType: string;
+
         constructor() {
             super();
             super.setMethod("POST");
@@ -69,6 +75,18 @@ module api.content {
             return this.size;
         }
 
+        setContentTypeNames(contentTypeNames: string[]) {
+            this.contentTypeNames = contentTypeNames
+        }
+
+        setAllowedContentPaths(allowedContentPaths: string[]) {
+            this.allowedContentPaths = allowedContentPaths;
+        }
+
+        setRelationshipType(relationshipType: string) {
+            this.relationshipType = relationshipType;
+        }
+
         setQueryExpr(searchString: string) {
 
             var fulltextExpression: Expression = new api.query.FulltextSearchExpressionBuilder().
@@ -99,7 +117,10 @@ module api.content {
                 size: this.getSize(),
                 expand: this.expandAsString(),
                 contentId: this.getId().toString(),
-                inputName: this.getInputName()
+                inputName: this.getInputName(),
+                contentTypeNames: this.contentTypeNames,
+                allowedContentPaths: this.allowedContentPaths,
+                relationshipType: this.relationshipType
             };
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryLoader.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryLoader.ts
@@ -15,12 +15,8 @@ module api.content {
 
         private order: OrderExpr[];
 
-        constructor(allowedContentTypes?: string[]) {
+        constructor() {
             this.contentSummaryRequest = new ContentSummaryRequest();
-
-            if (!!allowedContentTypes) {
-                this.setAllowedContentTypes(allowedContentTypes);
-            }
 
             // Setting default order
             this.order = ContentSummaryLoader.ORDER_BY_MODIFIED_TIME_DESC;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelectorLoader.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelectorLoader.ts
@@ -1,22 +1,17 @@
 module api.content.form.inputtype.contentselector {
 
-    /**
-     * Extends ContentSummaryLoader to restrict requests before allowed content types are set.
-     * If search() method was called before allowed content types are set
-     * then search string is preserved and request postponed.
-     * After content types are set, search request is made with latest preserved search string.
-     */
     export class ContentSelectorLoader extends api.util.loader.BaseLoader<json.ContentQueryResultJson<json.ContentSummaryJson>, ContentSummary> {
-
-        private postponedSearchString: string;
 
         private contentSelectorQueryRequest: ContentSelectorQueryRequest;
 
-        constructor(contentId: api.content.ContentId, inputName: string) {
+        constructor(builder: Builder) {
             this.contentSelectorQueryRequest = new ContentSelectorQueryRequest();
             super(this.contentSelectorQueryRequest);
-            this.contentSelectorQueryRequest.setId(contentId);
-            this.contentSelectorQueryRequest.setInputName(inputName);
+            this.contentSelectorQueryRequest.setId(builder.id);
+            this.contentSelectorQueryRequest.setInputName(builder.inputName);
+            this.contentSelectorQueryRequest.setContentTypeNames(builder.contentTypeNames);
+            this.contentSelectorQueryRequest.setAllowedContentPaths(builder.allowedContentPaths);
+            this.contentSelectorQueryRequest.setRelationshipType(builder.relationshipType);
         }
 
         search(searchString: string): wemQ.Promise<ContentSummary[]> {
@@ -30,5 +25,53 @@ module api.content.form.inputtype.contentselector {
             return this.contentSelectorQueryRequest.sendAndParse();
         }
 
+        public static create(): Builder {
+            return new Builder();
+        }
+    }
+
+    export class Builder {
+
+        constructor() {
+        }
+
+        id: ContentId;
+
+        inputName: string;
+
+        contentTypeNames: string[] = [];
+
+        allowedContentPaths: string[] = [];
+
+        relationshipType: string;
+
+        public setId(id: ContentId): Builder {
+            this.id = id;
+            return this;
+        }
+
+        public setInputName(name: string): Builder {
+            this.inputName = name;
+            return this;
+        }
+
+        public setContentTypeNames(contentTypeNames: string[]): Builder {
+            this.contentTypeNames = contentTypeNames;
+            return this;
+        }
+
+        public setAllowedContentPaths(allowedContentPaths: string[]): Builder {
+            this.allowedContentPaths = allowedContentPaths;
+            return this;
+        }
+
+        public setRelationshipType(relationshipType: string): Builder {
+            this.relationshipType = relationshipType;
+            return this;
+        }
+
+        public build(): ContentSelectorLoader {
+            return new ContentSelectorLoader(this);
+        }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageContentComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageContentComboBox.ts
@@ -13,7 +13,7 @@ module api.content.form.inputtype.image {
 
         constructor(builder: ImageContentComboBoxBuilder) {
 
-            var loader = builder.loader ? builder.loader : new ContentSummaryLoader(builder.allowedContentTypes);
+            var loader = builder.loader ? builder.loader : new ContentSummaryLoader();
 
             var richComboBoxBuilder = new RichComboBoxBuilder().
                 setComboBoxName(builder.name ? builder.name : 'imageContentSelector').
@@ -49,8 +49,6 @@ module api.content.form.inputtype.image {
 
         loader: api.util.loader.BaseLoader<json.ContentQueryResultJson<json.ContentSummaryJson>, ContentSummary>;
 
-        allowedContentTypes: string[];
-
         minWidth: number;
 
         selectedOptionsView: ImageSelectorSelectedOptionsView;
@@ -69,11 +67,6 @@ module api.content.form.inputtype.image {
 
         setLoader(loader: api.util.loader.BaseLoader<json.ContentQueryResultJson<json.ContentSummaryJson>, ContentSummary>): ImageContentComboBoxBuilder {
             this.loader = loader;
-            return this;
-        }
-
-        setAllowedContentTypes(allowedTypes: string[]): ImageContentComboBoxBuilder {
-            this.allowedContentTypes = allowedTypes;
             return this;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/image/ImagePlaceholder.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/image/ImagePlaceholder.ts
@@ -42,10 +42,12 @@ module api.liveedit.image {
                 new ImageOpenUploadDialogEvent(this).fire();
             });
 
+            var loader = new api.content.ContentSummaryLoader();
+            loader.setAllowedContentTypeNames([ContentTypeName.IMAGE]);
+
             this.comboBox = api.content.ContentComboBox.create().
                 setMaximumOccurrences(1).
-                setAllowedContentTypes([ContentTypeName.IMAGE.toString()]).
-                setLoader(new api.content.ContentSummaryLoader()).
+                setLoader(loader).
                 setMinWidth(270).
                 build();
 


### PR DESCRIPTION
- While implementing XP-2153, I did not take into account inputs that come from mixins and parts, whereas current implementation expects content selectors to be specified in content types only. Due to its not possible to precisely fetch part's and mixin's input configs just by content id and input name, I had to use exact data from rendered input.
- Removed setAllowedContentTypes() method of ContentCombobox builder to exclude ambiguities with setting content types that are actually required for loader
- Fixed problem with not setting Image content type into ContentSummaryLoader
- Added possibility to pass ContentTypes for ContentSelector query as a parameter - this allows to programmatically set allow types, not only by config
- Updated tests