### PR TITLE
XP-3629 Selector inputs - Highlight focused icons in SelectedOptionsView

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/form/form-item-set-occurrence-view.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/form/form-item-set-occurrence-view.less
@@ -37,11 +37,12 @@
 
   & > .remove-button {
     &:extend(.icon);
-    .icon-close;
+    .icon-close();
+    .focusable();
 
-    margin-left: 8px;
-    margin-right: 10px;
-    line-height: 22px;
+    margin: 5px 10px 0 8px;
+    border: 1px solid transparent;
+    line-height: 12px;
     float: right;
     text-decoration: none;
     cursor: pointer;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/form/input/input-occurrence-view.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/form/input/input-occurrence-view.less
@@ -49,6 +49,9 @@
 
     > .drag-control, > .remove-button {
       display: block;
+      border: 1px solid transparent;
+      .focusable();
+
     }
 
     .input-wrapper {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/button/dropdown-handle.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/button/dropdown-handle.less
@@ -9,6 +9,8 @@
   z-index: 100;
   background-color: transparent;
 
+  .focusable();
+
   &:after {
     content: "";
     position: absolute;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/security/acl/access-control-entry.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/security/acl/access-control-entry.less
@@ -33,12 +33,9 @@
   }
 
   .icon-close {
-    position: absolute;
-    top: 16px;
-    right: 16px;
-    cursor: pointer;
-    font-size: 12px;
-    text-decoration: none;
+    border: 1px solid transparent;
+    .close-mixin();
+    .focusable();
   }
 
   .permission-selector {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/security/acl/userstore-access-control-entry.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/security/acl/userstore-access-control-entry.less
@@ -32,13 +32,9 @@
   }
 
   .icon-close {
-    position: absolute;
-    top: 16px;
-    right: 16px;
-    cursor: pointer;
-    font-size: 12px;
-    display: block;
-    text-decoration: none;
+    border: 1px solid transparent;
+    .close-mixin();
+    .focusable();
   }
 
   .permission-selector {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/security/principal-selected-option-view.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/security/principal-selected-option-view.less
@@ -10,12 +10,8 @@
   }
 
   .icon-close {
-    position: absolute;
-    top: 16px;
-    right: 16px;
-    cursor: pointer;
-    font-size: 12px;
-    text-decoration: none;
+    border: 1px solid transparent;
+    .close-mixin();
+    .focusable();
   }
-
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/selector/combobox/selected-options.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/selector/combobox/selected-options.less
@@ -42,7 +42,9 @@
 
     .remove, .edit {
       &:extend(.icon);
+      .focusable();
 
+      border: 1px solid transparent;
       float: right;
       font-size: 12px;
       text-decoration: none;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/variables/mixins.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/variables/mixins.less
@@ -286,6 +286,14 @@
   }
 }
 
+.focusable() {
+  &:focus:not(:disabled) {
+    box-sizing: border-box;
+    box-shadow: 0 0 5px @admin-input-blue;
+    border: 1px solid @admin-input-blue;
+  }
+}
+
 // Reset all possible attributes user might have added to a page element
 // Use for all styles present on live edit page in order to reset user styles
 // http://stackoverflow.com/a/15903168
@@ -704,4 +712,14 @@
     font-size: 14px;
     line-height: 16px;
   }
+}
+
+.close-mixin {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  cursor: pointer;
+  font-size: 12px;
+  display: block;
+  text-decoration: none;
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/variables/mixins.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/variables/mixins.less
@@ -714,7 +714,7 @@
   }
 }
 
-.close-mixin {
+.close-mixin() {
   position: absolute;
   top: 16px;
   right: 16px;


### PR DESCRIPTION
Added `.focusable` mixin.
Added focusable styles to several buttons and icons.
Moved `.icon-close` button styles to mixin.