### PR TITLE
XP-3617 Simplify collapse of the widget selector dropdown

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/WidgetsSelectionRow.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/WidgetsSelectionRow.ts
@@ -1,12 +1,12 @@
 import "../../../api.ts";
+import {WidgetView} from "./WidgetView";
+import {DetailsPanel} from "./DetailsPanel";
+import {InfoWidgetToggleButton} from "./button/InfoWidgetToggleButton";
 
 import Dropdown = api.ui.selector.dropdown.Dropdown;
 import DropdownConfig = api.ui.selector.dropdown.DropdownConfig;
 import Option = api.ui.selector.Option;
 import OptionSelectedEvent = api.ui.selector.OptionSelectedEvent;
-import {WidgetView} from "./WidgetView";
-import {DetailsPanel} from "./DetailsPanel";
-import {InfoWidgetToggleButton} from "./button/InfoWidgetToggleButton";
 
 export class WidgetsSelectionRow extends api.dom.DivEl {
 
@@ -103,6 +103,10 @@ export class WidgetSelectorDropdown extends Dropdown<WidgetViewOption> {
                     this.hideDropdown();
                 }
             }
+        });
+
+        api.util.AppHelper.focusInOut(this, () => {
+            this.hideDropdown();
         });
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/Dropdown.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/dropdown/Dropdown.ts
@@ -108,7 +108,7 @@ module api.ui.selector.dropdown {
 
             this.selectedOptionView.onOpenDropdown(() => {
                 this.showDropdown();
-                this.input.giveFocus();
+                this.giveFocus();
             });
 
             this.setupListeners();
@@ -172,7 +172,8 @@ module api.ui.selector.dropdown {
         }
 
         giveFocus(): boolean {
-            return this.input.giveFocus();
+            // If input is hidden or disabled, try dropdown handler.
+            return this.input.giveFocus() || this.dropdownHandle.giveFocus();
         }
 
         isDropdownShown(): boolean {


### PR DESCRIPTION
Fixed the `Dropdown.giveFocus()` event, when the input inside it is hidden.
Added `FocusInOut` handler into the `WidgetSelectorDropdown`.