### PR TITLE
XP-3192 PageEditor selection boxes are badly positioned in xeon app

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/Highlighter.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/Highlighter.ts
@@ -37,8 +37,12 @@ module api.liveedit {
                 this.hide();
                 return;
             }
-            var dimensions = itemView.getEl().getDimensionsTopRelativeToParent();
+            var dimensions = itemView.getEl().getDimensions();
             var style = itemView.getType().getConfig().getHighlighterStyle();
+
+            if (!!itemView.getPageView() && itemView.getPageView().hasToolbarContainer()) {
+                dimensions.top = dimensions.top - itemView.getPageView().getEditorToolbarHeight();
+            }
 
             this.resize(dimensions, this.preProcessStyle(style));
             this.show();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
@@ -257,6 +257,10 @@ module api.liveedit {
             return this.hasClass("has-toolbar-container");
         }
 
+        getEditorToolbarHeight(): number {
+            return !!this.editorToolbar ? this.editorToolbar.getEl().getHeightWithMargin() : 0;
+        }
+
         private setIgnorePropertyChanges(value: boolean) {
             this.ignorePropertyChanges = value;
         }


### PR DESCRIPTION
- Problem was common for LiveEditComponents - getDimensionsTopRelativeToParent() returned incorrect top offset which did not allow to correctly position highlighter box
- Adjusted highlight dimensions calculation to use getOffset() method instead of getOffsetToParent() and added correction on an top offset value of the text editor toolbar