### PR TITLE
XP-2645 Site Configurator dialog: when a HtmlArea present in a dialog…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionView.ts
@@ -71,8 +71,8 @@ module api.content.site.inputtype.siteconfigurator {
         private initFormView() {
             this.formValidityChangedHandler = (event: api.form.FormValidityChangedEvent) => {
                 this.toggleClass("invalid", !event.isValid())
-            }
-            this.formView = this.createFormView(this.formContext, this.siteConfig);
+            };
+            this.formView = this.createFormView(this.siteConfig);
         }
 
         private createEditButton(): api.dom.AEl {
@@ -98,7 +98,7 @@ module api.content.site.inputtype.siteconfigurator {
                 var formViewStateOnDialogOpen = this.formView;
                 this.unbindValidationEvent(formViewStateOnDialogOpen);
 
-                this.formView = this.createFormView(this.formContext, tempSiteConfig);
+                this.formView = this.createFormView(tempSiteConfig);
                 this.bindValidationEvent(this.formView);
 
                 var okCallback = () => {
@@ -153,8 +153,8 @@ module api.content.site.inputtype.siteconfigurator {
             return SiteConfig.create().setConfig(propSet).setApplicationKey(this.siteConfig.getApplicationKey()).build();
         }
 
-        private createFormView(formContext: api.content.form.ContentFormContext, siteConfig: SiteConfig): FormView {
-            var formView = new FormView(formContext, this.application.getForm(), siteConfig.getConfig());
+        private createFormView(siteConfig: SiteConfig): FormView {
+            var formView = new FormView(this.formContext, this.application.getForm(), siteConfig.getConfig());
             formView.addClass("site-form");
             formView.layout().then(() => {
                 this.formView.validate(false, true);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
@@ -349,8 +349,12 @@ module api.form.inputtype.text {
         }
 
         private setEditorContent(editorId: string, property: Property): void {
-            if (property.hasNonNullValue()) {
-                this.getEditor(editorId).setContent(this.processPropertyValue(property.getString()));
+            var editor = this.getEditor(editorId);
+            if (property.hasNonNullValue() && editor) {
+                editor.setContent(this.processPropertyValue(property.getString()));
+            }
+            else if (!editor) {
+                console.log("Editor with id '" + editorId + "' not found")
             }
         }
 
@@ -413,7 +417,7 @@ module api.form.inputtype.text {
         }
 
         private destroyEditor(id: string): void {
-            var editor = this.getEditor(id)
+            var editor = this.getEditor(id);
             if (editor) {
                 try {
                     editor.destroy(false);


### PR DESCRIPTION
… and a text typed into it, need to press twice "Apply" button

-Issue is that extra objects are created (HTMLArea in our case) during site configurator initialization (formview.layout() is adding listeners to property object), and it's listeners were called on hiting 'apply' button. As a solution adding additional check for HtmlArea setContent