### PR TITLE
XP-3763 ContextWindow, Insertables panel, impossible drag and drop items

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/contextwindow/insert/InsertablesPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/contextwindow/insert/InsertablesPanel.ts
@@ -87,7 +87,7 @@ export class InsertablesPanel extends api.ui.panel.Panel {
             }
         });
 
-        this.onRendered(this.initializeDraggables.bind(this));
+        this.insertablesGrid.onRendered(this.initializeDraggables.bind(this));
         this.onRemoved(this.destroyDraggables.bind(this));
     }
 


### PR DESCRIPTION
- initializeDraggables() handler was called upon rendering InsertablesPanel. It resulted in trying to make children of insertables panel draggable, when they were not rendered yet, hence, set initializeDraggables() to be triggered on insertablesGrid render.