### PR TITLE
Include .gitignore in init-project clones

### DIFF
--- a/modules/tools/toolbox/src/main/java/com/enonic/xp/toolbox/app/InitAppCommand.java
+++ b/modules/tools/toolbox/src/main/java/com/enonic/xp/toolbox/app/InitAppCommand.java
@@ -139,7 +139,6 @@ public final class InitAppCommand
     private void copyGitUnrelatedContent( File source, File target )
         throws IOException
     {
-        // Remove the .gitkeep and .gitignore files
         Files.walkFileTree( source.toPath(), new GitUnrelatedContentCopyFileVisitor( source.toPath(), target.toPath() ) );
     }
 
@@ -183,12 +182,9 @@ public final class InitAppCommand
             throws IOException
         {
             final String fileName = sourceFilePath.getFileName().toString();
-            if ( !".gitkeep".equals( fileName ) && !".gitignore".equals( fileName ) )
-            {
-                final Path sourceFileSubPath = sourcePath.relativize( sourceFilePath );
-                final Path targetFilePath = Paths.get( targetPath.toString(), sourceFileSubPath.toString() );
-                Files.move( sourceFilePath, targetFilePath, StandardCopyOption.REPLACE_EXISTING, LinkOption.NOFOLLOW_LINKS );
-            }
+            final Path sourceFileSubPath = sourcePath.relativize( sourceFilePath );
+            final Path targetFilePath = Paths.get( targetPath.toString(), sourceFileSubPath.toString() );
+            Files.move( sourceFilePath, targetFilePath, StandardCopyOption.REPLACE_EXISTING, LinkOption.NOFOLLOW_LINKS );
             return FileVisitResult.CONTINUE;
         }
 


### PR DESCRIPTION
This commit includes `.gitignore` and `.gitkeep` when downloading a
starter kit. Because it makes sense. 🙄

Fixes #2939