### PR TITLE
XP-2764 ServerEvents: no client event is thrown for server event when…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/event/ContentPublishedEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/event/ContentPublishedEvent.ts
@@ -2,18 +2,22 @@ module api.content.event {
 
     export class ContentPublishedEvent extends api.event.Event {
 
-        private contentId: api.content.ContentId;
+        private contentSummary: api.content.ContentSummary;
 
         private compareStatus: api.content.CompareStatus;
 
-        constructor(contentId: api.content.ContentId, compareStatus: api.content.CompareStatus) {
+        constructor(contentSummary: api.content.ContentSummary, compareStatus: api.content.CompareStatus) {
             super();
-            this.contentId = contentId;
+            this.contentSummary = contentSummary;
             this.compareStatus = compareStatus;
         }
 
         public getContentId(): api.content.ContentId {
-            return this.contentId;
+            return this.contentSummary.getContentId();
+        }
+
+        public getContentSummary(): api.content.ContentSummary {
+            return this.contentSummary;
         }
 
         public getCompareStatus(): api.content.CompareStatus {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/event/ContentUpdatedEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/event/ContentUpdatedEvent.ts
@@ -1,20 +1,20 @@
 module api.content.event {
 
-    export interface ContentUpdatedEventJson {
-        contentId: string;
-    }
-
     export class ContentUpdatedEvent extends api.event.Event {
 
-        private contentId: api.content.ContentId;
+        private contentSummary: api.content.ContentSummary;
 
-        constructor(contentId: api.content.ContentId) {
+        constructor(contentSummary: api.content.ContentSummary) {
             super();
-            this.contentId = contentId;
+            this.contentSummary = contentSummary;
         }
 
         public getContentId(): api.content.ContentId {
-            return this.contentId;
+            return this.contentSummary.getContentId();
+        }
+
+        public getContentSummary(): api.content.ContentSummary {
+            return this.contentSummary;
         }
 
         static on(handler: (event: ContentUpdatedEvent) => void) {
@@ -25,8 +25,5 @@ module api.content.event {
             api.event.Event.unbind(api.ClassHelper.getFullName(this), handler);
         }
 
-        static fromJson(json: ContentUpdatedEventJson): ContentUpdatedEvent {
-            return new ContentUpdatedEvent(new ContentId(json.contentId));
-        }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/Element.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/Element.ts
@@ -94,7 +94,7 @@ module api.dom {
 
         private rendered: boolean;
 
-        public static debug: boolean = true;
+        public static debug: boolean = false;
 
         private addedListeners: {(event: ElementAddedEvent) : void}[] = [];
         private removedListeners: {(event: ElementRemovedEvent) : void}[] = [];


### PR DESCRIPTION
… a browse panel is present and content is not loaded in grid

- refactored ContentServerEventsHandler to fetch content if necessary and pass it to listeners
- refactored ContentBrowsePanel to listen to ContentServerEventsHandler only, without depending on the grid
- updated published and updated events to contain content summary
- turned off debug in Element