### PR TITLE
XP-2590 Page editor - Wrong behaviour of context menu for text component

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemView.ts
@@ -122,6 +122,10 @@ module api.liveedit {
 
         public static debug: boolean = false;
 
+        private static debouncedClickHandler: (itemView: ItemView,
+                                               event: MouseEvent) => void = api.util.AppHelper.debounce(ItemView.handleItemViewClickEvent,
+            300, false);
+
         constructor(builder: ItemViewBuilder) {
             api.util.assertNotNull(builder.type, "type cannot be null");
 
@@ -474,27 +478,31 @@ module api.liveedit {
             return this;
         }
 
+        private static handleItemViewClickEvent(itemView: ItemView, event: MouseEvent) {
+            if (!itemView.isSelected() || event.which == 3) {
+                // we prevented mouse events to bubble up so if parent view is selected
+                // it won't receive mouse event and won't be deselected
+                // therefore we deselect it manually
+                itemView.deselectParent();
+                itemView.getPageView().deselectChildViews();
+
+                var clickPosition = !itemView.isEmpty() ? {x: event.pageX, y: event.pageY} : null;
+                event.which == 3 ?
+                itemView.select(clickPosition, null, false, true) :
+                itemView.select(clickPosition, ItemViewContextMenuPosition.NONE, false, true);
+            } else {
+                itemView.deselect();
+            }
+        }
+
         handleClick(event: MouseEvent) {
+
             event.stopPropagation();
             if (event.which == 3) { // right click
                 event.preventDefault();
             }
 
-            if (!this.isSelected() || event.which == 3) {
-                // we prevented mouse events to bubble up so if parent view is selected
-                // it won't receive mouse event and won't be deselected
-                // therefore we deselect it manually
-                this.deselectParent();
-                this.getPageView().deselectChildViews();
-
-                var clickPosition = !this.isEmpty() ? {x: event.pageX, y: event.pageY} : null;
-                event.which == 3 ?
-                this.select(clickPosition, null, false, true) :
-                this.select(clickPosition, ItemViewContextMenuPosition.NONE, false, true);
-
-            } else {
-                this.deselect();
-            }
+            ItemView.debouncedClickHandler(this, event);
         }
 
         handleShaderClick(event: MouseEvent) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
@@ -130,7 +130,6 @@ module api.liveedit.text {
             super.handleClick(event);
         }
 
-
         handleClick(event: MouseEvent) {
             if (TextComponentView.debug) {
                 console.group('Handling click [' + this.getId() + '] at ' + new Date().getTime());
@@ -138,6 +137,9 @@ module api.liveedit.text {
             }
 
             event.stopPropagation();
+            if (event.which == 3) { // right click
+                event.preventDefault();
+            }
 
             if (this.isEditMode()) {
                 if (TextComponentView.debug) {


### PR DESCRIPTION
- Added debounced click handler for ItemView which helps to avoid calling same handler during click event fall-through. Also, set debounce time to 300ms, as text component click handler is called after quite a while (at least on my machine)