### PR TITLE
XP-2793 Page Editor - Text edit mode toolbar

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/ElementHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/ElementHelper.ts
@@ -612,12 +612,13 @@ module api.dom {
             };
         }
 
-        getDimensionsRelativeToParent(): ElementDimensions {
-            var offset = this.getOffsetToParent();
+        getDimensionsTopRelativeToParent(): ElementDimensions {
+            var offsetToParent = this.getOffsetToParent();
+            var offsetToDocument = this.getOffset();
 
             return {
-                top: offset.top,
-                left: offset.left,
+                top: offsetToParent.top,
+                left: offsetToDocument.left,
                 width: this.getWidthWithBorder(),
                 height: this.getHeightWithBorder()
             };

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/Highlighter.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/Highlighter.ts
@@ -6,6 +6,8 @@ module api.liveedit {
 
         private static INSTANCE: Highlighter;
 
+        private lastHighlightedItemView: ItemView;
+
         constructor() {
             // Needs to be a SVG element as the css has pointer-events:none
             // CSS pointer-events only works for SVG in IE
@@ -35,16 +37,22 @@ module api.liveedit {
                 this.hide();
                 return;
             }
-            var dimensions = itemView.getEl().getDimensionsRelativeToParent();
+            var dimensions = itemView.getEl().getDimensionsTopRelativeToParent();
             var style = itemView.getType().getConfig().getHighlighterStyle();
 
             this.resize(dimensions, this.preProcessStyle(style));
             this.show();
+
+            this.lastHighlightedItemView = itemView;
         }
 
         highlightElement(dimensions: ElementDimensions, style: HighlighterStyle): void {
             this.resize(dimensions, style);
             this.show();
+        }
+
+        updateLastHighlightedItemView() {
+            this.highlightItemView(this.lastHighlightedItemView);
         }
 
         protected preProcessStyle(style: HighlighterStyle): HighlighterStyle {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
@@ -441,6 +441,11 @@ module api.liveedit {
             if (flag) {
                 new PageTextModeStartedEvent(this).fire();
             }
+            else {
+                api.liveedit.Highlighter.get().updateLastHighlightedItemView();
+                api.liveedit.SelectedHighlighter.get().updateLastHighlightedItemView();
+            }
+
         }
 
         hasTargetWithinTextComponent(target: HTMLElement) {


### PR DESCRIPTION
-Issue: When the editor is in edit mode and another component is clicked/selected, its border will be displaced (shifted up by toolbar height).
-Explained: issue was in that empty text component takes different vertical space when in/out edit mode,  and after selecting other item it is getting highlighted, text edit mode gets switched off, empty text component takes more vertical space as when in text edit mode and moves html content except highlights that positioned absolutely.
-Solution: refresh highlights on switching text edit mode off