### PR TITLE
XP-2899 Executable files are created as media:unknown

### DIFF
--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/AbstractCreatingOrUpdatingContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/AbstractCreatingOrUpdatingContentCommand.java
@@ -17,6 +17,9 @@ class AbstractCreatingOrUpdatingContentCommand
         ImmutableList.of( MediaType.OCTET_STREAM, MediaType.create( "application", "force-download" ),
                           MediaType.create( "application", "x-force-download" ) );
 
+    private final static ImmutableList<MediaType> EXECUTABLE_CONTENT_TYPES =
+        ImmutableList.of( MediaType.OCTET_STREAM, MediaType.create( "text", "plain" ), MediaType.create( "application", "x-bzip2" ) );
+
     final MixinService mixinService;
 
     final SiteService siteService;
@@ -79,6 +82,18 @@ class AbstractCreatingOrUpdatingContentCommand
     {
         final MediaType mediaType = MediaType.parse( contentType );
         return BINARY_CONTENT_TYPES.stream().anyMatch( mediaType::is );
+    }
+
+    protected boolean isExecutableContentType( final String contentType, final String fileName )
+    {
+        final MediaType mediaType = MediaType.parse( contentType );
+        return EXECUTABLE_CONTENT_TYPES.stream().anyMatch( mediaType::is ) && isExecutableFileName( fileName );
+    }
+
+    private boolean isExecutableFileName( final String fileName )
+    {
+        return fileName.endsWith( ".exe" ) || fileName.endsWith( ".msi" ) || fileName.endsWith( ".dmg" ) ||
+            fileName.endsWith( ".bat" ) || fileName.endsWith( ".sh" );
     }
 }
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentTypeFromMimeTypeResolver.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentTypeFromMimeTypeResolver.java
@@ -82,7 +82,20 @@ final class ContentTypeFromMimeTypeResolver
         MAP.put( "application/msword", ContentTypeName.documentMedia() );
 
         // Executable
-        // TODO
+        MAP.put( "application/x-tika-msoffice", ContentTypeName.executableMedia() ); // .msi
+        MAP.put( "application/x-msi", ContentTypeName.executableMedia() ); // .msi
+        MAP.put( "application/x-msdownload", ContentTypeName.executableMedia() ); // .exe
+        MAP.put( "application/exe", ContentTypeName.executableMedia() ); // .exe
+        MAP.put( "application/x-exe", ContentTypeName.executableMedia() ); // .exe
+        MAP.put( "application/dos-exe", ContentTypeName.executableMedia() ); // .exe
+        MAP.put( "vms/exe", ContentTypeName.executableMedia() ); // .exe
+        MAP.put( "application/x-winexe", ContentTypeName.executableMedia() ); // .exe
+        MAP.put( "application/msdos-windows", ContentTypeName.executableMedia() );  // .exe
+        MAP.put( "application/x-apple-diskimage", ContentTypeName.executableMedia() );  // .dmg
+        MAP.put( "application/x-sh", ContentTypeName.executableMedia() ); // .sh
+        MAP.put( "application/x-shar", ContentTypeName.executableMedia() ); // .sh
+        MAP.put( "application/bat", ContentTypeName.executableMedia() ); // .bat
+        MAP.put( "application/x-bat", ContentTypeName.executableMedia() ); // .bat
 
         // Presentation
         MAP.put( "application/vnd.openxmlformats-officedocument.presentationml.presentation", ContentTypeName.presentationMedia() );

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateMediaCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateMediaCommand.java
@@ -44,7 +44,11 @@ final class CreateMediaCommand
         Preconditions.checkNotNull( params.getMimeType(), "Unable to resolve media type" );
 
         final ContentTypeName resolvedTypeFromMimeType = ContentTypeFromMimeTypeResolver.resolve( params.getMimeType() );
-        final ContentTypeName type = resolvedTypeFromMimeType != null ? resolvedTypeFromMimeType : ContentTypeName.unknownMedia();
+        final ContentTypeName type = resolvedTypeFromMimeType != null
+            ? resolvedTypeFromMimeType
+            : isExecutableContentType( params.getMimeType(), params.getName() )
+                ? ContentTypeName.executableMedia()
+                : ContentTypeName.unknownMedia();
 
         final PropertyTree data = new PropertyTree();
         new MediaFormDataBuilder().

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
@@ -48,7 +48,11 @@ final class UpdateMediaCommand
         Preconditions.checkNotNull( params.getMimeType(), "Unable to resolve media type" );
 
         final ContentTypeName resolvedTypeFromMimeType = ContentTypeFromMimeTypeResolver.resolve( params.getMimeType() );
-        final ContentTypeName type = resolvedTypeFromMimeType != null ? resolvedTypeFromMimeType : ContentTypeName.unknownMedia();
+        final ContentTypeName type = resolvedTypeFromMimeType != null
+            ? resolvedTypeFromMimeType
+            : isExecutableContentType( params.getMimeType(), params.getName() )
+                ? ContentTypeName.executableMedia()
+                : ContentTypeName.unknownMedia();
 
         final CreateAttachment mediaAttachment = CreateAttachment.create().
             name( params.getName() ).


### PR DESCRIPTION
- Added mime type resolver entries to determine executable files
- Also added special handling for executable files that uses file name and most expected mime type to determine if file is executable