### PR TITLE
XP-2645 Site Configurator dialog: when a HtmlArea present in a dialog…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionView.ts
@@ -73,7 +73,7 @@ module api.content.site.inputtype.siteconfigurator {
                 this.toggleClass("invalid", !event.isValid())
             }
 
-            this.formView = this.createFormView(this.formContext, this.siteConfig);
+            this.formView = new FormView(this.formContext, this.application.getForm(), this.siteConfig.getConfig());
         }
 
         private createEditButton(): api.dom.AEl {


### PR DESCRIPTION
… and a text typed into it, need to press twice "Apply" button

-No need to layout formView until Site Configurator dialog is open; Issue was that extra objects were created (HTMLArea in our case) during site configurator initialization, and it's listeners were called on hiting 'apply' button.  Now formview layout to be called only on dialog opening.