### PR TITLE
XP-3140 Bad validation for ImageSelector content: red icon does not a…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelector.ts
@@ -7,6 +7,7 @@ module api.content.form.inputtype.contentselector {
     import ValueTypes = api.data.ValueTypes;
     import GetRelationshipTypeByNameRequest = api.schema.relationshiptype.GetRelationshipTypeByNameRequest;
     import RelationshipTypeName = api.schema.relationshiptype.RelationshipTypeName;
+    import ContentDeletedEvent = api.content.event.ContentDeletedEvent;
 
     export class ContentSelector extends api.form.inputtype.support.BaseInputTypeManagingAdd<api.content.ContentId> {
 
@@ -24,15 +25,35 @@ module api.content.form.inputtype.contentselector {
 
         private allowedContentPaths: string[];
 
+        private contentDeletedListener: (event: ContentDeletedEvent) => void;
+
         constructor(config?: api.content.form.inputtype.ContentInputTypeViewContext) {
             super("relationship");
             this.addClass("input-type-view");
             this.config = config;
             this.readConfig(config.inputConfig);
+            this.handleContentDeletedEvent();
         }
 
         public getContentComboBox(): ContentComboBox {
             return this.contentComboBox;
+        }
+
+        private handleContentDeletedEvent() {
+            this.contentDeletedListener = (event) => {
+                event.getDeletedItems().forEach((deletedItem) => {
+                    var option = this.contentComboBox.getSelectedOptionView().getById(deletedItem.getContentId().toString());
+                    if (option != null) {
+                        this.contentComboBox.getSelectedOptionView().removeOption(option.getOption(), false);
+                    }
+                });
+            }
+
+            ContentDeletedEvent.on(this.contentDeletedListener);
+
+            this.onRemoved((event) => {
+                ContentDeletedEvent.un(this.contentDeletedListener);
+            })
         }
 
         private readConfig(inputConfig: { [element: string]: { [name: string]: string }[]; }): void {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -78,19 +78,19 @@ module api.content.form.inputtype.image {
                 this.updateSelectedItemsIcons();
             });
 
-            if (!this.contentDeletedListener) {
-                this.contentDeletedListener = (event) => {
-                    event.getDeletedItems().filter((deletedItem) => {
-                        return !!deletedItem;
-                    }).forEach((deletedItem) => {
+            this.handleContentDeletedEvent();
+        }
 
-                        var option = this.selectedOptionsView.getById(deletedItem.getContentId().toString());
-                        if (option != null) {
-                            this.selectedOptionsView.removeSelectedOptions([option]);
-                        }
-                    });
-                }
+        private handleContentDeletedEvent() {
+            this.contentDeletedListener = (event) => {
+                event.getDeletedItems().forEach((deletedItem) => {
+                    var option = this.selectedOptionsView.getById(deletedItem.getContentId().toString());
+                    if (option != null) {
+                        this.selectedOptionsView.removeSelectedOptions([option]);
+                    }
+                });
             }
+
             ContentDeletedEvent.on(this.contentDeletedListener);
 
             this.onRemoved((event) => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
@@ -131,6 +131,10 @@ module api.ui.selector.combobox {
             return this.selectedOptionsView.getByOption(option);
         }
 
+        getSelectedOptionView(): SelectedOptionsView<OPTION_DISPLAY_VALUE> {
+            return this.selectedOptionsView;
+        }
+
         isOptionSelected(option: Option<OPTION_DISPLAY_VALUE>): boolean {
             return this.comboBox.isOptionSelected(option);
         }


### PR DESCRIPTION
…ppear in the wizard and grid, when image, that was specified in the content was removed

- Made content selector to behave similar as image selector on content deleted event - remove appropriate option from dropdown and update form
- Moved content deleted event handling logic from constructor in ImageSelector