### PR TITLE
XP-2538 Wrong behavior in Edit Permissions Dialog, when new ACL-entry…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -65,6 +65,8 @@ module api.ui.selector.combobox {
 
         private expandedListeners: {(event: api.ui.selector.DropdownExpandedEvent): void}[] = [];
 
+        private selectiondDelta = [];
+
         public static debug: boolean = false;
 
         /**
@@ -290,8 +292,10 @@ module api.ui.selector.combobox {
 
             // fast alternative to isSelectionChanged()
             if (this.applySelectionsButton && this.applySelectionsButton.isVisible()) {
-                this.clearSelection(true);
-                this.comboBoxDropdown.applyMultipleSelection();
+                this.selectiondDelta.forEach((value: string) => {
+                    var row = this.comboBoxDropdown.getDropdownGrid().getRowByValue(value);
+                    this.handleRowSelected(row);
+                });
                 this.input.setValue("");
                 this.hideDropdown();
             } else {
@@ -686,9 +690,28 @@ module api.ui.selector.combobox {
             this.input.giveFocus();
             if (this.isSelectionChanged()) {
                 this.applySelectionsButton.show();
+                this.updateSelectionDelta();
             } else {
                 this.applySelectionsButton.hide();
             }
+        }
+
+        private updateSelectionDelta() {
+
+            var selectedValues = this.getSelectedOptions().map((x) => {
+                return x.value;
+            });
+
+            var gridOptions = [];
+
+            this.comboBoxDropdown.getDropdownGrid().getElement().getSelectedRows().forEach((row: number) => {
+                gridOptions.push(this.comboBoxDropdown.getDropdownGrid().getOptionByRow(row).value);
+            });
+
+            this.selectiondDelta = gridOptions
+                .filter(x => selectedValues.indexOf(x) == -1)
+                .concat(selectedValues.filter(x => gridOptions.indexOf(x) == -1));
+
         }
 
         /**


### PR DESCRIPTION
… added

-Updated so when changing selection by checkbox in combobox dropdown we save selection difference between what is already selected and displayed and what was selected in open dropdown; then when hitting apply we won't clean all previously selected option and re-add them but will only update that difference rows