### PR TITLE
XP-3478 Delete dialog - Show spinner while fetching child items

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
@@ -10,6 +10,7 @@ import CompareStatus = api.content.CompareStatus;
 import BrowseItem = api.app.browse.BrowseItem;
 import SelectionItem = api.app.browse.SelectionItem;
 import ListBox = api.ui.selector.list.ListBox;
+import LoadMask = api.ui.mask.LoadMask;
 
 export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
 
@@ -28,6 +29,8 @@ export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
     private dependantsHeader: api.dom.H6El;
 
     private dependantList: ListBox<ContentSummaryAndCompareStatus>;
+
+    protected loadMask: LoadMask;
 
     constructor(dialogName: string, dialogSubName: string, dependantsName: string) {
         super({
@@ -73,6 +76,11 @@ export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
 
         this.appendChildToContentPanel(this.dependantsContainer);
 
+        this.initLoadMask();
+    }
+
+    private initLoadMask() {
+        this.loadMask = new LoadMask(this.getContentPanel());
     }
 
     protected createItemList(): ListBox<ContentSummaryAndCompareStatus> {
@@ -102,6 +110,8 @@ export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
     show() {
         api.dom.Body.get().appendChild(this);
         super.show();
+        this.appendChildToContentPanel(this.loadMask);
+        this.loadMask.show();
     }
 
     close() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
@@ -28,8 +28,6 @@ export class ContentPublishDialog extends DependantItemsDialog {
 
     private childrenLoaded: boolean = false;
 
-    private loadMask: LoadMask;
-
     // stashes previous checkbox state items, until selected items changed
     private stash: {[checked:string]:ContentSummaryAndCompareStatus[]} = {};
 
@@ -48,8 +46,6 @@ export class ContentPublishDialog extends DependantItemsDialog {
 
         this.initChildrenCheckbox();
 
-        this.initLoadMask();
-
         this.getItemList().onItemsRemoved((items: ContentSummaryAndCompareStatus[]) => {
             if (!this.isIgnoreItemsChanged()) {
                 this.clearStashedItems();
@@ -57,12 +53,6 @@ export class ContentPublishDialog extends DependantItemsDialog {
             }
         });
     }
-
-    private initLoadMask() {
-        this.loadMask = new LoadMask(this.getContentPanel());
-        this.appendChildToContentPanel(this.loadMask);
-    }
-
 
     protected createDependantList(): ListBox<ContentSummaryAndCompareStatus> {
         let dependants = new PublishDialogDependantList();
@@ -81,12 +71,6 @@ export class ContentPublishDialog extends DependantItemsDialog {
         });
 
         return dependants;
-    }
-
-    show() {
-        super.show();
-        this.appendChildToContentPanel(this.loadMask);
-        this.loadMask.show();
     }
 
     open() {
@@ -126,8 +110,14 @@ export class ContentPublishDialog extends DependantItemsDialog {
             return this.reloadPublishDependencies(childrenNotLoadedYet);
         } else {
             // apply the stash to avoid extra heavy request
-            this.setDependantItems(stashedItems.slice());
-            this.centerMyself();
+            this.publishButton.setEnabled(false);
+            this.loadMask.show();
+            setTimeout(() => {
+                this.setDependantItems(stashedItems.slice());
+                this.centerMyself();
+                this.publishButton.setEnabled(true);
+                this.loadMask.hide();
+            }, 100);
             return wemQ<void>(null);
         }
     }
@@ -222,7 +212,7 @@ export class ContentPublishDialog extends DependantItemsDialog {
 
         this.overwriteDefaultArrows(this.childrenCheckbox);
 
-        this.appendChildToContentPanel(this.childrenCheckbox);
+        this.getButtonRow().appendChild(this.childrenCheckbox);
     }
 
     private getContentToPublishIds(): ContentId[] {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentUnpublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentUnpublishDialog.ts
@@ -57,6 +57,8 @@ export class ContentUnpublishDialog extends DependantItemsDialog {
 
             this.hideLoadingSpinnerAtButton();
             this.unpublishButton.setEnabled(true);
+        }).finally(() => {
+            this.loadMask.hide();
         });
 
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialog.ts
@@ -51,20 +51,37 @@ export class ContentDeleteDialog extends DependantItemsDialog {
         this.updateSubTitle();
 
         var items = this.getItemList().getItems();
+
+        this.manageDescendants(items);
+
+        this.countItemsToDeleteAndUpdateButtonCounter();
+    }
+
+    protected manageDescendants(items: ContentSummaryAndCompareStatus[]) {
+        this.loadMask.show();
+        this.deleteButton.setEnabled(false);
         this.loadDescendants(items)
             .then((descendants: ContentSummaryAndCompareStatus[]) => {
 
                 this.setDependantItems(descendants);
 
-                if (!this.isAnyOnline(items) && !this.isAnyOnline(descendants)) {
-                    this.instantDeleteCheckbox.hide();
+                if (!this.isAnyOnline(items)) {
+                    this.verifyInstantDeleteVisibility(descendants);
                 }
 
                 this.centerMyself();
+            }).finally(() => {
+                this.loadMask.hide();
+                this.deleteButton.setEnabled(true);
             });
+    }
 
-
-        this.countItemsToDeleteAndUpdateButtonCounter();
+    private verifyInstantDeleteVisibility(items: ContentSummaryAndCompareStatus[]) {
+        if (this.isAnyOnline(items)) {
+            this.instantDeleteCheckbox.show();
+        } else {
+            this.instantDeleteCheckbox.hide();
+        }
     }
 
     setContentToDelete(contents: ContentSummaryAndCompareStatus[]): ContentDeleteDialog {
@@ -73,26 +90,11 @@ export class ContentDeleteDialog extends DependantItemsDialog {
         this.setIgnoreItemsChanged(false);
         this.updateSubTitle();
 
-        if (this.isAnyOnline(contents)) {
-            this.instantDeleteCheckbox.show();
-        } else {
-            this.instantDeleteCheckbox.hide();
-        }
+        this.verifyInstantDeleteVisibility(contents);
+
         this.instantDeleteCheckbox.setChecked(false, true);
 
-        if (contents) {
-            this.loadDescendants(contents)
-                .then((descendants: ContentSummaryAndCompareStatus[]) => {
-
-                    this.setDependantItems(descendants);
-
-                    if (!this.isAnyOnline(contents) && this.isAnyOnline(descendants)) {
-                        this.instantDeleteCheckbox.show();
-                    }
-
-                    this.centerMyself();
-                });
-        }
+        this.manageDescendants(contents);
 
         this.countItemsToDeleteAndUpdateButtonCounter();
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/publish/content-publish-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/publish/content-publish-dialog.less
@@ -55,8 +55,7 @@
 .@{_COMMON_PREFIX}modal-dialog {
   &._0-240, &._240-360 {
     &.publish-dialog .include-child-check {
-      bottom: auto;
-      right: 10px;
+      left: 16px;
     }
   }
 }


### PR DESCRIPTION
- Moved mask code to a common parent of delete and publish dialogs - DependantItemsDialog
- Simplified a little of code in DeletedDialog
- Added 100ms timeout in publish dialog before stash' items are displayed to give mask enough time to render - seems like element.show() method does it in asynchronous??? way
- Moved include checkbox in publish dialog to button row so that it does not cause autoscroll on click when there are many dependant items. Fixed display of checkbox in small resolutions.