### PR TITLE
XP-3085 SiteConfigurator dialog:  toolbar not appears in the htmlarea

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorDialog.ts
@@ -120,6 +120,7 @@ module api.content.site.inputtype.siteconfigurator {
                 this.addClass("animated");
                 this.centerMyself();
                 wemjq(this.getHTMLElement()).find('input[type=text],textarea,select').first().focus();
+                this.updateTabbable();
             }, 100);
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
@@ -92,6 +92,8 @@ module api.form.inputtype.text {
                 textAreaWrapper.addClass(focusedEditorCls);
 
                 this.notifyFocused(e);
+
+                api.util.AppHelper.dispatchCustomEvent("focusin", this);
             };
 
             var onNodeChangeHandler = (e) => {
@@ -103,6 +105,8 @@ module api.form.inputtype.text {
                 textAreaWrapper.removeClass(focusedEditorCls);
 
                 this.notifyBlurred(e);
+
+                api.util.AppHelper.dispatchCustomEvent("focusout", this);
             };
 
             var onKeydownHandler = (e) => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/AppHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/AppHelper.ts
@@ -50,6 +50,12 @@ module api.util {
                 timeout = setTimeout(unBeforeUnload, 100);
             });
         }
+
+        static dispatchCustomEvent(name: string, element: api.dom.Element) {
+            let event = document.createEvent('Event');
+            event.initEvent(name, true, true);
+            element.getHTMLElement().dispatchEvent(event);
+        }
     }
 
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.css
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.css
@@ -50,6 +50,9 @@
   display: flex;
   background-color: #ffffff;
 }
+.mce-toolbar .mce-flow-layout {
+  text-align: center;
+}
 .mce-toolbar .mce-btn-group {
   border-right: 1px solid #cccccc;
 }
@@ -90,7 +93,7 @@
 }
 .mce-toolbar .mce-btn-group .mce-btn button,
 .mce-toolbar .mce-btn-group .mce-menubtn button {
-  padding: 2px 8px;
+  padding: 2px 8px 2px 7px;
   height: 34px;
 }
 .mce-toolbar .mce-btn-group .mce-btn .mce-caret,

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
@@ -53,6 +53,10 @@
   display: flex;
   background-color: @admin-white;
 
+  .mce-flow-layout {
+    text-align: center;
+  }
+
   .mce-btn-group {
     border-right: 1px solid @admin-medium-gray-border;
     .mce-menubtn, .mce-btn, .mce-first, .mce-last, .mce-first.mce-last {
@@ -83,7 +87,7 @@
       }
 
       button {
-        padding: 2px 8px;
+        padding: 2px 8px 2px 7px;
         height: 34px;
       }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/text-view.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/text-view.less
@@ -122,7 +122,6 @@
 
   &.sticky-toolbar {
     .box-shadow(0px 8px 8px 0 @admin-toolbar-shadow);
-    z-index: 1000;
   }
 
   .mce-tinymce-inline {


### PR DESCRIPTION
Added `focusin` and `focusout` event firing in focus/blur handlers of the `HtmlArea`, since it doesn't have any real focusable elements.