### PR TITLE
XP-3614 Site Config dialog - Apply mask when HTML area modal dialog i…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorDialog.ts
@@ -11,6 +11,7 @@ module api.content.site.inputtype.siteconfigurator {
     import PrincipalSelector = api.content.form.inputtype.principalselector.PrincipalSelector;
     import ImageSelector = api.content.form.inputtype.image.ImageSelector;
     import ComboBox = api.ui.selector.combobox.ComboBox;
+    import CreateHtmlAreaDialogEvent = api.util.htmlarea.dialog.CreateHtmlAreaDialogEvent;
 
     export class SiteConfiguratorDialog extends api.ui.dialog.ModalDialog {
 
@@ -36,6 +37,15 @@ module api.content.site.inputtype.siteconfigurator {
             this.getCancelAction().onExecuted(() => cancelCallback());
 
             this.addCancelButtonToBottom();
+
+            CreateHtmlAreaDialogEvent.on((event: CreateHtmlAreaDialogEvent) => {
+                this.addClass("masked");
+
+                api.util.htmlarea.dialog.HTMLAreaDialogHandler.getOpenDialog().onRemoved(() => {
+                    this.removeClass("masked");
+                })
+            });
+
 
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ModalDialog.ts
@@ -188,7 +188,9 @@ module api.util.htmlarea.dialog {
 
         close() {
             super.close();
-            this.editor.focus();
+            if (!this.editor["destroyed"]) {
+                this.editor.focus();
+            }
             this.remove();
         }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/application/inputtype/siteconfigurator/site-configurator.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/application/inputtype/siteconfigurator/site-configurator.less
@@ -142,4 +142,26 @@
       position: fixed !important;
     }
   }
+
+  &.masked {
+
+    border: 1px solid;
+
+    .image-selector .image-uploader-el .dropzone-container .dropzone {
+      background-color: #808080;
+      border: 1px solid #676767;
+    }
+
+    &:after {
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+      background-color: black;
+      opacity: 0.5;
+      content: "";
+      position: absolute;
+    }
+  }
+
 }


### PR DESCRIPTION
…s active

-Used :after pseudo element to style siteconfig dialog like it is masked instead of updating z-index because when updating z-index siteconfig dialog appears under mask element and when clicking out of recently opened modal dialog -  site config dialog gets closed in spite if click was over it because click is being perfromed on mask
-added check for editor to exist in close() method of modal dialog, otherwise error is thrown when opened modal dialog and clicking out siteconfig dialog (siteconfig dialog gets closed when clicked out)