### PR TITLE
XP-3569 Macros not HTML escaped in macro dialog

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/MacroDockedPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/MacroDockedPanel.ts
@@ -126,7 +126,7 @@ module api.util.htmlarea.dialog {
                 this.previewPanel.appendChild(new MacroPreviewFrame(macroPreview));
             } else {
                 var appendMe = new api.dom.DivEl("preview-content");
-                appendMe.setHtml(macroPreview.getHtml(), false);
+                appendMe.setHtml(macroPreview.getHtml());
                 this.previewPanel.appendChild(appendMe)
             }
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/MacroModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/MacroModalDialog.ts
@@ -95,7 +95,7 @@ module api.util.htmlarea.dialog {
 
         private insertMacroIntoTextArea(): void {
             this.macroDockedPanel.getMacroPreviewString().then((macroString: string) => {
-                var macro = this.callback(macroString);
+                var macro = this.callback(api.util.StringHelper.escapeHtml(macroString));
                 this.close();
             }).catch((reason: any) => {
                 api.DefaultErrorHandler.handle(reason);


### PR DESCRIPTION
- Made macro string to be escaped in macro preview and on inserting into html area