### PR TITLE
XP-3930 [Chrome Canary] Valid email doesn't pass validation when savi…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/text/EmailInput.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/text/EmailInput.ts
@@ -24,7 +24,7 @@ module api.ui.text {
             this.focusListeners = [];
             this.blurListeners = [];
             this.input = new InputEl(undefined, 'email');
-            this.input.setPattern("^[a-zA-Z0-9\_\-\.]+@[a-zA-Z0-9\-]+(?:\.[a-zA-Z0-9\-]{2,})*(?:\.[a-zA-Z]{2,4})$");
+            this.input.setPattern("^[a-zA-Z0-9_\\\-\\\.]+@[a-zA-Z0-9\\\-]+(?:\\\.[a-zA-Z0-9\\\-]{2,})*(?:\\\.[a-zA-Z]{2,4})$");
 
             this.input.onFocus((event: FocusEvent) => {
                 this.notifyFocused(event);


### PR DESCRIPTION
…ng a user

Fixed the email regex, since we pass it as a string and all escaped symbols became unescaped. We need to keep them escaped in the final regex.