### PR TITLE
XP-3658 Context menu of the Content grid is visible in the wizard

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentTabMenu.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentTabMenu.ts
@@ -1,12 +1,12 @@
 import "../../api.ts";
+import {SortContentTabMenuItem} from "./SortContentTabMenuItem";
+import {SortContentTabMenuItems} from "./SortContentTabMenuItems";
 
 import ChildOrder = api.content.ChildOrder;
 import FieldOrderExpr = api.content.FieldOrderExpr;
 import FieldOrderExprBuilder = api.content.FieldOrderExprBuilder;
 import ContentSummary = api.content.ContentSummary;
 import DropdownHandle = api.ui.button.DropdownHandle;
-import {SortContentTabMenuItem} from "./SortContentTabMenuItem";
-import {SortContentTabMenuItems} from "./SortContentTabMenuItems";
 
 export class SortContentTabMenu extends api.ui.tab.TabMenu {
 
@@ -36,13 +36,13 @@ export class SortContentTabMenu extends api.ui.tab.TabMenu {
 
     }
 
-    hideMenu() {
+    protected hideMenu() {
         super.hideMenu();
         this.dropdownHandle.up();
 
     }
 
-    showMenu() {
+    protected showMenu() {
         super.showMenu();
         this.dropdownHandle.down();
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/bar/AppBarTabMenu.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/bar/AppBarTabMenu.ts
@@ -5,6 +5,7 @@ module api.app.bar {
     import ResponsiveItem = api.ui.responsive.ResponsiveItem;
 
     import TabMenuItem = api.ui.tab.TabMenuItem;
+    import HideTabMenuEvent = api.ui.tab.HideTabMenuEvent;
 
     export class AppBarTabMenu extends api.ui.tab.TabMenu {
 
@@ -89,15 +90,20 @@ module api.app.bar {
             this.updateTabMenuButtonVisibility();
         }
 
-        createTabMenuButton(): AppBarTabMenuButton {
+        protected createTabMenuButton(): AppBarTabMenuButton {
             this.appBarTabMenuButton = new AppBarTabMenuButton();
             return this.appBarTabMenuButton;
         }
 
-        setButtonLabel(value: string): AppBarTabMenu {
+        protected setButtonLabel(value: string): AppBarTabMenu {
             super.setButtonLabel(value);
             this.notifyButtonLabelChanged();
             return this;
+        }
+
+        protected handleClick(e: MouseEvent) {
+            e.preventDefault();
+            new HideTabMenuEvent(this).fire();
         }
 
         addNavigationItem(tab: AppBarTabMenuItem) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/AccessSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/AccessSelector.ts
@@ -50,7 +50,7 @@ module api.ui.security.acl {
             return this;
         }
 
-        setButtonLabel(value: string): AccessSelector {
+        protected setButtonLabel(value: string): AccessSelector {
             this.getTabMenuButtonEl().setLabel(value, false);
             return this;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabMenu.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabMenu.ts
@@ -27,20 +27,28 @@ module api.ui.tab {
         constructor(className?: string) {
             super("tab-menu" + (className ? " " + className : ""));
 
+            this.initTabMenuButton();
+            this.menuEl = new api.dom.UlEl("menu");
+
+            this.appendChild(this.tabMenuButton);
+            this.appendChild(this.menuEl);
+
+            this.initListeners();
+        }
+
+        private initTabMenuButton() {
             this.tabMenuButton = this.createTabMenuButton();
             this.tabMenuButton.hide();
             this.tabMenuButton.addClass("tab-menu-button");
+
             this.tabMenuButton.onClicked((event: MouseEvent) => {
                 if (this.enabled) {
                     this.toggleMenu();
                 }
             });
-            this.appendChild(this.tabMenuButton);
+        }
 
-            this.menuEl = new api.dom.UlEl("menu");
-            this.appendChild(this.menuEl);
-
-
+        private initListeners() {
             api.dom.Body.get().onClicked((event: MouseEvent) => {
                 if (!this.getEl().contains(<HTMLElement> event.target)) {
                     this.hideMenu();
@@ -49,10 +57,7 @@ module api.ui.tab {
 
             this.onClicked((e: MouseEvent) => {
                 if (this.enabled) {
-                    // menu itself was clicked so do nothing
-                    e.preventDefault();
-                    e.stopPropagation();
-                    new HideTabMenuEvent(this).fire();
+                    this.handleClick(e);
                 }
             });
         }
@@ -63,13 +68,20 @@ module api.ui.tab {
             return this;
         }
 
-        createTabMenuButton(): TabMenuButton {
+        protected createTabMenuButton(): TabMenuButton {
             return new TabMenuButton();
         }
 
-        setButtonLabel(value: string): TabMenu {
+        protected setButtonLabel(value: string): TabMenu {
             this.tabMenuButton.setLabel(value);
             return this;
+        }
+
+        protected handleClick(e: MouseEvent) {
+            // menu itself was clicked so do nothing
+            e.preventDefault();
+            e.stopPropagation();
+            new HideTabMenuEvent(this).fire();
         }
 
         setButtonClass(cls: string): TabMenu {
@@ -98,13 +110,13 @@ module api.ui.tab {
             }
         }
 
-        hideMenu() {
+        protected hideMenu() {
             this.menuEl.hide();
             this.menuVisible = false;
             this.removeClass('expanded');
         }
 
-        showMenu() {
+        protected showMenu() {
             this.menuEl.show();
             this.menuVisible = true;
             this.addClass('expanded');


### PR DESCRIPTION
-AppBarTabMenu click handler was calling e.stoppropagation, as a result context menu's listener that triggers close on click outside of menu was not called. Fixed by removing e.stoppropagation for AppBarTabMenu
-Small refactoring: made some methods used only inside TabMenu hierarchy protected