### PR TITLE
XP-3627 [Firefox] Clicking outside expanded dropdown will not close it

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/Element.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/Element.ts
@@ -944,20 +944,27 @@ module api.dom {
             this.getEl().removeEventListener("blur", listener);
         }
 
-        onFocusIn(listener: (event: FocusEvent) => void) {
-            this.getEl().addEventListener("focusin", listener);
+        // No native support of focusin/focusout events in Firefox yet.
+
+        onFocusIn(listener: (event: any) => void) {
+            // this.getEl().addEventListener("focusin", listener);
+            wemjq(this.el.getHTMLElement()).on("focusin", listener);
+
         }
 
-        unFocusIn(listener: (event: FocusEvent) => void) {
-            this.getEl().removeEventListener("focusin", listener);
+        unFocusIn(listener: (event: any) => void) {
+            // this.getEl().removeEventListener("focusin", listener);
+            wemjq(this.el.getHTMLElement()).off("focusin", listener);
         }
 
-        onFocusOut(listener: (event: FocusEvent) => void) {
-            this.getEl().addEventListener("focusout", listener);
+        onFocusOut(listener: (event: any) => void) {
+            // this.getEl().addEventListener("focusout", listener);
+            wemjq(this.el.getHTMLElement()).on("focusout", listener);
         }
 
-        unFocusOut(listener: (event: FocusEvent) => void) {
-            this.getEl().removeEventListener("focusout", listener);
+        unFocusOut(listener: (event: any) => void) {
+            // this.getEl().removeEventListener("focusout", listener);
+            wemjq(this.el.getHTMLElement()).off("focusout", listener);
         }
 
         onScroll(listener: (event: Event) => void) {


### PR DESCRIPTION
Replaced native focusin/focusout events with jQuery events.