### PR TITLE
XP-3969 SiteWizard. 'Publish Tree' menu item diasbled on the wizard-t…

### DIFF
--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentServiceImpl.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentServiceImpl.java
@@ -229,6 +229,8 @@ public class ContentServiceImpl
                 requireValid( true ).
                 contentData( new PropertyTree() ).
                 build() );
+
+            return this.getById( content.getId() );
         }
 
         return content;


### PR DESCRIPTION
…oolbar, when site has been published

-When creating site content we return content object representing site before template was created under it, so value of 'hasChildren' param is not actual; Fixed so after creating site template fetching content again and returning it