### PR TITLE
XP-3091 ImageInspectionPanel: image name and subname exceeds screen s…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/context-window.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/context-window.less
@@ -178,6 +178,10 @@
       .input-view .form-input {
         min-width: 100%;
       }
+
+      fieldset {
+        display: table-cell;  //fix for FF - width of a fieldset is never less than the intrinsic width of its content
+      }
     }
 
     &.customized {


### PR DESCRIPTION
…ize (Firefox)

-Width of a fieldset is never less than the intrinsic width of its content, Gecko¹ goes a step further and enforces it in the rendering engine.
Workaround is to use display: table-cell on fieldset

See:
http://stackoverflow.com/questions/17408815/fieldset-resizes-wrong-appears-to-have-unremovable-min-width-min-content
and
http://stackoverflow.com/questions/1716183/html-fieldset-allows-children-to-expand-indefinitely