### PR TITLE
XP-4023 HtmlArea not updated when saved in other browser window

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaHelper.ts
@@ -25,7 +25,7 @@ module api.util.htmlarea.editor {
                 imgSrcs;
 
             if (!processedContent) {
-                return value;
+                return "";
             }
 
             while (processedContent.search(" src=\"" + ImageModalDialog.imagePrefix) > -1) {


### PR DESCRIPTION
Fixed the originalValue set in `HtmlArea`'s `TextArea` input, so that the check for isDirty will be valid for non-modified empty input.
Previously, the base value of originalValue was `null`, not the empty string.