### PR TITLE
XP-3006 ComponentViews are broken after move and reset in LiveEdit

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ComponentView.ts
@@ -343,6 +343,9 @@ module api.liveedit {
 
             // Register with new region...
             toRegionView.addComponentView(this, toIndex);
+            if (parentView && this.component) {
+                this.registerComponentListeners(this.component);
+            }
         }
 
         onItemViewAdded(listener: (event: ItemViewAddedEvent) => void) {


### PR DESCRIPTION
- As during move components are unsubscribed from events, made them to be subscribed again