### PR TITLE
XP-4021 SiteWizard, ContextWindow- 'Inspection Panel' should not hide…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -610,7 +610,7 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
         return super.saveChanges().then((content: Content) => {
             if (liveFormPanel) {
                 this.liveEditModel.setContent(content);
-                liveFormPanel.loadPage();
+                liveFormPanel.loadPage(false);
             }
 
             return content;


### PR DESCRIPTION
…, when page controller was changed on the panel

- Added missing argument to loadPage call that got overwritten mistakenly due to various merges