### PR TITLE
XP-3012 Delete item dialog: content deleted, when the button "Cancel"…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/action/DeleteContentAction.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/action/DeleteContentAction.ts
@@ -12,8 +12,9 @@ module app.browse.action {
             this.onExecuted(() => {
                 var contents: api.content.ContentSummaryAndCompareStatus[]
                     = grid.getSelectedDataList();
-                new ContentDeletePromptEvent(contents).
-                    setYesCallback(() => {
+                new ContentDeletePromptEvent(contents)
+                    .setNoCallback(null)
+                    .setYesCallback(() => {
                         var excludeStatuses = [CompareStatus.EQUAL, CompareStatus.PENDING_DELETE, CompareStatus.NEWER],
                         deselected = [];
                         grid.getSelectedDataList().forEach((content: ContentSummaryAndCompareStatus) => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialogAction.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialogAction.ts
@@ -2,7 +2,7 @@ module app.remove {
 
     export class ContentDeleteDialogAction extends api.ui.Action {
         constructor() {
-            super("Delete", "enter");
+            super("Delete");
             this.setIconClass("delete-action");
         }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ConfirmationDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ConfirmationDialog.ts
@@ -22,15 +22,15 @@ module api.ui.dialog {
             this.appendChildToContentPanel(this.questionEl);
 
             this.noAction = new api.ui.Action("No", "esc");
-            this.noAction.onExecuted((action: api.ui.Action) => {
+            this.noAction.onExecuted(() => {
                 this.close();
                 if (this.noCallback) {
                     this.noCallback();
                 }
             });
 
-            this.yesAction = new api.ui.Action("Yes", "enter");
-            this.yesAction.onExecuted((action: api.ui.Action) => {
+            this.yesAction = new api.ui.Action("Yes");
+            this.yesAction.onExecuted(() => {
                 this.close();
                 if (this.yesCallback) {
                     this.yesCallback();


### PR DESCRIPTION
… tabbed and "Enter" pressed

XP-3013 Confirmation (Delete) dialog: content deleted, when the button "No" tabbed and "Enter" pressed

Removed the `enter` key from the on-action binding of the delete confirmation dialogues.