### PR TITLE
XP-3696 Error handling - Highlighting of invalid fields

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormView.ts
@@ -41,6 +41,8 @@ module api.form {
 
         public static debug: boolean = false;
 
+        public static VALIDATION_CLASS: string = "display-validation-errors";
+
         /**
          * @param context the form context.
          * @param form the form to display.
@@ -187,9 +189,9 @@ module api.form {
 
         public displayValidationErrors(value: boolean) {
             if (value) {
-                this.addClass("display-validation-errors");
+                this.addClass(FormView.VALIDATION_CLASS);
             } else {
-                this.removeClass("display-validation-errors");
+                this.removeClass(FormView.VALIDATION_CLASS);
             }
             for (var i = 0; i < this.formItemViews.length; i++) {
                 this.formItemViews[i].displayValidationErrors(value);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -194,6 +194,8 @@ module api.ui.selector.combobox {
             this.comboBoxDropdown.renderDropdownGrid();
 
             this.input.setReadOnly(true);
+
+            this.addClass("expanded");
         }
 
         setEmptyDropdownText(label: string) {
@@ -208,6 +210,7 @@ module api.ui.selector.combobox {
             }
 
             this.input.setReadOnly(false);
+            this.removeClass("expanded");
         }
 
         setOptions(options: Option<OPTION_DISPLAY_VALUE>[], saveSelection?: boolean) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ModalDialog.ts
@@ -83,7 +83,7 @@ module api.util.htmlarea.dialog {
 
         protected createForm(formItems:FormItem[]):Form {
             var form = new Form(),
-                validationCls = ModalDialog.VALIDATION_CLASS;
+                validationCls = api.form.FormView.VALIDATION_CLASS;
 
             formItems.forEach((formItem:FormItem) => {
                 form.add(this.createFieldSet(formItem));
@@ -98,9 +98,9 @@ module api.util.htmlarea.dialog {
 
         protected displayValidationErrors(value: boolean) {
             if (value) {
-                this.mainForm.addClass(ModalDialog.VALIDATION_CLASS);
+                this.mainForm.addClass(api.form.FormView.VALIDATION_CLASS);
             } else {
-                this.mainForm.removeClass(ModalDialog.VALIDATION_CLASS);
+                this.mainForm.removeClass(api.form.FormView.VALIDATION_CLASS);
             }
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/error-highlight.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/error-highlight.less
@@ -1,0 +1,58 @@
+.input-error(@color: @input-light-red) {
+  background-color: @color;
+
+  &:focus {
+    .box-shadow(0px 0px 5px @color);
+  }
+}
+
+.input-glow(@color: @admin-input-blue) {
+  &:hover {
+    &:not([disabled]) {
+      border: 1px solid @color;
+    }
+    &[disabled] {
+      border: 1px solid greyscale(@color);
+    }
+  }
+  &:focus {
+    .box-shadow(0px 0px 5px @color);
+    border: 1px solid @color;
+  }
+}
+
+.highlight(@color: @admin-input-red) {
+  .input-error();
+  .input-glow(@color);
+  &:hover {
+    .box-shadow(0px 0px 5px @color);
+  }
+}
+
+.highlight-background(@color: @input-light-red) {
+  background-color: @color;
+  -webkit-transition: background-color 200ms cubic-bezier(0.0, 0.0, 0.2, 1);
+  transition: background-color 200ms cubic-bezier(0.0, 0.0, 0.2, 1);
+}
+
+.input-view-error() {
+  padding: 10px 10px 10px 10px;
+
+  .highlight-background();
+
+  .form-input {
+    .input-error();
+
+    &.media-uploader-el a.dropzone {
+      .highlight()
+    }
+
+    &.@{_COMMON_PREFIX}text-input {
+      .input-glow(@admin-input-red);
+    }
+
+    &.@{_COMMON_PREFIX}combobox.expanded > .@{_COMMON_PREFIX}text-input {
+      background-color: @admin-white;
+    }
+  }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/form-common.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/form-common.less
@@ -27,7 +27,20 @@
 
   &.display-validation-errors {
     .validation-viewer {
+      font-size: 14px;
       display: block;
+    }
+
+    .input-view {
+      padding: 10px 10px 0px 10px;
+
+      &.invalid {
+        .input-view-error();
+      }
+
+      label + .input-wrapper {
+        margin-left: @form-label-width - 12px;
+      }
     }
   }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/input-common.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/input-common.less
@@ -7,29 +7,6 @@
   font-size: 15px;
 }
 
-.input-error(@color: @input-light-red) {
-  background-color: @color;
-
-  &:focus {
-    .box-shadow(0px 0px 5px @color);
-  }
-}
-
-.input-glow(@color: @admin-input-blue) {
-  &:hover {
-    &:not([disabled]) {
-      border: 1px solid @color;
-    }
-    &[disabled] {
-      border: 1px solid greyscale(@color);
-    }
-  }
-  &:focus {
-    .box-shadow(0px 0px 5px @color);
-    border: 1px solid @color;
-  }
-}
-
 ::-ms-clear {
   display: none;
 }
@@ -42,18 +19,11 @@
     margin-bottom: @form-field-spacing;
   }
 
-  //  padding: 10px 10px 0;
   border-bottom-width: 0;
 
   select, input, textarea {
     .input-glow();
   }
-
-  .display-validation-errors &.invalid {
-    .input-error();
-    padding: 10px;
-  }
-;
 
   .error {
     display: none;
@@ -137,7 +107,6 @@
       }
     }
   }
-
 
   .input-wrapper .form-input {
     width: 100%;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/modal-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/modal-dialog.less
@@ -12,7 +12,7 @@
       }
     }
 
-    &.display-validation-errors .input-view.invalid {
+    &.display-validation-errors .input-view {
       label + .input-wrapper {
         margin-left: @label-width - 12px;
       }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/styles.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/styles.less
@@ -10,6 +10,7 @@
 @import "variables/transitions";
 @import "variables/shadows";
 // api
+@import "api/error-highlight";
 @import "api/form-common";
 @import "api/input-common";
 @import "api/notify";

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/common.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/common.less
@@ -10,6 +10,7 @@
 @import "../../common/styles/variables/shadows";
 @import "../../common/icons/icons";
 
+@import "../../common/styles/api/error-highlight";
 @import "../../common/styles/api/form-common";
 @import "../../common/styles/api/input-common";
 @import "../../common/styles/api/content/image-uploader-el";


### PR DESCRIPTION
- Made controls inside invalid form item  use the same pink background as the parent div
- Animated appearance/disappearance of the pink background around invalid field
- Used font-size 14px for error message
- Moved common error input styling into separate less file
- Changed padding of input views that may display validation errors so that both valid and invalid inputs appear with same indent and so that validity change does not make input jump
- Added "expanded" class toggling for combobox so that its children aware if its state