### PR TITLE
XP-3134 Page Components view / Mobile - Make it easier to target the …

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsView.ts
@@ -304,6 +304,9 @@ module app.wizard {
 
                 if(!this.pageView.isLocked()) {
                     this.highlightRow(rowElement, selected);
+                    if (this.isMenuIcon(event.target) && api.BrowserHelper.isIOS()) {
+                        this.showContextMenu(new api.dom.ElementHelper(rowElement).getSiblingIndex(), {x: event.pageX, y: event.pageY});
+                    }
                 }
             });
 
@@ -341,6 +344,13 @@ module app.wizard {
             this.tree.onRemoved((event) => this.tree.getGrid().unsubscribeOnClick(this.clickListener));
 
             this.tree.onLoaded(() => this.bindTextComponentViewsUpdateOnTextModify());
+        }
+
+        private isMenuIcon(element: HTMLElement): boolean {
+            if (!!element && !!element.className && element.className.indexOf("menu-icon") > -1) {
+                return true;
+            }
+            return false;
         }
 
         private bindTextComponentViewsUpdateOnTextModify() {


### PR DESCRIPTION
…Context menu icon

- In IOS when there is an element that is displayed or hidden on hover, the first tap acts as hover - this is intended in IOS so that user does not miss important content.
- Added check for menu-icon tap in IOS that will open the ContextMenu explicitly. Fix will work best with changes of XP-3135