### PR TITLE
XP-3523 Error appears in the browser console when new Fragment create…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ComponentView.ts
@@ -356,6 +356,7 @@ module api.liveedit {
             if (parentIsPage) {
                 // unbind the old view from the component and bind the new one
                 this.unregisterComponentListeners(this.component);
+                this.unbindMouseListeners();
 
                 this.getPageView().registerFragmentComponentView(replacement);
 
@@ -364,6 +365,7 @@ module api.liveedit {
 
                 // unbind the old view from the component and bind the new one
                 this.unregisterComponentListeners(this.component);
+                this.unbindMouseListeners();
 
                 var parentRegionView = this.parentRegionView;
                 this.parentRegionView.unregisterComponentView(this);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemView.ts
@@ -265,7 +265,7 @@ module api.liveedit {
             });
         }
 
-        private unbindMouseListeners() {
+        protected unbindMouseListeners() {
             this.unMouseEnter(this.mouseEnterListener);
             this.unMouseLeave(this.mouseLeaveListener);
             this.unClicked(this.mouseClickedListener);


### PR DESCRIPTION
…d from a text component

- On replace() call I added unbind of componentView listeners as replaced items do not seem to be used anymore, hence no need to handle their listeners.