### PR TITLE
XP-3501 IE11 users cannot edit any content

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/ContentItemPreviewPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/ContentItemPreviewPanel.ts
@@ -1,4 +1,5 @@
 import "../../api.ts";
+import {ContentPreviewPathChangedEvent} from "./ContentPreviewPathChangedEvent";
 
 import RenderingMode = api.rendering.RenderingMode;
 import ContentImageUrlResolver = api.content.ContentImageUrlResolver;
@@ -7,8 +8,6 @@ import ContentSummary = api.content.ContentSummary;
 import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
 import UriHelper = api.util.UriHelper;
 import ContentTypeName = api.schema.content.ContentTypeName;
-import {ContentPreviewPathChangedEvent} from "./ContentPreviewPathChangedEvent";
-import {ContentBrowseItem} from "../browse/ContentBrowseItem";
 
 export class ContentItemPreviewPanel extends api.app.view.ItemPreviewPanel {
 
@@ -52,7 +51,8 @@ export class ContentItemPreviewPanel extends api.app.view.ItemPreviewPanel {
             try {
                 if (frameWindow) {
                     var pathname: string = frameWindow.location.pathname;
-                    if (pathname && pathname !== 'blank') {
+                    // /blank is for IE
+                    if (pathname && pathname !== 'blank' && pathname !== '/blank') {
                         new ContentPreviewPathChangedEvent(pathname).fire();
                     }
                     frameWindow.addEventListener("click", this.frameClickHandler.bind(this));

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ClassHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ClassHelper.ts
@@ -66,7 +66,9 @@ module api {
          */
         static getFullName(instance): string {
             var constructor = (typeof instance === 'function') ? instance : instance["constructor"];
-            return ClassHelper.findPath(window, constructor) || constructor["name"];
+            //last one expression for IE
+            return ClassHelper.findPath(window, constructor) || constructor["name"] ||
+                   constructor.toString().match(/^function\s*([^\s(]+)/)[1];
         }
 
         /**

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/rest/JsonRequest.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/rest/JsonRequest.ts
@@ -25,10 +25,8 @@ module api.rest {
             return this;
         }
 
-        setTimeout(timeoutMillis): JsonRequest<RAW_JSON_TYPE> {
-            if (timeoutMillis) {
-                this.timeoutMillis = timeoutMillis;
-            }
+        setTimeout(timeoutMillis: number): JsonRequest<RAW_JSON_TYPE> {
+            this.timeoutMillis = timeoutMillis;
             return this;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/rest/ResourceRequest.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/rest/ResourceRequest.ts
@@ -52,8 +52,7 @@ module api.rest {
             var jsonRequest = new JsonRequest<RAW_JSON_TYPE>().
                 setMethod(this.method).
                 setParams(this.getParams()).
-                setPath(this.getRequestPath()).
-                setTimeout(!this.heavyOperation ? this.timeoutMillis : -1);
+                setPath(this.getRequestPath()).setTimeout(!this.heavyOperation ? this.timeoutMillis : 0);
             return jsonRequest.send();
         }
 


### PR DESCRIPTION
-(Syntax Error) Issue was that IE can't accept timeout value '-1' in XMLHttpRequest, need to set zero if you don't want timeout to expire
 -IE does not support yet function.name property, added name extractor for IE (in ClaassHelper.ts)
 -In IE window.location.pathname for blank page is '/blank', we checked only 'blank' before (ContentItemPreviewPanel.ts)