### PR TITLE
XP-3709 Checkbox - Adjustable label placement and clickable label

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
@@ -207,7 +207,7 @@ export class ContentPublishDialog extends DependantItemsDialog {
 
         let childrenCheckboxListener = () => this.refreshPublishDependencies().done();
 
-        this.childrenCheckbox = new api.ui.Checkbox('Include child items');
+        this.childrenCheckbox = api.ui.Checkbox.create().setLabelText('Include child items').build();
         this.childrenCheckbox.addClass('include-child-check');
         this.childrenCheckbox.onValueChanged(childrenCheckboxListener);
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialog.ts
@@ -37,7 +37,7 @@ export class ContentDeleteDialog extends DependantItemsDialog {
 
         this.addCancelButtonToBottom();
 
-        this.instantDeleteCheckbox = new api.ui.Checkbox("Instantly delete published items");
+        this.instantDeleteCheckbox = api.ui.Checkbox.create().setLabelText("Instantly delete published items").build();
         this.instantDeleteCheckbox.addClass('instant-delete-check');
 
         this.appendChild(this.instantDeleteCheckbox);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/EditPermissionsDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/EditPermissionsDialog.ts
@@ -1,10 +1,10 @@
 import "../../api.ts";
+import {ContentPermissionsAppliedEvent} from "./ContentPermissionsAppliedEvent";
 
 import Content = api.content.Content;
 import AccessControlComboBox = api.ui.security.acl.AccessControlComboBox;
 import AccessControlEntry = api.security.acl.AccessControlEntry;
 import AccessControlList = api.security.acl.AccessControlList;
-import {ContentPermissionsAppliedEvent} from "./ContentPermissionsAppliedEvent";
 
 export class EditPermissionsDialog extends api.ui.dialog.ModalDialog {
 
@@ -29,7 +29,7 @@ export class EditPermissionsDialog extends api.ui.dialog.ModalDialog {
 
         this.addClass('edit-permissions-dialog');
 
-        this.inheritPermissionsCheck = new api.ui.Checkbox().setLabel('Inherit permissions');
+        this.inheritPermissionsCheck = api.ui.Checkbox.create().setLabelText('Inherit permissions').build();
         this.inheritPermissionsCheck.addClass('inherit-perm-check');
         this.appendChildToContentPanel(this.inheritPermissionsCheck);
 
@@ -65,7 +65,7 @@ export class EditPermissionsDialog extends api.ui.dialog.ModalDialog {
         };
         this.inheritPermissionsCheck.onValueChanged(changeListener);
 
-        this.overwriteChildPermissionsCheck = new api.ui.Checkbox().setLabel('Overwrite child permissions');
+        this.overwriteChildPermissionsCheck = api.ui.Checkbox.create().setLabelText('Overwrite child permissions').build();
         this.overwriteChildPermissionsCheck.addClass('overwrite-child-check');
         this.appendChildToContentPanel(this.overwriteChildPermissionsCheck);
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/aggregation/BucketView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/aggregation/BucketView.ts
@@ -20,7 +20,7 @@ module api.aggregation {
             this.parentAggregationView = parentAggregationView;
             this.displayName = displayName;
 
-            this.checkbox = new api.ui.Checkbox(this.resolveLabelValue(), select);
+            this.checkbox = api.ui.Checkbox.create().setLabelText(this.resolveLabelValue()).setChecked(select).build();
 
             this.checkbox.onValueChanged((event: api.ValueChangedEvent) => {
                 this.notifySelectionChanged(eval(event.getOldValue()), eval(event.getNewValue()));

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionView.ts
@@ -58,7 +58,7 @@ module api.content.form.inputtype.image {
         layout() {
             this.icon = new api.dom.ImgEl();
             this.label = new api.dom.DivEl("label");
-            this.check = new api.ui.Checkbox();
+            this.check = api.ui.Checkbox.create().build();
             this.progress = new api.ui.ProgressBar();
             this.error = new api.dom.DivEl("error");
             this.loadMask = new LoadMask(this);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/InputView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/InputView.ts
@@ -61,12 +61,15 @@ module api.form {
 
         public layout(): wemQ.Promise<void> {
 
-            if (this.input.getLabel()) {
-                var label = new InputLabel(this.input);
-                this.appendChild(label);
-            } else {
-                this.addClass("no-label");
+            if (this.input.getInputType().getName() !== "Checkbox") { //checkbox input type generates clickable label itself
+                if (this.input.getLabel()) {
+                    var label = new InputLabel(this.input);
+                    this.appendChild(label);
+                } else {
+                    this.addClass("no-label");
+                }
             }
+
 
             if (this.input.isMaximizeUIInputWidth()) {
                 this.addClass("label-over-input");

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/checkbox/Checkbox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/checkbox/Checkbox.ts
@@ -5,6 +5,7 @@ module api.content.form.inputtype.checkbox {
     import ValueType = api.data.ValueType;
     import ValueTypes = api.data.ValueTypes;
     import BaseInputTypeSingleOccurrence = api.form.inputtype.support.BaseInputTypeSingleOccurrence;
+    import LabelPosition = api.ui.LabelPosition;
 
     export class Checkbox extends BaseInputTypeSingleOccurrence<boolean> {
 
@@ -26,7 +27,8 @@ module api.content.form.inputtype.checkbox {
 
         layoutProperty(input: api.form.Input, property: Property): wemQ.Promise<void> {
             var checked = property.hasNonNullValue() ? property.getBoolean() : false;
-            this.checkbox = new api.ui.Checkbox(undefined, checked);
+            this.checkbox =
+                api.ui.Checkbox.create().setLabelText(input.getLabel()).setChecked(checked).setLabelPosition(LabelPosition.TOP).build();
             this.appendChild(this.checkbox);
 
             if (!ValueTypes.BOOLEAN.equals(property.getType())) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/Checkbox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/Checkbox.ts
@@ -9,17 +9,20 @@ module api.ui {
 
         public static debug = false;
 
-        constructor(text?: string, checked?: boolean) {
-            super("div", "checkbox", undefined, String(checked != undefined ? checked : false));
-            // we need an id for the label to interact nicely
-            this.checkbox = <api.dom.InputEl> new api.dom.Element(new api.dom.NewElementBuilder().
-                setTagName('input').
-                setGenerateId(true));
-            this.checkbox.getEl().setAttribute('type', 'checkbox');
-            this.appendChild(this.checkbox);
+        constructor(builder: CheckboxBuilder) {
+            super("div", "checkbox", undefined, String(builder.checked || false));
 
-            this.label = new api.dom.LabelEl(text, this.checkbox);
+            this.initCheckbox();
+            this.initLabel(builder.text, builder.labelPosition);
+
+            this.appendChild(this.checkbox)
             this.appendChild(this.label);
+        }
+
+        private initCheckbox() {
+            // we need an id for the label to interact nicely
+            this.checkbox = <api.dom.InputEl> new api.dom.Element(new api.dom.NewElementBuilder().setTagName('input').setGenerateId(true));
+            this.checkbox.getEl().setAttribute('type', 'checkbox');
 
             wemjq(this.checkbox.getHTMLElement()).change((e) => {
                 if (Checkbox.debug) {
@@ -28,6 +31,16 @@ module api.ui {
                 this.refreshValueChanged();
                 this.refreshDirtyState();
             });
+
+        }
+
+        private initLabel(text: string, labelPosition: LabelPosition) {
+            this.label = new api.dom.LabelEl(text, this.checkbox);
+            this.label.addClass(this.getLabelPositionAsString(labelPosition));
+        }
+
+        private getLabelPositionAsString(labelPosition: LabelPosition = LabelPosition.RIGHT): string {
+            return LabelPosition[labelPosition].toLowerCase();
         }
 
         setChecked(newValue: boolean, silent?: boolean): Checkbox {
@@ -105,6 +118,10 @@ module api.ui {
             return this.checkbox.getEl().getAttribute('placeholder');
         }
 
+        static create(): CheckboxBuilder {
+            return new CheckboxBuilder();
+        }
+
         onFocus(listener: (event: FocusEvent) => void) {
             this.checkbox.onFocus(listener);
         }
@@ -121,4 +138,43 @@ module api.ui {
             this.checkbox.unBlur(listener);
         }
     }
+
+    export enum LabelPosition {
+        TOP,
+        RIGHT,
+        LEFT
+    }
+
+    export class CheckboxBuilder {
+        text: string;
+
+        checked: boolean;
+
+        labelPosition: LabelPosition;
+
+        constructor() {
+        }
+
+        setLabelText(value: string): CheckboxBuilder {
+            this.text = value;
+            return this;
+        }
+
+        setChecked(value: boolean): CheckboxBuilder {
+            this.checked = value;
+            return this;
+        }
+
+        setLabelPosition(value: LabelPosition): CheckboxBuilder {
+            this.labelPosition = value;
+            return this;
+        }
+
+        build(): Checkbox {
+            return new Checkbox(this);
+        }
+    }
+
+
+
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ImageModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ImageModalDialog.ts
@@ -471,7 +471,7 @@ module api.util.htmlarea.dialog {
         }
 
         private createKeepOriginalSizeCheckbox(): api.ui.Checkbox {
-            var keepOriginalSizeCheckbox = new api.ui.Checkbox();
+            var keepOriginalSizeCheckbox = api.ui.Checkbox.create().build();
             keepOriginalSizeCheckbox.addClass('keep-size-check');
             keepOriginalSizeCheckbox.onValueChanged(() => {
                 this.imageLoadMask.show();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
@@ -8,6 +8,7 @@ module api.util.htmlarea.dialog {
     import Dropdown = api.ui.selector.dropdown.Dropdown;
     import DropdownConfig = api.ui.selector.dropdown.DropdownConfig;
     import Option = api.ui.selector.Option;
+    import LabelPosition = api.ui.LabelPosition;
 
     export class LinkModalDialog extends ModalDialog {
         private dockedPanel: DockedPanel;
@@ -168,9 +169,10 @@ module api.util.htmlarea.dialog {
         }
 
         private createTargetCheckbox(id: string, isTabSelected: boolean): FormItem {
-            var checkbox = new api.ui.Checkbox(null, this.getTarget(isTabSelected));
+            var checkbox = api.ui.Checkbox.create().setLabelText("Open in new tab").setChecked(
+                this.getTarget(isTabSelected)).setLabelPosition(LabelPosition.LEFT).build();
 
-            return this.createFormItem(id, "Open in new tab", null, null, checkbox);
+            return this.createFormItem(id, null, null, null, checkbox);
         }
 
         protected getMainFormItems(): FormItem [] {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/checkbox.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/checkbox.less
@@ -10,20 +10,44 @@
   }
 
   label {
-    color: #777 !important;
-    display: block;
+    display: inline-block;
     white-space: nowrap;
     padding: 0px 5px 0px 23px;
     cursor: pointer;
 
-    &:before {
+    &.left:before, &.right:before, &.top:after {
       content: '';
-      position: absolute;
       display: block;
       background: url("../../../images/admin-unchecked.gif") -1px -2px no-repeat;
       width: 13px;
       height: 13px;
+    }
+
+    &.top {
+      padding-left: 0px;
+      margin-bottom: 19px;
+
+      &:after {
+        position: absolute;
+        top: 21px;
+      }
+    }
+
+    &.right:before {
+      position: absolute;
       left: 4px;
+      margin-top: 2px;
+    }
+
+    &.left {
+      padding-left: 0px;
+      display: inline-block;
+
+      &:before {
+        float: right;
+        margin-left: 7px;
+        margin-top: 2px;
+      }
     }
   }
 
@@ -45,9 +69,7 @@
     }
 
     &:checked + label {
-      color: #333 !important;
-
-      &:before {
+      &:before, &:after {
         background: url("../../../images/admin-checked.gif") -1px -2px no-repeat;
       }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/modal-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/modal-dialog.less
@@ -424,4 +424,11 @@
     }
   }
 
+  &.link-modal-dialog {
+    input[type="checkbox"] + label:before {
+      position: absolute;
+      margin-left: 120px;
+    }
+  }
+
 }


### PR DESCRIPTION
-Added builder for ui.Checkbox to clearly set parameters required for object construction (instead of passing custom arguments which may present or may not)
-Updated ui.Checkbox styling to allow label appear to the left, top, right from checkbox; added LabelPosition enum to pass to ui.Checkbox to know where to put label (to the right from checkbox is default)
-Updated classes that use ui.Checkbox to construct it via builder
-Updated inputtype.Checkbox to create ui.Checkbox via build and with label positioned on top
-Updated InputView to handle checkbox inputtype separately: not creating InputLabel for it anymore because clickable label will be provided by ui.Checkbox
-Updated styling for LinkModalDialog's checkbox