### PR TITLE
XP-3109 HtmlArea content, error appears when version with smaller num…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -580,6 +580,7 @@ module app.wizard {
                             this.liveFormPanel.skipNextReloadConfirmation(true);
                             this.liveFormPanel.loadPage();
                         }
+                        this.resetLastFocusedElement();
                     });
                 }
             };

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardPanel.ts
@@ -180,7 +180,7 @@ module api.app.wizard {
                     this.giveInitialFocus();
                 }
 
-                if (this.lastFocusedElement) {
+                if (!!this.lastFocusedElement) {
                     this.lastFocusedElement.focus();
                 }
             });
@@ -273,6 +273,10 @@ module api.app.wizard {
                     this.lastFocusedElement = <HTMLElement>el.target;
                 })
             })
+        }
+
+        resetLastFocusedElement() {
+            this.lastFocusedElement = null;
         }
 
         getTabId(): api.app.bar.AppBarTabId {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
@@ -154,7 +154,9 @@ module api.form.inputtype.text {
                     HTMLAreaHelper.updateImageAlignmentBehaviour(editor);
                     this.onShown((event) => {
                         // invoke auto resize on shown in case contents have been updated while inactive
-                        editor.execCommand('mceAutoResize', false, null, {skip_focus: true});
+                        if (!!editor['contentAreaContainer'] || !!editor['bodyElement']) {
+                            editor.execCommand('mceAutoResize', false, null, {skip_focus: true});
+                        }
                     });
                 });
         }


### PR DESCRIPTION
…ber of htmlareas was restored

- Added check for onShown callback that will trigger tinymce command only if editor is attached to window document. It might get detached on version rollback, for example. Also made lastFocusedElement property to be reset on version rollback.