### PR TITLE
XP-3855 Validation - Content type selector is validated upon creation…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/schema/content/ContentTypeComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/schema/content/ContentTypeComboBox.ts
@@ -9,7 +9,6 @@ module api.schema.content {
                 .setSelectedOptionsView(new ContentTypeSelectedOptionsView())
                 .setOptionDisplayValueViewer(new ContentTypeSummaryViewer())
                 .setMaximumOccurrences(maximumOccurrences));
-            loader.load();
         }
 
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/schema/content/inputtype/ContentTypeFilter.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/schema/content/inputtype/ContentTypeFilter.ts
@@ -71,8 +71,6 @@ module api.schema.content.inputtype {
 
             this.setLayoutInProgress(false);
             this.combobox.unLoaded(this.onContentTypesLoadedHandler);
-
-            this.validate(false);
         }
 
         private onContentTypeSelected(selectedOption: api.ui.selector.combobox.SelectedOption<ContentTypeSummary>): void {
@@ -107,7 +105,10 @@ module api.schema.content.inputtype {
 
             this.appendChild(this.combobox = this.createComboBox());
 
-            return wemQ<void>(null);
+            return this.combobox.getLoader().load().then(() => {
+                this.validate(false);
+                return wemQ<void>(null);
+            });
         }
 
 


### PR DESCRIPTION
… of a page template

- Moved  load() call out of ContentTypeComboBox constructor to input type's layout method.
- Made layout promise of ContentTypeFilter input type to resolve after content filter value is loaded - it makes this input to behave similarly as other inputs and fixes problem of "highlight-validity-change" being set to ContentTypeFilter's InputView by wizard panel before its value is set and validated.