### PR TITLE
XP-2404 BUG? Broken images after upload crash admin

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/ContentItemPreviewPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/view/ContentItemPreviewPanel.ts
@@ -20,6 +20,11 @@ module app.view {
                 var myEl = this.getEl();
                 this.centerImage(imgEl.getWidth(), imgEl.getHeight(), myEl.getWidth(), myEl.getHeight());
             });
+
+            this.image.onError((event: UIEvent) => {
+                this.setNoPreview();
+            });
+
             this.appendChild(this.image);
 
             api.ui.responsive.ResponsiveManager.onAvailableSizeChanged(this, (item: api.ui.responsive.ResponsiveItem) => {
@@ -76,9 +81,7 @@ module app.view {
                         this.frame.setSrc(api.rendering.UriHelper.getPortalUri(item.getPath(), RenderingMode.PREVIEW,
                             api.content.Branch.DRAFT));
                     } else {
-                        this.getEl().removeClass("image-preview page-preview").addClass('no-preview');
-                        this.frame.setSrc("about:blank");
-                        this.mask.hide();
+                        this.setNoPreview();
                     }
                 }
             }
@@ -87,6 +90,12 @@ module app.view {
 
         public getItem(): ViewItem<ContentSummaryAndCompareStatus> {
             return this.item;
+        }
+
+        private setNoPreview() {
+            this.getEl().removeClass("image-preview page-preview").addClass('no-preview');
+            this.frame.setSrc("about:blank");
+            this.mask.hide();
         }
 
         private showMask() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/ContentWizardPanel.ts
@@ -44,6 +44,7 @@ module app.wizard {
     import WizardStep = api.app.wizard.WizardStep;
     import WizardStepValidityChangedEvent = api.app.wizard.WizardStepValidityChangedEvent;
     import ContentRequiresSaveEvent = api.content.ContentRequiresSaveEvent;
+    import ImageErrorEvent = api.content.ImageErrorEvent;
 
     import Application = api.application.Application;
     import ApplicationKey = api.application.ApplicationKey;
@@ -305,6 +306,7 @@ module app.wizard {
 
             this.initPublishButtonForMobile();
             this.handleSiteConfigApply();
+            this.handleBrokenImageInTheWizard();
 
             api.app.wizard.MaskContentWizardPanelEvent.on(event => {
                 if (this.getPersistedItem().getContentId().equals(event.getContentId())) {
@@ -323,6 +325,20 @@ module app.wizard {
             ContentRequiresSaveEvent.on(siteConfigApplyHandler);
             this.onClosed(() => {
                 ContentRequiresSaveEvent.un(siteConfigApplyHandler);
+            });
+        }
+
+        private handleBrokenImageInTheWizard() {
+            var brokenImageHandler = (event: ImageErrorEvent) => {
+                if (this.getPersistedItem().getId() === event.getContentId().toString()) {
+                    this.wizardActions.enableDeleteOnly();
+                    this.publishAction.setEnabled(false);
+                }
+            };
+
+            ImageErrorEvent.on(brokenImageHandler);
+            this.onClosed(() => {
+                ImageErrorEvent.un(brokenImageHandler);
             });
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/action/ContentWizardActions.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/action/ContentWizardActions.ts
@@ -54,6 +54,12 @@ module app.wizard.action {
             this.enableActionsForExistingByPermissions(existing);
         }
 
+        enableDeleteOnly() {
+            this.save.setEnabled(false);
+            this.duplicate.setEnabled(false);
+            this.delete.setEnabled(true)
+        }
+
         private enableActionsForExistingByPermissions(existing: api.content.Content) {
             new api.security.auth.IsAuthenticatedRequest().
                 sendAndParse().

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ImageErrorEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ImageErrorEvent.ts
@@ -1,0 +1,26 @@
+module api.content {
+
+    import Content = api.content.Content;
+
+    export class ImageErrorEvent extends api.event.Event {
+
+        private contentId: ContentId;
+
+        constructor(contentId: ContentId) {
+            super();
+            this.contentId = contentId;
+        }
+
+        getContentId(): ContentId {
+            return this.contentId;
+        }
+
+        static on(handler: (event: ImageErrorEvent) => void) {
+            api.event.Event.bind(api.ClassHelper.getFullName(this), handler);
+        }
+
+        static un(handler?: (event: ImageErrorEvent) => void) {
+            api.event.Event.unbind(api.ClassHelper.getFullName(this), handler);
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ImageUploader.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ImageUploader.ts
@@ -150,32 +150,32 @@ module api.content {
             }
         }
 
-        private createImageEditor(imgUrl: string): ImageEditor {
+        private createImageEditor(value: string): ImageEditor {
+
+            var contentId = new api.content.ContentId(value),
+                imgUrl = new ContentImageUrlResolver().
+                    setContentId(contentId).
+                    setTimestamp(new Date()).
+                    setSource(true).
+                    resolve();
 
             this.togglePlaceholder(true);
 
-            var imageEditor = new ImageEditor(imgUrl);
-            imageEditor.onEditModeChanged((edit: boolean, crop: Rect, zoom: Rect, focus: Point) => {
-                this.notifyEditModeChanged(edit, crop, zoom, focus);
-            });
-            imageEditor.onFocusAutoPositionedChanged((auto: boolean) => this.notifyFocusAutoPositionedChanged(auto));
-            imageEditor.onCropAutoPositionedChanged((auto: boolean) => this.notifyCropAutoPositionedChanged(auto));
+            var imageEditor = new ImageEditor();
+            this.subscribeImageEditorOnEvents(imageEditor, contentId);
+            imageEditor.setSrc(imgUrl);
 
-            imageEditor.getImage().onLoaded((event: UIEvent) => {
-                this.togglePlaceholder(false);
-            });
+            return imageEditor;
+        }
 
-            imageEditor.getUploadButton().onClicked(() => {
-                wemjq(this.getDropzone().getEl().getHTMLElement()).simulate("click");
-            });
-
-            imageEditor.getLastButtonInContainer().onBlur(() => {
-                this.toggleSelected(imageEditor);
-            });
-
-            var index = -1;
-            imageEditor.onEditModeChanged((edit: boolean, position: Rect, zoom: Rect, focus: Point) => {
+        private subscribeImageEditorOnEvents(imageEditor: ImageEditor, contentId: api.content.ContentId) {
+            var focusAutoPositionedChangedHandler = (auto: boolean) => this.notifyFocusAutoPositionedChanged(auto);
+            var cropAutoPositionedChangedHandler = (auto: boolean) => this.notifyCropAutoPositionedChanged(auto);
+            var editModeChangedHandler = (edit: boolean, position: Rect, zoom: Rect, focus: Point) => {
+                this.notifyEditModeChanged(edit, position, zoom, focus);
                 this.togglePlaceholder(edit);
+
+                var index = -1;
 
                 if (edit) {
                     index = imageEditor.getSiblingIndex();
@@ -184,9 +184,46 @@ module api.content {
                 } else {
                     this.getResultContainer().insertChild(imageEditor.removeClass(ImageUploader.STANDOUT_CLASS), index);
                 }
+            };
+            var uploadButtonClickedHandler = () => {
+                wemjq(this.getDropzone().getEl().getHTMLElement()).simulate("click");
+            };
+            var getLastButtonInContainerBlurHandler = () => {
+                this.toggleSelected(imageEditor);
+            };
+            var shaderVisibilityChangedHandler = (visible: boolean) => {
+                new api.app.wizard.MaskContentWizardPanelEvent(contentId, visible).fire();
+            };
+
+            var imageErrorHandler = (event: UIEvent) => {
+                new api.content.ImageErrorEvent(contentId).fire();
+                this.imageEditors = this.imageEditors.filter((curr) => {
+                    return curr !== imageEditor;
+                })
+                api.notify.showError('Failed to upload an image ' + contentId.toString());
+            };
+
+            imageEditor.getImage().onLoaded((event: UIEvent) => {
+                this.togglePlaceholder(false);
+                imageEditor.onShaderVisibilityChanged(shaderVisibilityChangedHandler);
+                imageEditor.onEditModeChanged(editModeChangedHandler);
+                imageEditor.onFocusAutoPositionedChanged(focusAutoPositionedChangedHandler);
+                imageEditor.onCropAutoPositionedChanged(cropAutoPositionedChangedHandler);
+                imageEditor.getUploadButton().onClicked(uploadButtonClickedHandler);
+                imageEditor.getLastButtonInContainer().onBlur(getLastButtonInContainerBlurHandler);
             });
 
-            return imageEditor;
+            imageEditor.onImageError(imageErrorHandler);
+
+            imageEditor.onRemoved(() => {
+                imageEditor.unShaderVisibilityChanged(shaderVisibilityChangedHandler);
+                imageEditor.unEditModeChanged(editModeChangedHandler);
+                imageEditor.unFocusAutoPositionedChanged(focusAutoPositionedChangedHandler);
+                imageEditor.unCropAutoPositionedChanged(cropAutoPositionedChangedHandler);
+                imageEditor.getUploadButton().unClicked(uploadButtonClickedHandler);
+                imageEditor.getLastButtonInContainer().unBlur(getLastButtonInContainerBlurHandler);
+                imageEditor.unImageError(imageErrorHandler);
+            });
         }
 
         private positionImageEditor(imageEditor: ImageEditor) {
@@ -196,23 +233,19 @@ module api.content {
                 setLeftPx(resultOffset.left);
         }
 
+        protected getExistingItem(value: string): api.dom.Element {
+            return this.imageEditors.filter(elem => {
+                return !!elem.getSrc() && elem.getSrc().indexOf(value) > -1;
+            })[0];
+        }
+
         createResultItem(value: string): api.dom.DivEl {
+
             if (!this.initialWidth) {
                 this.initialWidth = this.getParentElement().getEl().getWidth();
             }
 
-            var contentId = new api.content.ContentId(value),
-                imgUrl = new ContentImageUrlResolver().
-                    setContentId(contentId).
-                    setTimestamp(new Date()).
-                    setSource(true).
-                    resolve();
-
-            var imageEditor = this.createImageEditor(imgUrl);
-
-            imageEditor.onShaderVisibilityChanged((visible: boolean) => {
-                new api.app.wizard.MaskContentWizardPanelEvent(contentId, visible).fire();
-            });
+            var imageEditor = this.createImageEditor(value);
 
             this.imageEditors.push(imageEditor);
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/_module.ts
@@ -101,6 +101,7 @@
 ///<reference path='EditContentEvent.ts' />
 ///<reference path='TreeGridItemClickedEvent.ts' />
 ///<reference path='ContentRequiresSaveEvent.ts' />
+///<reference path='ImageErrorEvent.ts' />
 
 ///<reference path='Widget.ts' />
 ///<reference path='WidgetDescriptorResourceRequest.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/ImgEl.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/ImgEl.ts
@@ -6,6 +6,8 @@ module api.dom {
 
         private loadedListeners: {(event: UIEvent): void}[] = [];
 
+        private errorListeners: {(event: UIEvent): void}[] = [];
+
         public static debug = false;
 
         /* 1px x 1px gif with a 1bit palette */
@@ -23,6 +25,13 @@ module api.dom {
                     console.log('ImgEl.onLoaded', this.getSrc(), this.loaded.toString());
                 }
                 this.notifyLoaded(event);
+            });
+            this.onImgElError((event: UIEvent) => {
+                this.loaded = true;
+                if (ImgEl.debug) {
+                    console.log('ImgEl.onLoaded', this.getSrc(), this.loaded.toString());
+                }
+                this.notifyError(event);
             });
         }
 
@@ -54,8 +63,18 @@ module api.dom {
             this.loadedListeners.push(listener);
         }
 
+        onError(listener: (event: UIEvent) => void) {
+            this.errorListeners.push(listener);
+        }
+
         unLoaded(listener: (event: UIEvent) => void) {
             this.loadedListeners = this.loadedListeners.filter((curr) => {
+                return curr !== listener;
+            })
+        }
+
+        unError(listener: (event: UIEvent) => void) {
+            this.errorListeners = this.errorListeners.filter((curr) => {
                 return curr !== listener;
             })
         }
@@ -64,8 +83,16 @@ module api.dom {
             this.loadedListeners.forEach(listener => listener(event));
         }
 
+        private notifyError(event: UIEvent) {
+            this.errorListeners.forEach(listener => listener(event));
+        }
+
         private onImgElLoaded(listener: (event: UIEvent) => void) {
             this.getEl().addEventListener("load", listener);
+        }
+
+        private onImgElError(listener: (event: UIEvent) => void) {
+            this.getEl().addEventListener("error", listener);
         }
 
         isLoaded(): boolean {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/uploader/Uploader.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/uploader/Uploader.ts
@@ -2,6 +2,7 @@ module api.ui.uploader {
 
     import Button = api.ui.button.Button;
     import CloseButton = api.ui.button.CloseButton;
+    import Element = api.dom.Element;
 
     export class PluploadStatus {
         public static QUEUED = plupload.QUEUED;
@@ -300,19 +301,54 @@ module api.ui.uploader {
             }
             this.value = value;
 
-            if (value && this.config.showResult) {
-                this.setResultVisible();
+            if (value) {
+                if (this.config.showResult) {
+                    this.setResultVisible();
+                } else {
+                    this.setDropzoneVisible();
+                }
             } else {
                 this.setDropzoneVisible();
+                this.getResultContainer().removeChildren();
+                return this;
             }
-            var results = this.getResultContainer().removeChildren();
+
+            var newItemsToAppend: Element[] = [],
+                existingItems: Element[] = [];
 
             this.parseValues(value).forEach((val) => {
                 if (val) {
-                    results.appendChild(this.createResultItem(val));
+                    var existingItem = this.getExistingItem(val);
+                    if (!existingItem) {
+                        newItemsToAppend.push(this.createResultItem(val));
+                    } else {
+                        existingItems.push(existingItem);
+                    }
                 }
             });
+
+            this.removeAllChildrenExceptGiven(existingItems);
+            this.appendNewItems(newItemsToAppend);
+
             return this;
+        }
+
+        private appendNewItems(newItemsToAppend: Element[]) {
+            newItemsToAppend.forEach((elem) => {
+                this.getResultContainer().appendChild(elem);
+            });
+        }
+
+        private removeAllChildrenExceptGiven(itemsToKeep: Element[]) {
+            this.getResultContainer().getChildren().forEach((elem) => {
+                if (!itemsToKeep.some((itemToKeep) => itemToKeep == elem)) {
+                    elem.remove();
+                }
+            });
+        }
+
+        protected getExistingItem(value: string): Element {
+            return null;
         }
 
         parseValues(jsonString: string): string[] {


### PR DESCRIPTION
- Fixed preview panel of content browser when image is broken
- Added image load error listening functionality
- Added removal of image editor upon failing to upload an image
- Added image error event that notifies editor to enable delete button only disable publish button
- Made uploader to check if it tries to re-create existing item - currently method setValue() of uploader is called a  few times with the same value - this helps to avoid loading same image several times