### PR TITLE
XP-3961 Welcome Tour - Replace "Finish" button with "Install Demo Apps"

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/home/home.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/home/home.less
@@ -221,7 +221,7 @@
 
     .step-5 {
       .demo-apps {
-        margin: 10px 0px 10px 0px;
+        margin: 10px 0px 49px 0px;
         display: flex;
         align-items: center;
         justify-content: space-around;
@@ -253,7 +253,7 @@
           .demo-app-status {
             position: absolute;
             width: 100%;
-            bottom: -23px;
+            bottom: -28px;
             font-size: 16px;
             color: @admin-green;
 


### PR DESCRIPTION
-If there's at least one uninstalled or out-of-date demo app, replacing Finish button with "Install Demo Apps" (green background color and the same height as "Previous"). It is disabled while apps and their statuses/versions are being fetched
-Once clicked, the button  becomes disabled and its caption  changes to "Installing..."
-After apps have been installed/updated, the button is replaced with "Finish"
-If all of the demo apps are already installed and up-to-date when the last step of the Welcome tour opens, the button "Finish" is displayed
-Last step updated to have the same height as previous steps.