### PR TITLE
XP-3124 Open ContentSelector doesn't close when another ContentSelect…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -166,8 +166,6 @@ module api.ui.selector.combobox {
             this.comboBoxDropdown.renderDropdownGrid();
 
             this.input.setReadOnly(true);
-
-            this.setOnBlurListener();
         }
 
         setEmptyDropdownText(label: string) {
@@ -470,8 +468,22 @@ module api.ui.selector.combobox {
 
         private setupListeners() {
 
-            this.onClicked((event: MouseEvent) => {
-                this.setOnBlurListener();
+            let focusoutTimeout = 0;
+
+            this.onFocusOut(() => {
+                focusoutTimeout = setTimeout(() => {
+                    this.hideDropdown();
+                    this.active = false;
+                }, 50);
+            });
+
+            this.onFocusIn(() => {
+                clearTimeout(focusoutTimeout);
+            });
+
+            // Prevent focus loss on mouse down
+            this.onMouseDown((event: MouseEvent) => {
+                event.preventDefault();
             });
 
             this.onScrolled((event: WheelEvent) => {
@@ -495,14 +507,12 @@ module api.ui.selector.combobox {
                     if (this.isDropdownShown()) {
                         this.hideDropdown();
                         this.giveInputFocus();
-                    }
-                    else {
+                    } else {
                         this.showDropdown();
-                        this.loadOptionsAfterShowDropdown().then(() => {
-                            this.giveInputFocus();
-                        }).catch((reason: any) => {
+                        this.giveInputFocus();
+                        this.loadOptionsAfterShowDropdown().catch((reason: any) => {
                             api.DefaultErrorHandler.handle(reason);
-                        }).done();
+                        });
 
                     }
                 }
@@ -714,39 +724,6 @@ module api.ui.selector.combobox {
                 .filter(x => selectedValues.indexOf(x) == -1)
                 .concat(selectedValues.filter(x => gridOptions.indexOf(x) == -1));
 
-        }
-
-        /**
-         * Setup event listener that hides dropdown when combobox loses focus.
-         * Listener is added to document body when combobox makes active and removed on click outside of combobox.
-         */
-        private setOnBlurListener() {
-            // reference to this combobox to use it in closure
-            var combobox = this;
-
-            // function variable to be able to add and remove it as listener
-            var hideDropdownOnBlur = function (event: Event) {
-
-                var comboboxHtmlElement = combobox.getHTMLElement();
-
-                // check if event occured inside combobox then do nothing and return
-                for (var element = event.target; element; element = (<any>element).parentNode) {
-                    if (element == comboboxHtmlElement) {
-                        return;
-                    }
-                }
-
-                // if combobox lost focus then hide dropdown options and remove unnecessary listener
-                combobox.hideDropdown();
-                combobox.active = false;
-                api.dom.Body.get().getEl().removeEventListener('click', hideDropdownOnBlur);
-            };
-
-            // set callback function on document body if combobox wasn't marked as active
-            if (!this.active) {
-                this.active = true;
-                api.dom.Body.get().onClicked(hideDropdownOnBlur);
-            }
         }
 
         onOptionSelected(listener: (event: SelectedOption<OPTION_DISPLAY_VALUE>)=>void) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/Dropdown.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/Dropdown.ts
@@ -286,8 +286,22 @@ module api.ui.selector.dropdown {
 
         private setupListeners() {
 
-            this.onClicked(() => {
-                this.setOnBlurListener();
+            let focusoutTimeout = 0;
+
+            this.onFocusOut(() => {
+                focusoutTimeout = setTimeout(() => {
+                    this.hideDropdown();
+                    this.active = false;
+                }, 50);
+            });
+
+            this.onFocusIn(() => {
+                clearTimeout(focusoutTimeout);
+            });
+
+            // Prevent focus loss on mouse down
+            this.onMouseDown((event: MouseEvent) => {
+                event.preventDefault();
             });
 
             this.dropdownHandle.onClicked((event: any) => {
@@ -353,39 +367,6 @@ module api.ui.selector.dropdown {
 
                 this.input.getHTMLElement().focus();
             });
-        }
-
-        /**
-         * Setup event listener that hides dropdown when combobox loses focus.
-         * Listener is added to document body when combobox makes active and removed on click outside of combobox.
-         */
-        private setOnBlurListener() {
-            // reference to this combobox to use it in closure
-            var combobox = this;
-
-            // function variable to be able to add and remove it as listener
-            var hideDropdownOnBlur = function (event: Event) {
-
-                var comboboxHtmlElement = combobox.getHTMLElement();
-
-                // check if event occured inside combobox then do nothing and return
-                for (var element = event.target; element; element = (<any>element).parentNode) {
-                    if (element == comboboxHtmlElement) {
-                        return;
-                    }
-                }
-
-                // if combobox lost focus then hide dropdown options and remove unnecessary listener
-                combobox.hideDropdown();
-                combobox.active = false;
-                api.dom.Body.get().getEl().removeEventListener('click', hideDropdownOnBlur);
-            }
-
-            // set callback function on document body if combobox wasn't marked as active
-            if (!this.active) {
-                this.active = true;
-                api.dom.Body.get().onClicked(hideDropdownOnBlur);
-            }
         }
 
         onOptionSelected(listener: (event: OptionSelectedEvent<OPTION_DISPLAY_VALUE>)=>void) {


### PR DESCRIPTION
…or is opened

Replaced `click` body event with `focusout`.