### PR TITLE
XP-3217 Page Editor - Disable anchor links in the root of a part

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/part/PartComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/part/PartComponentView.ts
@@ -28,12 +28,20 @@ module api.liveedit.part {
 
             this.partPlaceholder = new PartPlaceholder(this);
 
+            this.resetHrefForRootLink(builder);
+
             super(builder.
                 setViewer(new PartComponentViewer()).
                 setPlaceholder(this.partPlaceholder).
                 setInspectActionRequired(true));
 
             this.parseContentViews(this);
+        }
+
+        private resetHrefForRootLink(builder: PartComponentViewBuilder) {
+            if (builder.element && builder.element.getEl().hasAttribute("href")) {
+                builder.element.getEl().setAttribute("href", "#");
+            }
         }
 
         setComponent(partComponent: PartComponent) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/part-view.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/part-view.less
@@ -5,3 +5,8 @@
   }
 
 }
+
+a[data-portal-component-type="part"] {
+  display: block;
+  pointer-events: auto;
+}


### PR DESCRIPTION
- For parts that start with link: enabled pointer-events; set display property to 'block' value in order to enable correct selection and behavior
- In PartComponentView constructor I replaced href attribute value in order to disable navigation Otherwise, parts with links in the root just don't behave correctly