### PR TITLE
XP-2608 Page Editor - Auto-hide the wizard panel when a new text comp…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveFormPanel.ts
@@ -404,7 +404,6 @@ module app.wizard.page {
                     this.inspectComponent(<ComponentView<Component>>itemView);
                 }
 
-                this.minimizeContentFormPanelIfNeeded();
             });
 
             this.liveEditPageProxy.onItemViewDeselected((event: ItemViewDeselectedEvent) => {
@@ -419,6 +418,9 @@ module app.wizard.page {
 
             this.liveEditPageProxy.onComponentAdded((event: ComponentAddedEvent) => {
                 // do something when component is added
+                if (api.ObjectHelper.iFrameSafeInstanceOf(event.getComponentView(), ComponentView)) {
+                    this.minimizeContentFormPanelIfNeeded();
+                }
             });
 
             this.liveEditPageProxy.onComponentRemoved((event: ComponentRemovedEvent) => {


### PR DESCRIPTION
…onent is dragged to the page

-Moved call to minimizing wizard panel to onComponentAdded() because it is called for all ComponentViews, meanwhile onItemViewSelected() is called for all ComponentViews except TextComponentView what brought this issue