### PR TITLE
XP-3376 Replace Publish action button with the new menu button in ContentWizard toolbar

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/action/UnpublishContentAction.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/action/UnpublishContentAction.ts
@@ -1,16 +1,13 @@
 import "../../../api.ts";
-
-import Action = api.ui.Action;
 import {ContentUnpublishPromptEvent} from "../ContentUnpublishPromptEvent";
 import {ContentTreeGrid} from "../ContentTreeGrid";
+
+import Action = api.ui.Action;
 
 export class UnpublishContentAction extends Action {
 
     constructor(grid: ContentTreeGrid) {
         super("Unpublish");
-
-        this.setVisible(false);
-        this.setEnabled(false);
 
         this.onExecuted(() => {
             var contents: api.content.ContentSummaryAndCompareStatus[]

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentUnpublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentUnpublishDialog.ts
@@ -1,4 +1,5 @@
 import "../../api.ts";
+import {DependantItemsDialog} from "../dialog/DependantItemsDialog";
 
 import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
 import DialogButton = api.ui.dialog.DialogButton;
@@ -8,7 +9,7 @@ import CompareStatus = api.content.CompareStatus;
 import ContentId = api.content.ContentId;
 import ContentPublishItem = api.content.ContentPublishItem;
 import ListBox = api.ui.selector.list.ListBox;
-import {DependantItemsDialog, DialogDependantList} from "../dialog/DependantItemsDialog";
+import {DependantItemsDialog} from "../dialog/DependantItemsDialog";
 
 
 export class ContentUnpublishDialog extends DependantItemsDialog {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentUnpublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentUnpublishDialog.ts
@@ -9,7 +9,6 @@ import CompareStatus = api.content.CompareStatus;
 import ContentId = api.content.ContentId;
 import ContentPublishItem = api.content.ContentPublishItem;
 import ListBox = api.ui.selector.list.ListBox;
-import {DependantItemsDialog} from "../dialog/DependantItemsDialog";
 
 
 export class ContentUnpublishDialog extends DependantItemsDialog {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -1,4 +1,18 @@
 import "../../api.ts";
+import {DefaultModels} from "./page/DefaultModels";
+import {ContentWizardStepForm} from "./ContentWizardStepForm";
+import {SettingsWizardStepForm} from "./SettingsWizardStepForm";
+import {SecurityWizardStepForm} from "./SecurityWizardStepForm";
+import {DisplayNameScriptExecutor} from "./DisplayNameScriptExecutor";
+import {LiveFormPanel, LiveFormPanelConfig} from "./page/LiveFormPanel";
+import {ContentWizardToolbarPublishControls} from "./ContentWizardToolbarPublishControls";
+import {ContentWizardActions} from "./action/ContentWizardActions";
+import {ContentWizardPanelParams} from "./ContentWizardPanelParams";
+import {ContentWizardToolbar} from "./ContentWizardToolbar";
+import {ContentPermissionsAppliedEvent} from "./ContentPermissionsAppliedEvent";
+import {Router} from "../Router";
+import {PersistNewContentRoutine} from "./PersistNewContentRoutine";
+import {UpdatePersistedContentRoutine} from "./UpdatePersistedContentRoutine";
 
 import PropertyTree = api.data.PropertyTree;
 import FormView = api.form.FormView;
@@ -65,20 +79,6 @@ import ContentNamedEvent = api.content.event.ContentNamedEvent;
 import ActiveContentVersionSetEvent = api.content.event.ActiveContentVersionSetEvent;
 
 import DialogButton = api.ui.dialog.DialogButton;
-import {DefaultModels} from "./page/DefaultModels";
-import {ContentWizardStepForm} from "./ContentWizardStepForm";
-import {SettingsWizardStepForm} from "./SettingsWizardStepForm";
-import {SecurityWizardStepForm} from "./SecurityWizardStepForm";
-import {DisplayNameScriptExecutor} from "./DisplayNameScriptExecutor";
-import {LiveFormPanel, LiveFormPanelConfig} from "./page/LiveFormPanel";
-import {ContentWizardToolbarPublishControls} from "./ContentWizardToolbarPublishControls";
-import {ContentWizardActions} from "./action/ContentWizardActions";
-import {ContentWizardPanelParams} from "./ContentWizardPanelParams";
-import {ContentWizardToolbar} from "./ContentWizardToolbar";
-import {ContentPermissionsAppliedEvent} from "./ContentPermissionsAppliedEvent";
-import {Router} from "../Router";
-import {PersistNewContentRoutine} from "./PersistNewContentRoutine";
-import {UpdatePersistedContentRoutine} from "./UpdatePersistedContentRoutine";
 
 export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
 
@@ -125,6 +125,8 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
     private previewAction: api.ui.Action;
 
     private publishAction: api.ui.Action;
+
+    private publishTreeAction: api.ui.Action;
 
     private unpublishAction: api.ui.Action;
 
@@ -188,6 +190,7 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
         this.wizardActions = new ContentWizardActions(this);
         this.previewAction = this.wizardActions.getPreviewAction();
         this.publishAction = this.wizardActions.getPublishAction();
+        this.publishTreeAction = this.wizardActions.getPublishTreeAction();
         this.unpublishAction = this.wizardActions.getUnpublishAction();
 
         var mainToolbar = new ContentWizardToolbar({
@@ -196,6 +199,7 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
             duplicateAction: this.wizardActions.getDuplicateAction(),
             previewAction: this.wizardActions.getPreviewAction(),
             publishAction: this.wizardActions.getPublishAction(),
+            publishTreeAction: this.wizardActions.getPublishTreeAction(),
             unpublishAction: this.wizardActions.getUnpublishAction(),
             showLiveEditAction: this.wizardActions.getShowLiveEditAction(),
             showFormAction: this.wizardActions.getShowFormAction(),
@@ -739,6 +743,7 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
                 this.contentWizardHeader.disableNameGeneration(this.contentCompareStatus !== CompareStatus.NEW);
 
                 this.contentWizardToolbarPublishControls.setCompareStatus(this.contentCompareStatus);
+                this.contentWizardToolbarPublishControls.setLeafContent(!contentSummaryAndCompareStatus.hasChildren());
                 this.managePublishButtonStateForMobile(this.contentCompareStatus);
             });
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbar.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbar.ts
@@ -29,7 +29,6 @@ export class ContentWizardToolbar extends api.ui.toolbar.Toolbar {
         super.addAction(params.deleteAction);
         super.addAction(params.duplicateAction);
         super.addAction(params.previewAction);
-        super.addAction(params.unpublishAction);
         super.addGreedySpacer();
 
         this.cycleViewModeButton = new CycleButton([params.showLiveEditAction, params.showFormAction]);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbar.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbar.ts
@@ -9,6 +9,7 @@ export interface ContentWizardToolbarParams {
     duplicateAction:api.ui.Action;
     deleteAction:api.ui.Action;
     publishAction:api.ui.Action;
+    publishTreeAction:api.ui.Action;
     unpublishAction:api.ui.Action;
     previewAction:api.ui.Action;
     showLiveEditAction:api.ui.Action;
@@ -35,7 +36,9 @@ export class ContentWizardToolbar extends api.ui.toolbar.Toolbar {
         this.componentsViewToggler = new TogglerButton("icon-clipboard", "Show Component View");
         this.contextWindowToggler = new TogglerButton("icon-cog", "Show Inspection Panel");
 
-        this.contentWizardToolbarPublishControls = new ContentWizardToolbarPublishControls(params.publishAction, params.unpublishAction);
+        this.contentWizardToolbarPublishControls = new ContentWizardToolbarPublishControls(
+            params.publishAction, params.publishTreeAction, params.unpublishAction
+        );
 
         super.addElement(this.contentWizardToolbarPublishControls);
         super.addElement(this.componentsViewToggler);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbarPublishControls.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbarPublishControls.ts
@@ -4,26 +4,29 @@ import Action = api.ui.Action;
 import DialogButton = api.ui.dialog.DialogButton;
 import SpanEl = api.dom.SpanEl;
 import CompareStatus = api.content.CompareStatus;
+import MenuButton = api.ui.button.MenuButton;
 
 export class ContentWizardToolbarPublishControls extends api.dom.DivEl {
 
-    private publishButton: DialogButton;
+    private publishButton: MenuButton;
+    private publishAction: Action;
+    private publishTreeAction: Action;
     private unpublishAction: Action;
     private contentStateSpan: SpanEl;
-    private publishAction: Action;
     private contentCanBePublished: boolean = false;
     private userCanPublish: boolean = true;
+    private leafContent: boolean = true;
     private contentCompareStatus: CompareStatus;
 
-    constructor(publish: Action, unpublish: Action) {
+    constructor(publish: Action, publishTree: Action, unpublish: Action) {
         super("toolbar-publish-controls");
-
-        this.unpublishAction = unpublish;
 
         this.publishAction = publish;
         this.publishAction.setIconClass("publish-action");
+        this.publishTreeAction = publishTree;
+        this.unpublishAction = unpublish;
 
-        this.publishButton = new DialogButton(publish);
+        this.publishButton = new MenuButton(publish, [publishTree, unpublish]);
         this.publishButton.addClass("content-wizard-toolbar-publish-button");
 
         this.contentStateSpan = new SpanEl("content-status");
@@ -52,14 +55,23 @@ export class ContentWizardToolbarPublishControls extends api.dom.DivEl {
         }
     }
 
+    public setLeafContent(leafContent: boolean, refresh: boolean = true) {
+        this.leafContent = leafContent;
+        if (refresh) {
+            this.refreshState();
+        }
+    }
+
     public refreshState() {
-        var canBeEnabled = this.contentCompareStatus !== CompareStatus.EQUAL && this.contentCanBePublished && this.userCanPublish;
-        this.publishAction.setEnabled(canBeEnabled);
+        let canBePublished = !this.isOnline() && this.contentCanBePublished && this.userCanPublish;
+        let canTreeBePublished = !this.leafContent && this.contentCanBePublished && this.userCanPublish;
+        let canBeUnpublished = this.contentCompareStatus != CompareStatus.NEW && this.contentCompareStatus != CompareStatus.UNKNOWN;
+        
+        this.publishAction.setEnabled(canBePublished);
+        this.publishTreeAction.setEnabled(canTreeBePublished);
+        this.unpublishAction.setEnabled(canBeUnpublished);
 
         this.contentStateSpan.setHtml(this.getContentStateValueForSpan(this.contentCompareStatus), false);
-
-        var isPublished = this.contentCompareStatus != CompareStatus.NEW && this.contentCompareStatus != CompareStatus.UNKNOWN;
-        this.unpublishAction.setVisible(isPublished);
     }
 
     public isOnline(): boolean {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/action/ContentWizardActions.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/action/ContentWizardActions.ts
@@ -3,6 +3,7 @@ import {ContentWizardPanel} from "../ContentWizardPanel";
 import {DuplicateContentAction} from "./DuplicateContentAction";
 import {DeleteContentAction} from "./DeleteContentAction";
 import {PublishAction} from "./PublishAction";
+import {PublishTreeAction} from "./PublishTreeAction";
 import {UnpublishAction} from "./UnpublishAction";
 import {PreviewAction} from "./PreviewAction";
 import {ShowLiveEditAction} from "./ShowLiveEditAction";
@@ -22,6 +23,8 @@ export class ContentWizardActions extends api.app.wizard.WizardActions<api.conte
     private duplicate: api.ui.Action;
 
     private publish: api.ui.Action;
+    
+    private publishTree: api.ui.Action;
 
     private unpublish: api.ui.Action;
 
@@ -40,15 +43,16 @@ export class ContentWizardActions extends api.app.wizard.WizardActions<api.conte
         this.close = new api.app.wizard.CloseAction(wizardPanel);
         this.saveAndClose = new api.app.wizard.SaveAndCloseAction(wizardPanel);
         this.publish = new PublishAction(wizardPanel);
+        this.publishTree = new PublishTreeAction(wizardPanel);
         this.unpublish = new UnpublishAction(wizardPanel);
         this.preview = new PreviewAction(wizardPanel);
         this.showLiveEditAction = new ShowLiveEditAction(wizardPanel);
         this.showFormAction = new ShowFormAction(wizardPanel);
         this.showSplitEditAction = new ShowSplitEditAction(wizardPanel);
 
-        super(this.save, this.delete, this.duplicate,
-            this.preview, this.publish, this.unpublish, this.close,
-            this.showLiveEditAction, this.showFormAction,
+        super(this.save, this.delete, this.duplicate, this.preview, 
+            this.publish, this.publishTree, this.unpublish, this.close,
+            this.showLiveEditAction, this.showFormAction, 
             this.showSplitEditAction, this.saveAndClose);
     }
 
@@ -91,6 +95,7 @@ export class ContentWizardActions extends api.app.wizard.WizardActions<api.conte
             }
             if (!hasPublishPermission) {
                 this.publish.setEnabled(false);
+                this.publishTree.setEnabled(false);
             } else {
                 // check if already published to show unpublish button
                 api.content.ContentSummaryAndCompareStatusFetcher.fetchByContent(existing)
@@ -153,6 +158,10 @@ export class ContentWizardActions extends api.app.wizard.WizardActions<api.conte
 
     getPublishAction(): api.ui.Action {
         return this.publish;
+    }
+
+    getPublishTreeAction(): api.ui.Action {
+        return this.publishTree;
     }
 
     getUnpublishAction(): api.ui.Action {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/action/PublishAction.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/action/PublishAction.ts
@@ -1,14 +1,14 @@
 import "../../../api.ts";
+import {ContentWizardPanel} from "../ContentWizardPanel";
+import {ContentPublishPromptEvent} from "../../browse/ContentPublishPromptEvent";
 
 import Content = api.content.Content;
 import ContentId = api.content.ContentId;
 import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
-import {ContentWizardPanel} from "../ContentWizardPanel";
-import {ContentPublishPromptEvent} from "../../browse/ContentPublishPromptEvent";
 
 export class PublishAction extends api.ui.Action {
 
-    constructor(wizard: ContentWizardPanel) {
+    constructor(wizard: ContentWizardPanel, includeChildItems: boolean = false) {
         super("Publish");
 
         this.setEnabled(false);
@@ -22,14 +22,16 @@ export class PublishAction extends api.ui.Action {
                     this.setEnabled(false);
                     wizard.saveChanges().then((content) => {
                         if (content) {
-                            new ContentPublishPromptEvent([ContentSummaryAndCompareStatus.fromContentSummary(content)]).fire();
+                            let contentSummary = ContentSummaryAndCompareStatus.fromContentSummary(content);
+                            new ContentPublishPromptEvent([contentSummary], includeChildItems).fire();
                         }
                     }).catch((reason: any) => {
                         api.DefaultErrorHandler.handle(reason)
                     }).finally(() => this.setEnabled(true)).done();
                 } else {
-                    new ContentPublishPromptEvent([ContentSummaryAndCompareStatus.fromContentSummary(
-                        wizard.getPersistedItem())]).fire();
+                    let contentSummary = ContentSummaryAndCompareStatus.fromContentSummary(wizard.getPersistedItem());
+                    contentSummary.setCompareStatus(wizard.getContentCompareStatus());
+                    new ContentPublishPromptEvent([contentSummary], includeChildItems).fire();
                 }
             } else {
                 api.notify.showWarning('The content cannot be published yet. One or more form values are not valid.');

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/action/PublishTreeAction.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/action/PublishTreeAction.ts
@@ -1,0 +1,12 @@
+import "../../../api.ts";
+import {ContentWizardPanel} from "../ContentWizardPanel";
+import {PublishAction} from "./PublishAction";
+
+
+export class PublishTreeAction extends PublishAction {
+
+    constructor(wizard: ContentWizardPanel) {
+        super(wizard, true);
+        this.setLabel("Publish Tree");
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/action/UnpublishAction.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/action/UnpublishAction.ts
@@ -1,16 +1,36 @@
 import "../../../api.ts";
-
 import {ContentWizardPanel} from "../ContentWizardPanel";
-import {ContentPublishPromptEvent} from "../../browse/ContentPublishPromptEvent";
+import {ContentUnpublishPromptEvent} from "../../browse/ContentUnpublishPromptEvent";
+import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
 
 export class UnpublishAction extends api.ui.Action {
+
+    private wizard: ContentWizardPanel;
 
     constructor(wizard: ContentWizardPanel) {
         super("Unpublish");
 
-        this.onExecuted(() => {
-            console.log('Unpublish action')
-        });
+        this.wizard = wizard;
 
+        this.onExecuted(() => {
+            if (this.wizard.hasUnsavedChanges()) {
+                this.setEnabled(false);
+                this.wizard.saveChanges().then((content) => {
+                    if (content) {
+                        this.fireContentUnpublishPromptEvent();
+                    }
+                }).catch((reason: any) => {
+                    api.DefaultErrorHandler.handle(reason)
+                }).finally(() => this.setEnabled(true)).done();
+            } else {
+                this.fireContentUnpublishPromptEvent();
+            }
+        });
+    }
+
+    private fireContentUnpublishPromptEvent(): void {
+        let contentSummary = ContentSummaryAndCompareStatus.fromContentSummary(this.wizard.getPersistedItem());
+        contentSummary.setCompareStatus(this.wizard.getContentCompareStatus());
+        new ContentUnpublishPromptEvent([contentSummary]).fire();
     }
 }


### PR DESCRIPTION
Removed the Unpublish button from the content wizard.
Replaced publish button with `MenuButton` in `ContentWizardPanel` and other places.