### PR TITLE
XP-3908 Dashboard icons - Tour and About do not work under mobile

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/assets/js/home/launcher.js
+++ b/modules/admin/admin-ui/src/main/resources/assets/js/home/launcher.js
@@ -98,7 +98,7 @@ function addLongClickHandler(container) {
     var toolWindows = [];
     
     var appTiles = container.querySelector('.launcher-app-container').querySelectorAll("a");
-    for (let i = 0; i < appTiles.length; i++) {
+    for (var i = 0; i < appTiles.length; i++) {
         appTiles[i].addEventListener("click", function (e) {
             if (window.CONFIG.appId == e.currentTarget.getAttribute("data-id") && window.CONFIG.appId == "home") {
                 e.preventDefault();


### PR DESCRIPTION
-IOS only, android devices were ok. Issue occured because of using 'let' variable declaration