### PR TITLE
XP-3774 Exception appears during deleting of Roles or Group

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanel.ts
@@ -93,17 +93,17 @@ export class PrincipalWizardPanel extends UserItemWizardPanel<Principal> {
                 }
             });
 
-            var deleteHandler = (event: api.security.event.PrincipalDeletedEvent) => {
+            var deleteHandler = ((event: api.security.event.PrincipalDeletedEvent) => {
                 event.getDeletedItems().forEach((path: string) => {
-                    if (this.getPersistedItem().getKey().toPath() == path) {
+                    if (!!this.getPersistedItem() && this.getPersistedItem().getKey().toPath() == path) {
                         this.close();
                     }
                 });
-            };
+            }).bind(this);
 
             this.onRemoved((event) => {
                 ResponsiveManager.unAvailableSizeChanged(this);
-                api.security.event.PrincipalDeletedEvent.un(deleteHandler.bind(this));
+                api.security.event.PrincipalDeletedEvent.un(deleteHandler);
             });
 
             this.onShown((event: api.dom.ElementShownEvent) => {
@@ -114,7 +114,7 @@ export class PrincipalWizardPanel extends UserItemWizardPanel<Principal> {
                 }
 
                 responsiveItem.update();
-                api.security.event.PrincipalDeletedEvent.on(deleteHandler.bind(this));
+                api.security.event.PrincipalDeletedEvent.on(deleteHandler);
             });
 
             this.constructing = false;


### PR DESCRIPTION
- Delete handler function was passed to event .on() and .un() methods with 'bind(this)' call. 'bind(this)' returns a new function which results in two 'unequal' functions passed to event. hence it is  impossible to unbind such function
- Added check for existence of this.getPersistedItem() as in a wizard of new item it returns undefined