### PR TITLE
XP-3346 Page Componenet View: context menu  is closed immediately aft…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsView.ts
@@ -1,4 +1,6 @@
 import "../../api.ts";
+import {LiveEditPageProxy} from "./page/LiveEditPageProxy";
+import {PageComponentsTreeGrid} from "./PageComponentsTreeGrid";
 
 import ItemViewSelectedEvent = api.liveedit.ItemViewSelectedEvent;
 import ItemViewDeselectedEvent = api.liveedit.ItemViewDeselectedEvent;
@@ -20,8 +22,6 @@ import Mask = api.ui.mask.Mask;
 import ResponsiveManager = api.ui.responsive.ResponsiveManager;
 import ResponsiveItem = api.ui.responsive.ResponsiveItem;
 import ResponsiveRanges = api.ui.responsive.ResponsiveRanges;
-import {LiveEditPageProxy} from "./page/LiveEditPageProxy";
-import {PageComponentsTreeGrid} from "./PageComponentsTreeGrid";
 
 export class PageComponentsView extends api.dom.DivEl {
 
@@ -552,6 +552,7 @@ export class PageComponentsView extends api.dom.DivEl {
         return cellNumber == 1;
     }
 
+    //
     private showContextMenu(row: number, clickPosition: api.liveedit.Position) {
         var node = this.tree.getGrid().getDataView().getItem(row);
         if (node) {
@@ -569,7 +570,7 @@ export class PageComponentsView extends api.dom.DivEl {
         }
 
         if (!this.contextMenu) {
-            this.contextMenu = new api.liveedit.ItemViewContextMenu(null, contextMenuActions, false);
+            this.contextMenu = new api.liveedit.ItemViewContextMenu(null, contextMenuActions, false, false);
             this.contextMenu.onHidden(this.removeMenuOpenStyleFromMenuIcon.bind(this));
         } else {
             this.contextMenu.setActions(contextMenuActions);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemViewContextMenu.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemViewContextMenu.ts
@@ -1,6 +1,7 @@
 module api.liveedit {
 
     import MinimizeWizardPanelEvent = api.app.wizard.MinimizeWizardPanelEvent;
+    import Action = api.ui.Action;
 
     export enum ItemViewContextMenuOrientation {
         UP,
@@ -16,7 +17,7 @@ module api.liveedit {
 
         private orientationListeners: {(orientation: ItemViewContextMenuOrientation): void}[] = [];
 
-        constructor(menuTitle: ItemViewContextMenuTitle, actions: api.ui.Action[], showArrow: boolean = true) {
+        constructor(menuTitle: ItemViewContextMenuTitle, actions: Action[], showArrow: boolean = true, listenToWizard: boolean = true) {
             super('menu item-view-context-menu');
 
             if (showArrow) {
@@ -85,7 +86,9 @@ module api.liveedit {
                 this.hide();
             };
 
-            MinimizeWizardPanelEvent.on(minimizeHandler);
+            if (listenToWizard) {
+                MinimizeWizardPanelEvent.on(minimizeHandler);
+            }
 
             this.onRemoved(() => MinimizeWizardPanelEvent.un(minimizeHandler));
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/menu/menu.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/menu/menu.less
@@ -16,6 +16,7 @@
     background-color: transparent;
     font-family: @admin-font-family;
     font-size: 14px;
+    font-weight: normal;
     color: @admin-font-gray3;
     border-width: 0;
     cursor: pointer;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/common.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/common.less
@@ -30,6 +30,7 @@
 @import "../../common/styles/api/app/names-view";
 @import "../../common/styles/api/app/names-and-icon-view";
 @import "../../common/styles/api/ui/tooltip";
+@import "../../common/styles/api/ui/menu/menu";
 @import "../../common/styles/api/ui/menu/context-menu";
 @import "../../common/styles/api/ui/menu/item-view-context-menu";
 //modal-dialogs


### PR DESCRIPTION
…er it was opened

Made the `ItemViewContextMenu` of `PageComponentsView` remain visible on `WizardPanel` minimized.
Fixed `ItemViewContextMenu` styles in live edit.