### PR TITLE
XP-3124 Open ContentSelector doesn't close when another ContentSelector is opened

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
@@ -95,6 +95,7 @@ module api.form.inputtype.text {
                 this.notifyFocused(e);
 
                 api.util.AppHelper.dispatchCustomEvent("focusin", this);
+                new api.ui.selector.SelectorOnBlurEvent(this).fire();
             };
 
             var onNodeChangeHandler = (e) => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/SelectorOnBlurEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/SelectorOnBlurEvent.ts
@@ -1,0 +1,27 @@
+module api.ui.selector {
+
+    import Element = api.dom.Element;
+
+    export class SelectorOnBlurEvent extends api.event.Event {
+
+        private selector: Element;
+
+        constructor(selector: Element) {
+            super();
+            this.selector = selector;
+        }
+
+        getSelector(): Element {
+            return this.selector;
+        }
+
+        static on(handler: (event: SelectorOnBlurEvent) => void) {
+            api.event.Event.bind(api.ClassHelper.getFullName(this), handler);
+        }
+
+        static un(handler?: (event: SelectorOnBlurEvent) => void) {
+            api.event.Event.unbind(api.ClassHelper.getFullName(this), handler);
+        }
+    }
+
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/_module.ts
@@ -9,3 +9,4 @@
 ///<reference path='DropdownGrid.ts' />
 ///<reference path='DropdownList.ts' />
 ///<reference path='DropdownExpandedEvent.ts' />
+///<reference path='SelectorOnBlurEvent.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -475,10 +475,10 @@ module api.ui.selector.combobox {
             let comboBoxOnBlurEventHandler = (event: SelectorOnBlurEvent) => {
                 if (combobox === event.getSelector()) {
                     return;
-                } else {
-                    combobox.hideDropdown();
-                    combobox.active = false;
                 }
+
+                combobox.hideDropdown();
+                combobox.active = false;
 
             };
 
@@ -486,6 +486,19 @@ module api.ui.selector.combobox {
 
             this.onRemoved(() => {
                 SelectorOnBlurEvent.un(comboBoxOnBlurEventHandler);
+            });
+
+            this.onFocusOut(() => {
+                timeout = setTimeout(() => {
+                    combobox.hideDropdown();
+                    combobox.active = false;
+                }, 200);
+            });
+
+            var timeout;
+
+            this.onFocusIn(() => {
+                clearTimeout(timeout);
             });
 
             this.onClicked((event: MouseEvent) => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -470,8 +470,27 @@ module api.ui.selector.combobox {
 
         private setupListeners() {
 
+            let combobox = this;
+
+            let comboBoxOnBlurEventHandler = (event: SelectorOnBlurEvent) => {
+                if (combobox === event.getSelector()) {
+                    return;
+                } else {
+                    combobox.hideDropdown();
+                    combobox.active = false;
+                }
+
+            };
+
+            SelectorOnBlurEvent.on(comboBoxOnBlurEventHandler);
+
+            this.onRemoved(() => {
+                SelectorOnBlurEvent.un(comboBoxOnBlurEventHandler);
+            });
+
             this.onClicked((event: MouseEvent) => {
                 this.setOnBlurListener();
+                new SelectorOnBlurEvent(combobox).fire();
             });
 
             this.onScrolled((event: WheelEvent) => {
@@ -481,6 +500,7 @@ module api.ui.selector.combobox {
             this.input.onClicked((event: MouseEvent) => {
                 this.giveInputFocus();
                 event.stopPropagation();
+                new SelectorOnBlurEvent(combobox).fire();
             });
 
             this.comboBoxDropdown.onRowSelection((event: DropdownGridRowSelectedEvent) => {
@@ -506,6 +526,8 @@ module api.ui.selector.combobox {
 
                     }
                 }
+
+                new SelectorOnBlurEvent(combobox).fire();
             });
 
             if (this.applySelectionsButton) {
@@ -518,8 +540,7 @@ module api.ui.selector.combobox {
                 this.preservedInputValueChangedEvent = event;
                 if (this.delayedInputValueChangedHandling == 0) {
                     this.handleInputValueChanged();
-                }
-                else {
+                } else {
                     this.setEmptyDropdownText("Just keep on typing...");
                     this.delayedHandleInputValueChangedFnCall.delayCall();
                 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/Dropdown.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/Dropdown.ts
@@ -286,26 +286,22 @@ module api.ui.selector.dropdown {
 
         private setupListeners() {
 
-            let dropdown = this;
+            let focusoutTimeout = 0;
 
-            let dropdownOnBlurEventHandler = (event: SelectorOnBlurEvent) => {
-                if (dropdown === event.getSelector()) {
-                    return;
-                } else {
-                    dropdown.hideDropdown();
-                    dropdown.active = false;
-                }
-
-            };
-
-            SelectorOnBlurEvent.on(dropdownOnBlurEventHandler);
-
-            this.onRemoved(() => {
-                SelectorOnBlurEvent.un(dropdownOnBlurEventHandler);
+            this.onFocusOut(() => {
+                focusoutTimeout = setTimeout(() => {
+                    this.hideDropdown();
+                    this.active = false;
+                }, 50);
             });
 
-            this.onClicked(() => {
-                this.setOnBlurListener();
+            this.onFocusIn(() => {
+                clearTimeout(focusoutTimeout);
+            });
+
+            // Prevent focus loss on mouse down
+            this.onMouseDown((event: MouseEvent) => {
+                event.preventDefault();
             });
 
             this.dropdownHandle.onClicked((event: any) => {
@@ -316,8 +312,6 @@ module api.ui.selector.dropdown {
                     this.showDropdown();
                 }
                 this.giveFocus();
-
-                new SelectorOnBlurEvent(dropdown).fire();
             });
 
             this.input.onValueChanged((event: api.ValueChangedEvent) => {
@@ -373,39 +367,6 @@ module api.ui.selector.dropdown {
 
                 this.input.getHTMLElement().focus();
             });
-        }
-
-        /**
-         * Setup event listener that hides dropdown when combobox loses focus.
-         * Listener is added to document body when combobox makes active and removed on click outside of combobox.
-         */
-        private setOnBlurListener() {
-            // reference to this combobox to use it in closure
-            var combobox = this;
-
-            // function variable to be able to add and remove it as listener
-            var hideDropdownOnBlur = function (event: Event) {
-
-                var comboboxHtmlElement = combobox.getHTMLElement();
-
-                // check if event occured inside combobox then do nothing and return
-                for (var element = event.target; element; element = (<any>element).parentNode) {
-                    if (element == comboboxHtmlElement) {
-                        return;
-                    }
-                }
-
-                // if combobox lost focus then hide dropdown options and remove unnecessary listener
-                combobox.hideDropdown();
-                combobox.active = false;
-                api.dom.Body.get().getEl().removeEventListener('click', hideDropdownOnBlur);
-            };
-
-            // set callback function on document body if combobox wasn't marked as active
-            if (!this.active) {
-                this.active = true;
-                api.dom.Body.get().onClicked(hideDropdownOnBlur);
-            }
         }
 
         onOptionSelected(listener: (event: OptionSelectedEvent<OPTION_DISPLAY_VALUE>)=>void) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/Dropdown.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/Dropdown.ts
@@ -286,6 +286,24 @@ module api.ui.selector.dropdown {
 
         private setupListeners() {
 
+            let dropdown = this;
+
+            let dropdownOnBlurEventHandler = (event: SelectorOnBlurEvent) => {
+                if (dropdown === event.getSelector()) {
+                    return;
+                } else {
+                    dropdown.hideDropdown();
+                    dropdown.active = false;
+                }
+
+            };
+
+            SelectorOnBlurEvent.on(dropdownOnBlurEventHandler);
+
+            this.onRemoved(() => {
+                SelectorOnBlurEvent.un(dropdownOnBlurEventHandler);
+            });
+
             this.onClicked(() => {
                 this.setOnBlurListener();
             });
@@ -298,6 +316,8 @@ module api.ui.selector.dropdown {
                     this.showDropdown();
                 }
                 this.giveFocus();
+
+                new SelectorOnBlurEvent(dropdown).fire();
             });
 
             this.input.onValueChanged((event: api.ValueChangedEvent) => {
@@ -379,7 +399,7 @@ module api.ui.selector.dropdown {
                 combobox.hideDropdown();
                 combobox.active = false;
                 api.dom.Body.get().getEl().removeEventListener('click', hideDropdownOnBlur);
-            }
+            };
 
             // set callback function on document body if combobox wasn't marked as active
             if (!this.active) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/DatePickerPopup.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/DatePickerPopup.ts
@@ -4,8 +4,6 @@ module api.ui.time {
 
         calendar: Calendar;
 
-        closeOnOutsideClick: boolean = true;
-
         setCalendar(value: Calendar): DatePickerPopupBuilder {
             this.calendar = value;
             return this;
@@ -13,15 +11,6 @@ module api.ui.time {
 
         getCalendar(): Calendar {
             return this.calendar;
-        }
-
-        setCloseOnOutsideClick(value: boolean): DatePickerPopupBuilder {
-            this.closeOnOutsideClick = value;
-            return this;
-        }
-
-        isCloseOnOutsideClick(): boolean {
-            return this.closeOnOutsideClick;
         }
 
         build(): DatePickerPopup {
@@ -101,10 +90,6 @@ module api.ui.time {
                 this.year.setHtml(year.toString());
             });
             this.appendChild(this.calendar);
-
-            if (builder.isCloseOnOutsideClick()) {
-                api.dom.Body.get().onClicked((e: MouseEvent) => this.outsideClickListener(e));
-            }
         }
 
         getSelectedDate(): Date {
@@ -121,12 +106,6 @@ module api.ui.time {
 
         unSelectedDateChanged(listener: (event: SelectedDateChangedEvent) => void) {
             this.calendar.unSelectedDateChanged(listener);
-        }
-
-        private outsideClickListener(e: MouseEvent) {
-            if (!this.getEl().contains(<HTMLElement> e.target)) {
-                this.hide();
-            }
         }
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/DateTimePicker.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/DateTimePicker.ts
@@ -145,7 +145,7 @@ module api.ui.time {
             wrapper.appendChild(this.popup);
 
             this.popupTrigger = new api.ui.button.Button();
-            this.popupTrigger.addClass('icon-calendar4');
+            this.popupTrigger.addClass('icon-calendar');
             wrapper.appendChild(this.popupTrigger);
 
             this.appendChild(wrapper);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/DateTimePicker.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/DateTimePicker.ts
@@ -136,8 +136,7 @@ module api.ui.time {
                 setMinutes(builder.minutes).
                 setCalendar(calendar).
                 setTimezone(builder.timezone).
-                setUseLocalTimezoneIfNotPresent(builder.useLocalTimezoneIfNotPresent).
-                setCloseOnOutsideClick(false);
+                setUseLocalTimezoneIfNotPresent(builder.useLocalTimezoneIfNotPresent);
             this.popup = new DateTimePickerPopup(popupBuilder);
             this.popup.onShown(() => {
                 new DateTimePickerShownEvent(this).fire();
@@ -149,6 +148,30 @@ module api.ui.time {
             wrapper.appendChild(this.popupTrigger);
 
             this.appendChild(wrapper);
+
+            this.setupListeners(builder);
+        }
+
+        private setupListeners(builder: DateTimePickerBuilder) {
+
+            if (builder.closeOnOutsideClick) {
+                let focusoutTimeout = 0;
+
+                this.onFocusOut(() => {
+                    focusoutTimeout = setTimeout(() => {
+                        this.popup.hide();
+                    }, 50);
+                });
+
+                this.onFocusIn(() => {
+                    clearTimeout(focusoutTimeout);
+                });
+
+                // Prevent focus loss on mouse down
+                this.popup.onMouseDown((event: MouseEvent) => {
+                    event.preventDefault();
+                });
+            }
 
             this.popupTrigger.onClicked((e: MouseEvent) => {
                 e.preventDefault();
@@ -229,29 +252,6 @@ module api.ui.time {
                     this.popup.hide();
                 }
             });
-
-            api.dom.Body.get().onKeyDown((e: KeyboardEvent) => this.popupTabListener(e));
-            if (builder.closeOnOutsideClick) {
-                api.dom.Body.get().onClicked((e: MouseEvent) => this.outsideClickListener(e));
-            }
-        }
-
-        // as popup blur and focus events behave incorrectly - we manually catch tab navigation event in popup below
-        private popupTabListener(e: KeyboardEvent) {
-            if (api.ui.KeyHelper.isTabKey(e) && !this.getEl().contains(<HTMLElement> e.target)) {
-                if (this.popup.isVisible()) {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    this.popupTrigger.getEl().focus();
-                    this.popup.hide();
-                }
-            }
-        }
-
-        private outsideClickListener(e: MouseEvent) {
-            if (!this.getEl().contains(<HTMLElement> e.target)) {
-                this.popup.hide();
-            }
         }
 
         private onDateTimePickerShown(event: DateTimePickerShownEvent) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/DateTimePickerPopup.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/DateTimePickerPopup.ts
@@ -15,8 +15,6 @@ module api.ui.time {
         // use local timezone if timezone value is not initialized
         useLocalTimezoneIfNotPresent: boolean = false;
 
-        closeOnOutsideClick: boolean = true;
-
         setHours(value: number): DateTimePickerPopupBuilder {
             this.hours = value;
             return this;
@@ -62,15 +60,6 @@ module api.ui.time {
             return this.timezone;
         }
 
-        setCloseOnOutsideClick(value: boolean): DateTimePickerPopupBuilder {
-            this.closeOnOutsideClick = value;
-            return this;
-        }
-
-        isCloseOnOutsideClick(): boolean {
-            return this.closeOnOutsideClick;
-        }
-
         build(): DateTimePickerPopup {
             return new DateTimePickerPopup(this);
         }
@@ -86,24 +75,17 @@ module api.ui.time {
         constructor(builder: DateTimePickerPopupBuilder) {
             super('date-time-dialog');
 
-            var closeOnOutsideClick = builder.isCloseOnOutsideClick();
-            builder.setCloseOnOutsideClick(false);
-
             this.datePickerPopup = new DatePickerPopupBuilder().
                 setCalendar(builder.getCalendar()).
-                setCloseOnOutsideClick(false).build();
+                build();
             this.timePickerPopup = new TimePickerPopupBuilder().
                 setHours(builder.getHours()).
-                setCloseOnOutsideClick(false).
                 setTimezone(builder.timezone).
                 setUseLocalTimezoneIfNotPresent(builder.useLocalTimezoneIfNotPresent).
-                setMinutes(builder.getMinutes()).build();
+                setMinutes(builder.getMinutes()).
+                build();
 
             this.appendChildren(<api.dom.Element>this.datePickerPopup, <api.dom.Element>this.timePickerPopup);
-
-            if (closeOnOutsideClick) {
-                api.dom.Body.get().onClicked((e: MouseEvent) => this.outsideClickListener(e));
-            }
         }
 
         getSelectedDate(): Date {
@@ -145,12 +127,6 @@ module api.ui.time {
 
         setSelectedDate(date: Date, silent?: boolean) {
             this.datePickerPopup.setSelectedDate(date, silent);
-        }
-
-        private outsideClickListener(e: MouseEvent) {
-            if (!this.getEl().contains(<HTMLElement> e.target)) {
-                this.hide();
-            }
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/TimePickerPopup.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/TimePickerPopup.ts
@@ -13,8 +13,6 @@ module api.ui.time {
         // use local timezone if timezone value is not initialized
         useLocalTimezoneIfNotPresent: boolean = false;
 
-        closeOnOutsideClick: boolean = true;
-
         setHours(value: number): TimePickerPopupBuilder {
             this.hours = value;
             return this;
@@ -49,15 +47,6 @@ module api.ui.time {
 
         isUseLocalTimezoneIfNotPresent(): boolean {
             return this.useLocalTimezoneIfNotPresent;
-        }
-
-        setCloseOnOutsideClick(value: boolean): TimePickerPopupBuilder {
-            this.closeOnOutsideClick = value;
-            return this;
-        }
-
-        isCloseOnOutsideClick(): boolean {
-            return this.closeOnOutsideClick;
         }
 
         build(): TimePickerPopup {
@@ -181,11 +170,6 @@ module api.ui.time {
 
             this.hour.setHtml(this.padNumber(this.selectedHour || 0, 2));
             this.minute.setHtml(this.padNumber(this.selectedMinute || 0, 2));
-
-            if (builder.isCloseOnOutsideClick()) {
-                api.dom.Body.get().onClicked((e: MouseEvent) => this.outsideClickListener(e));
-            }
-
         }
 
         getSelectedTime(): {hour: number; minute: number} {
@@ -260,12 +244,6 @@ module api.ui.time {
             this.timeChangedListeners.forEach((listener) => {
                 listener(hours, minutes);
             });
-        }
-
-        private outsideClickListener(e: MouseEvent) {
-            if (!this.getEl().contains(<HTMLElement> e.target)) {
-                this.hide();
-            }
         }
 
         setSelectedTime(hours: number, minutes: number, silent?: boolean) {


### PR DESCRIPTION
Fixed the selector blur event issue, which was caused by the propagation stop on click.
Added `onfocus` handler.
Update `ComboBox` and `Dropdown` focus handling.
Fixed `TimePicker`, `DatePicker` and `DateTimePicker` popups closing.
Fix the calendar icon.