### PR TITLE
XP-3639 Move Content Dialog - Close on pressing Escape

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ConfirmContentDeleteDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ConfirmContentDeleteDialog.ts
@@ -1,5 +1,4 @@
 import "../../api.ts";
-
 import {DeleteAction} from "../view/DeleteAction";
 
 export interface ConfirmContentDeleteDialogConfig {
@@ -108,6 +107,12 @@ export class ConfirmContentDeleteDialog extends api.ui.dialog.ModalDialog {
                 this.confirmDeleteAction.setEnabled(false);
             }
 
+        });
+
+        this.input.onKeyUp((event: KeyboardEvent) => {
+            if (event.keyCode === 27) {
+                this.getCancelAction().execute();
+            }
         });
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentMoveComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentMoveComboBox.ts
@@ -29,6 +29,10 @@ module api.content {
             this.contentLoader.setFilterSourceContentType(contentType);
         }
 
+        clearCombobox() {
+            super.clearCombobox();
+            this.contentLoader.resetSearchString();
+        }
     }
 
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/MoveContentSummaryLoader.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/MoveContentSummaryLoader.ts
@@ -9,8 +9,6 @@ module api.content {
 
     export class MoveContentSummaryLoader extends ContentSummaryPreLoader {
 
-        private preservedSearchString: string;
-
         private contentSummaryRequest: ContentSummaryRequest;
 
         private filterContentPath: ContentPath;
@@ -40,6 +38,10 @@ module api.content {
             return this.load();
         }
 
+        resetSearchString() {
+            this.contentSummaryRequest.setSearchString("");
+        }
+
 
         load(): wemQ.Promise<ContentSummary[]> {
 
@@ -63,11 +65,8 @@ module api.content {
                         } else {
                             this.notifyLoadedData([]);
                         }
-                        if (this.preservedSearchString) {
-                            this.search(this.preservedSearchString);
-                            this.preservedSearchString = null;
-                        }
-                        deferred.resolve(contents);
+
+                    deferred.resolve(contents);
                     }).
                     catch((reason: any) => deferred.reject(reason)).
                     done();


### PR DESCRIPTION
-Issue occurs due to mousetrap skips event triggered by our shortcut if it's source is in input element. Same for input in delete confirmation dialog
-small refactoring on move dialog
-Fixed one more issue that was found during original task investigation: in move dialog request that being sent when opening destination dropdown is not properly cleared when reopening dialog; if you've entered some values and then reopened dialog and tried to open input dropdown - your request (in spite of fact  that input is empty after reopen) will send request with search string set with previously entered values.