### PR TITLE
XP-3230 contentSelector / imageSelector - Bad handling of deleted items

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/ContentsExistJson.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/ContentsExistJson.java
@@ -1,0 +1,55 @@
+package com.enonic.xp.admin.impl.json.content;
+
+import java.util.List;
+
+import org.codehaus.jparsec.util.Lists;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.enonic.xp.content.ContentId;
+
+public class ContentsExistJson
+{
+    private final List<ContentExistJson> contentsExistJson = Lists.arrayList();
+
+    public ContentsExistJson()
+    {
+    }
+
+    public void add( final ContentId contentId, final boolean exists )
+    {
+        contentsExistJson.add( new ContentExistJson( contentId.toString(), exists ) );
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public List<ContentExistJson> getContentsExistJson()
+    {
+        return contentsExistJson;
+    }
+}
+
+class ContentExistJson
+{
+
+    private final String contentId;
+
+    private final boolean exists;
+
+    public ContentExistJson( final String contentId, final boolean exists )
+    {
+        this.contentId = contentId;
+        this.exists = exists;
+    }
+
+    public String getContentId()
+    {
+        return contentId;
+    }
+
+    @JsonProperty("exists")
+    @SuppressWarnings("UnusedDeclaration")
+    public boolean exists()
+    {
+        return exists;
+    }
+}

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -44,6 +44,7 @@ import com.enonic.xp.admin.impl.json.content.ContentListJson;
 import com.enonic.xp.admin.impl.json.content.ContentPermissionsJson;
 import com.enonic.xp.admin.impl.json.content.ContentSummaryJson;
 import com.enonic.xp.admin.impl.json.content.ContentSummaryListJson;
+import com.enonic.xp.admin.impl.json.content.ContentsExistJson;
 import com.enonic.xp.admin.impl.json.content.DependenciesJson;
 import com.enonic.xp.admin.impl.json.content.GetActiveContentVersionsResultJson;
 import com.enonic.xp.admin.impl.json.content.GetContentVersionsForViewResultJson;
@@ -704,10 +705,23 @@ public final class ContentResource
     public List<ContentPermissionsJson> getPermissionsByIds( final ContentIdsJson params )
     {
         final List<ContentPermissionsJson> result = new ArrayList<>();
-        for ( String contentId : params.getContentIds() )
+        for ( final ContentId contentId : params.getContentIds() )
         {
-            final AccessControlList permissions = contentService.getPermissionsById( ContentId.from( contentId ) );
-            result.add( new ContentPermissionsJson( contentId, permissions, principalsResolver ) );
+            final AccessControlList permissions = contentService.getPermissionsById( contentId );
+            result.add( new ContentPermissionsJson( contentId.toString(), permissions, principalsResolver ) );
+        }
+
+        return result;
+    }
+
+    @POST
+    @Path("contentsExist")
+    public ContentsExistJson contentsExist( final ContentIdsJson params )
+    {
+        final ContentsExistJson result = new ContentsExistJson();
+        for ( final ContentId contentId : params.getContentIds() )
+        {
+            result.add( contentId, contentService.contentExists( contentId ) );
         }
 
         return result;

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/ContentIdsJson.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/ContentIdsJson.java
@@ -2,17 +2,21 @@ package com.enonic.xp.admin.impl.rest.resource.content.json;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.enonic.xp.content.ContentIds;
+
 public class ContentIdsJson
 {
-    private List<String> contentIds;
+    private ContentIds contentIds;
 
-    public List<String> getContentIds()
+    public ContentIdsJson( @JsonProperty("contentIds") final List<String> contentIds )
     {
-        return contentIds;
+        this.contentIds = ContentIds.from( contentIds );
     }
 
-    public void setContentIds( final List<String> contentIds )
+    public ContentIds getContentIds()
     {
-        this.contentIds = contentIds;
+        return contentIds;
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentComboBox.ts
@@ -19,6 +19,8 @@ module api.content {
                 setOptionDisplayValueViewer(new api.content.ContentSummaryViewer()).
                 setDelayedInputValueChangedHandling(750).
                 setValue(builder.value).
+                setDisplayMissingSelectedOptions(builder.displayMissingSelectedOptions).
+                setRemoveMissingSelectedOptions(builder.removeMissingSelectedOptions).
                 setMinWidth(builder.minWidth);
 
             super(richComboBoxBuilder);
@@ -63,13 +65,40 @@ module api.content {
     export class ContentSelectedOptionsView extends api.ui.selector.combobox.BaseSelectedOptionsView<ContentSummary> {
 
         createSelectedOption(option: api.ui.selector.Option<ContentSummary>): SelectedOption<ContentSummary> {
-            var optionView = new ContentSelectedOptionView(option);
+            var optionView = !!option.displayValue ? new ContentSelectedOptionView(option) : new MissingContentSelectedOptionView(option);
             return new SelectedOption<ContentSummary>(optionView, this.count());
         }
     }
 
-    export class ContentSelectedOptionView extends api.ui.selector.combobox.RichSelectedOptionView<ContentSummary> {
+    export class MissingContentSelectedOptionView extends api.ui.selector.combobox.BaseSelectedOptionView<ContentSummary> {
 
+        private id: string;
+
+        constructor(option: api.ui.selector.Option<ContentSummary>) {
+            this.id = option.value;
+            super(option);
+        }
+
+        layout() {
+            var removeButtonEl = new api.dom.AEl("remove"),
+                message = new api.dom.H6El("missing-content");
+
+            message.setHtml("No access to content with id=" + this.id);
+
+            removeButtonEl.onClicked((event: Event) => {
+                this.notifyRemoveClicked();
+
+                event.stopPropagation();
+                event.preventDefault();
+                return false;
+            });
+
+            this.appendChild(removeButtonEl);
+            this.appendChild(message);
+        }
+    }
+
+    export class ContentSelectedOptionView extends api.ui.selector.combobox.RichSelectedOptionView<ContentSummary> {
 
         constructor(option: api.ui.selector.Option<ContentSummary>) {
             super(option);
@@ -117,6 +146,10 @@ module api.content {
 
         postLoad: () => void;
 
+        displayMissingSelectedOptions: boolean;
+
+        removeMissingSelectedOptions: boolean;
+
         setName(value: string): ContentComboBoxBuilder {
             this.name = value;
             return this;
@@ -139,6 +172,16 @@ module api.content {
 
         setValue(value: string): ContentComboBoxBuilder {
             this.value = value;
+            return this;
+        }
+
+        setDisplayMissingSelectedOptions(value: boolean): ContentComboBoxBuilder {
+            this.displayMissingSelectedOptions = value;
+            return this;
+        }
+
+        setRemoveMissingSelectedOptions(value: boolean): ContentComboBoxBuilder {
+            this.removeMissingSelectedOptions = value;
             return this;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentsExistRequest.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentsExistRequest.ts
@@ -1,0 +1,32 @@
+module api.content {
+
+    import ContentsExistJson = api.content.json.ContentsExistJson;
+
+    export class ContentsExistRequest extends ContentResourceRequest<ContentsExistJson, ContentsExistResult> {
+
+        private contentIds: string[] = [];
+
+        constructor(contentIds: string[]) {
+            super();
+            super.setMethod("POST");
+            this.contentIds = contentIds;
+        }
+
+        getParams(): Object {
+            return {
+                contentIds: this.contentIds
+            };
+        }
+
+        getRequestPath(): api.rest.Path {
+            return api.rest.Path.fromParent(super.getResourcePath(), "contentsExist");
+        }
+
+        sendAndParse(): wemQ.Promise<ContentsExistResult> {
+
+            return this.send().then((response: api.rest.JsonResponse<ContentsExistJson>) => {
+                return new ContentsExistResult(response.getResult());
+            });
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentsExistResult.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentsExistResult.ts
@@ -1,0 +1,17 @@
+module api.content {
+
+    export class ContentsExistResult {
+
+        private contentsExistMap: Object = {}
+
+        constructor(json: api.content.json.ContentsExistJson) {
+            json.contentsExistJson.forEach(item => {
+                this.contentsExistMap[item.contentId] = item.exists;
+            });
+        }
+
+        contentExists(id: string): boolean {
+            return this.contentsExistMap.hasOwnProperty(id) && this.contentsExistMap[id];
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/_module.ts
@@ -90,6 +90,8 @@
 ///<reference path='CreateContentFilter.ts' />
 ///<reference path='CountContentsWithDescendantsRequest.ts' />
 ///<reference path='GetDescendantsOfContents.ts' />
+///<reference path='ContentsExistRequest.ts' />
+///<reference path='ContentsExistResult.ts' />
 
 ///<reference path='OrderExpr.ts' />
 ///<reference path='DynamicOrderExpr.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageContentComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageContentComboBox.ts
@@ -23,7 +23,9 @@ module api.content.form.inputtype.image {
                 setOptionDisplayValueViewer(new ImageSelectorViewer()).
                 setDelayedInputValueChangedHandling(750).
                 setValue(builder.value).
-                setMinWidth(builder.minWidth);
+                setMinWidth(builder.minWidth).
+                setRemoveMissingSelectedOptions(true).
+                setDisplayMissingSelectedOptions(true);
 
             // Actually the hack.
             // ImageSelectorSelectedOptionsView and BaseSelectedOptionsView<ContentSummary> are incompatible in loaders.

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorDisplayValue.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorDisplayValue.ts
@@ -10,6 +10,8 @@ module api.content.form.inputtype.image {
 
         private content: ContentSummary;
 
+        private empty: boolean;
+
         constructor() {
         }
 
@@ -19,6 +21,19 @@ module api.content.form.inputtype.image {
 
         static fromContentSummary(content: ContentSummary) {
             return new ImageSelectorDisplayValue().setContentSummary(content);
+        }
+
+        static makeEmpty() {
+            return new ImageSelectorDisplayValue().setEmpty(true);
+        }
+
+        isEmptyContent(): boolean {
+            return this.empty;
+        }
+
+        setEmpty(value: boolean): ImageSelectorDisplayValue {
+            this.empty = value;
+            return this;
         }
 
         setUploadItem(item: UploadItem<ContentSummary>): ImageSelectorDisplayValue {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
@@ -75,7 +75,12 @@ module api.content.form.inputtype.image {
             var selectedOption: SelectedOption<ImageSelectorDisplayValue> = this.createSelectedOption(option);
             this.getSelectedOptions().push(selectedOption);
 
-            var optionView: ImageSelectorSelectedOptionView = <ImageSelectorSelectedOptionView>selectedOption.getOptionView();
+            var optionView: ImageSelectorSelectedOptionView = <ImageSelectorSelectedOptionView>selectedOption.getOptionView(),
+                isMissingContent = option.displayValue.isEmptyContent();
+
+            if (isMissingContent) {
+                optionView.showError("No access to image.");
+            }
 
             optionView.onClicked((event: MouseEvent) => {
 
@@ -157,7 +162,7 @@ module api.content.form.inputtype.image {
                 this.notifyOptionSelected(selectedOption);
             }
 
-            new Tooltip(optionView, option.displayValue.getPath(), 1000);
+            new Tooltip(optionView, isMissingContent ? option.value : option.displayValue.getPath(), 1000);
         }
 
         updateUploadedOption(option: Option<ImageSelectorDisplayValue>) {
@@ -170,6 +175,13 @@ module api.content.form.inputtype.image {
             };
 
             selectedOption.getOptionView().setOption(newOption);
+        }
+
+        makeEmptyOption(id: string): Option<ImageSelectorDisplayValue> {
+            return <Option<ImageSelectorDisplayValue>>{
+                value: id,
+                displayValue: ImageSelectorDisplayValue.makeEmpty()
+            };
         }
 
         private uncheckOthers(option: SelectedOption<ImageSelectorDisplayValue>) {
@@ -212,8 +224,18 @@ module api.content.form.inputtype.image {
             var showToolbar = this.selection.length > 0;
             this.toolbar.setVisible(showToolbar);
             if (showToolbar) {
-                this.toolbar.setSelectionCount(this.selection.length);
+                this.toolbar.setSelectionCount(this.selection.length, this.getNumberOfEditableOptions());
             }
+        }
+
+        private getNumberOfEditableOptions(): number {
+            var count = 0;
+            this.selection.forEach(selectedOption => {
+                if (!selectedOption.getOption().displayValue.isEmptyContent()) {
+                    count++;
+                }
+            });
+            return count;
         }
 
         private hideImageSelectorDialog() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/SelectionToolbar.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/SelectionToolbar.ts
@@ -8,7 +8,9 @@ module api.content.form.inputtype.image {
 
         private removeButton: Button;
 
-        private selectionCount: number;
+        private removableCount: number;
+
+        private editableCount: number;
 
         private editClickListeners: {(): void;}[] = [];
 
@@ -32,14 +34,16 @@ module api.content.form.inputtype.image {
             this.appendChild(this.removeButton);
         }
 
-        setSelectionCount(count: number) {
-            this.selectionCount = count;
+        setSelectionCount(removableCount: number, editableCount) {
+            this.editableCount = editableCount;
+            this.removableCount = removableCount;
             this.refreshUI();
         }
 
         private refreshUI() {
-            this.editButton.setLabel("Edit" + (this.selectionCount > 0 ? " (" + this.selectionCount + ")" : ""));
-            this.removeButton.setLabel("Remove " + (this.selectionCount > 0 ? " (" + this.selectionCount + ")" : ""));
+            this.editButton.setLabel("Edit" + (this.editableCount > 0 ? " (" + this.editableCount + ")" : ""));
+            this.editButton.setEnabled(this.editableCount > 0);
+            this.removeButton.setLabel("Remove " + (this.removableCount > 0 ? " (" + this.removableCount + ")" : ""));
         }
 
         notifyEditClicked() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/ContentsExistJson.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/ContentsExistJson.ts
@@ -1,0 +1,14 @@
+module api.content.json {
+
+    export interface ContentsExistJson {
+
+        contentsExistJson: ContentExistJson[]
+    }
+
+    export interface ContentExistJson {
+
+        contentId: string;
+
+        exists: boolean;
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/_module.ts
@@ -30,3 +30,4 @@
 ///<reference path='ContentVersionViewJson.ts' />
 ///<reference path='ContentDependencyGroupJson.ts' />
 ///<reference path='ContentDependencyJson.ts' />
+///<reference path='ContentsExistJson.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/BaseSelectedOptionsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/BaseSelectedOptionsView.ts
@@ -180,6 +180,13 @@ module api.ui.selector.combobox {
             this.list.forEach((selectedOption: SelectedOption<T>, index: number) => selectedOption.setIndex(index));
         }
 
+        makeEmptyOption(id: string): Option<T> {
+            return <Option<T>>{
+                value: id,
+                displayValue: null
+            };
+        }
+
         protected notifyOptionDeselected(removed: SelectedOption<T>) {
             this.optionRemovedListeners.forEach((listener) => {
                 listener(removed);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -35,6 +35,9 @@ module api.ui.selector.combobox {
 
         noOptionsText?: string;
 
+        displayMissingSelectedOptions?: boolean
+
+        removeMissingSelectedOptions?: boolean
     }
 
     export class ComboBox<OPTION_DISPLAY_VALUE> extends api.dom.FormInputEl {
@@ -69,9 +72,15 @@ module api.ui.selector.combobox {
 
         private expandedListeners: {(event: api.ui.selector.DropdownExpandedEvent): void}[] = [];
 
+        private contentMissingListeners: {(ids: string[]): void}[] = [];
+
         private selectiondDelta = [];
 
         private noOptionsText: string;
+
+        private displayMissingSelectedOptions: boolean = false;
+
+        private removeMissingSelectedOptions: boolean = false;
 
         public static debug: boolean = false;
 
@@ -100,6 +109,14 @@ module api.ui.selector.combobox {
 
             if (config.minWidth) {
                 this.minWidth = config.minWidth;
+            }
+
+            if (config.displayMissingSelectedOptions) {
+                this.displayMissingSelectedOptions = config.displayMissingSelectedOptions;
+            }
+
+            if (config.removeMissingSelectedOptions) {
+                this.removeMissingSelectedOptions = config.removeMissingSelectedOptions;
             }
 
             this.noOptionsText = config.noOptionsText;
@@ -263,12 +280,63 @@ module api.ui.selector.combobox {
                 this.clearSelection(false, false, true);
             }
 
+            if (this.displayMissingSelectedOptions || this.removeMissingSelectedOptions) {
+                this.selectExistingAndHandleMissing(value);
+            } else {
+                this.selectExistingOptions(value);
+            }
+        }
+
+        private selectExistingAndHandleMissing(value: string) {
+            var missingOptionIds = this.getMissingOptionsIds(value),
+                nonExistingIds: string[] = [];
+
+            if (missingOptionIds.length > 0) {
+                new api.content.ContentsExistRequest(missingOptionIds).sendAndParse().then((result: api.content.ContentsExistResult) => {
+                    this.splitValues(value).forEach((val) => {
+                        var option = this.getOptionByValue(val);
+                        if (option != null) {
+                            this.selectOption(option, true);
+                        } else {
+                            var contentExists = result.contentExists(val);
+                            if (this.displayMissingSelectedOptions && (contentExists || !this.removeMissingSelectedOptions)) {
+                                var option = (<BaseSelectedOptionsView<OPTION_DISPLAY_VALUE>> this.selectedOptionsView).makeEmptyOption(val);
+                                this.selectOption(option, true);
+                            }
+                            if (!contentExists) {
+                                nonExistingIds.push(val);
+                            }
+                        }
+                    });
+
+                    if (this.removeMissingSelectedOptions) {
+                        this.notifyContentMissing(nonExistingIds);
+                    }
+
+                });
+            } else {
+                this.selectExistingOptions(value);
+            }
+        }
+
+        private selectExistingOptions(value: string) {
             this.splitValues(value).forEach((val) => {
                 var option = this.getOptionByValue(val);
                 if (option != null) {
                     this.selectOption(option, true);
                 }
             });
+        }
+
+        private getMissingOptionsIds(value: string): string[] {
+            var result: string[] = [];
+            this.splitValues(value).forEach((val) => {
+                var option = this.getOptionByValue(val);
+                if (option == null) {
+                    result.push(val);
+                }
+            });
+            return result;
         }
 
         protected splitValues(value: string): string[] {
@@ -487,7 +555,7 @@ module api.ui.selector.combobox {
         }
 
         private setupListeners() {
-            
+
             api.util.AppHelper.focusInOut(this, () => {
                 this.hideDropdown();
                 this.active = false;
@@ -766,6 +834,22 @@ module api.ui.selector.combobox {
             var event = new api.ui.selector.DropdownExpandedEvent(this.comboBoxDropdown.getDropdownGrid().getElement(), expanded);
             this.expandedListeners.forEach((listener: (event: api.ui.selector.DropdownExpandedEvent)=>void) => {
                 listener(event);
+            });
+        }
+
+        onContentMissing(listener: (ids: string[])=>void) {
+            this.contentMissingListeners.push(listener);
+        }
+
+        unContentMissing(listener: (ids: string[])=>void) {
+            this.contentMissingListeners = this.contentMissingListeners.filter(function (curr) {
+                return curr != listener;
+            });
+        }
+
+        private notifyContentMissing(ids: string[]) {
+            this.contentMissingListeners.forEach((listener: (ids: string[])=>void) => {
+                listener(ids);
             });
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
@@ -43,7 +43,9 @@ module api.ui.selector.combobox {
                 minWidth: builder.minWidth,
                 value: builder.value,
                 noOptionsText: builder.noOptionsText,
-                maxHeight: builder.maxHeight
+                maxHeight: builder.maxHeight,
+                displayMissingSelectedOptions: builder.displayMissingSelectedOptions,
+                removeMissingSelectedOptions: builder.removeMissingSelectedOptions
             };
 
             this.loader = builder.loader;
@@ -456,6 +458,10 @@ module api.ui.selector.combobox {
 
         noOptionsText: string;
 
+        displayMissingSelectedOptions: boolean;
+
+        removeMissingSelectedOptions: boolean;
+
         setComboBoxName(comboBoxName: string): RichComboBoxBuilder<T> {
             this.comboBoxName = comboBoxName;
             return this;
@@ -521,6 +527,15 @@ module api.ui.selector.combobox {
             return this;
         }
 
+        setDisplayMissingSelectedOptions(value: boolean): RichComboBoxBuilder<T> {
+            this.displayMissingSelectedOptions = value;
+            return this;
+        }
+
+        setRemoveMissingSelectedOptions(value: boolean): RichComboBoxBuilder<T> {
+            this.removeMissingSelectedOptions = value;
+            return this;
+        }
 
         build(): RichComboBox<T> {
             return new RichComboBox(this);


### PR DESCRIPTION
- Added displayMissingSelectedOptions and removeMissingSelectedOptions to comboBox in order to enable handling of missing contents
- Made Content and Image selectors to remove missing properties on appropriate event
- Added service to ContentResource with appropriate front-end classes that check existence of passed content ids. Service is used by ComboBox.
- Made comboBox to generate event for removal of non-existing content references and render placeholder if content is not available (due to permissions. for example)
- Adjusted xXxSelectedOptionsView classes to generate empty view for missing content's placeholder
- Adjusted image selector toolbar to handle such placeholders
- Made Selectors to notify user via notification popup that missing references were removed