### PR TITLE
XP-2622 Modal dialog - Mask doesn't disappear after clicking outside …

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/EditPermissionsDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/EditPermissionsDialog.ts
@@ -178,6 +178,13 @@ module app.wizard {
                 this.dialogTitle.setPath('');
             }
             super.show();
+
+            if(this.comboBox.getComboBox().isVisible()) {
+                this.comboBox.giveFocus();
+            }
+            else {
+                this.inheritPermissionsCheck.giveFocus();
+            }
         }
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/SaveBeforeCloseDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/SaveBeforeCloseDialog.ts
@@ -33,9 +33,6 @@ module api.app.wizard {
             this.addAction(this.noAction);
 
             this.getCancelAction().setMnemonic("c");
-            this.getCancelAction().onExecuted(() => {
-                this.close();
-            });
         }
 
         show() {


### PR DESCRIPTION
…of the dialog

-Issue origin: OpenEditPermissonsDialog event was triggered second time when pressing enter key after opening dialog due to focus still remained on 'Edit Permissions' button, thus opening handler called twice and two masks added on page.

-Fix: Setting focus on access control combobox or inherit permissions checkbox (same is done for other modal dialogs)

-Issue with mask on SaveBefoeClose dialog - redundant cancel acttion was created and when executed it was updating modaldialog's openDialogsCounter incrorrectly thus mask was not removed on close