### PR TITLE
XP-3135 Page Components view / Mobile - Close Context menu after sele…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsView.ts
@@ -625,6 +625,9 @@ module app.wizard {
                     if (data.getType().isComponentType()) {
                         api.liveedit.Highlighter.get().highlightElement(dimensions, data.getType().getConfig().getHighlighterStyle());
                     }
+                    if (api.BrowserHelper.isIOS()) {
+                        this.selectItem(hoveredNode);
+                    }
                 }
             }
         }


### PR DESCRIPTION
…cting a different node

- In IOS when there is an element that is displayed or hidden on hover, the first tap acts as hover - this is intended in IOS so that user does not miss important content.
- I used OnMouseEnter event of grid (in case of IOS it is triggered on tap) to explicitly select tapped item