### PR TITLE
XP-3049 Version Panel not scrolled, when history item was extended

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/WidgetView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/WidgetView.ts
@@ -126,6 +126,7 @@ module app.view.detail {
         }
 
         slideOut() {
+            this.getEl().setMaxHeightPx(this.getEl().getHeight()); // enables transition
             this.getEl().setMaxHeightPx(0);
         }
 
@@ -135,6 +136,9 @@ module app.view.detail {
             }
             else {
                 this.getEl().setMaxHeightPx(this.getParentElement().getEl().getHeight());
+                setTimeout(() => {
+                    this.getEl().setMaxHeight("none");
+                }, 100);
             }
         }
 


### PR DESCRIPTION
In order to enable dynamic height and keep widget view "transitionable":
- Made max-height property to be set to "none" on slide-in after animation ends
- Made max-height property to be equal to view's height before slide-out