### PR TITLE
XP-3569 Macros not HTML escaped in macro dialog

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/MacroDockedPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/MacroDockedPanel.ts
@@ -126,9 +126,13 @@ module api.util.htmlarea.dialog {
                 this.previewPanel.appendChild(new MacroPreviewFrame(macroPreview));
             } else {
                 var appendMe = new api.dom.DivEl("preview-content");
-                appendMe.setHtml(macroPreview.getHtml(), false);
+                appendMe.setHtml(macroPreview.getHtml(), this.isDisableMacro());
                 this.previewPanel.appendChild(appendMe)
             }
+        }
+
+        private isDisableMacro(): boolean {
+            return this.macroDescriptor.getKey().getName().indexOf("disable") >= 0;
         }
 
         public validateMacroForm(): boolean {


### PR DESCRIPTION
- Added a check that will escape html string of noformat preview