### PR TITLE
XP-3198 Mobile preview - Incorrect behaviour of the detail panel icon

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/MobileContentItemStatisticsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/MobileContentItemStatisticsPanel.ts
@@ -22,6 +22,7 @@ module app.view {
             setUseSplitter(false).
             setUseViewer(false).
             setSlideFrom(app.view.detail.SLIDE_FROM.BOTTOM).
+            setIsMobile(true).
             build();
         private detailsToggleButton: MobileDetailsPanelToggleButton;
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/DetailsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/DetailsPanel.ts
@@ -496,12 +496,24 @@ module app.view.detail {
         }
     }
 
+    export class MobileDetailsPanel extends DetailsPanel {
+
+        private slideOutTop() {
+            this.getEl().setTopPx(api.BrowserHelper.isIOS() ? -window.innerHeight : -window.outerHeight);
+        }
+
+        private slideOutBottom() {
+            this.getEl().setTopPx(api.BrowserHelper.isIOS() ? window.innerHeight : window.outerHeight);
+        }
+    }
+
     export class Builder {
 
         private useViewer: boolean = true;
         private slideFrom: SLIDE_FROM = SLIDE_FROM.RIGHT;
         private name: string;
         private useSplitter: boolean = true;
+        private isMobile: boolean = false;
 
         public setUseViewer(value: boolean): Builder {
             this.useViewer = value;
@@ -539,8 +551,13 @@ module app.view.detail {
             return this.useSplitter;
         }
 
+        public setIsMobile(value: boolean): Builder {
+            this.isMobile = value;
+            return this;
+        }
+
         public build(): DetailsPanel {
-            return new DetailsPanel(this);
+            return this.isMobile ? new MobileDetailsPanel(this) : new DetailsPanel(this);
         }
     }
 


### PR DESCRIPTION
- Added mobile details panel that will check for IOS in order to use innerHeight property instead of outerHeight in slide up/bottom functions as IOS treats outerHeight differently than other platforms