### PR TITLE
XP-2788 Page Editor - Use the same HTML Area class as in the Content …

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
@@ -254,7 +254,7 @@ module api.liveedit.text {
                 fixed_toolbar_container: '.mce-toolbar-container',
 
                 toolbar: [
-                    "bold italic underline strikethrough formatselect | cut copy pastetext | bullist numlist outdent indent | charmap anchor link unlink"
+                    "styleselect | cut copy pastetext | bullist numlist outdent indent | charmap anchor link unlink | code"
                 ],
 
                 formats: {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/form/inputtype/text/html-area.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/form/inputtype/text/html-area.less
@@ -1,4 +1,4 @@
-.html-area {
+.html-area, .mce-toolbar-container {
   .mce-btn {
     background-image: none;
     border-radius: 0;
@@ -97,4 +97,8 @@
     }
   }
 
+}
+
+.mce-toolbar-container .mce-toolbar-grp {
+  display: block;
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/common.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/common.less
@@ -32,3 +32,5 @@
 @import "../../common/styles/api/ui/dialog/modal-dialog";
 @import "../../common/styles/api/ui/panel/docked-panel";
 @import "../../common/styles/api/ui/checkbox";
+//tinymce toolbar overriden styles
+@import "../../common/styles/api/form/inputtype/text/html-area";

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/page-view.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/page-view.less
@@ -30,6 +30,17 @@
       }
     }
   }
+
+  .html-area-modal-dialog {
+    .@{_COMMON_PREFIX}text-input {
+      color: inherit;
+      font-size: 12px;
+    }
+
+    .input-wrapper .checkbox.form-input {
+      margin-top: 0px;
+    }
+  }
 }
 
 .@{_CLS_PREFIX}page-placeholder {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/text-view.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/text-view.less
@@ -95,7 +95,7 @@
 
 .close-edit-mode-button.icon-close {
   position: fixed;
-  top: 12px;
+  top: 8px;
   right: 12px;
   z-index: @z-index-context-menu + 1;
   pointer-events: auto;


### PR DESCRIPTION
…Wizard

- Made text editor tiny mce toolbar of live edit to use same styling as html area uses. I did not use html-area class in live edit text component as it is not applicable to it.
- Adjusted some overriden styling for editor dialogs
- Made text editor toolbar to use almost same set of buttons excluding image and table buttons