### PR TITLE
XP-2624 FF specific bug: impossible to close a wizard panel

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
@@ -432,7 +432,12 @@ module api.form.inputtype.text {
         private destroyEditor(id: string): void {
             var editor = this.getEditor(id)
             if (editor) {
-                editor.destroy(false);
+                try {
+                    editor.destroy(false);
+                }
+                catch(e) {
+                    //error thrown in FF on tab close - XP-2624
+                }
             }
         }
 


### PR DESCRIPTION
-Issue  origin: destroyEditor() method fails on content tab close. Appeared on latest FF versions, origin unknown but seems some resources cleanup fails on already disposed code

Tried replacing code 'editor.destroy(false)' with 'editor.remove()' and 'tinymce.EditorManager.execCommand('mceRemoveEditor',true/false, editor_id);' but didn't help.

Implementing workaround with try/catch as the only solution that helps