### PR TITLE
XP-3583 Avoid redundant back-end call in ContentBrowseFilterPanel

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/filter/ContentBrowseFilterPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/filter/ContentBrowseFilterPanel.ts
@@ -207,7 +207,14 @@ export class ContentBrowseFilterPanel extends api.app.browse.filter.BrowseFilter
 
     private getAggregations(contentQuery: ContentQuery,
                             contentQueryResult: ContentQueryResult<ContentSummary,ContentSummaryJson>): wemQ.Promise<api.aggregation.Aggregation[]> {
-        return new ContentQueryRequest<ContentSummaryJson,ContentSummary>(this.cloneContentQueryNoContentTypes(contentQuery)).setExpand(
+
+        var clonedContentQueryNoContentTypes: ContentQuery = this.cloneContentQueryNoContentTypes(contentQuery);
+
+        if (api.ObjectHelper.objectEquals(contentQuery, clonedContentQueryNoContentTypes)) {
+            return wemQ(this.combineAggregations(contentQueryResult, contentQueryResult));
+        }
+
+        return new ContentQueryRequest<ContentSummaryJson,ContentSummary>(clonedContentQueryNoContentTypes).setExpand(
             api.rest.Expand.SUMMARY).sendAndParse().then(
             (contentQueryResultNoContentTypesSelected: ContentQueryResult<ContentSummary,ContentSummaryJson>) => {
                 return this.combineAggregations(contentQueryResult, contentQueryResultNoContentTypesSelected);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/query/ContentQuery.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/query/ContentQuery.ts
@@ -1,6 +1,6 @@
 module api.content.query {
 
-    export class ContentQuery{
+    export class ContentQuery implements api.Equitable {
 
         static POSTLOAD_SIZE = 10;
 
@@ -93,5 +93,41 @@ module api.content.query {
             return this.queryFilters;
         }
 
+        equals(o: api.Equitable): boolean {
+            if (!api.ObjectHelper.iFrameSafeInstanceOf(o, ContentQuery)) {
+                return false;
+            }
+
+            var other = <ContentQuery>o;
+
+            if (!api.ObjectHelper.numberEquals(this.from, other.from)) {
+                return false;
+            }
+
+            if (!api.ObjectHelper.numberEquals(this.size, other.size)) {
+                return false;
+            }
+
+            if (!api.ObjectHelper.arrayEquals(this.contentTypeNames, other.contentTypeNames)) {
+                return false;
+            }
+
+            if (!api.ObjectHelper.anyArrayEquals(this.aggregationQueries, other.aggregationQueries)) {
+                return false;
+            }
+
+            if (!api.ObjectHelper.anyArrayEquals(this.queryFilters, other.queryFilters)) {
+                return false;
+            }
+
+            if ((!this.queryExpr && other.queryExpr) ||
+                (this.queryExpr && !other.queryExpr) ||
+                (this.queryExpr && other.queryExpr &&
+                 !api.ObjectHelper.stringEquals(this.queryExpr.toString(), other.queryExpr.toString()))) {
+                return false;
+            }
+
+            return true;
+        }
     }
 }


### PR DESCRIPTION
- Made contentQuery equitable so that getAggregations() may compare query that already made with a new one and use existing results if equal