### PR TITLE
XP-3625 Pressing Enter or Tab in the dropdown must move focus to the next input in the form

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/contextwindow/inspect/region/ImageInspectionPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/contextwindow/inspect/region/ImageInspectionPanel.ts
@@ -15,6 +15,7 @@ import ComponentPropertyChangedEvent = api.content.page.region.ComponentProperty
 import Option = api.ui.selector.Option;
 import SelectedOption = api.ui.selector.combobox.SelectedOption;
 import PropertyTree = api.data.PropertyTree;
+import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
 export class ImageInspectionPanel extends ComponentInspectionPanel<ImageComponent> {
 
@@ -134,15 +135,15 @@ export class ImageInspectionPanel extends ComponentInspectionPanel<ImageComponen
 
     private initSelectorListeners() {
 
-        this.imageSelector.onOptionSelected((selectedOption: SelectedOption<ContentSummary>) => {
+        this.imageSelector.onOptionSelected((event: SelectedOptionEvent<ContentSummary>) => {
             if (this.handleSelectorEvents) {
-                var option: Option<ContentSummary> = selectedOption.getOption();
+                var option: Option<ContentSummary> = event.getSelectedOption().getOption();
                 var imageContent = option.displayValue;
                 this.imageComponent.setImage(imageContent.getContentId(), imageContent.getDisplayName());
             }
         });
 
-        this.imageSelector.onOptionDeselected((option: SelectedOption<ContentSummary>) => {
+        this.imageSelector.onOptionDeselected((event: SelectedOptionEvent<ContentSummary>) => {
             if (this.handleSelectorEvents) {
                 this.imageComponent.reset();
             }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/authappselector/AuthApplicationSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/authappselector/AuthApplicationSelector.ts
@@ -121,9 +121,7 @@ module api.content.site.inputtype.siteconfigurator {
             });
 
             comboBox.onOptionSelected((event: SelectedOptionEvent<Application>) => {
-                if (event.getKeyCode() === 13) {
-                    new FocusSwitchEvent(this).fire();
-                }
+                this.fireFocusSwitchEvent(event);
 
                 this.ignorePropertyChange = true;
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/authappselector/AuthApplicationSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/authappselector/AuthApplicationSelector.ts
@@ -19,6 +19,7 @@ module api.content.site.inputtype.siteconfigurator {
     import SiteConfig = api.content.site.SiteConfig;
     import GetApplicationRequest = api.application.GetApplicationRequest;
     import LoadedDataEvent = api.util.loader.event.LoadedDataEvent;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class AuthApplicationSelector extends api.form.inputtype.support.BaseInputTypeManagingAdd<Application> {
 
@@ -109,18 +110,19 @@ module api.content.site.inputtype.siteconfigurator {
             comboBox.onBeforeOptionCreated(() => this.ignorePropertyChange = true);
             comboBox.onAfterOptionCreated(() => this.ignorePropertyChange = false);
 
-            comboBox.onOptionDeselected((removed: SelectedOption<Application>) => {
+            comboBox.onOptionDeselected((event: SelectedOptionEvent<Application>) => {
                 this.ignorePropertyChange = true;
 
-                this.getPropertyArray().remove(removed.getIndex());
+                this.getPropertyArray().remove(event.getSelectedOption().getIndex());
 
                 this.ignorePropertyChange = false;
                 this.validate(false);
             });
 
-            comboBox.onOptionSelected((selectedOption: SelectedOption<Application>) => {
+            comboBox.onOptionSelected((event: SelectedOptionEvent<Application>) => {
                 this.ignorePropertyChange = true;
 
+                const selectedOption = event.getSelectedOption();
                 var key = selectedOption.getOption().displayValue.getApplicationKey();
                 if (!key) {
                     return;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/authappselector/AuthApplicationSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/authappselector/AuthApplicationSelector.ts
@@ -20,6 +20,7 @@ module api.content.site.inputtype.siteconfigurator {
     import GetApplicationRequest = api.application.GetApplicationRequest;
     import LoadedDataEvent = api.util.loader.event.LoadedDataEvent;
     import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
+    import FocusSwitchEvent = api.ui.FocusSwitchEvent;
 
     export class AuthApplicationSelector extends api.form.inputtype.support.BaseInputTypeManagingAdd<Application> {
 
@@ -120,6 +121,10 @@ module api.content.site.inputtype.siteconfigurator {
             });
 
             comboBox.onOptionSelected((event: SelectedOptionEvent<Application>) => {
+                if (event.getKeyCode() === 13) {
+                    new FocusSwitchEvent(this).fire();
+                }
+
                 this.ignorePropertyChange = true;
 
                 const selectedOption = event.getSelectedOption();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelector.ts
@@ -9,6 +9,7 @@ module api.content.form.inputtype.contentselector {
     import RelationshipTypeName = api.schema.relationshiptype.RelationshipTypeName;
     import ContentDeletedEvent = api.content.event.ContentDeletedEvent;
     import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
+    import FocusSwitchEvent = api.ui.FocusSwitchEvent;
 
     export class ContentSelector extends api.form.inputtype.support.BaseInputTypeManagingAdd<api.content.ContentId> {
 
@@ -59,7 +60,7 @@ module api.content.form.inputtype.contentselector {
                             this.contentComboBox.getSelectedOptionView().removeOption(option.getOption(), false);
                         }
                     });
-            }
+            };
 
             ContentDeletedEvent.on(this.contentDeletedListener);
 
@@ -159,6 +160,12 @@ module api.content.form.inputtype.contentselector {
                             this.getPropertyArray().remove(event.getSelectedOption().getIndex());
                                 this.updateSelectedOptionStyle();
                                 this.validate(false);
+                        });
+
+                        this.contentComboBox.onOptionSelected((event: SelectedOptionEvent<any>) => {
+                            if (event.getKeyCode() === 13) {
+                                new FocusSwitchEvent(this).fire();
+                            }
                             });
 
                             this.setupSortable();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelector.ts
@@ -8,6 +8,7 @@ module api.content.form.inputtype.contentselector {
     import GetRelationshipTypeByNameRequest = api.schema.relationshiptype.GetRelationshipTypeByNameRequest;
     import RelationshipTypeName = api.schema.relationshiptype.RelationshipTypeName;
     import ContentDeletedEvent = api.content.event.ContentDeletedEvent;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class ContentSelector extends api.form.inputtype.support.BaseInputTypeManagingAdd<api.content.ContentId> {
 
@@ -136,9 +137,9 @@ module api.content.form.inputtype.contentselector {
                                 this.contentComboBox.select(content);
                             });
 
-                            this.contentComboBox.onOptionSelected((selectedOption: api.ui.selector.combobox.SelectedOption<api.content.ContentSummary>) => {
+                        this.contentComboBox.onOptionSelected((event: SelectedOptionEvent<api.content.ContentSummary>) => {
 
-                                var reference = api.util.Reference.from(selectedOption.getOption().displayValue.getContentId());
+                            var reference = api.util.Reference.from(event.getSelectedOption().getOption().displayValue.getContentId());
 
                                 var value = new Value(reference, ValueTypes.REFERENCE);
                                 if (this.contentComboBox.countSelected() == 1) { // overwrite initial value
@@ -153,9 +154,9 @@ module api.content.form.inputtype.contentselector {
                                 this.validate(false);
                             });
 
-                            this.contentComboBox.onOptionDeselected((removed: api.ui.selector.combobox.SelectedOption<api.content.ContentSummary>) => {
+                        this.contentComboBox.onOptionDeselected((event: SelectedOptionEvent<api.content.ContentSummary>) => {
 
-                                this.getPropertyArray().remove(removed.getIndex());
+                            this.getPropertyArray().remove(event.getSelectedOption().getIndex());
                                 this.updateSelectedOptionStyle();
                                 this.validate(false);
                             });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelector.ts
@@ -66,7 +66,7 @@ module api.content.form.inputtype.contentselector {
 
             this.onRemoved((event) => {
                 ContentDeletedEvent.un(this.contentDeletedListener);
-            })
+            });
         }
 
         private readConfig(inputConfig: { [element: string]: { [name: string]: string }[]; }): void {
@@ -139,6 +139,9 @@ module api.content.form.inputtype.contentselector {
                             });
 
                         this.contentComboBox.onOptionSelected((event: SelectedOptionEvent<api.content.ContentSummary>) => {
+                            if (event.getKeyCode() === 13) {
+                                new FocusSwitchEvent(this).fire();
+                            }
 
                             var reference = api.util.Reference.from(event.getSelectedOption().getOption().displayValue.getContentId());
 
@@ -158,14 +161,8 @@ module api.content.form.inputtype.contentselector {
                         this.contentComboBox.onOptionDeselected((event: SelectedOptionEvent<api.content.ContentSummary>) => {
 
                             this.getPropertyArray().remove(event.getSelectedOption().getIndex());
-                                this.updateSelectedOptionStyle();
-                                this.validate(false);
-                        });
-
-                        this.contentComboBox.onOptionSelected((event: SelectedOptionEvent<any>) => {
-                            if (event.getKeyCode() === 13) {
-                                new FocusSwitchEvent(this).fire();
-                            }
+                            this.updateSelectedOptionStyle();
+                            this.validate(false);
                             });
 
                             this.setupSortable();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/contentselector/ContentSelector.ts
@@ -139,9 +139,7 @@ module api.content.form.inputtype.contentselector {
                             });
 
                         this.contentComboBox.onOptionSelected((event: SelectedOptionEvent<api.content.ContentSummary>) => {
-                            if (event.getKeyCode() === 13) {
-                                new FocusSwitchEvent(this).fire();
-                            }
+                            this.fireFocusSwitchEvent(event);
 
                             var reference = api.util.Reference.from(event.getSelectedOption().getOption().displayValue.getContentId());
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -246,9 +246,7 @@ module api.content.form.inputtype.image {
             });
 
             comboBox.onOptionSelected((event: SelectedOptionEvent<ImageSelectorDisplayValue>) => {
-                if (event.getKeyCode() === 13) {
-                    new FocusSwitchEvent(this).fire();
-                }
+                this.fireFocusSwitchEvent(event);
 
                 if (!this.isLayoutInProgress()) {
                     var contentId = event.getSelectedOption().getOption().displayValue.getContentId();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -246,6 +246,10 @@ module api.content.form.inputtype.image {
             });
 
             comboBox.onOptionSelected((event: SelectedOptionEvent<ImageSelectorDisplayValue>) => {
+                if (event.getKeyCode() === 13) {
+                    new FocusSwitchEvent(this).fire();
+                }
+
                 if (!this.isLayoutInProgress()) {
                     var contentId = event.getSelectedOption().getOption().displayValue.getContentId();
                     if (!contentId) {
@@ -261,12 +265,6 @@ module api.content.form.inputtype.image {
 
                 this.getPropertyArray().set(moved.getIndex(), ValueTypes.REFERENCE.newValue(moved.getOption().value));
                 this.validate(false);
-            });
-
-            comboBox.onOptionSelected((event: SelectedOptionEvent<ImageSelectorDisplayValue>) => {
-                if (event.getKeyCode() === 13) {
-                    new FocusSwitchEvent(this).fire();
-                }
             });
 
             return contentComboBox;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -31,6 +31,8 @@ module api.content.form.inputtype.image {
     import ContentSelectorLoader = api.content.form.inputtype.contentselector.ContentSelectorLoader;
     import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
+    import FocusSwitchEvent = api.ui.FocusSwitchEvent;
+
     export class ImageSelector extends api.form.inputtype.support.BaseInputTypeManagingAdd<ContentId> {
 
         private config: api.content.form.inputtype.ContentInputTypeViewContext;
@@ -101,7 +103,7 @@ module api.content.form.inputtype.image {
                             this.selectedOptionsView.removeSelectedOptions([option]);
                         }
                     });
-            }
+            };
 
             ContentDeletedEvent.on(this.contentDeletedListener);
 
@@ -259,6 +261,12 @@ module api.content.form.inputtype.image {
 
                 this.getPropertyArray().set(moved.getIndex(), ValueTypes.REFERENCE.newValue(moved.getOption().value));
                 this.validate(false);
+            });
+
+            comboBox.onOptionSelected((event: SelectedOptionEvent<ImageSelectorDisplayValue>) => {
+                if (event.getKeyCode() === 13) {
+                    new FocusSwitchEvent(this).fire();
+                }
             });
 
             return contentComboBox;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -29,6 +29,7 @@ module api.content.form.inputtype.image {
     import FileUploadFailedEvent = api.ui.uploader.FileUploadFailedEvent;
 
     import ContentSelectorLoader = api.content.form.inputtype.contentselector.ContentSelectorLoader;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class ImageSelector extends api.form.inputtype.support.BaseInputTypeManagingAdd<ContentId> {
 
@@ -233,17 +234,18 @@ module api.content.form.inputtype.image {
             });
             comboBox.setInputIconUrl(inputIconUrl);
 
-            comboBox.onOptionDeselected((removed: SelectedOption<ImageSelectorDisplayValue>) => {
+            comboBox.onOptionDeselected((event: SelectedOptionEvent<ImageSelectorDisplayValue>) => {
                 // property not found.
-                if (!!removed.getOption().displayValue.getContentSummary()) {
-                    this.getPropertyArray().remove(removed.getIndex());
+                const option = event.getSelectedOption();
+                if (option.getOption().displayValue.getContentSummary()) {
+                    this.getPropertyArray().remove(option.getIndex());
                 }
                 this.validate(false);
             });
 
-            comboBox.onOptionSelected((added: SelectedOption<ImageSelectorDisplayValue>) => {
+            comboBox.onOptionSelected((event: SelectedOptionEvent<ImageSelectorDisplayValue>) => {
                 if (!this.isLayoutInProgress()) {
-                    var contentId = added.getOption().displayValue.getContentId();
+                    var contentId = event.getSelectedOption().getOption().displayValue.getContentId();
                     if (!contentId) {
                         return;
                     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
@@ -56,11 +56,11 @@ module api.content.form.inputtype.image {
             return new SelectedOption<ImageSelectorDisplayValue>(new ImageSelectorSelectedOptionView(option), this.count());
         }
 
-        addOption(option: Option<ImageSelectorDisplayValue>, silent: boolean = false): boolean {
+        addOption(option: Option<ImageSelectorDisplayValue>, silent: boolean = false, keyCode: number = -1): boolean {
 
             var selectedOption = this.getByOption(option);
             if (!selectedOption) {
-                this.addNewOption(option, silent);
+                this.addNewOption(option, silent, keyCode);
                 return true;
             } else if (selectedOption) {
                 var displayValue = selectedOption.getOption().displayValue;
@@ -72,7 +72,7 @@ module api.content.form.inputtype.image {
             return false;
         }
 
-        private addNewOption(option: Option<ImageSelectorDisplayValue>, silent: boolean) {
+        private addNewOption(option: Option<ImageSelectorDisplayValue>, silent: boolean, keyCode: number = -1) {
             var selectedOption: SelectedOption<ImageSelectorDisplayValue> = this.createSelectedOption(option);
             this.getSelectedOptions().push(selectedOption);
 
@@ -155,7 +155,7 @@ module api.content.form.inputtype.image {
             optionView.insertBeforeEl(this.toolbar);
 
             if (!silent) {
-                this.notifyOptionSelected(new SelectedOptionEvent(selectedOption));
+                this.notifyOptionSelected(new SelectedOptionEvent(selectedOption, keyCode));
             }
 
             new Tooltip(optionView, option.displayValue.getPath(), 1000);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
@@ -10,6 +10,7 @@ module api.content.form.inputtype.image {
     import ValueChangedEvent = api.form.inputtype.ValueChangedEvent;
     import LoadMask = api.ui.mask.LoadMask;
     import Tooltip = api.ui.Tooltip;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class ImageSelectorSelectedOptionsView extends api.ui.selector.combobox.BaseSelectedOptionsView<ImageSelectorDisplayValue> {
 
@@ -154,7 +155,7 @@ module api.content.form.inputtype.image {
             optionView.insertBeforeEl(this.toolbar);
 
             if (!silent) {
-                this.notifyOptionSelected(selectedOption);
+                this.notifyOptionSelected(new SelectedOptionEvent(selectedOption));
             }
 
             new Tooltip(optionView, option.displayValue.getPath(), 1000);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/principalselector/PrincipalSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/principalselector/PrincipalSelector.ts
@@ -7,6 +7,7 @@ module api.content.form.inputtype.principalselector {
     import ValueTypes = api.data.ValueTypes;
     import GetRelationshipTypeByNameRequest = api.schema.relationshiptype.GetRelationshipTypeByNameRequest;
     import RelationshipTypeName = api.schema.relationshiptype.RelationshipTypeName;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class PrincipalSelector extends api.form.inputtype.support.BaseInputTypeManagingAdd<api.security.Principal> {
 
@@ -75,12 +76,13 @@ module api.content.form.inputtype.principalselector {
                 setAllowedTypes(this.principalTypes);
             var comboBox = new api.ui.security.PrincipalComboBox(principalLoader, input.getOccurrences().getMaximum(), value);
 
-            comboBox.onOptionDeselected((removed: api.ui.selector.combobox.SelectedOption<api.security.Principal>) => {
-                this.getPropertyArray().remove(removed.getIndex());
+            comboBox.onOptionDeselected((event: SelectedOptionEvent<api.security.Principal>) => {
+                this.getPropertyArray().remove(event.getSelectedOption().getIndex());
                 this.validate(false);
             });
 
-            comboBox.onOptionSelected((selectedOption: api.ui.selector.combobox.SelectedOption<api.security.Principal>) => {
+            comboBox.onOptionSelected((event: SelectedOptionEvent<api.security.Principal>) => {
+                const selectedOption = event.getSelectedOption();
                 var key = selectedOption.getOption().displayValue.getKey();
                 if (!key) {
                     return;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/principalselector/PrincipalSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/principalselector/PrincipalSelector.ts
@@ -83,9 +83,7 @@ module api.content.form.inputtype.principalselector {
             });
 
             comboBox.onOptionSelected((event: SelectedOptionEvent<api.security.Principal>) => {
-                if (event.getKeyCode() === 13) {
-                    new FocusSwitchEvent(this).fire();
-                }
+                this.fireFocusSwitchEvent(event);
 
                 const selectedOption = event.getSelectedOption();
                 var key = selectedOption.getOption().displayValue.getKey();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/principalselector/PrincipalSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/principalselector/PrincipalSelector.ts
@@ -8,6 +8,7 @@ module api.content.form.inputtype.principalselector {
     import GetRelationshipTypeByNameRequest = api.schema.relationshiptype.GetRelationshipTypeByNameRequest;
     import RelationshipTypeName = api.schema.relationshiptype.RelationshipTypeName;
     import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
+    import FocusSwitchEvent = api.ui.FocusSwitchEvent;
 
     export class PrincipalSelector extends api.form.inputtype.support.BaseInputTypeManagingAdd<api.security.Principal> {
 
@@ -82,6 +83,10 @@ module api.content.form.inputtype.principalselector {
             });
 
             comboBox.onOptionSelected((event: SelectedOptionEvent<api.security.Principal>) => {
+                if (event.getKeyCode() === 13) {
+                    new FocusSwitchEvent(this).fire();
+                }
+
                 const selectedOption = event.getSelectedOption();
                 var key = selectedOption.getOption().displayValue.getKey();
                 if (!key) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfigurator.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfigurator.ts
@@ -18,6 +18,7 @@ module api.content.site.inputtype.siteconfigurator {
     import ApplicationKey = api.application.ApplicationKey;
     import SiteConfig = api.content.site.SiteConfig
     import LoadedDataEvent = api.util.loader.event.LoadedDataEvent;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class SiteConfigurator extends api.form.inputtype.support.BaseInputTypeManagingAdd<Application> {
 
@@ -107,18 +108,19 @@ module api.content.site.inputtype.siteconfigurator {
             var comboBox = new SiteConfiguratorComboBox(input.getOccurrences().getMaximum() || 0, siteConfigProvider, this.formContext,
                 value);
 
-            comboBox.onOptionDeselected((removed: SelectedOption<Application>) => {
+            comboBox.onOptionDeselected((event: SelectedOptionEvent<Application>) => {
                 this.ignorePropertyChange = true;
 
-                this.getPropertyArray().remove(removed.getIndex());
+                this.getPropertyArray().remove(event.getSelectedOption().getIndex());
 
                 this.ignorePropertyChange = false;
                 this.validate(false);
             });
 
-            comboBox.onOptionSelected((selectedOption: SelectedOption<Application>) => {
+            comboBox.onOptionSelected((event: SelectedOptionEvent<Application>) => {
                 this.ignorePropertyChange = true;
 
+                const selectedOption = event.getSelectedOption();
                 var key = selectedOption.getOption().displayValue.getApplicationKey();
                 if (!key) {
                     return;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfigurator.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfigurator.ts
@@ -119,9 +119,7 @@ module api.content.site.inputtype.siteconfigurator {
             });
 
             comboBox.onOptionSelected((event: SelectedOptionEvent<Application>) => {
-                if (event.getKeyCode() === 13) {
-                    new FocusSwitchEvent(this).fire();
-                }
+                this.fireFocusSwitchEvent(event);
 
                 this.ignorePropertyChange = true;
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfigurator.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfigurator.ts
@@ -19,6 +19,7 @@ module api.content.site.inputtype.siteconfigurator {
     import SiteConfig = api.content.site.SiteConfig
     import LoadedDataEvent = api.util.loader.event.LoadedDataEvent;
     import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
+    import FocusSwitchEvent = api.ui.FocusSwitchEvent;
 
     export class SiteConfigurator extends api.form.inputtype.support.BaseInputTypeManagingAdd<Application> {
 
@@ -118,6 +119,10 @@ module api.content.site.inputtype.siteconfigurator {
             });
 
             comboBox.onOptionSelected((event: SelectedOptionEvent<Application>) => {
+                if (event.getKeyCode() === 13) {
+                    new FocusSwitchEvent(this).fire();
+                }
+
                 this.ignorePropertyChange = true;
 
                 const selectedOption = event.getSelectedOption();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FocusSwitchEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FocusSwitchEvent.ts
@@ -1,0 +1,25 @@
+module api.form {
+
+    import InputTypeView = api.form.inputtype.InputTypeView;
+
+    export class FocusSwitchEvent extends api.event.Event {
+        private inputTypeView: InputTypeView<any>;
+
+        constructor(inputTypeView: InputTypeView<any>) {
+            super();
+            this.inputTypeView = inputTypeView;
+        }
+
+        getInputTypeView(): InputTypeView<any> {
+            return this.inputTypeView;
+        }
+
+        static on(handler: (event: FocusSwitchEvent) => void, contextWindow: Window = window) {
+            api.event.Event.bind(api.ClassHelper.getFullName(this), handler, contextWindow);
+        }
+
+        static un(handler?: (event: FocusSwitchEvent) => void, contextWindow: Window = window) {
+            api.event.Event.unbind(api.ClassHelper.getFullName(this), handler, contextWindow);
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormItemLayer.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormItemLayer.ts
@@ -2,6 +2,7 @@ module api.form {
 
     import PropertySet = api.data.PropertySet;
     import PropertyArray = api.data.PropertyArray;
+    import FocusSwitchEvent = api.ui.FocusSwitchEvent;
 
     export class FormItemLayer {
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/_module.ts
@@ -44,4 +44,3 @@
 
 ///<reference path='ValidationRecordingViewer.ts' />
 ///<reference path='AdditionalValidationRecord.ts' />
-///<reference path='FocusSwitchEvent.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/_module.ts
@@ -44,4 +44,4 @@
 
 ///<reference path='ValidationRecordingViewer.ts' />
 ///<reference path='AdditionalValidationRecord.ts' />
-
+///<reference path='FocusSwitchEvent.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/combobox/ComboBox.ts
@@ -8,6 +8,7 @@ module api.form.inputtype.combobox {
     import SelectedOption = api.ui.selector.combobox.SelectedOption;
     import OptionSelectedEvent = api.ui.selector.OptionSelectedEvent;
     import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
+    import FocusSwitchEvent = api.ui.FocusSwitchEvent;
 
     export class ComboBox extends api.form.inputtype.support.BaseInputTypeManagingAdd<string> {
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/combobox/ComboBox.ts
@@ -6,6 +6,8 @@ module api.form.inputtype.combobox {
     import ValueType = api.data.ValueType;
     import ValueTypes = api.data.ValueTypes;
     import SelectedOption = api.ui.selector.combobox.SelectedOption;
+    import OptionSelectedEvent = api.ui.selector.OptionSelectedEvent;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class ComboBox extends api.form.inputtype.support.BaseInputTypeManagingAdd<string> {
 
@@ -97,12 +99,13 @@ module api.form.inputtype.combobox {
             comboBox.onOptionFilterInputValueChanged((event: api.ui.selector.OptionFilterInputValueChangedEvent<string>) => {
                 this.comboBox.setFilterArgs({searchString: event.getNewValue()});
             });
-            comboBox.onOptionSelected((selectedOption: SelectedOption<string>) => {
+            comboBox.onOptionSelected((event: SelectedOptionEvent<string>) => {
                 this.ignorePropertyChange = true;
 
-                var value = new Value(selectedOption.getOption().value, ValueTypes.STRING);
-                if (selectedOption.getIndex() >= 0) {
-                    this.getPropertyArray().set(selectedOption.getIndex(), value);
+                const option = event.getSelectedOption();
+                var value = new Value(option.getOption().value, ValueTypes.STRING);
+                if (option.getIndex() >= 0) {
+                    this.getPropertyArray().set(option.getIndex(), value);
                 } else {
                     this.getPropertyArray().add(value);
                 }
@@ -110,10 +113,10 @@ module api.form.inputtype.combobox {
                 this.ignorePropertyChange = false;
                 this.validate(false);
             });
-            comboBox.onOptionDeselected((removed: api.ui.selector.combobox.SelectedOption<string>) => {
+            comboBox.onOptionDeselected((event: SelectedOptionEvent<string>) => {
                 this.ignorePropertyChange = true;
 
-                this.getPropertyArray().remove(removed.getIndex());
+                this.getPropertyArray().remove(event.getSelectedOption().getIndex());
 
                 this.ignorePropertyChange = false;
                 this.validate(false);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/combobox/ComboBox.ts
@@ -114,9 +114,7 @@ module api.form.inputtype.combobox {
                 this.ignorePropertyChange = false;
                 this.validate(false);
 
-                if (event.getKeyCode() === 13) {
-                    new FocusSwitchEvent(this).fire();
-                }
+                this.fireFocusSwitchEvent(event);
             });
             comboBox.onOptionDeselected((event: SelectedOptionEvent<string>) => {
                 this.ignorePropertyChange = true;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/combobox/ComboBox.ts
@@ -112,6 +112,10 @@ module api.form.inputtype.combobox {
 
                 this.ignorePropertyChange = false;
                 this.validate(false);
+
+                if (event.getKeyCode() === 13) {
+                    new FocusSwitchEvent(this).fire();
+                }
             });
             comboBox.onOptionDeselected((event: SelectedOptionEvent<string>) => {
                 this.ignorePropertyChange = true;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/support/BaseInputTypeManagingAdd.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/support/BaseInputTypeManagingAdd.ts
@@ -6,6 +6,8 @@ module api.form.inputtype.support {
     import Value = api.data.Value;
     import ValueType = api.data.ValueType;
     import ValueTypes = api.data.ValueTypes;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
+    import FocusSwitchEvent = api.ui.FocusSwitchEvent;
 
     export class BaseInputTypeManagingAdd<RAW_VALUE_TYPE> extends api.dom.DivEl implements api.form.inputtype.InputTypeView<RAW_VALUE_TYPE> {
 
@@ -38,6 +40,12 @@ module api.form.inputtype.support {
                     this.update(this.propertyArray, true).done();
                 }
             };
+        }
+
+        protected fireFocusSwitchEvent(event: SelectedOptionEvent<any>) {
+            if (event.getKeyCode() === 13) {
+                new FocusSwitchEvent(this).fire();
+            }
         }
 
         protected getValueFromPropertyArray(propertyArray: api.data.PropertyArray): string {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/fragment/FragmentPlaceholder.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/fragment/FragmentPlaceholder.ts
@@ -9,6 +9,7 @@ module api.liveedit.fragment {
     import CompareExpr = api.query.expr.CompareExpr;
     import FieldExpr = api.query.expr.FieldExpr;
     import ValueExpr = api.query.expr.ValueExpr;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class FragmentPlaceholder extends api.liveedit.ItemViewPlaceholder {
 
@@ -33,10 +34,10 @@ module api.liveedit.fragment {
             this.comboboxWrapper.appendChildren(this.comboBox);
             this.appendChild(this.comboboxWrapper);
 
-            this.comboBox.onOptionSelected((selectedOption: api.ui.selector.combobox.SelectedOption<api.content.ContentSummary>) => {
+            this.comboBox.onOptionSelected((event: SelectedOptionEvent<api.content.ContentSummary>) => {
 
                 var component: FragmentComponent = this.fragmentComponentView.getComponent();
-                var fragmentContent = selectedOption.getOption().displayValue;
+                var fragmentContent = event.getSelectedOption().getOption().displayValue;
 
                 if (this.isInsideLayout()) {
                     new GetContentByIdRequest(fragmentContent.getContentId()).sendAndParse().done((content: Content) => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/image/ImagePlaceholder.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/image/ImagePlaceholder.ts
@@ -5,6 +5,7 @@ module api.liveedit.image {
     import PageItemType = api.liveedit.PageItemType;
     import ContentTypeName = api.schema.content.ContentTypeName;
     import ImageComponent = api.content.page.region.ImageComponent;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class ImagePlaceholder extends api.liveedit.ItemViewPlaceholder {
 
@@ -55,10 +56,10 @@ module api.liveedit.image {
             this.comboboxWrapper.appendChildren(this.comboBox, this.uploadButton);
             this.appendChild(this.comboboxWrapper);
 
-            this.comboBox.onOptionSelected((selectedOption: api.ui.selector.combobox.SelectedOption<api.content.ContentSummary>) => {
+            this.comboBox.onOptionSelected((event: SelectedOptionEvent<api.content.ContentSummary>) => {
 
                 var component: ImageComponent = this.imageComponentView.getComponent();
-                var imageContent = selectedOption.getOption().displayValue;
+                var imageContent = event.getSelectedOption().getOption().displayValue;
 
                 component.setImage(imageContent.getContentId(), imageContent.getDisplayName());
                 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/layout/LayoutPlaceholder.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/layout/LayoutPlaceholder.ts
@@ -7,6 +7,7 @@ module api.liveedit.layout {
     import GetLayoutDescriptorsByApplicationsRequest = api.content.page.region.GetLayoutDescriptorsByApplicationsRequest;
     import LayoutDescriptorLoader = api.content.page.region.LayoutDescriptorLoader;
     import LayoutDescriptorComboBox = api.content.page.region.LayoutDescriptorComboBox;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class LayoutPlaceholder extends ItemViewPlaceholder {
 
@@ -27,9 +28,9 @@ module api.liveedit.layout {
 
             this.appendChild(this.comboBox);
 
-            this.comboBox.onOptionSelected((selectedOption: api.ui.selector.combobox.SelectedOption<LayoutDescriptor>) => {
+            this.comboBox.onOptionSelected((event: SelectedOptionEvent<LayoutDescriptor>) => {
                 this.layoutComponentView.showLoadingSpinner();
-                var descriptor = selectedOption.getOption().displayValue;
+                var descriptor = event.getSelectedOption().getOption().displayValue;
 
                 var layoutComponent: LayoutComponent = this.layoutComponentView.getComponent();
                 layoutComponent.setDescriptor(descriptor.getKey(), descriptor);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/part/PartPlaceholder.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/part/PartPlaceholder.ts
@@ -9,6 +9,7 @@ module api.liveedit.part {
     import GetPartDescriptorsByApplicationsRequest = api.content.page.region.GetPartDescriptorsByApplicationsRequest;
     import PartItemType = api.liveedit.part.PartItemType;
     import PageItemType = api.liveedit.PageItemType;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class PartPlaceholder extends ItemViewPlaceholder {
 
@@ -32,9 +33,9 @@ module api.liveedit.part {
 
             this.appendChild(this.comboBox);
 
-            this.comboBox.onOptionSelected((selectedOption: api.ui.selector.combobox.SelectedOption<PartDescriptor>) => {
+            this.comboBox.onOptionSelected((event: SelectedOptionEvent<PartDescriptor>) => {
                 this.partComponentView.showLoadingSpinner();
-                var descriptor: Descriptor = selectedOption.getOption().displayValue;
+                var descriptor: Descriptor = event.getSelectedOption().getOption().displayValue;
                 var partComponent: PartComponent = this.partComponentView.getComponent();
                 partComponent.setDescriptor(descriptor.getKey(), descriptor);
             });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/schema/content/inputtype/ContentTypeFilter.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/schema/content/inputtype/ContentTypeFilter.ts
@@ -14,6 +14,7 @@ module api.schema.content.inputtype {
     import ContentTypeSummary = api.schema.content.ContentTypeSummary;
     import SelectedOption = api.ui.selector.combobox.SelectedOption;
     import ApplicationKey = api.application.ApplicationKey;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class ContentTypeFilter extends api.form.inputtype.support.BaseInputTypeManagingAdd<string> {
 
@@ -51,8 +52,10 @@ module api.schema.content.inputtype {
                 comboBox = new ContentTypeComboBox(this.getInput().getOccurrences().getMaximum(), loader);
 
             comboBox.onLoaded(this.onContentTypesLoadedHandler);
-            comboBox.onOptionSelected((selectedOption: api.ui.selector.combobox.SelectedOption<ContentTypeSummary>) => this.onContentTypeSelected(selectedOption));
-            comboBox.onOptionDeselected((option: SelectedOption<ContentTypeSummary>) => this.onContentTypeDeselected(option));
+            comboBox.onOptionSelected(
+                (event: SelectedOptionEvent<ContentTypeSummary>) => this.onContentTypeSelected(event.getSelectedOption()));
+            comboBox.onOptionDeselected(
+                (event: SelectedOptionEvent<ContentTypeSummary>) => this.onContentTypeDeselected(event.getSelectedOption()));
 
             return comboBox;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/schema/content/inputtype/ContentTypeFilter.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/schema/content/inputtype/ContentTypeFilter.ts
@@ -15,6 +15,7 @@ module api.schema.content.inputtype {
     import SelectedOption = api.ui.selector.combobox.SelectedOption;
     import ApplicationKey = api.application.ApplicationKey;
     import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
+    import FocusSwitchEvent = api.ui.FocusSwitchEvent;
 
     export class ContentTypeFilter extends api.form.inputtype.support.BaseInputTypeManagingAdd<string> {
 
@@ -52,10 +53,16 @@ module api.schema.content.inputtype {
                 comboBox = new ContentTypeComboBox(this.getInput().getOccurrences().getMaximum(), loader);
 
             comboBox.onLoaded(this.onContentTypesLoadedHandler);
-            comboBox.onOptionSelected(
-                (event: SelectedOptionEvent<ContentTypeSummary>) => this.onContentTypeSelected(event.getSelectedOption()));
-            comboBox.onOptionDeselected(
-                (event: SelectedOptionEvent<ContentTypeSummary>) => this.onContentTypeDeselected(event.getSelectedOption()));
+
+            comboBox.onOptionSelected((event: SelectedOptionEvent<ContentTypeSummary>) => {
+                if (event.getKeyCode() === 13) {
+                    new FocusSwitchEvent(this).fire();
+                }
+                this.onContentTypeSelected(event.getSelectedOption());
+            });
+
+            comboBox.onOptionDeselected((event: SelectedOptionEvent<ContentTypeSummary>) =>
+                this.onContentTypeDeselected(event.getSelectedOption()));
 
             return comboBox;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/schema/content/inputtype/ContentTypeFilter.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/schema/content/inputtype/ContentTypeFilter.ts
@@ -55,9 +55,7 @@ module api.schema.content.inputtype {
             comboBox.onLoaded(this.onContentTypesLoadedHandler);
 
             comboBox.onOptionSelected((event: SelectedOptionEvent<ContentTypeSummary>) => {
-                if (event.getKeyCode() === 13) {
-                    new FocusSwitchEvent(this).fire();
-                }
+                this.fireFocusSwitchEvent(event);
                 this.onContentTypeSelected(event.getSelectedOption());
             });
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/FocusSwitchEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/FocusSwitchEvent.ts
@@ -1,4 +1,4 @@
-module api.form {
+module api.ui {
 
     import InputTypeView = api.form.inputtype.InputTypeView;
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/RadioGroup.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/RadioGroup.ts
@@ -54,6 +54,10 @@ module api.ui {
             return undefined;
         }
 
+        giveFocus(): boolean {
+            return this.options.length < 1 ? false : this.options[0].giveFocus();
+        }
+
     }
 
 
@@ -119,6 +123,10 @@ module api.ui {
         public setChecked(checked: boolean, silent?: boolean): RadioButton {
             super.setValue(String(checked), silent);
             return this;
+        }
+
+        giveFocus(): boolean {
+            return this.radio.giveFocus();
         }
 
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/_module.ts
@@ -20,3 +20,4 @@
 ///<reference path='DragHelper.ts' />
 ///<reference path='NamesAndIconViewer.ts' />
 ///<reference path='ActivatedEvent.ts' />
+///<reference path='FocusSwitchEvent.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/AccessControlComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/AccessControlComboBox.ts
@@ -6,6 +6,7 @@ module api.ui.security.acl {
     import Permission = api.security.acl.Permission;
     import AccessControlEntry = api.security.acl.AccessControlEntry;
     import AccessControlEntryLoader = api.security.acl.AccessControlEntryLoader;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class AccessControlComboBox extends api.ui.selector.combobox.RichComboBox<AccessControlEntry> {
 
@@ -71,8 +72,8 @@ module api.ui.security.acl {
         private maximumOccurrences: number;
         private list: SelectedOption<AccessControlEntry>[] = [];
 
-        private selectedOptionRemovedListeners: {(removed: SelectedOption<AccessControlEntry>): void;}[] = [];
-        private selectedOptionAddedListeners: {(added: SelectedOption<AccessControlEntry>): void;}[] = [];
+        private selectedOptionRemovedListeners: {(removed: SelectedOptionEvent<AccessControlEntry>): void;}[] = [];
+        private selectedOptionAddedListeners: {(added: SelectedOptionEvent<AccessControlEntry>): void;}[] = [];
 
         constructor(className?: string) {
             super(className);
@@ -115,12 +116,12 @@ module api.ui.security.acl {
         }
 
 
-        addOption(option: Option<AccessControlEntry>, silent: boolean = false): boolean {
+        addOption(option: Option<AccessControlEntry>, silent: boolean = false, keyCode: number = -1): boolean {
             this.addItem(option.displayValue);
 
             if (!silent) {
                 var selectedOption = this.getByOption(option);
-                this.notifySelectedOptionAdded(selectedOption);
+                this.notifySelectedOptionAdded(new SelectedOptionEvent(selectedOption, keyCode));
             }
             return true;
         }
@@ -145,7 +146,7 @@ module api.ui.security.acl {
             }
 
             if (!silent) {
-                this.notifySelectedOptionRemoved(selectedOption);
+                this.notifySelectedOptionRemoved(new SelectedOptionEvent(selectedOption));
             }
         }
 
@@ -189,33 +190,33 @@ module api.ui.security.acl {
             this.list.forEach((selectedOption: SelectedOption<AccessControlEntry>, index: number) => selectedOption.setIndex(index));
         }
 
-        private notifySelectedOptionRemoved(removed: SelectedOption<AccessControlEntry>) {
+        private notifySelectedOptionRemoved(removed: SelectedOptionEvent<AccessControlEntry>) {
             this.selectedOptionRemovedListeners.forEach((listener) => {
                 listener(removed);
             });
         }
 
-        onOptionDeselected(listener: {(removed: SelectedOption<AccessControlEntry>): void;}) {
+        onOptionDeselected(listener: {(removed: SelectedOptionEvent<AccessControlEntry>): void;}) {
             this.selectedOptionRemovedListeners.push(listener);
         }
 
-        unOptionDeselected(listener: {(removed: SelectedOption<AccessControlEntry>): void;}) {
+        unOptionDeselected(listener: {(removed: SelectedOptionEvent<AccessControlEntry>): void;}) {
             this.selectedOptionRemovedListeners = this.selectedOptionRemovedListeners.filter(function (curr) {
                 return curr != listener;
             });
         }
 
-        onOptionSelected(listener: {(added: SelectedOption<AccessControlEntry>): void;}) {
+        onOptionSelected(listener: {(added: SelectedOptionEvent<AccessControlEntry>): void;}) {
             this.selectedOptionAddedListeners.push(listener);
         }
 
-        unOptionSelected(listener: {(added: SelectedOption<AccessControlEntry>): void;}) {
+        unOptionSelected(listener: {(added: SelectedOptionEvent<AccessControlEntry>): void;}) {
             this.selectedOptionAddedListeners = this.selectedOptionAddedListeners.filter(function (curr) {
                 return curr != listener;
             });
         }
 
-        private notifySelectedOptionAdded(added: SelectedOption<AccessControlEntry>) {
+        private notifySelectedOptionAdded(added: SelectedOptionEvent<AccessControlEntry>) {
             this.selectedOptionAddedListeners.forEach((listener) => {
                 listener(added);
             });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/UserStoreAccessControlComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/UserStoreAccessControlComboBox.ts
@@ -6,6 +6,7 @@ module api.ui.security.acl {
     import Permission = api.security.acl.Permission;
     import UserStoreAccessControlEntry = api.security.acl.UserStoreAccessControlEntry;
     import UserStoreAccessControlEntryLoader = api.security.acl.UserStoreAccessControlEntryLoader;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class UserStoreAccessControlComboBox extends api.ui.selector.combobox.RichComboBox<UserStoreAccessControlEntry> {
 
@@ -65,8 +66,8 @@ module api.ui.security.acl {
         private maximumOccurrences: number;
         private list: SelectedOption<UserStoreAccessControlEntry>[] = [];
 
-        private selectedOptionRemovedListeners: {(removed: SelectedOption<UserStoreAccessControlEntry>): void;}[] = [];
-        private selectedOptionAddedListeners: {(added: SelectedOption<UserStoreAccessControlEntry>): void;}[] = [];
+        private selectedOptionRemovedListeners: {(removed: SelectedOptionEvent<UserStoreAccessControlEntry>): void;}[] = [];
+        private selectedOptionAddedListeners: {(added: SelectedOptionEvent<UserStoreAccessControlEntry>): void;}[] = [];
 
         constructor(className?: string) {
             super(className);
@@ -115,7 +116,7 @@ module api.ui.security.acl {
         }
 
 
-        addOption(option: Option<UserStoreAccessControlEntry>, silent: boolean = false): boolean {
+        addOption(option: Option<UserStoreAccessControlEntry>, silent: boolean = false, keyCode: number = -1): boolean {
             if(option.readOnly)
             {
                 this.addItemReadOnly(option.displayValue)
@@ -126,7 +127,7 @@ module api.ui.security.acl {
             }
             if (!silent) {
                 var selectedOption = this.getByOption(option);
-                this.notifySelectedOptionAdded(selectedOption);
+                this.notifySelectedOptionAdded(new SelectedOptionEvent(selectedOption, keyCode));
             }
             return true;
         }
@@ -151,7 +152,7 @@ module api.ui.security.acl {
             }
 
             if (!silent) {
-                this.notifySelectedOptionRemoved(selectedOption);
+                this.notifySelectedOptionRemoved(new SelectedOptionEvent(selectedOption));
             }
         }
 
@@ -196,33 +197,33 @@ module api.ui.security.acl {
                                index: number) => selectedOption.setIndex(index));
         }
 
-        private notifySelectedOptionRemoved(removed: SelectedOption<UserStoreAccessControlEntry>) {
+        private notifySelectedOptionRemoved(removed: SelectedOptionEvent<UserStoreAccessControlEntry>) {
             this.selectedOptionRemovedListeners.forEach((listener) => {
                 listener(removed);
             });
         }
 
-        onOptionDeselected(listener: {(removed: SelectedOption<UserStoreAccessControlEntry>): void;}) {
+        onOptionDeselected(listener: {(removed: SelectedOptionEvent<UserStoreAccessControlEntry>): void;}) {
             this.selectedOptionRemovedListeners.push(listener);
         }
 
-        unOptionDeselected(listener: {(removed: SelectedOption<UserStoreAccessControlEntry>): void;}) {
+        unOptionDeselected(listener: {(removed: SelectedOptionEvent<UserStoreAccessControlEntry>): void;}) {
             this.selectedOptionRemovedListeners = this.selectedOptionRemovedListeners.filter(function (curr) {
                 return curr != listener;
             });
         }
 
-        onOptionSelected(listener: {(added: SelectedOption<UserStoreAccessControlEntry>): void;}) {
+        onOptionSelected(listener: {(added: SelectedOptionEvent<UserStoreAccessControlEntry>): void;}) {
             this.selectedOptionAddedListeners.push(listener);
         }
 
-        unOptionSelected(listener: {(added: SelectedOption<UserStoreAccessControlEntry>): void;}) {
+        unOptionSelected(listener: {(added: SelectedOptionEvent<UserStoreAccessControlEntry>): void;}) {
             this.selectedOptionAddedListeners = this.selectedOptionAddedListeners.filter(function (curr) {
                 return curr != listener;
             });
         }
 
-        private notifySelectedOptionAdded(added: SelectedOption<UserStoreAccessControlEntry>) {
+        private notifySelectedOptionAdded(added: SelectedOptionEvent<UserStoreAccessControlEntry>) {
             this.selectedOptionAddedListeners.forEach((listener) => {
                 listener(added);
             });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownGrid.ts
@@ -93,11 +93,9 @@ module api.ui.selector {
 
             // Listen to click in grid and issue selection
             this.grid.subscribeOnClick((e, args) => {
-
                 this.notifyRowSelection(args.row);
 
                 e.preventDefault();
-                e.stopPropagation();
                 return false;
             });
 
@@ -348,6 +346,14 @@ module api.ui.selector {
             this.multipleSelectionListeners.forEach((listener: (event: DropdownGridMultipleSelectionEvent)=>void) => {
                 listener(event);
             });
+        }
+
+        onClick(callback: (e, args) => void) {
+            this.grid.subscribeOnClick(callback);
+        }
+
+        unClick(callback: (e, args) => void) {
+            this.grid.unsubscribeOnClick(callback);
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/OptionSelectedEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/OptionSelectedEvent.ts
@@ -6,9 +6,12 @@ module api.ui.selector {
 
         private index: number;
 
-        constructor(option: Option<OPTION_DISPLAY_VALUE>, index: number = -1) {
+        private keyCode: number;
+
+        constructor(option: Option<OPTION_DISPLAY_VALUE>, index: number = -1, keyCode: number = -1) {
             this.option = option;
             this.index = index;
+            this.keyCode = keyCode;
         }
 
         getOption(): Option<OPTION_DISPLAY_VALUE> {
@@ -17,6 +20,10 @@ module api.ui.selector {
 
         getIndex(): number {
             return this.index;
+        }
+
+        getKeyCode(): number {
+            return this.keyCode;
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/BaseSelectedOptionsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/BaseSelectedOptionsView.ts
@@ -13,9 +13,9 @@ module api.ui.selector.combobox {
 
         private maximumOccurrences: number;
 
-        private optionRemovedListeners: {(removed: SelectedOption<T>): void;}[] = [];
+        private optionRemovedListeners: {(removed: SelectedOptionEvent<T>): void;}[] = [];
 
-        private optionAddedListeners: {(added: SelectedOption<T>): void;}[] = [];
+        private optionAddedListeners: {(added: SelectedOptionEvent<T>): void;}[] = [];
 
         private optionMovedListeners: {(moved: SelectedOption<T>) : void}[] = [];
 
@@ -109,7 +109,7 @@ module api.ui.selector.combobox {
             this.appendChild(selectedOption.getOptionView());
 
             if (!silent) {
-                this.notifyOptionSelected(selectedOption);
+                this.notifyOptionSelected(new SelectedOptionEvent(selectedOption));
             }
 
             return true;
@@ -182,32 +182,32 @@ module api.ui.selector.combobox {
 
         protected notifyOptionDeselected(removed: SelectedOption<T>) {
             this.optionRemovedListeners.forEach((listener) => {
-                listener(removed);
+                listener(new SelectedOptionEvent(removed));
             });
         }
 
-        onOptionDeselected(listener: {(removed: SelectedOption<T>): void;}) {
+        onOptionDeselected(listener: {(removed: SelectedOptionEvent<T>): void;}) {
             this.optionRemovedListeners.push(listener);
         }
 
-        unOptionDeselected(listener: {(removed: SelectedOption<T>): void;}) {
+        unOptionDeselected(listener: {(removed: SelectedOptionEvent<T>): void;}) {
             this.optionRemovedListeners = this.optionRemovedListeners.filter(function (curr) {
                 return curr != listener;
             });
         }
 
-        onOptionSelected(listener: (added: SelectedOption<T>)=>void) {
+        onOptionSelected(listener: (added: SelectedOptionEvent<T>)=>void) {
             this.optionAddedListeners.push(listener);
         }
 
-        unOptionSelected(listener: (added: SelectedOption<T>)=>void) {
-            this.optionAddedListeners = this.optionAddedListeners.filter((current: (added: SelectedOption<T>)=>void) => {
+        unOptionSelected(listener: (added: SelectedOptionEvent<T>)=>void) {
+            this.optionAddedListeners = this.optionAddedListeners.filter((current: (added: SelectedOptionEvent<T>)=>void) => {
                 return listener != current;
             });
         }
 
-        protected notifyOptionSelected(added: SelectedOption<T>) {
-            this.optionAddedListeners.forEach((listener: (added: SelectedOption<T>)=>void) => {
+        protected notifyOptionSelected(added: SelectedOptionEvent<T>) {
+            this.optionAddedListeners.forEach((listener: (added: SelectedOptionEvent<T>)=>void) => {
                 listener(added);
             });
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/BaseSelectedOptionsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/BaseSelectedOptionsView.ts
@@ -94,7 +94,7 @@ module api.ui.selector.combobox {
             return new SelectedOption<T>(new BaseSelectedOptionView(option), this.count());
         }
 
-        addOption(option: api.ui.selector.Option<T>, silent: boolean = false): boolean {
+        addOption(option: api.ui.selector.Option<T>, silent: boolean = false, keyCode: number): boolean {
 
             if (this.isSelected(option) || this.maximumOccurrencesReached()) {
                 return false;
@@ -109,7 +109,7 @@ module api.ui.selector.combobox {
             this.appendChild(selectedOption.getOptionView());
 
             if (!silent) {
-                this.notifyOptionSelected(new SelectedOptionEvent(selectedOption));
+                this.notifyOptionSelected(new SelectedOptionEvent(selectedOption, keyCode));
             }
 
             return true;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -164,7 +164,6 @@ module api.ui.selector.combobox {
             return this.comboBoxDropdown.isDropdownShown();
         }
 
-        // 
         showDropdown() {
 
             this.doUpdateDropdownTopPositionAndWidth();
@@ -275,11 +274,11 @@ module api.ui.selector.combobox {
             return value.split(';');
         }
 
-        handleRowSelected(index: number) {
+        handleRowSelected(index: number, keyCode: number = -1) {
             var option = this.getOptionByRow(index);
             if (option != null && !option.readOnly) {
                 if (!this.isOptionSelected(option)) {
-                    this.selectOption(option);
+                    this.selectOption(option, false, keyCode);
                 } else {
                     this.deselectOption(option);
                 }
@@ -308,13 +307,13 @@ module api.ui.selector.combobox {
                    (filteredOption.sort().join() !== gridOptions.sort().join());
         }
 
-        selectRowOrApplySelection(index: number) {
+        selectRowOrApplySelection(index: number, keyCode: number = -1) {
 
             // fast alternative to isSelectionChanged()
             if (this.applySelectionsButton && this.applySelectionsButton.isVisible()) {
                 this.selectiondDelta.forEach((value: string) => {
                     var row = this.comboBoxDropdown.getDropdownGrid().getRowByValue(value);
-                    this.handleRowSelected(row);
+                    this.handleRowSelected(row, keyCode);
                 });
                 this.input.setValue("");
                 this.hideDropdown();
@@ -324,13 +323,13 @@ module api.ui.selector.combobox {
             }
         }
 
-        selectOption(option: Option<OPTION_DISPLAY_VALUE>, silent: boolean = false) {
+        selectOption(option: Option<OPTION_DISPLAY_VALUE>, silent: boolean = false, keyCode: number = -1) {
             api.util.assertNotNull(option, "option cannot be null");
             if (this.isOptionSelected(option)) {
                 return;
             }
 
-            var added = this.selectedOptionsView.addOption(option, silent);
+            var added = this.selectedOptionsView.addOption(option, silent, keyCode);
             if (!added) {
                 return;
             }
@@ -559,14 +558,14 @@ module api.ui.selector.combobox {
             this.onKeyDown(this.handleKeyDown.bind(this));
 
             if (this.selectedOptionsView) {
-                this.selectedOptionsView.onOptionDeselected((removedOption: SelectedOption<OPTION_DISPLAY_VALUE>) => {
-                    this.handleSelectedOptionRemoved(removedOption);
+                this.selectedOptionsView.onOptionDeselected((event: SelectedOptionEvent<OPTION_DISPLAY_VALUE>) => {
+                    this.handleSelectedOptionRemoved();
                 });
-                this.selectedOptionsView.onOptionSelected((addedOption: SelectedOption<OPTION_DISPLAY_VALUE>) => {
-                    this.handleSelectedOptionAdded(addedOption);
+                this.selectedOptionsView.onOptionSelected((event: SelectedOptionEvent<OPTION_DISPLAY_VALUE>) => {
+                    this.handleSelectedOptionAdded();
                 });
                 this.selectedOptionsView.onOptionMoved((movedOption: SelectedOption<OPTION_DISPLAY_VALUE>) => {
-                    this.handleSelectedOptionMoved(movedOption);
+                    this.handleSelectedOptionMoved();
                 });
             }
         }
@@ -641,7 +640,7 @@ module api.ui.selector.combobox {
                 event.preventDefault();
                 break;
             case 13: // Enter
-                this.selectRowOrApplySelection(this.comboBoxDropdown.getActiveRow());
+                this.selectRowOrApplySelection(this.comboBoxDropdown.getActiveRow(), 13);
                 event.stopPropagation();
                 event.preventDefault();
                 break;
@@ -674,7 +673,7 @@ module api.ui.selector.combobox {
             return this.getOptionByRow(this.comboBoxDropdown.getActiveRow()).readOnly;
         }
 
-        private handleSelectedOptionRemoved(removedSelectedOption: SelectedOption<OPTION_DISPLAY_VALUE>) {
+        private handleSelectedOptionRemoved() {
             this.comboBoxDropdown.markSelections(this.getSelectedOptions());
 
             this.dropdownHandle.setEnabled(true);
@@ -692,13 +691,13 @@ module api.ui.selector.combobox {
             this.refreshValueChanged();
         }
 
-        private handleSelectedOptionAdded(addedSelectedOption: SelectedOption<OPTION_DISPLAY_VALUE>) {
+        private handleSelectedOptionAdded() {
 
             this.refreshDirtyState();
             this.refreshValueChanged();
         }
 
-        private handleSelectedOptionMoved(movedSelectedOption: SelectedOption<OPTION_DISPLAY_VALUE>) {
+        private handleSelectedOptionMoved() {
 
             this.refreshDirtyState();
             this.refreshValueChanged();
@@ -732,11 +731,11 @@ module api.ui.selector.combobox {
 
         }
 
-        onOptionSelected(listener: (event: SelectedOption<OPTION_DISPLAY_VALUE>)=>void) {
+        onOptionSelected(listener: (event: SelectedOptionEvent<OPTION_DISPLAY_VALUE>)=>void) {
             this.selectedOptionsView.onOptionSelected(listener);
         }
 
-        unOptionSelected(listener: (event: SelectedOption<OPTION_DISPLAY_VALUE>)=>void) {
+        unOptionSelected(listener: (event: SelectedOptionEvent<OPTION_DISPLAY_VALUE>)=>void) {
             this.selectedOptionsView.unOptionSelected(listener);
         }
 
@@ -769,11 +768,11 @@ module api.ui.selector.combobox {
             });
         }
 
-        onOptionDeselected(listener: {(removed: SelectedOption<OPTION_DISPLAY_VALUE>): void;}) {
+        onOptionDeselected(listener: {(removed: SelectedOptionEvent<OPTION_DISPLAY_VALUE>): void;}) {
             this.selectedOptionsView.onOptionDeselected(listener);
         }
 
-        unOptionDeselected(listener: {(removed: SelectedOption<OPTION_DISPLAY_VALUE>): void;}) {
+        unOptionDeselected(listener: {(removed: SelectedOptionEvent<OPTION_DISPLAY_VALUE>): void;}) {
             this.selectedOptionsView.unOptionDeselected(listener);
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -318,7 +318,7 @@ module api.ui.selector.combobox {
                 this.input.setValue("");
                 this.hideDropdown();
             } else {
-                this.handleRowSelected(index);
+                this.handleRowSelected(index, keyCode);
                 this.input.setValue("");
             }
         }
@@ -496,6 +496,10 @@ module api.ui.selector.combobox {
                 event.stopPropagation();
             });
 
+            this.getComboBoxDropdownGrid().onClick(() => {
+                this.giveInputFocus();
+            });
+
             this.input.onClicked((event: MouseEvent) => {
                 this.giveInputFocus();
                 event.stopPropagation();
@@ -666,7 +670,9 @@ module api.ui.selector.combobox {
                 break;
             }
 
-            this.input.giveFocus()
+            if (event.which !== 13) {
+                this.input.giveFocus();
+            }
         }
 
         private isSelectedRowReadOnly(): boolean {
@@ -704,7 +710,6 @@ module api.ui.selector.combobox {
         }
 
         private handleMultipleSelectionChanged(event: DropdownGridMultipleSelectionEvent) {
-            this.input.giveFocus();
             if (this.isSelectionChanged()) {
                 this.applySelectionsButton.show();
                 this.updateSelectionDelta();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichComboBox.ts
@@ -264,19 +264,19 @@ module api.ui.selector.combobox {
             this.comboBox.setInputIconUrl(url);
         }
 
-        onOptionDeselected(listener: {(option: SelectedOption<OPTION_DISPLAY_VALUE>):void;}) {
+        onOptionDeselected(listener: {(option: SelectedOptionEvent<OPTION_DISPLAY_VALUE>): void;}) {
             this.comboBox.onOptionDeselected(listener);
         }
 
-        unOptionDeselected(listener: {(removed: SelectedOption<OPTION_DISPLAY_VALUE>): void;}) {
+        unOptionDeselected(listener: {(removed: SelectedOptionEvent<OPTION_DISPLAY_VALUE>): void;}) {
             this.comboBox.unOptionDeselected(listener);
         }
 
-        onOptionSelected(listener: {(option: SelectedOption<OPTION_DISPLAY_VALUE>): void;}) {
+        onOptionSelected(listener: {(option: SelectedOptionEvent<OPTION_DISPLAY_VALUE>): void;}) {
             this.comboBox.onOptionSelected(listener);
         }
 
-        unOptionSelected(listener: {(option: SelectedOption<OPTION_DISPLAY_VALUE>): void;}) {
+        unOptionSelected(listener: {(option: SelectedOptionEvent<OPTION_DISPLAY_VALUE>): void;}) {
             this.comboBox.unOptionSelected(listener);
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/SelectedOptionEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/SelectedOptionEvent.ts
@@ -1,0 +1,22 @@
+module api.ui.selector.combobox {
+
+    export class SelectedOptionEvent<T> {
+
+        private selectedOption: SelectedOption<T>;
+
+        private keyCode: number;
+
+        constructor(selectedOption: SelectedOption<T>, keyCode: number = -1) {
+            this.selectedOption = selectedOption;
+            this.keyCode = keyCode;
+        }
+
+        getSelectedOption(): SelectedOption<T> {
+            return this.selectedOption;
+        }
+
+        getKeyCode(): number {
+            return this.keyCode;
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/SelectedOptionsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/SelectedOptionsView.ts
@@ -8,7 +8,7 @@ module api.ui.selector.combobox {
 
         createSelectedOption(option: api.ui.selector.Option<T>): SelectedOption<T>;
 
-        addOption(option: api.ui.selector.Option<T>, silent: boolean): boolean;
+        addOption(option: api.ui.selector.Option<T>, silent: boolean, keyCode: number): boolean;
 
         removeOption(optionToRemove: api.ui.selector.Option<T>, silent: boolean);
 
@@ -28,13 +28,13 @@ module api.ui.selector.combobox {
 
         moveOccurrence(formIndex: number, toIndex: number);
 
-        onOptionSelected(listener: {(added: SelectedOption<T>): void;});
+        onOptionSelected(listener: {(added: SelectedOptionEvent<T>): void;});
 
-        unOptionSelected(listener: {(added: SelectedOption<T>): void;});
+        unOptionSelected(listener: {(added: SelectedOptionEvent<T>): void;});
 
-        onOptionDeselected(listener: {(removed: SelectedOption<T>): void;});
+        onOptionDeselected(listener: {(removed: SelectedOptionEvent<T>): void;});
 
-        unOptionDeselected(listener: {(removed: SelectedOption<T>): void;});
+        unOptionDeselected(listener: {(removed: SelectedOptionEvent<T>): void;});
 
         onOptionMoved(listener: (moved: SelectedOption<T>) => void);
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/_module.ts
@@ -8,3 +8,4 @@
 ///<reference path='SelectedOption.ts' />
 ///<reference path='RichComboBox.ts' />
 ///<reference path='RichSelectedOptionView.ts' />
+///<reference path='SelectedOptionEvent.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/Dropdown.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/Dropdown.ts
@@ -255,22 +255,22 @@ module api.ui.selector.dropdown {
             return this;
         }
 
-        selectRow(index: number, silent: boolean = false) {
+        selectRow(index: number, silent: boolean = false, keyCode: number = -1) {
             var option = this.getOptionByRow(index);
             if (option != null) {
-                this.selectOption(option, silent);
+                this.selectOption(option, silent, keyCode);
                 api.dom.FormEl.moveFocusToNextFocusable(this.input);
             }
         }
 
-        selectOption(option: Option<OPTION_DISPLAY_VALUE>, silent: boolean = false) {
+        selectOption(option: Option<OPTION_DISPLAY_VALUE>, silent: boolean = false, keyCode: number = -1) {
 
             this.dropdownList.markSelections([option]);
 
             this.selectedOptionView.setOption(option);
 
             if (!silent) {
-                this.notifyOptionSelected(option);
+                this.notifyOptionSelected(option, keyCode);
             }
 
             this.hideDropdown();
@@ -355,17 +355,14 @@ module api.ui.selector.dropdown {
 
                 if (event.which == 38) { // up
                     this.dropdownList.navigateToPreviousRow();
-                }
-                else if (event.which == 40) { // down
+                } else if (event.which == 40) { // down
                     this.dropdownList.navigateToNextRow();
-                }
-                else if (event.which == 13) { // enter
-                    this.selectRow(this.dropdownList.getActiveRow());
+                } else if (event.which == 13) { // enter
+                    this.selectRow(this.dropdownList.getActiveRow(), false, 13);
                     this.input.getEl().setValue("");
                     event.preventDefault();
                     event.stopPropagation();
-                }
-                else if (event.which == 27) { // esc
+                } else if (event.which == 27) { // esc
                     this.hideDropdown();
                 }
 
@@ -383,8 +380,8 @@ module api.ui.selector.dropdown {
             });
         }
 
-        private notifyOptionSelected(item: Option<OPTION_DISPLAY_VALUE>) {
-            var event = new OptionSelectedEvent<OPTION_DISPLAY_VALUE>(item);
+        private notifyOptionSelected(item: Option<OPTION_DISPLAY_VALUE>, keyCode: number = -1) {
+            var event = new OptionSelectedEvent<OPTION_DISPLAY_VALUE>(item, -1, keyCode);
             this.optionSelectedListeners.forEach((listener: (event: OptionSelectedEvent<OPTION_DISPLAY_VALUE>)=>void) => {
                 listener(event);
             });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ImageModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ImageModalDialog.ts
@@ -12,6 +12,7 @@ module api.util.htmlarea.dialog {
     import OptionSelectedEvent = api.ui.selector.OptionSelectedEvent;
     import Content = api.content.Content;
     import Action = api.ui.Action;
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class ImageModalDialog extends ModalDialog {
 
@@ -84,8 +85,8 @@ module api.util.htmlarea.dialog {
                 loader.load();
             }
 
-            imageSelectorComboBox.onOptionSelected((selectedOption: api.ui.selector.combobox.SelectedOption<api.content.ContentSummary>) => {
-                var imageContent = selectedOption.getOption().displayValue;
+            imageSelectorComboBox.onOptionSelected((event: SelectedOptionEvent<api.content.ContentSummary>) => {
+                var imageContent = event.getSelectedOption().getOption().displayValue;
                 if (!imageContent.getContentId()) {
                     return;
                 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/MacroModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/MacroModalDialog.ts
@@ -6,6 +6,7 @@ module api.util.htmlarea.dialog {
     import MacroDescriptor = api.macro.MacroDescriptor;
     import FormContext = api.form.FormContext;
     import ApplicationKey = api.application.ApplicationKey
+    import SelectedOptionEvent = api.ui.selector.combobox.SelectedOptionEvent;
 
     export class MacroModalDialog extends ModalDialog {
 
@@ -63,11 +64,11 @@ module api.util.htmlarea.dialog {
 
             this.addClass("macro-selector");
 
-            macroSelectorComboBox.onOptionSelected((selectedOption: api.ui.selector.combobox.SelectedOption<api.macro.MacroDescriptor>) => {
+            macroSelectorComboBox.onOptionSelected((event: SelectedOptionEvent<api.macro.MacroDescriptor>) => {
                 formItem.addClass("selected-item-preview");
                 this.addClass("shows-preview");
 
-                this.macroDockedPanel.setMacroDescriptor(selectedOption.getOption().displayValue);
+                this.macroDockedPanel.setMacroDescriptor(event.getSelectedOption().getOption().displayValue);
             });
 
             macroSelectorComboBox.onExpanded((event: api.ui.selector.DropdownExpandedEvent) => {


### PR DESCRIPTION
Added `SelectedOptionEvent`.
Replaced argument of type `SelectedOption` with `SelectedOptionEvent` for option select/deselect events.
Added `FocusSwitchEvent` event and its handlers.
Implemented focus switch for the most selector input types.
Implemented `giveFocus()` logic in `RadioGroup` and related elements.