### PR TITLE
XP-2538 Wrong behavior in Edit Permissions Dialog, when new ACL-entry…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/AccessControlComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/AccessControlComboBox.ts
@@ -23,6 +23,15 @@ module api.ui.security.acl {
                 setOptionDisplayValueViewer(new AccessControlEntryViewer()).
                 setDelayedInputValueChangedHandling(500);
             super(builder);
+
+            this.onLoaded((comboboxItems: AccessControlEntry[]) => {
+
+                var displayedItems = this.aceSelectedOptionsView.getSelectedOptions().map((item: SelectedOption<AccessControlEntry>) => {
+                    return item.getOption().displayValue;
+                });
+
+                this.setAllowedPermissionsToComboboxItems(comboboxItems, displayedItems);
+            })
         }
 
         setEditable(editable: boolean) {
@@ -37,6 +46,17 @@ module api.ui.security.acl {
 
         unItemValueChanged(listener: (item: AccessControlEntry) => void) {
             this.aceSelectedOptionsView.unItemValueChanged(listener);
+        }
+
+        private setAllowedPermissionsToComboboxItems(comboboxItems: AccessControlEntry[], displayedItems: AccessControlEntry[]) {
+            displayedItems.forEach((displayedItem: AccessControlEntry) => {
+                for(let i=0; i < comboboxItems.length; i++) {
+                    if(displayedItem.getPrincipal().equals(comboboxItems[i].getPrincipal())) {
+                        comboboxItems[i].setAllowedPermissions(displayedItem.getAllowedPermissions());
+                        break;
+                    }
+                }
+            })
         }
     }
 


### PR DESCRIPTION
… added

-Issue origin: items for edit permissions dialog combobox are fetched without permissions of principals (so it is AccessControlEntry where only principal set); When we pick some
items in combobox we see displayed values below combobox where permissions are set by default as Can Read . If we pick new entry in combobox by clicking on it it will be added in the
end of list of displayed values with default Can Read permission as AccessControlEntries in combobox do not have permissions set. However when we select new items in combobox
 via checkboxes and 'Apply' button it will first clean previously selected displayed values and repick them again from combobox (where as we remember no permissions set for principals ) so default Can Read permission will be set for those.
 -Fix: whenever combobox dropdown is open - set permissions for it's AccessControlEntries as in already selected displayed values AccessControlEntries thus they will have non-default permissions in case repicked from combobox