### PR TITLE
XP-2944 Users app: Header with display name shifted up after page rel…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/GroupRoleWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/GroupRoleWizardPanel.ts
@@ -95,5 +95,12 @@ module app.wizard {
         isPersistedEqualsViewed(): boolean {
             throw new Error("Must be implemented by inheritors");
         }
+
+        show() {
+            setTimeout(() => {
+                super.show();
+            }, 0);
+
+        }
     }
 }


### PR DESCRIPTION
…oad in Chrome for Roles and Groups

-issue in Chrome with jquery show(): after it is called on RoleWizardPanel and GroupWizardPanel those panels are not really shown (tried investigating why but no answer) so notifyshown is not triggered on children and so on...
-Solved by adding zero timeout for show() to let rendering engine finish first