### PR TITLE
XP-3140 Bad validation for ImageSelector content: red icon does not a…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -78,19 +78,30 @@ module api.content.form.inputtype.image {
                 this.updateSelectedItemsIcons();
             });
 
-            if (!this.contentDeletedListener) {
-                this.contentDeletedListener = (event) => {
-                    event.getDeletedItems().filter((deletedItem) => {
-                        return !!deletedItem;
-                    }).forEach((deletedItem) => {
+            this.handleContentDeletedEvent();
+        }
 
+        private handleContentDeletedEvent() {
+            this.contentDeletedListener = (event) => {
+                if (this.selectedOptionsView.count() == 0) {
+                    return;
+                }
+
+                var selectedContentIdsMap: {} = {};
+                this.selectedOptionsView.getSelectedOptions().forEach(
+                    (selectedOption: any) => selectedContentIdsMap[selectedOption.getOption().displayValue.getContentId().toString()] = "");
+
+                event.getDeletedItems().
+                    filter(deletedItem => !deletedItem.isPending() &&
+                                          selectedContentIdsMap.hasOwnProperty(deletedItem.getContentId().toString())).
+                    forEach((deletedItem) => {
                         var option = this.selectedOptionsView.getById(deletedItem.getContentId().toString());
                         if (option != null) {
                             this.selectedOptionsView.removeSelectedOptions([option]);
                         }
                     });
-                }
             }
+
             ContentDeletedEvent.on(this.contentDeletedListener);
 
             this.onRemoved((event) => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
@@ -131,6 +131,10 @@ module api.ui.selector.combobox {
             return this.selectedOptionsView.getByOption(option);
         }
 
+        getSelectedOptionView(): SelectedOptionsView<OPTION_DISPLAY_VALUE> {
+            return this.selectedOptionsView;
+        }
+
         isOptionSelected(option: Option<OPTION_DISPLAY_VALUE>): boolean {
             return this.comboBox.isOptionSelected(option);
         }


### PR DESCRIPTION
…ppear in the wizard and grid, when image, that was specified in the content was removed

- Made content selector to behave similar as image selector on content deleted event - remove appropriate option from dropdown and update form
- Moved content deleted event handling logic from constructor in ImageSelector