### PR TITLE
XP-2571 Duplicated content elements in ContentTreeGrid

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -163,7 +163,7 @@ module api.ui.treegrid {
             this.appendChild(this.grid);
 
             if (builder.isAutoLoad()) {
-                this.reload();
+                this.reload().then(() => this.grid.resizeCanvas());
             }
 
             if (builder.isPartialLoadEnabled()) {
@@ -624,7 +624,7 @@ module api.ui.treegrid {
 
         // Hard reset
 
-        reload(parentNodeData?: DATA): void {
+        reload(parentNodeData?: DATA): wemQ.Promise<void> {
             var expandedNodesDataId = this.grid.getDataView().getItems().filter((item) => {
                 return item.isExpanded();
             }).map((item) => {
@@ -637,16 +637,17 @@ module api.ui.treegrid {
             this.initData([]);
 
             this.mask();
-            this.reloadNode(null, expandedNodesDataId)
+
+            return this.reloadNode(null, expandedNodesDataId)
                 .then(() => {
                     this.root.setCurrentSelection(selection);
                     this.initData(this.root.getCurrentRoot().treeToList());
                     this.updateExpanded();
                 }).catch((reason: any) => {
                     api.DefaultErrorHandler.handle(reason);
-                }).finally(() => {
+                }).then(() => {
                     this.updateExpanded();
-                }).done(() => this.notifyLoaded());
+                }).then(() => this.notifyLoaded());
         }
 
         private reloadNode(parentNode?: TreeNode<DATA>, expandedNodesDataId?: String[]): wemQ.Promise<void> {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeNode.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeNode.ts
@@ -130,12 +130,17 @@ module api.ui.treegrid {
             return root;
         }
 
+        private removeDuplicates() {
+            this.children = api.util.ArrayHelper.removeDuplicates(this.children, (child) => child.getDataId());
+        }
+
         getChildren(): TreeNode<DATA>[] {
             return this.children;
         }
 
         setChildren(children: TreeNode<DATA>[]) {
             this.children = children;
+            this.removeDuplicates();
 
             this.children.forEach((child) => {
                 child.setParent(this);
@@ -160,6 +165,7 @@ module api.ui.treegrid {
         insertChild(child: TreeNode<DATA>, index: number = 0) {
             this.children = this.children || [];
             this.children.splice(index, 0, child);
+            this.removeDuplicates();
             this.clearViewers();
             child.setParent(this);
         }
@@ -176,6 +182,7 @@ module api.ui.treegrid {
             } else {
                 this.children.push(child);
             }
+            this.removeDuplicates();
             this.clearViewers();
             child.setParent(this);
         }


### PR DESCRIPTION
Fixed the initial TreeGrid rendering issue, when the columns do not fit well.
Added duplicate handler in the TreeNode - no items with the same dataId can be added on the same level.