### PR TITLE
XP-2468 Page Editor - Auto-hide the wizard panel in low-res when page…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/LiveFormPanel.ts
@@ -394,6 +394,8 @@ module app.wizard.page {
                     }
                     this.inspectComponent(<ComponentView<Component>>itemView);
                 }
+
+                this.minimizeContentFormPanelIfNeeded();
             });
 
             this.liveEditPageProxy.onItemViewDeselected((event: ItemViewDeselectedEvent) => {
@@ -452,6 +454,12 @@ module app.wizard.page {
                 new app.wizard.ShowContentFormEvent().fire();
                 this.contentWizardPanel.showForm();
             });
+        }
+
+        private minimizeContentFormPanelIfNeeded() {
+            if (this.contextWindow.isFloating() && !this.contentWizardPanel.isMinimized()) {
+                this.contentWizardPanel.toggleMinimize();
+            }
         }
 
         private inspectPage() {


### PR DESCRIPTION
… is being edited

- Added check into LiveFormPanel's onItemViewSelected() handler that will hide the wizard's form panel if live edit' context window is floating and wizard's from panel is not yet minimized