### PR TITLE
XP-3050 Version History Panel: only last 10 versions displayed in the…

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/ContentVersionViewJson.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/ContentVersionViewJson.java
@@ -1,0 +1,27 @@
+package com.enonic.xp.admin.impl.json.content;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import com.enonic.xp.content.ContentVersion;
+import com.enonic.xp.security.Principal;
+
+public class ContentVersionViewJson
+    extends ContentVersionJson
+{
+
+    private ImmutableList<String> workspaces;
+
+    public ContentVersionViewJson( final ContentVersion contentVersion, final Principal modifier, final List<String> workspaces )
+    {
+        super( contentVersion, modifier );
+        this.workspaces = ImmutableList.copyOf( workspaces );
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public ImmutableList<String> getWorkspaces()
+    {
+        return workspaces;
+    }
+}

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/GetContentVersionsForViewResultJson.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/GetContentVersionsForViewResultJson.java
@@ -1,0 +1,136 @@
+package com.enonic.xp.admin.impl.json.content;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+
+import com.enonic.xp.admin.impl.rest.resource.content.ContentPrincipalsResolver;
+import com.enonic.xp.content.ActiveContentVersionEntry;
+import com.enonic.xp.content.ContentConstants;
+import com.enonic.xp.content.ContentVersion;
+import com.enonic.xp.content.ContentVersions;
+import com.enonic.xp.content.FindContentVersionsResult;
+import com.enonic.xp.content.GetActiveContentVersionsResult;
+
+public class GetContentVersionsForViewResultJson
+{
+    private ActiveContentVersionEntryJson activeVersion;
+
+    private Set<ContentVersionViewJson> contentVersions = Sets.newLinkedHashSet();
+
+    private final long totalHits;
+
+    private final long hits;
+
+    private final int from;
+
+    private final int size;
+
+    public GetContentVersionsForViewResultJson( final FindContentVersionsResult allVersions,
+                                                final GetActiveContentVersionsResult activeVersions,
+                                                final ContentPrincipalsResolver principalsResolver )
+    {
+
+        final ContentVersions filteredVersions = filterContentVersions( allVersions );
+
+        this.totalHits = allVersions.getTotalHits();
+        this.from = allVersions.getFrom();
+        this.size = allVersions.getSize();
+        this.hits = allVersions.getHits();
+
+        for ( final ContentVersion contentVersion : filteredVersions )
+        {
+            this.contentVersions.add(
+                new ContentVersionViewJson( contentVersion, principalsResolver.findPrincipal( contentVersion.getModifier() ),
+                                            findWorkspaces( contentVersion, activeVersions ) ) );
+        }
+
+        final ActiveContentVersionEntry activeVersion = getActiveContentVersion( activeVersions );
+
+        if ( activeVersion != null )
+        {
+            this.activeVersion = new ActiveContentVersionEntryJson( activeVersion, principalsResolver );
+        }
+    }
+
+    private List<String> findWorkspaces( final ContentVersion contentVersion, final GetActiveContentVersionsResult activeVersions )
+    {
+        final List<String> result = new ArrayList<>();
+        activeVersions.getActiveContentVersions().stream().filter(
+            activeVersion -> activeVersion.getContentVersion().getId().equals( contentVersion.getId() ) ).
+            forEach( activeVersion -> result.add( activeVersion.getBranch().toString() ) );
+        return result;
+    }
+
+    private ActiveContentVersionEntry getActiveContentVersion( final GetActiveContentVersionsResult activeVersions )
+    {
+        return activeVersions.getActiveContentVersions().stream().filter(
+            activeVersion -> ContentConstants.BRANCH_DRAFT.equals( activeVersion.getBranch() ) ).findFirst().get();
+    }
+
+    private ContentVersions filterContentVersions( final FindContentVersionsResult allVersions )
+    {
+
+        if ( allVersions.getHits() == 0 )
+        {
+            return allVersions.getContentVersions();
+        }
+
+        final Iterator<ContentVersion> iterator = allVersions.getContentVersions().iterator();
+
+        final ContentVersions.Builder filteredContentVersions = ContentVersions.create().
+            contentId( allVersions.getContentVersions().getContentId() );
+
+        ContentVersion previouslyAdded = iterator.next();
+        filteredContentVersions.add( previouslyAdded );
+
+        int msRangeFilter = 500;
+
+        while ( iterator.hasNext() )
+        {
+            final ContentVersion contentVersion = iterator.next();
+            if ( Math.abs( previouslyAdded.getModified().toEpochMilli() - contentVersion.getModified().toEpochMilli() ) > msRangeFilter )
+            {
+                filteredContentVersions.add( contentVersion );
+                previouslyAdded = contentVersion;
+            }
+        }
+
+        return filteredContentVersions.build();
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public ActiveContentVersionEntryJson getActiveVersion()
+    {
+        return activeVersion;
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public Set<ContentVersionViewJson> getContentVersions()
+    {
+        return contentVersions;
+    }
+
+    public long getTotalHits()
+    {
+        return totalHits;
+    }
+
+    public long getHits()
+    {
+        return hits;
+    }
+
+    public int getFrom()
+    {
+        return from;
+    }
+
+    public int getSize()
+    {
+        return size;
+    }
+}

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -47,6 +47,7 @@ import com.enonic.xp.admin.impl.json.content.ContentListJson;
 import com.enonic.xp.admin.impl.json.content.ContentSummaryJson;
 import com.enonic.xp.admin.impl.json.content.ContentSummaryListJson;
 import com.enonic.xp.admin.impl.json.content.GetActiveContentVersionsResultJson;
+import com.enonic.xp.admin.impl.json.content.GetContentVersionsForViewResultJson;
 import com.enonic.xp.admin.impl.json.content.GetContentVersionsResultJson;
 import com.enonic.xp.admin.impl.json.content.ReorderChildrenResultJson;
 import com.enonic.xp.admin.impl.json.content.RootPermissionsJson;
@@ -868,6 +869,26 @@ public final class ContentResource
             build() );
 
         return new GetActiveContentVersionsResultJson( result, this.principalsResolver );
+    }
+
+    @POST
+    @Path("getVersionsForView")
+    public GetContentVersionsForViewResultJson getContentVersionsForView( final GetContentVersionsJson params )
+    {
+        final ContentId contentId = ContentId.from( params.getContentId() );
+
+        final FindContentVersionsResult allVersions = contentService.getVersions( FindContentVersionsParams.create().
+            contentId( contentId ).
+            from( params.getFrom() != null ? params.getFrom() : 0 ).
+            size( params.getSize() != null ? params.getSize() : 50 ).
+            build() );
+
+        final GetActiveContentVersionsResult activeVersions = contentService.getActiveVersions( GetActiveContentVersionsParams.create().
+            branches( Branches.from( ContentConstants.BRANCH_DRAFT, ContentConstants.BRANCH_MASTER ) ).
+            contentId( contentId ).
+            build() );
+
+        return new GetContentVersionsForViewResultJson( allVersions, activeVersions, this.principalsResolver );
     }
 
     @GET

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentVersions.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentVersions.ts
@@ -1,0 +1,39 @@
+module api.content {
+
+    export class ContentVersions {
+
+        private contentVersions: ContentVersion[];
+
+        private activeVersion: ContentVersion;
+
+        getContentVersions(): ContentVersion[] {
+            return this.contentVersions;
+        }
+
+        getActiveVersion(): ContentVersion {
+            return this.activeVersion;
+        }
+
+        constructor(contentVersions: ContentVersion[], activeVersion: ContentVersion) {
+            this.contentVersions = contentVersions;
+            this.activeVersion = activeVersion;
+        }
+
+        static fromJson(contentVersionForViewJson: api.content.json.GetContentVersionsForViewResultsJson): ContentVersions {
+
+            var contentVersions: ContentVersion[] = [];
+            contentVersionForViewJson.contentVersions.forEach((contentVersionViewJson: api.content.json.ContentVersionViewJson) => {
+                contentVersions.push(ContentVersion.fromJson(contentVersionViewJson, contentVersionViewJson.workspaces));
+            });
+
+            var activeVersion;
+            if (!!contentVersionForViewJson.activeVersion) {
+                activeVersion = ContentVersion.fromJson(contentVersionForViewJson.activeVersion.contentVersion,
+                    [contentVersionForViewJson.activeVersion.branch]);
+            }
+
+            return new ContentVersions(contentVersions, activeVersion);
+        }
+    }
+
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/GetContentVersionsForViewRequest.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/GetContentVersionsForViewRequest.ts
@@ -1,0 +1,44 @@
+module api.content {
+
+    export class GetContentVersionsForViewRequest extends ContentResourceRequest<json.GetContentVersionsForViewResultsJson, ContentVersions> {
+
+        private contentId: ContentId;
+        private from: number;
+        private size: number;
+
+        constructor(contentId: ContentId) {
+            super();
+            super.setMethod("POST");
+            this.contentId = contentId;
+        }
+
+        setFrom(from: number): GetContentVersionsForViewRequest {
+            this.from = from;
+            return this;
+        }
+
+        setSize(size: number): GetContentVersionsForViewRequest {
+            this.size = size;
+            return this;
+        }
+
+        getParams(): Object {
+            return {
+                contentId: this.contentId.toString(),
+                from: this.from,
+                size: this.size
+            };
+        }
+
+        getRequestPath(): api.rest.Path {
+            return api.rest.Path.fromParent(super.getResourcePath(), 'getVersionsForView');
+        }
+
+        sendAndParse(): wemQ.Promise<ContentVersions> {
+
+            return this.send().then((response: api.rest.JsonResponse<json.GetContentVersionsForViewResultsJson>) => {
+                return ContentVersions.fromJson(response.getResult());
+            });
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/_module.ts
@@ -74,6 +74,8 @@
 ///<reference path='ContentVersionViewer.ts' />
 ///<reference path='GetActiveContentVersionsRequest.ts' />
 ///<reference path='GetContentVersionsRequest.ts' />
+///<reference path='ContentVersions.ts' />
+///<reference path='GetContentVersionsForViewRequest.ts' />
 ///<reference path='GetNearestSiteRequest.ts' />
 ///<reference path='OrderChildMovement.ts' />
 ///<reference path='OrderChildMovements.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/ContentVersionViewJson.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/ContentVersionViewJson.ts
@@ -1,0 +1,7 @@
+module api.content.json {
+
+    export interface ContentVersionViewJson extends ContentVersionJson {
+
+        workspaces: string[];
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/GetContentVersionsForViewResultsJson.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/GetContentVersionsForViewResultsJson.ts
@@ -1,0 +1,18 @@
+module api.content.json {
+
+    export interface GetContentVersionsForViewResultsJson {
+
+        from: number;
+
+        size: number;
+
+        hits: number;
+
+        totalHits: number;
+
+        activeVersion: ActiveContentVersionJson;
+
+        contentVersions: ContentVersionViewJson[];
+    }
+}
+

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/_module.ts
@@ -25,3 +25,5 @@
 ///<reference path='EffectivePermissionJson.ts' />
 ///<reference path='EffectivePermissionAccessJson.ts' />
 ///<reference path='EffectivePermissionMemberJson.ts' />
+///<reference path='GetContentVersionsForViewResultsJson.ts' />
+///<reference path='ContentVersionViewJson.ts' />


### PR DESCRIPTION
… panel

Following problems were found: default number of items to fetch was 10 and never changed, and then those 10 items were filtered - it meant that only last 10 version records had chance to get into view.
- Moved filtering of content versions to back-end - this enabled usage of single request instead of two and simplified front-end logic
- Added separate request and method to handle ContentVersionsView items
- Extended default number of content versions to fetch to 50, as ContentVersionsView does not manage content version items in batches