### PR TITLE
XP-2847 Wizard Step Navigator - Wrong width in docked mode

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardPanel.ts
@@ -221,7 +221,7 @@ module api.app.wizard {
             if (this.minimized) {
                 navigationWidth = this.splitPanel.getEl().getHeight();
             } else {
-                navigationWidth = this.stepsPanel.getEl().getWidth();
+                navigationWidth = this.stepsPanel.getEl().getWidth() - this.stepNavigatorAndToolbarContainer.getEl().getPaddingLeft();
             }
             this.stepNavigatorAndToolbarContainer.getEl().setWidthPx(navigationWidth);
         }


### PR DESCRIPTION
-Issue was in left padding 0->95px changing on step navigator after stretching; included left padding in width calculation