### PR TITLE
XP-3551 Wrong state of 'New' and 'Sort' buttons on the browsePanel to…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/action/ContentTreeGridActions.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/action/ContentTreeGridActions.ts
@@ -292,7 +292,7 @@ export class ContentTreeGridActions implements TreeGridActions<ContentSummaryAnd
                         loginResult, item)
                 });
 
-                if (!contentTypesAllowChildren && !canCreate) {
+                if (!contentTypesAllowChildren || !canCreate) {
                     this.SHOW_NEW_CONTENT_DIALOG_ACTION.setEnabled(false);
                     this.SORT_CONTENT.setEnabled(false);
                 }


### PR DESCRIPTION
…olbar, when content, that not allows children is selected

- Adjusted condition that disables new and sort buttons