### PR TITLE
XP-3934 Impossible to close wizard for User, Role and Group

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/PrincipalWizardPanel.ts
@@ -132,34 +132,18 @@ export class PrincipalWizardPanel extends UserItemWizardPanel<Principal> {
                 break;
             }
 
-            var responsiveItem = ResponsiveManager.onAvailableSizeChanged(this, (item: ResponsiveItem) => {
-                if (this.isVisible()) {
-                    this.updateStickyToolbar();
-                }
-            });
-
             var deleteHandler = ((event: api.security.event.PrincipalDeletedEvent) => {
                 event.getDeletedItems().forEach((path: string) => {
                     if (!!this.getPersistedItem() && this.getPersistedItem().getKey().toPath() == path) {
                         this.close();
                     }
                 });
-            }).bind(this);
-
-            this.onRemoved((event) => {
-                ResponsiveManager.unAvailableSizeChanged(this);
-                api.security.event.PrincipalDeletedEvent.un(deleteHandler);
             });
 
-            this.onShown((event: api.dom.ElementShownEvent) => {
-                if (this.getPersistedItem()) {
-                    Router.setHash("edit/" + this.getPersistedItem().getKey());
-                } else {
-                    Router.setHash("new/" + PrincipalType[this.principalParams.persistedType].toLowerCase());
-                }
+            api.security.event.PrincipalDeletedEvent.on(deleteHandler);
 
-                responsiveItem.update();
-                api.security.event.PrincipalDeletedEvent.on(deleteHandler);
+            this.onRemoved((event) => {
+                api.security.event.PrincipalDeletedEvent.un(deleteHandler);
             });
 
             return rendered;
@@ -276,5 +260,13 @@ export class PrincipalWizardPanel extends UserItemWizardPanel<Principal> {
         this.principalNamedListeners.forEach((listener: (event: PrincipalNamedEvent)=>void)=> {
             listener.call(this, new PrincipalNamedEvent(this, principal));
         });
+    }
+
+    protected updateHash() {
+        if (this.getPersistedItem()) {
+            Router.setHash("edit/" + this.getPersistedItem().getKey());
+        } else {
+            Router.setHash("new/" + PrincipalType[this.principalParams.persistedType].toLowerCase());
+        }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserItemWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserItemWizardPanel.ts
@@ -71,7 +71,13 @@ export class UserItemWizardPanel<USER_ITEM_TYPE extends api.Equitable> extends a
                 }
             });
 
+            this.updateHash();
             this.onRemoved((event) => ResponsiveManager.unAvailableSizeChanged(this));
+
+            this.onShown((event: api.dom.ElementShownEvent) => {
+                this.updateHash();
+                responsiveItem.update();
+            });
 
             return rendered;
         });
@@ -121,5 +127,7 @@ export class UserItemWizardPanel<USER_ITEM_TYPE extends api.Equitable> extends a
         return this.wizardActions.getCloseAction();
     }
 
-
+    protected updateHash() {
+        throw new Error("Must be implemented by inheritors");
+    }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserStoreWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserStoreWizardPanel.ts
@@ -138,26 +138,6 @@ export class UserStoreWizardPanel extends UserItemWizardPanel<UserStore> {
 
             this.getFormIcon().addClass("icon-address-book");
 
-            var responsiveItem = ResponsiveManager.onAvailableSizeChanged(this, (item: ResponsiveItem) => {
-                if (this.isVisible()) {
-                    this.updateStickyToolbar();
-                }
-            });
-
-            this.onRemoved((event) => {
-                ResponsiveManager.unAvailableSizeChanged(this);
-            });
-
-            this.onShown((event: api.dom.ElementShownEvent) => {
-                if (this.getPersistedItem()) {
-                    Router.setHash("edit/" + this.getPersistedItem().getKey());
-                } else {
-                    Router.setHash("new/");
-                }
-
-                responsiveItem.update();
-            });
-
             return rendered;
         });
     }
@@ -338,6 +318,14 @@ export class UserStoreWizardPanel extends UserItemWizardPanel<UserStore> {
             api.security.UserItemDeletedEvent.un(principalDeletedHandler);
         });
 
+    }
+
+    protected updateHash() {
+        if (this.getPersistedItem()) {
+            Router.setHash("edit/" + this.getPersistedItem().getKey());
+        } else {
+            Router.setHash("new/");
+        }
     }
 
 }


### PR DESCRIPTION
-Issue origin: Wizard panel's doRenderOnDataLoaded() method is called after wizard's show event have already triggered, thus when this method was called in PrincipalWizardPanel deleteHandler was not bind as it was assigned in onShown handler
-Optimizing common things in doRenderOnDataLoaded for user items