### PR TITLE
XP-3032 Modal (confirmation) dialog: "Enter" key is bound on confirmation, regardless of focus; automatic focus on some dialogs is missing.

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/action/DeleteContentAction.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/action/DeleteContentAction.ts
@@ -12,8 +12,9 @@ module app.browse.action {
             this.onExecuted(() => {
                 var contents: api.content.ContentSummaryAndCompareStatus[]
                     = grid.getSelectedDataList();
-                new ContentDeletePromptEvent(contents).
-                    setYesCallback(() => {
+                new ContentDeletePromptEvent(contents)
+                    .setNoCallback(null)
+                    .setYesCallback(() => {
                         var excludeStatuses = [CompareStatus.EQUAL, CompareStatus.PENDING_DELETE, CompareStatus.NEWER],
                         deselected = [];
                         grid.getSelectedDataList().forEach((content: ContentSummaryAndCompareStatus) => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
@@ -459,6 +459,7 @@ module app.publish {
             this.publishButton.setEnabled(canPublish);
             if (canPublish) {
                 this.getButtonRow().focusDefaultAction();
+                this.updateTabbable();
             }
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
@@ -182,6 +182,8 @@ module app.publish {
             this.includeChildItemsCheck.addClass('include-child-check');
             this.includeChildItemsCheck.onValueChanged(this.includeChildrenCheckedListener);
             this.includeChildItemsCheck.setLabel('Include child items');
+
+            this.overwriteDefaultArrows(this.includeChildItemsCheck);
         }
 
         /**

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
@@ -535,7 +535,7 @@ module app.publish {
 
     export class ContentPublishDialogAction extends api.ui.Action {
         constructor() {
-            super("Publish", "enter");
+            super("Publish");
             this.setIconClass("publish-action");
         }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
@@ -455,7 +455,11 @@ module app.publish {
             this.cleanPublishButtonText();
 
             this.publishButton.setLabel(count > 0 ? "Publish (" + count + ")" : "Publish");
-            this.publishButton.setEnabled(count > 0 && this.allResolvedItemsAreValid());
+            let canPublish = count > 0 && this.allResolvedItemsAreValid();
+            this.publishButton.setEnabled(canPublish);
+            if (canPublish) {
+                this.getButtonRow().focusDefaultAction();
+            }
         }
 
         private contentItemsAreValid(contentPublishItems: ContentsResolved<ContentPublishItem>): boolean {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialogAction.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialogAction.ts
@@ -2,7 +2,7 @@ module app.remove {
 
     export class ContentDeleteDialogAction extends api.ui.Action {
         constructor() {
-            super("Delete", "enter");
+            super("Delete");
             this.setIconClass("delete-action");
         }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -1296,7 +1296,7 @@ module app.wizard {
 
         private initPublishButtonForMobile() {
 
-            var action: api.ui.Action = new api.ui.Action("Publish", "enter");
+            var action: api.ui.Action = new api.ui.Action("Publish");
             action.setIconClass("publish-action");
             action.onExecuted(() => {
                 this.publishAction.execute();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorDialog.ts
@@ -30,7 +30,7 @@ module api.content.site.inputtype.siteconfigurator {
         }
 
         private addOkButton(okCallback: () => void) {
-            var okAction = new api.ui.Action("Apply", "enter");
+            var okAction = new api.ui.Action("Apply");
             this.addAction(okAction, true, true);
             okAction.onExecuted(() => {
                 if (okCallback) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/Element.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/Element.ts
@@ -634,6 +634,15 @@ module api.dom {
             return indexFromDOM;
         }
 
+        getTabbableElements(): Element[] {
+            let selected = wemjq(this.getHTMLElement()).find(":tabbable");
+            let elements = [];
+            for (let i = 0; i < selected.length; i++) {
+                elements.push(Element.fromHtmlElement(selected[i]));
+            }
+            return elements;
+        }
+
         toString(): string {
             return wemjq('<div>').append(wemjq(this.getHTMLElement()).clone()).html();
         }
@@ -933,6 +942,22 @@ module api.dom {
 
         unBlur(listener: (event: FocusEvent) => void) {
             this.getEl().removeEventListener("blur", listener);
+        }
+
+        onFocusIn(listener: (event: FocusEvent) => void) {
+            this.getEl().addEventListener("focusin", listener);
+        }
+
+        unFocusIn(listener: (event: FocusEvent) => void) {
+            this.getEl().removeEventListener("focusin", listener);
+        }
+
+        onFocusOut(listener: (event: FocusEvent) => void) {
+            this.getEl().addEventListener("focusout", listener);
+        }
+
+        unFocusOut(listener: (event: FocusEvent) => void) {
+            this.getEl().removeEventListener("focusout", listener);
         }
 
         onScroll(listener: (event: Event) => void) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/KeyHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/KeyHelper.ts
@@ -34,6 +34,14 @@ module api.ui {
             return event.keyCode >= 37 && event.keyCode <= 40;
         }
 
+        static isArrowLeftKey(event: KeyboardEvent): boolean {
+            return event.keyCode === 37;
+        }
+
+        static isArrowRightKey(event: KeyboardEvent): boolean {
+            return event.keyCode === 39;
+        }
+
         static isControlKey(event: KeyboardEvent): boolean {
             return event.keyCode === 17;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ConfirmationDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ConfirmationDialog.ts
@@ -22,15 +22,15 @@ module api.ui.dialog {
             this.appendChildToContentPanel(this.questionEl);
 
             this.noAction = new api.ui.Action("No", "esc");
-            this.noAction.onExecuted((action: api.ui.Action) => {
+            this.noAction.onExecuted(() => {
                 this.close();
                 if (this.noCallback) {
                     this.noCallback();
                 }
             });
 
-            this.yesAction = new api.ui.Action("Yes", "enter");
-            this.yesAction.onExecuted((action: api.ui.Action) => {
+            this.yesAction = new api.ui.Action("Yes");
+            this.yesAction.onExecuted(() => {
                 this.close();
                 if (this.yesCallback) {
                     this.yesCallback();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
@@ -206,7 +206,7 @@ module api.ui.dialog {
             return this.contentPanel;
         }
 
-        hasTabbable(): boolean {
+        private hasTabbable(): boolean {
             return !!this.tabbable && this.tabbable.length > 0;
         }
 
@@ -214,7 +214,7 @@ module api.ui.dialog {
             this.tabbable = this.getTabbableElements();
         }
 
-        getTabbedIndex(): number {
+        private getTabbedIndex(): number {
             let activeElement = document.activeElement;
             let tabbedIndex = 0;
             if (this.hasTabbable()) {
@@ -228,7 +228,7 @@ module api.ui.dialog {
             return tabbedIndex;
         }
 
-        focusNextTabbable() {
+        private focusNextTabbable() {
             if (this.hasTabbable()) {
                 let tabbedIndex = this.getTabbedIndex();
                 tabbedIndex = tabbedIndex + 1 >= this.tabbable.length ? 0 : tabbedIndex + 1;
@@ -236,7 +236,7 @@ module api.ui.dialog {
             }
         }
 
-        focusPreviousTabbable() {
+        private focusPreviousTabbable() {
             if (this.hasTabbable()) {
                 let tabbedIndex = this.getTabbedIndex();
                 tabbedIndex = tabbedIndex - 1 < 0 ? this.tabbable.length - 1 : tabbedIndex - 1;
@@ -244,7 +244,7 @@ module api.ui.dialog {
             }
         }
 
-        overwriteDefaultArrows(element: api.dom.Element) {
+        protected overwriteDefaultArrows(element: api.dom.Element) {
             element.onKeyDown((event) => {
 
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
@@ -164,19 +164,6 @@ module api.ui.dialog {
             super.hide();
         }
 
-        close() {
-
-            if (ModalDialog.openDialogsCounter == 1) {
-                api.ui.mask.BodyMask.get().hide();
-            }
-
-            this.hide();
-
-            api.ui.KeyBindings.get().unshelveBindings();
-
-            ModalDialog.openDialogsCounter--;
-        }
-
         open() {
 
             api.ui.mask.BodyMask.get().show();
@@ -188,6 +175,19 @@ module api.ui.dialog {
             api.ui.KeyBindings.get().bindKeys(api.ui.Action.getKeyBindings(this.actions));
 
             ModalDialog.openDialogsCounter++;
+        }
+
+        close() {
+
+            if (ModalDialog.openDialogsCounter == 1) {
+                api.ui.mask.BodyMask.get().hide();
+            }
+
+            this.hide();
+
+            api.ui.KeyBindings.get().unshelveBindings();
+
+            ModalDialog.openDialogsCounter--;
         }
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/AnchorModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/AnchorModalDialog.ts
@@ -21,7 +21,7 @@ module api.util.htmlarea.dialog {
         }
 
         protected initializeActions() {
-            var submitAction = new api.ui.Action("Insert", "enter");
+            var submitAction = new api.ui.Action("Insert");
             this.setSubmitAction(submitAction);
 
             this.addAction(submitAction.onExecuted(() => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ImageModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ImageModalDialog.ts
@@ -338,7 +338,7 @@ module api.util.htmlarea.dialog {
         }
 
         protected initializeActions() {
-            var submitAction = new api.ui.Action(this.imageElement ? "Update" : "Insert", "enter");
+            var submitAction = new api.ui.Action(this.imageElement ? "Update" : "Insert");
             this.setSubmitAction(submitAction);
             this.addAction(submitAction.onExecuted(() => {
                 if (this.validate()) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
@@ -197,7 +197,7 @@ module api.util.htmlarea.dialog {
         }
 
         protected initializeActions() {
-            var submitAction = new api.ui.Action(this.link ? "Update" : "Insert", "enter");
+            var submitAction = new api.ui.Action(this.link ? "Update" : "Insert");
             this.setSubmitAction(submitAction);
 
             this.addAction(submitAction.onExecuted(() => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ModalDialog.ts
@@ -5,16 +5,14 @@ module api.util.htmlarea.dialog {
     import Fieldset = api.ui.form.Fieldset;
     import FormItem = api.ui.form.FormItem;
     import FormItemBuilder = api.ui.form.FormItemBuilder;
-    import BaseDialog = api.ui.dialog.ModalDialog;
-
-    export class ModalDialog extends BaseDialog {
-        private fields:{ [id: string]: api.dom.FormItemEl } = {};
+    
+    export class ModalDialog extends api.ui.dialog.ModalDialog {
+        private fields: { [id: string]: api.dom.FormItemEl } = {};
         private validated = false;
-        private editor:HtmlAreaEditor;
-        private mainForm:Form;
-        private firstFocusField:api.dom.Element;
-        private keyDownListener:{(KeyboardEvent): void};
-        private submitAction:api.ui.Action;
+        private editor: HtmlAreaEditor;
+        private mainForm: Form;
+        private firstFocusField: api.dom.Element;
+        private submitAction: api.ui.Action;
 
         public static CLASS_NAME = "html-area-modal-dialog";
 
@@ -29,26 +27,13 @@ module api.util.htmlarea.dialog {
 
             this.layout();
             this.initializeActions();
-
-            this.keyDownListener = (e:KeyboardEvent) => this.onDialogKeyDown(e);
-
-            api.dom.Body.get().onKeyDown(this.keyDownListener);
         }
 
         setSubmitAction(action:api.ui.Action) {
             this.submitAction = action;
         }
-
-        private onDialogKeyDown(e:KeyboardEvent) {
-            if (api.ui.KeyHelper.isEscKey(e)) {
-                this.getCancelAction().execute();
-            }
-            if (api.ui.KeyHelper.isEnterKey(e)) {
-                this.submitAction.execute();
-            }
-        }
-
-        protected getEditor():HtmlAreaEditor {
+        
+        protected getEditor(): HtmlAreaEditor {
             return this.editor;
         }
 
@@ -142,7 +127,6 @@ module api.util.htmlarea.dialog {
                                  inputEl?:api.dom.FormItemEl):FormItem {
             var formItemEl = inputEl || new api.ui.text.TextInput(),
                 formItemBuilder = new FormItemBuilder(formItemEl).setLabel(label),
-                required:boolean = false,
                 inputWrapper = new api.dom.DivEl("input-wrapper"),
                 formItem;
 
@@ -158,7 +142,6 @@ module api.util.htmlarea.dialog {
 
             if (validator) {
                 formItemBuilder.setValidator(validator);
-                required = true;
             }
 
             formItem = formItemBuilder.build();
@@ -191,7 +174,6 @@ module api.util.htmlarea.dialog {
 
         close() {
             super.close();
-            api.dom.Body.get().unKeyDown(this.keyDownListener);
             this.editor.focus();
             this.remove();
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/dialog/modal-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/dialog/modal-dialog.less
@@ -58,37 +58,43 @@
     }
   }
 
-  .@{_COMMON_PREFIX}button {
-    &.cancel-button-top {
-      &:extend(.icon);
-      .icon-close;
+  .cancel-button-top {
+    &:extend(.icon);
+    .icon-close;
 
-      position: absolute;
-      top: 5px;
-      right: 10px;
-      z-index: -1;
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    z-index: -1;
 
-      padding: 0;
+    width: 26px;
+    height: 26px;
+    line-height: 26px;
+    text-align: center;
+
+    padding: 0;
+    background-color: white;
+
+    &:before {
+      color: #53585f;
+    }
+
+    &:hover {
       background-color: white;
+      cursor: pointer;
 
-      &:before {
+      &:before, span {
         color: #53585f;
-      }
-
-      &:hover:not(:disabled) {
-        background-color: white;
-
-        &:before, span {
-          color: #53585f;
-        }
-      }
-
-      &:focus:not(:disabled) {
-        box-shadow: 0px 0px 5px white;
-        border: 1px solid white;
       }
     }
 
+    &:focus:not(:disabled) {
+      box-shadow: 0px 0px 5px white;
+      border: 1px solid white;
+    }
+  }
+
+  .@{_COMMON_PREFIX}button {
     &.cancel-button-bottom {
       .button();
       padding: 4px 19px 4px 19px;


### PR DESCRIPTION
Fixed the ContentPublishDialog lose focus from the start, when default button is disabled.
Replaced `ModalDialog` import as `BaseDialog` with default usage.

Removed "Enter" key binding from the modal dialogs.
Removed the unnecessary key bindings from the htmlArea modal dialog.

Added modal window focus lock.
Added support for the arrows to change the focus on some elements in modal window.