### PR TITLE
XP-3942 Publish Dialog. 'Include child items' not checked, when the '…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/main.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/main.ts
@@ -113,8 +113,9 @@ function startApplication() {
     ContentPublishPromptEvent.on((event) => {
         contentPublishDialog
             .setContentToPublish(event.getModels())
-            .setIncludeChildItems(event.isIncludeChildItems(), true)
             .open();
+
+        contentPublishDialog.setIncludeChildItems(event.isIncludeChildItems(), true);
     });
 
     var contentUnpublishDialog = new ContentUnpublishDialog();


### PR DESCRIPTION
…Publish Tree' menu item was selected

-Issue origin: when opening dialog it gets reappended to document body, that triggers elements to reset. Fix: set checkbox checked state after opening