### PR TITLE
XP-3426 Dropdown handle button is not visible in Page Editor

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/common.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/common.less
@@ -22,6 +22,7 @@
 // should go after combo/dropdown and text-input to set styles after reset
 @import "../../common/styles/api/ui/selector/option-filter-input";
 @import "../../common/styles/api/ui/button/button";
+@import "../../common/styles/api/ui/button/dropdown-handle";
 @import "../../common/styles/api/ui/toolbar";
 @import "../../common/styles/api/ui/dropzone";
 @import "../../common/styles/api/ui/mask";


### PR DESCRIPTION
Added dropdown-handle styles to the common css links of the live edit.