### PR TITLE
XP-3384 NewContent dialog: filtering does not work

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/create/NewContentDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/create/NewContentDialog.ts
@@ -1,4 +1,12 @@
 import "../../api.ts";
+import {MostPopularItemsBlock} from "./MostPopularItemsBlock";
+import {NewContentDialogListItem} from "./NewContentDialogListItem";
+import {RecentItemsBlock} from "./RecentItemsBlock";
+import {MostPopularItem} from "./MostPopularItem";
+import {NewContentDialogList} from "./NewContentDialogList";
+import {NewContentDialogItemSelectedEvent} from "./NewContentDialogItemSelectedEvent";
+import {NewMediaUploadEvent} from "./NewMediaUploadEvent";
+import {NewContentEvent} from "./NewContentEvent";
 
 import GetAllContentTypesRequest = api.schema.content.GetAllContentTypesRequest;
 import GetContentTypeByNameRequest = api.schema.content.GetContentTypeByNameRequest;
@@ -14,14 +22,6 @@ import ApplicationKey = api.application.ApplicationKey;
 import FileUploadStartedEvent = api.ui.uploader.FileUploadStartedEvent;
 import UploadItem = api.ui.uploader.UploadItem;
 import ListContentByPathRequest = api.content.ListContentByPathRequest;
-import {MostPopularItemsBlock} from "./MostPopularItemsBlock";
-import {NewContentDialogListItem} from "./NewContentDialogListItem";
-import {RecentItemsBlock} from "./RecentItemsBlock";
-import {MostPopularItem} from "./MostPopularItem";
-import {NewContentDialogList} from "./NewContentDialogList";
-import {NewContentDialogItemSelectedEvent} from "./NewContentDialogItemSelectedEvent";
-import {NewMediaUploadEvent} from "./NewMediaUploadEvent";
-import {NewContentEvent} from "./NewContentEvent";
 
 export class NewContentDialog extends api.ui.dialog.ModalDialog {
 
@@ -380,7 +380,6 @@ export class NewContentDialog extends api.ui.dialog.ModalDialog {
 
     private toggleMostPopularBlockShown() {
         if (this.mostPopularItems.length > 0) {
-            this.mostPopularItemsBlock.getMostPopularList().setItems(this.mostPopularItems);
             this.mostPopularItemsBlock.show();
         }
     }
@@ -403,7 +402,7 @@ export class NewContentDialog extends api.ui.dialog.ModalDialog {
 
     private resetNewContentDialogContent() {
         if (this.listItems.length > 0) {
-            this.contentList.setItems(this.listItems);
+            this.contentList.setItems(this.listItems.slice());
             this.recentItemsBlock.getRecentItemsList().setItems(this.listItems);
             this.mostPopularItemsBlock.getMostPopularList().setItems(this.mostPopularItems);
         } else {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/list/ListBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/list/ListBox.ts
@@ -20,8 +20,6 @@ module api.ui.selector.list {
             if (items.length > 0) {
                 this.layoutList(items);
                 this.notifyItemsAdded(items);
-            } else {
-                this.clearItems();
             }
         }
 


### PR DESCRIPTION
-listItems keeps original list of entries in new content dialog, it is being used to filter entries and show original list when no filtering applied. After listbox refactoring it happens that when items in contentList are being set it cleans old array of items so original list in listItems get erased.
Fixed by using copy of original array.