### PR TITLE
XP-3522 ContentWizardPanel: don't auto change the name/path after con…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -629,7 +629,7 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
                     this.contentCompareStatus = content.getCompareStatus();
                     this.contentWizardToolbarPublishControls.setCompareStatus(this.contentCompareStatus);
 
-                    this.contentWizardHeader.disableNameGeneration(this.contentCompareStatus === CompareStatus.NEW);
+                    this.contentWizardHeader.disableNameGeneration(this.contentCompareStatus === CompareStatus.EQUAL);
                 }
             });
         };


### PR DESCRIPTION
…tent has been published

- Changed checked content's compare status to be 'EQUAL'(published) instead of 'NEW' that triggers disabling of name generation on publish event