### PR TITLE
XP-3697 Error handling - Highlight fields on validity change

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -930,6 +930,9 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
 
             return wemQ.all(formViewLayoutPromises).spread<void>(() => {
 
+                this.contentWizardStepForm.getFormView().addClass("may-display-validation-errors");
+                this.contentWizardStepForm.getFormView().highlightInputsOnValidityChange(true);
+
                 if (this.liveFormPanel) {
 
                     if (!this.liveEditModel) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FieldSetView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FieldSetView.ts
@@ -124,6 +124,12 @@ module api.form {
             });
         }
 
+        public setHighlightOnValidityChange(highlight: boolean) {
+            this.formItemViews.forEach((view: FormItemView) => {
+                view.setHighlightOnValidityChange(highlight);
+            });
+        }
+
         hasValidUserInput(): boolean {
 
             var result = true;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormItemSetOccurrenceView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormItemSetOccurrenceView.ts
@@ -193,6 +193,12 @@ module api.form {
             });
         }
 
+        public setHighlightOnValidityChange(highlight: boolean) {
+            this.formItemViews.forEach((view: FormItemView) => {
+                view.setHighlightOnValidityChange(highlight);
+            });
+        }
+
         hasValidUserInput(): boolean {
 
             var result = true;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormItemSetView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormItemSetView.ts
@@ -264,6 +264,12 @@ module api.form {
             });
         }
 
+        public setHighlightOnValidityChange(highlight: boolean) {
+            this.formItemSetOccurrences.getOccurrenceViews().forEach((view: FormItemSetOccurrenceView) => {
+                view.setHighlightOnValidityChange(highlight);
+            });
+        }
+
         hasValidUserInput(): boolean {
 
             var result = true;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormItemView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormItemView.ts
@@ -30,6 +30,8 @@ module api.form {
 
         private editContentRequestListeners: {(content: api.content.ContentSummary): void}[] = [];
 
+        private highlightOnValidityChanged: boolean;
+
         constructor(config: FormItemViewConfig) {
             super(config.className);
             api.util.assertNotNull(config.context, "context cannot be null");
@@ -37,6 +39,11 @@ module api.form {
             this.context = config.context;
             this.formItem = config.formItem;
             this.parent = config.parent;
+            this.highlightOnValidityChanged = false;
+        }
+
+        public setHighlightOnValidityChange(highlight: boolean) {
+            this.highlightOnValidityChanged = highlight;
         }
 
         broadcastFormSizeChanged() {
@@ -79,6 +86,10 @@ module api.form {
 
         giveFocus(): boolean {
             return false;
+        }
+
+        highlightOnValidityChange(): boolean {
+            return this.highlightOnValidityChanged;
         }
 
         onEditContentRequest(listener: (content: api.content.ContentSummary) => void) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormView.ts
@@ -132,6 +132,12 @@ module api.form {
             return this.formItemLayer.update(propertySet, unchangedOnly);
         }
 
+        public highlightInputsOnValidityChange(highlight: boolean) {
+            this.formItemViews.forEach((formItemView: FormItemView) => {
+                formItemView.setHighlightOnValidityChange(highlight);
+            });
+        }
+
         private checkSizeChanges() {
             if (this.isVisible() && this.isSizeChanged()) {
                 this.preserveCurrentSize();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/Picker.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/Picker.ts
@@ -27,6 +27,13 @@ module api.ui.time {
             this.wrapChildrenAndAppend();
 
             this.setupListeners(builder);
+
+            this.setupCommonListeners();
+        }
+
+        private setupCommonListeners() {
+            this.popup.onShown(e => this.addClass("expanded"));
+            this.popup.onHidden(e => this.removeClass("expanded"));
         }
 
         protected handleShownEvent() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/error-highlight.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/error-highlight.less
@@ -35,8 +35,14 @@
   transition: background-color 200ms cubic-bezier(0.0, 0.0, 0.2, 1);
 }
 
+.show-validation-viewer() {
+  .validation-viewer {
+    font-size: 14px;
+    display: block;
+    color: @input-red-text;
+  }
+}
 .input-view-error() {
-  padding: 10px 10px 10px 10px;
 
   .highlight-background();
 
@@ -54,5 +60,15 @@
     &.@{_COMMON_PREFIX}combobox.expanded > .@{_COMMON_PREFIX}text-input {
       background-color: @admin-white;
     }
+  }
+
+  .date-time-picker, .time-picker, .date-picker {
+    &.expanded .form-input {
+      background-color: @admin-white;
+    }
+  }
+
+  label + .input-wrapper {
+    margin-left: @form-label-width - 12px;
   }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/form-common.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/form-common.less
@@ -22,26 +22,35 @@
 
   .validation-viewer {
     display: none;
-    color: @input-red-text;
+  }
+
+  &.may-display-validation-errors .input-view {
+    padding-top: 10px;
   }
 
   &.display-validation-errors {
-    .validation-viewer {
-      font-size: 14px;
-      display: block;
-    }
 
     .input-view {
       padding: 10px 10px 0px 10px;
 
       &.invalid {
+        padding: 10px 10px 10px 10px;
         .input-view-error();
       }
-
-      label + .input-wrapper {
-        margin-left: @form-label-width - 12px;
-      }
     }
+
+    .show-validation-viewer();
+  }
+
+  &:not(.display-validation-errors) .input-view.highlight-validity-change {
+
+    &.invalid {
+      padding: 10px 10px 10px 10px;
+      margin: 0px -10px 5px -10px;
+      .input-view-error();
+    }
+
+    .show-validation-viewer();
   }
 
   .form-element-spacing(@form-field-set-spacing);


### PR DESCRIPTION
- Made InputTypeViews to notify about validity change on broken user input also , not only on broken occurences
- Fixed input view to always have 'invalid' class when it's input is broken
- Added possibility to mark formItemViews as ones that should highlight error on form validity change. Added styling for such form item views
- Added "may-display-validation-errors" class for content wizard that adds top padding for input views so that they don't jump while user inputs and validation occurs
- Separated validation-error styling for cases when we display all validation errors at once and when we show validation errors one by one .
- Tried to make styling for validation errors as natural as possible - so that neighbor elements are affected as less as possible
- As in XP-3696 for dropdown, made datepicker inputs to have white background when picker is expanded