### PR TITLE
XP-4016 Error occurs when you try to set role 'Everyone'

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserMembershipsWizardStepForm.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/wizard/UserMembershipsWizardStepForm.ts
@@ -33,7 +33,8 @@ export class UserMembershipsWizardStepForm extends api.app.wizard.WizardStepForm
         this.rolesLoaded = false;
 
         var groupsLoader = new PrincipalLoader().setAllowedTypes([PrincipalType.GROUP]);
-        var rolesLoader = new PrincipalLoader().setAllowedTypes([PrincipalType.ROLE]).skipPrincipals([RoleKeys.EVERYONE]);
+        var rolesLoader = new PrincipalLoader().setAllowedTypes([PrincipalType.ROLE]).skipPrincipals([RoleKeys.EVERYONE,
+            RoleKeys.AUTHENTICATED]);
 
         this.groups = PrincipalComboBox.create().setLoader(groupsLoader).build();
         groupsLoader.load();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/security/RoleKeys.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/security/RoleKeys.ts
@@ -4,6 +4,8 @@ module api.security {
 
         public static EVERYONE: PrincipalKey = PrincipalKey.ofRole('system.everyone');
 
+        public static AUTHENTICATED: PrincipalKey = PrincipalKey.ofRole('system.authenticated');
+
         public static ADMIN: PrincipalKey = PrincipalKey.ofRole('system.admin');
     }
 }

--- a/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/SecurityServiceImpl.java
+++ b/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/SecurityServiceImpl.java
@@ -101,7 +101,8 @@ import static com.enonic.xp.core.impl.security.PrincipalKeyNodeTranslator.toNode
 public final class SecurityServiceImpl
     implements SecurityService
 {
-    private static final ImmutableSet<PrincipalKey> FORBIDDEN_FROM_RELATIONSHIP = ImmutableSet.of( RoleKeys.EVERYONE );
+    private static final ImmutableSet<PrincipalKey> FORBIDDEN_FROM_RELATIONSHIP =
+        ImmutableSet.of( RoleKeys.EVERYONE, RoleKeys.AUTHENTICATED );
 
     private static final String SU_PASSWORD_PROPERTY_KEY = "xp.suPassword";
 


### PR DESCRIPTION
- Added Authenticated RoleKey to RoleKeys and passed it to filter in UserMembershipsWizardStepForm