### PR TITLE
XP-3861 Content Wizard - Masking of panels

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveFormPanel.ts
@@ -74,12 +74,13 @@ import HtmlAreaDialogShownEvent = api.util.htmlarea.dialog.CreateHtmlAreaDialogE
 import HTMLAreaDialogHandler = api.util.htmlarea.dialog.HTMLAreaDialogHandler;
 
 import Panel = api.ui.panel.Panel;
+import LiveEditPageViewReadyEvent = api.liveedit.LiveEditPageViewReadyEvent;
 
 export interface LiveFormPanelConfig {
 
-    contentType:ContentTypeName;
+    contentType: ContentTypeName;
 
-    contentWizardPanel:ContentWizardPanel;
+    contentWizardPanel: ContentWizardPanel;
 
     defaultModels: DefaultModels;
 }
@@ -133,22 +134,37 @@ export class LiveFormPanel extends api.ui.panel.Panel {
 
         this.liveEditPageProxy = new LiveEditPageProxy();
 
-        this.contentInspectionPanel = new ContentInspectionPanel();
-        this.pageInspectionPanel = new PageInspectionPanel();
-        this.regionInspectionPanel = new RegionInspectionPanel();
-        this.imageInspectionPanel = new ImageInspectionPanel();
-        this.partInspectionPanel = new PartInspectionPanel();
-        this.layoutInspectionPanel = new LayoutInspectionPanel();
-        this.fragmentInspectionPanel = new FragmentInspectionPanel();
-        this.textInspectionPanel = new TextInspectionPanel();
+        this.contextWindow = this.createContextWindow(this.liveEditPageProxy, this.liveEditModel);
 
-        api.dom.WindowDOM.get().onBeforeUnload((event) => {
-            console.log("onbeforeunload " + this.liveEditModel.getContent().getDisplayName());
-            // the reload is triggered by the main frame,
-            // so let the live edit know it to skip the popup
-            this.liveEditPageProxy.skipNextReloadConfirmation(true);
+        // constructor to listen to live edit events during wizard rendering
+        this.contextWindowController = new ContextWindowController(
+            this.contextWindow,
+            this.contentWizardPanel
+        );
+    }
+
+    private createContextWindow(proxy: LiveEditPageProxy, model: LiveEditModel): ContextWindow {
+        this.emulatorPanel = new EmulatorPanel({
+            liveEditPage: proxy
         });
 
+        this.inspectionsPanel = this.createInspectionsPanel(model);
+
+        this.insertablesPanel = new InsertablesPanel({
+            liveEditPage: proxy,
+            content: this.content
+        });
+
+        return new ContextWindow(<ContextWindowConfig>{
+            liveEditPage: proxy,
+            liveFormPanel: this,
+            inspectionPanel: this.inspectionsPanel,
+            emulatorPanel: this.emulatorPanel,
+            insertablesPanel: this.insertablesPanel
+        });
+    }
+
+    private createInspectionsPanel(model: LiveEditModel): InspectionsPanel {
         var saveAction = new api.ui.Action('Apply');
         saveAction.onExecuted(() => {
             if (!this.pageView) {
@@ -164,7 +180,18 @@ export class LiveFormPanel extends api.ui.panel.Panel {
             }
         });
 
-        this.inspectionsPanel = new InspectionsPanel(<InspectionsPanelConfig>{
+        this.contentInspectionPanel = new ContentInspectionPanel(this.content);
+
+        this.pageInspectionPanel = new PageInspectionPanel(model);
+        this.partInspectionPanel = new PartInspectionPanel(model);
+        this.layoutInspectionPanel = new LayoutInspectionPanel(model);
+        this.imageInspectionPanel = new ImageInspectionPanel(model);
+        this.fragmentInspectionPanel = new FragmentInspectionPanel(model);
+
+        this.textInspectionPanel = new TextInspectionPanel();
+        this.regionInspectionPanel = new RegionInspectionPanel();
+
+        return new InspectionsPanel(<InspectionsPanelConfig>{
             contentInspectionPanel: this.contentInspectionPanel,
             pageInspectionPanel: this.pageInspectionPanel,
             regionInspectionPanel: this.regionInspectionPanel,
@@ -175,47 +202,47 @@ export class LiveFormPanel extends api.ui.panel.Panel {
             textInspectionPanel: this.textInspectionPanel,
             saveAction: saveAction
         });
+    }
 
-        this.emulatorPanel = new EmulatorPanel({
-            liveEditPage: this.liveEditPageProxy
+    doRender(): Q.Promise<boolean> {
+        return super.doRender().then((rendered) => {
+
+            api.dom.WindowDOM.get().onBeforeUnload((event) => {
+                console.log("onbeforeunload " + this.liveEditModel.getContent().getDisplayName());
+                // the reload is triggered by the main frame,
+                // so let the live edit know it to skip the popup
+                this.liveEditPageProxy.skipNextReloadConfirmation(true);
+            });
+
+            this.frameContainer = new Panel("frame-container");
+            this.frameContainer.appendChildren<api.dom.Element>(this.liveEditPageProxy.getIFrame(), this.liveEditPageProxy.getDragMask());
+
+            // append mask here in order for the context window to be above
+            this.appendChildren<api.dom.Element>(this.frameContainer, this.liveEditPageProxy.getLoadMask(), this.contextWindow);
+
+
+            this.contextWindow.onDisplayModeChanged(() => {
+                if (!this.contextWindow.isFloating()) {
+                    this.contentWizardPanel.getContextWindowToggler().setActive(true);
+                    this.contextWindow.slideIn();
+                }
+            });
+
+            this.liveEditListen();
+
+            // delay rendered event until live edit page is fully loaded
+            var liveEditDeferred = wemQ.defer();
+
+            this.liveEditPageProxy.onLiveEditPageViewReady((event: LiveEditPageViewReadyEvent) => {
+                liveEditDeferred.resolve(rendered);
+            });
+
+            this.liveEditPageProxy.onLiveEditPageInitializationError((event: LiveEditPageInitializationErrorEvent) => {
+                liveEditDeferred.reject(event.getMessage());
+            });
+
+            return liveEditDeferred.promise;
         });
-
-        this.insertablesPanel = new InsertablesPanel({
-            liveEditPage: this.liveEditPageProxy,
-            contentWizardPanel: config.contentWizardPanel,
-        });
-
-        this.frameContainer = new Panel("frame-container");
-        this.appendChild(this.frameContainer);
-        this.frameContainer.appendChild(this.liveEditPageProxy.getIFrame());
-        this.frameContainer.appendChild(this.liveEditPageProxy.getDragMask());
-
-        // append it here in order for the context window to be above
-        this.appendChild(this.liveEditPageProxy.getLoadMask());
-
-        this.contextWindow = new ContextWindow(<ContextWindowConfig>{
-            liveEditPage: this.liveEditPageProxy,
-            liveFormPanel: this,
-            inspectionPanel: this.inspectionsPanel,
-            emulatorPanel: this.emulatorPanel,
-            insertablesPanel: this.insertablesPanel
-        });
-
-        this.appendChild(this.contextWindow);
-
-        this.contextWindowController = new ContextWindowController(
-            this.contextWindow,
-            this.contentWizardPanel
-        );
-
-        this.contextWindow.onDisplayModeChanged(() => {
-            if (!this.contextWindow.isFloating()) {
-                this.contentWizardPanel.getContextWindowToggler().setActive(true);
-                this.contextWindow.slideIn();
-            }
-        });
-
-        this.liveEditListen();
     }
 
     remove(): LiveFormPanel {
@@ -321,7 +348,7 @@ export class LiveFormPanel extends api.ui.panel.Panel {
     loadPage(clearInspection: boolean = true) {
         if (this.pageSkipReload == false && !this.pageLoading) {
 
-            if(clearInspection) {
+            if (clearInspection) {
                 this.clearSelection();
             }
 
@@ -379,7 +406,6 @@ export class LiveFormPanel extends api.ui.panel.Panel {
         }
     }
 
-
     private liveEditListen() {
 
         this.liveEditPageProxy.onPageLocked((event: api.liveedit.PageLockedEvent) => {
@@ -392,16 +418,8 @@ export class LiveFormPanel extends api.ui.panel.Panel {
 
         this.liveEditPageProxy.onLiveEditPageViewReady((event: api.liveedit.LiveEditPageViewReadyEvent) => {
             this.pageView = event.getPageView();
-            var windowToggler = this.contentWizardPanel.getContextWindowToggler();
-            var componentsToggler = this.contentWizardPanel.getComponentsViewToggler();
             if (this.pageView) {
                 this.insertablesPanel.setPageView(this.pageView);
-                windowToggler.show();
-                componentsToggler.show();
-            } else {
-                windowToggler.hide();
-                componentsToggler.hide()
-            :
             }
         });
 
@@ -562,7 +580,7 @@ export class LiveFormPanel extends api.ui.panel.Panel {
         if (this.pageView && this.pageView.hasSelectedView()) {
             this.pageView.getSelectedView().deselect();
         }
-        this.contextWindow.showInspectionPanel(this.pageInspectionPanel);
+        this.inspectPage();
     }
 
     private inspectRegion(regionView: RegionView) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardPanel.ts
@@ -250,7 +250,7 @@ module api.app.wizard {
 
             this.updateToolbarActions();
 
-            this.formPanel = new api.ui.panel.Panel("form-panel");
+            this.formPanel = new api.ui.panel.Panel("form-panel rendering");
             this.formPanel.onScroll(() => this.updateStickyToolbar());
 
             this.formPanel.onAdded((event) => {
@@ -268,10 +268,10 @@ module api.app.wizard {
                 }
                 firstShow = true;
                 this.formMask.hide();
-                this.formPanel.getEl().setOpacity(1);
+                this.formPanel.removeClass('rendering');
 
                 if (this.mainToolbar) {
-                    this.mainToolbar.getEl().setOpacity(1);
+                    this.mainToolbar.removeClass('rendering');
                 }
 
                 // check validity on rendered
@@ -294,11 +294,13 @@ module api.app.wizard {
 
             this.mainToolbar = this.createMainToolbar();
             if (this.mainToolbar) {
+                this.mainToolbar.addClass('rendering');
                 this.appendChild(this.mainToolbar);
             }
 
             this.livePanel = this.createLivePanel();
             if (this.livePanel) {
+                this.livePanel.addClass('rendering');
 
                 this.toggleMinimizeListener = (event: api.ui.ActivatedEvent) => {
                     this.toggleMinimize(event.getIndex());
@@ -319,7 +321,7 @@ module api.app.wizard {
                         console.debug("WizardPanel: livePanel.onRendered");
                     }
                     this.liveMask.hide();
-                    this.livePanel.getEl().setOpacity(1);
+                    this.livePanel.removeClass('rendering');
                 });
 
                 this.splitPanel = this.createSplitPanel(this.formPanel, this.livePanel);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/Element.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/Element.ts
@@ -229,6 +229,10 @@ module api.dom {
             return renderPromise.then((rendered) => {
 
                 return this.initChildren(rendered);
+            }).catch((reason) => {
+
+                api.DefaultErrorHandler.handle(reason);
+                return false;
             });
         }
 
@@ -313,6 +317,10 @@ module api.dom {
 
         isRendered(): boolean {
             return this.rendered;
+        }
+
+        isAdded(): boolean {
+            return !!this.getHTMLElement().parentNode;
         }
 
         /**
@@ -575,7 +583,10 @@ module api.dom {
             } else if (parent.isRendering()) {
                 this.childrenAddedDuringInit = true;
             }
-            child.notifyAdded();
+            // notify added if I am added to dom only, otherwise do it on added to dom
+            if (this.isAdded()) {
+                child.notifyAdded();
+            }
             return this;
         }
 
@@ -831,7 +842,10 @@ module api.dom {
             this.addedListeners.forEach((listener) => {
                 listener(addedEvent);
             });
-            // Each child throw its own added
+
+            this.children.forEach((child: Element) => {
+                child.notifyAdded();
+            })
         }
 
         onRemoved(listener: (event: ElementRemovedEvent) => void) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/mask/Mask.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/mask/Mask.ts
@@ -1,5 +1,6 @@
 module api.ui.mask {
 
+    import ResponsiveManager = api.ui.responsive.ResponsiveManager;
     export class Mask extends api.dom.DivEl {
 
         private masked: api.dom.Element;
@@ -31,11 +32,11 @@ module api.ui.mask {
                     this.remove();
                 });
                 // Masked element might have been resized on window resize
-                api.dom.WindowDOM.get().onResized((event: UIEvent) => {
+                ResponsiveManager.onAvailableSizeChanged(api.dom.Body.get(), (item) => {
                     if (this.isVisible()) {
                         this.positionOver(this.masked);
                     }
-                }, this);
+                });
             }
             api.dom.Body.get().appendChild(this);
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/panel/SplitPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/panel/SplitPanel.ts
@@ -270,7 +270,7 @@ module api.ui.panel {
                 ResponsiveManager.onAvailableSizeChanged(this, debounced);
             }
 
-            this.onShown((event: api.dom.ElementShownEvent) => {
+            this.onAdded((event: api.dom.ElementShownEvent) => {
                 let splitPanelSize = this.isHorizontal() ? this.getEl().getHeight() : this.getEl().getWidth();
                 api.util.assert(this.firstPanelMinSize + this.secondPanelMinSize <= splitPanelSize,
                     "warning: total sum of first and second panel minimum sizes exceed total split panel size");
@@ -558,7 +558,7 @@ module api.ui.panel {
                 this.firstPanelSize = this.hiddenFirstPanelPreviousSize;
 
                 this.splitterIsHidden = false;
-                this.splitter.show();
+                this.showSplitter();
             }
 
             this.firstPanel.show();
@@ -574,7 +574,7 @@ module api.ui.panel {
 
             this.splitterIsHidden = false;
             if (showSplitter) {
-                this.splitter.show();
+                this.showSplitter();
             }
 
             this.secondPanelSize = this.hiddenSecondPanelPreviousSize;
@@ -594,7 +594,7 @@ module api.ui.panel {
             }
 
             this.splitterIsHidden = true;
-            this.splitter.hide();
+            this.hideSplitter();
 
             if (!this.firstPanelIsFullScreen) {
                 this.hiddenFirstPanelPreviousSize = this.firstPanelSize;
@@ -619,7 +619,7 @@ module api.ui.panel {
         foldSecondPanel() {
 
             this.splitterIsHidden = true;
-            this.splitter.hide();
+            this.hideSplitter();
 
             if (this.secondPanelShouldSlideRight) {
                 this.slideOutSecondPanelRight();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/responsive/ResponsiveManager.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/responsive/ResponsiveManager.ts
@@ -11,7 +11,7 @@ module api.ui.responsive {
         }): ResponsiveItem {
             var responsiveItem: ResponsiveItem = new ResponsiveItem(el, handler),
                 listener = () => {
-                    if (el.isRendered()) {
+                    if (el.isVisible()) {
                         responsiveItem.update();
                     }
                 },
@@ -34,7 +34,7 @@ module api.ui.responsive {
                 var renderedHandler = (event) => {
                     responsiveItem.update();
                     el.unRendered(renderedHandler); // update needs
-                }
+                };
                 el.onRendered(renderedHandler);
             }
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
@@ -34,7 +34,7 @@
     .opacity(0);
   }
 
-  .split-panel {
+  .live-form-panel {
     .opacity(0);
   }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
@@ -7,8 +7,11 @@
   }
 
   .toolbar {
-    .opacity(0);
     border-bottom: 1px solid @admin-medium-gray-border;
+
+    &.rendering * {
+      opacity: 0;
+    }
 
     &.scroll-shadow {
       .box-shadow(0px 2px 6px -2px #000);
@@ -31,10 +34,12 @@
 
   .form-panel {
     overflow-y: auto !important;
-    .opacity(0);
+    &.rendering {
+      .opacity(0);
+    }
   }
 
-  .live-form-panel {
+  .live-form-panel.rendering {
     .opacity(0);
   }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
@@ -22,19 +22,6 @@
 
   .split-panel {
 
-    &.prerendered {
-      .form-panel {
-        width: 100% !important;
-      }
-      .splitter, .live-form-panel {
-        width: 0;
-        visibility: hidden;
-      }
-      .minimize-edit {
-        display: none;
-      }
-    }
-
     &.toggle-form {
       .form-panel {
         width: 100% !important;


### PR DESCRIPTION
- updated content wizard to fire 'rendered' event after live edit is fully rendered
- tuned ContentWizardDataLoader to do more parallel requests to boost loading time
- updated 'added' event firing in Element, so that it is fired only if (after) parent is added to DOM
- updated Mask to resize on masked element resize