### PR TITLE
XP-3062 Text component editor - Console error after inserting and sav…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
@@ -150,7 +150,7 @@ module api.liveedit.text {
                 if (child.getEl().getTagName().toUpperCase() == 'SECTION') {
                     this.rootElement = child;
                     // convert image urls in text component for web
-                    child.setHtml(HTMLAreaHelper.prepareImgSrcsInValueForEdit(child.getHtml()), false);
+                    child.setHtml(child.getHtml(), false);
                     break;
                 }
             }
@@ -323,7 +323,7 @@ module api.liveedit.text {
                 then((editor: HtmlAreaEditor) => {
                     this.htmlAreaEditor = editor;
                     if (!!this.textComponent.getText()) {
-                        this.htmlAreaEditor.setContent(HTMLAreaHelper.prepareImgSrcsInValueForEdit(this.textComponent.getText()));
+                        this.htmlAreaEditor.setContent(this.textComponent.getText());
                     } else {
                         this.htmlAreaEditor.setContent(TextComponentView.DEFAULT_TEXT);
                         this.htmlAreaEditor.selection.select(this.htmlAreaEditor.getBody(), true);
@@ -359,7 +359,7 @@ module api.liveedit.text {
                 // copy editor content over to the root html element
                 this.rootElement.getHTMLElement().innerHTML = TextComponentView.DEFAULT_TEXT;
             } else {
-                var editorContent = HTMLAreaHelper.prepareEditorImageSrcsBeforeSave(this.htmlAreaEditor);
+                var editorContent = this.htmlAreaEditor.getContent();
                 this.textComponent.setText(editorContent);
                 // copy editor raw content (without any processing!) over to the root html element
                 this.rootElement.getHTMLElement().innerHTML = this.htmlAreaEditor.getContent({format : 'raw'});


### PR DESCRIPTION
…ing an image

- Removed usage of HtmlAreHelper.prepareImgSrcsInValueForEdit() and HtmlAreHelper.prepareEditorImageSrcsBeforeSave()  - before save it sets image src in a format of src="image://content-id" and before edit it sets it to real path - I don't get why its used in HtmlAreHelper as well. For live edit it caused errors in console because unparsed live edit page's html did contain text-components' image srcs in a format of src="image://content-id".