### PR TITLE
XP-2935 Updating media content does two updates, one with old data

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/upload/MediaUploader.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/upload/MediaUploader.ts
@@ -65,8 +65,6 @@ module api.content.form.inputtype.upload {
                 }
 
                 api.notify.showFeedback('\"' + fileName + '\" uploaded');
-
-                new ContentRequiresSaveEvent(content.getContentId()).fire();
             });
 
             this.mediaUploaderEl.onUploadFailed(() => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/FormInputEl.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/FormInputEl.ts
@@ -30,6 +30,8 @@ module api.dom {
                     }
                     // use doSetValue because descendants might override setValue method (i.e. CheckBox, RadioGroup)
                     this.doSetValue(originalValue, true);
+                    // doGetValue instead of value in case input trims/modifies value (i.e. textarea strips \r chars)
+                    this.originalValue = this.doGetValue();
                 });
             }
 
@@ -67,7 +69,8 @@ module api.dom {
             if (FormInputEl.debug) {
                 console.groupCollapsed(this.toString() + '.setValue(' + value + ')');
             }
-            if (this.oldValue != value) {
+            // let userInput force value update
+            if (this.oldValue != value || userInput) {
                 if (FormInputEl.debug) {
                     console.debug('update value from "' + this.oldValue + '" to "' + value + '"');
                 }
@@ -81,7 +84,8 @@ module api.dom {
                         console.debug('not dirty and not user input, update original value from "' + this.originalValue + '" to "' + value +
                                       '"');
                     }
-                    this.originalValue = value;
+                    // doGetValue instead of value in case input trims/modifies value (i.e. textarea strips \r chars)
+                    this.originalValue = this.doGetValue();
                 } else {
                     // update dirty according to new value and original value
                     // to keep dirty state consistent

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/processor/ProcessUpdateParams.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/processor/ProcessUpdateParams.java
@@ -2,6 +2,7 @@ package com.enonic.xp.core.impl.content.processor;
 
 import com.enonic.xp.content.UpdateContentParams;
 import com.enonic.xp.media.MediaInfo;
+import com.enonic.xp.schema.content.ContentType;
 
 public class ProcessUpdateParams
 {
@@ -9,10 +10,13 @@ public class ProcessUpdateParams
 
     private final MediaInfo mediaInfo;
 
-    public ProcessUpdateParams( final UpdateContentParams updateContentParams, final MediaInfo mediaInfo )
+    private final ContentType contentType;
+
+    public ProcessUpdateParams( final UpdateContentParams updateContentParams, final MediaInfo mediaInfo, final ContentType contentType )
     {
         this.updateContentParams = updateContentParams;
         this.mediaInfo = mediaInfo;
+        this.contentType = contentType;
     }
 
     public UpdateContentParams getUpdateContentParams()
@@ -23,5 +27,10 @@ public class ProcessUpdateParams
     public MediaInfo getMediaInfo()
     {
         return mediaInfo;
+    }
+
+    public ContentType getContentType()
+    {
+        return contentType;
     }
 }

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/processor/TextExtractorContentProcessor.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/processor/TextExtractorContentProcessor.java
@@ -65,8 +65,15 @@ public class TextExtractorContentProcessor
     @Override
     public ProcessUpdateResult processUpdate( final ProcessUpdateParams params )
     {
-        //final Mixins contentTypeMixins = getMixins( params.getUpdateContentParams(). );
-        return null;
+        final ContentType contentType = params.getContentType();
+
+        final Mixins contentTypeMixins = getMixins( contentType.getName() );
+
+        ExtraDatas extraDatas = params.getMediaInfo() != null ? extractMetadata( params.getMediaInfo(), contentTypeMixins ) : null;
+
+        return new ProcessUpdateResult( null, extraDatas == null ? null : edit -> {
+            edit.extraDatas = extraDatas;
+        } );
     }
 
     private ExtraDatas extractMetadata( final MediaInfo mediaInfo, final Mixins mixins )


### PR DESCRIPTION
- modified FormInputEl to store originalValue after setting it to input to make sure any browser-specific processing is made (i.e. textarea strips \r chars)
- removed ContentRequiresSaveEvent from MediaUploader
- invoked ContentProcessors in UpdateContentCommand
- implemented processUpdate in TextExtractorContentProcessor