### PR TITLE
XP-3777 ContentWizard bad styles for the display-name input, when dou…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/text/AutosizeTextInput.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/text/AutosizeTextInput.ts
@@ -43,6 +43,10 @@ module api.ui.text {
         }
 
         private updateSize() {
+            if (!this.isVisible()) {
+                return;
+            }
+
             var inputEl = this.getEl(),
                 cloneEl = this.clone.getEl();
 
@@ -60,7 +64,6 @@ module api.ui.text {
             } else {
                 inputEl.setWidthPx(cloneEl.getWidthWithBorder());
             }
-
 
             this.attendant.remove();
         }


### PR DESCRIPTION
…ble click on the content, that already opened

- Made AutoSize input to update it's size only if it's visible - otherwise, regular tab switch causes it to do unnecessary recalculation