### PR TITLE
XP-3206 HTML Area - Toolbar buttons are incorrectly positioned

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
@@ -195,7 +195,6 @@ module api.form.inputtype.text {
             });
 
             api.ui.responsive.ResponsiveManager.onAvailableSizeChanged(this, () => {
-                this.updateEditorToolbarWidth();
                 this.updateEditorToolbarPos(inputOccurence);
             });
 
@@ -205,28 +204,21 @@ module api.form.inputtype.text {
 
             this.onOccurrenceRendered(() => {
                 this.resetInputHeight();
-                this.updateEditorToolbarWidth();
             });
 
             this.onOccurrenceRemoved(() => {
                 this.resetInputHeight();
-                this.updateEditorToolbarWidth();
             });
         }
 
         private updateStickyEditorToolbar(inputOccurence: Element) {
             if (!this.editorTopEdgeIsVisible(inputOccurence) && this.editorLowerEdgeIsVisible(inputOccurence)) {
                 inputOccurence.addClass("sticky-toolbar");
-                this.updateEditorToolbarWidth();
                 this.updateEditorToolbarPos(inputOccurence);
             }
             else {
                 inputOccurence.removeClass("sticky-toolbar")
             }
-        }
-
-        private updateEditorToolbarWidth() {
-            wemjq(this.getHTMLElement()).find(".mce-toolbar-grp").width(wemjq(this.getHTMLElement()).find(".mce-edit-area").innerWidth());
         }
 
         private updateEditorToolbarPos(inputOccurence: Element) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
@@ -54,10 +54,6 @@
   display: flex;
   background-color: @admin-white;
 
-  .mce-flow-layout {
-    text-align: center;
-  }
-
   .mce-btn-group {
     border-right: 1px solid @admin-medium-gray-border;
     .mce-menubtn, .mce-btn, .mce-first, .mce-last, .mce-first.mce-last {


### PR DESCRIPTION
- Made toolbar buttons to be left aligned in non-live edit html areas
- Fixed problem with active toolbar width on resize - removed calls to updateEditorToolbarWidth(), which seems useless to me