### PR TITLE
XP-2575 Grid is still filtered when search-text was cleared

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/filter/TextSearchField.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/filter/TextSearchField.ts
@@ -32,5 +32,10 @@ module api.app.browse.filter {
             window.clearTimeout(this.timerId);
             this.setValue('', true);
         }
+
+        protected handleInput() {
+            //overriding super.handleInput method
+            //we handle onKeyDown event instead of onInput as onInput does not fire for 'enter' and 'tab' keys
+        }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/InputEl.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/InputEl.ts
@@ -6,10 +6,12 @@ module api.dom {
             super("input", className, prefix, originalValue);
             this.setType(type || 'text');
 
-            this.onInput((event: Event) => {
-                this.refreshDirtyState();
-                this.refreshValueChanged();
-            });
+            this.onInput(this.handleInput.bind(this));
+        }
+
+        protected handleInput() {
+            this.refreshDirtyState();
+            this.refreshValueChanged();
         }
 
         getName(): string {


### PR DESCRIPTION
-Issue appeared due to changes in InputEl after adding onInput handler with refreshValueChanged() call (XP-2234 Add and verify that all descendants of FormInputEl correctly update dirty flag)
-Issue origin: in TextSearchField we  handle keyDown events with timeout to let user end his input into Search Field. After adding onInput handler into InputEl that is TextSearchField's parent , refreshValueChanged() started to trigger twice - in parent's onInput and in TextSearchField's onKeyDown, but handler in onKeyDown has timeout delay so it was called extra time with already invalid data after onInput called ages ago.
-Fix: added handleInput method in InputEl called  in onInput handler thus  handleInput can be overridden, what was done for TextSearchField