### PR TITLE
XP-2640 EditPermissionsDialog - access control combobox is shown in s…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/AccessControlComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/AccessControlComboBox.ts
@@ -19,6 +19,7 @@ module api.ui.security.acl {
                 setComboBoxName("principalSelector").
                 setIdentifierMethod("getPrincipalKey").
                 setLoader(new AccessControlEntryLoader()).
+                setHideComboBoxWhenMaxReached(false).
                 setSelectedOptionsView(this.aceSelectedOptionsView).
                 setOptionDisplayValueViewer(new AccessControlEntryViewer()).
                 setDelayedInputValueChangedHandling(500);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
@@ -35,7 +35,7 @@ module api.ui.selector.combobox {
                 maximumOccurrences: builder.maximumOccurrences,
                 selectedOptionsView: this.selectedOptionsView,
                 optionDisplayValueViewer: builder.optionDisplayValueViewer,
-                hideComboBoxWhenMaxReached: true,
+                hideComboBoxWhenMaxReached: builder.hideComboBoxWhenMaxReached,
                 setNextInputFocusWhenMaxReached: builder.nextInputFocusWhenMaxReached,
                 delayedInputValueChangedHandling: builder.delayedInputValueChangedHandling,
                 minWidth: builder.minWidth,
@@ -404,6 +404,8 @@ module api.ui.selector.combobox {
 
         nextInputFocusWhenMaxReached: boolean = true;
 
+        hideComboBoxWhenMaxReached: boolean = true;
+
         minWidth: number;
 
         value: string;
@@ -445,6 +447,11 @@ module api.ui.selector.combobox {
 
         setNextInputFocusWhenMaxReached(value: boolean): RichComboBoxBuilder<T> {
             this.nextInputFocusWhenMaxReached = value;
+            return this;
+        }
+
+        setHideComboBoxWhenMaxReached(value: boolean): RichComboBoxBuilder<T> {
+            this.hideComboBoxWhenMaxReached = value;
             return this;
         }
 


### PR DESCRIPTION
…pite of 'Inherit permissions' is checked

-Issue origin: combobox is designed to be hidden when max occurences reached and shown again if some items deselected. EditPermissionsDialog unlike other modal dialogs can have it's combobox hidden on certain condition - when inherit permissions is checked; But when we open permissions dialog it makes initialization during which clearSelections() is called and combobox is getting shown like it had some items deselected.

-Fix: updating combobox behavior to take into account that not all comboboxes supposed to be shown on deselection.