### PR TITLE
XP-4028 Publish and unpublish button states does not change in Mobile…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -125,8 +125,6 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
 
     private isSecurityWizardStepFormAllowed: boolean;
 
-    private publishButtonForMobile: api.ui.dialog.DialogButton;
-
     private inMobileViewMode: boolean;
 
     private skipValidation: boolean;
@@ -327,7 +325,8 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
             unpublishAction: this.wizardActions.getUnpublishAction(),
             showLiveEditAction: this.wizardActions.getShowLiveEditAction(),
             showFormAction: this.wizardActions.getShowFormAction(),
-            showSplitEditAction: this.wizardActions.getShowSplitEditAction()
+            showSplitEditAction: this.wizardActions.getShowSplitEditAction(),
+            publishMobileAction: this.wizardActions.getPublishMobileAction()
         });
     }
 
@@ -386,15 +385,7 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
                 console.debug("ContentWizardPanel.doRenderOnDataLoaded");
             }
 
-            new api.content.resource.GetPermittedActionsRequest().
-                addPermissionsToBeChecked(Permission.PUBLISH).
-                addContentIds(this.getPersistedItem().getContentId()).
-                sendAndParse().
-                then((allowedPermissions: Permission[]) => {
-                    if (allowedPermissions.indexOf(Permission.PUBLISH) > -1) {
-                        this.initPublishButtonForMobile();
-                    }
-                });
+            this.appendChild(this.getContentWizardToolbarPublishControls().getPublishButtonForMobile());
 
             if (this.contentType.hasContentDisplayNameScript()) {
                 this.displayNameScriptExecutor.setScript(this.contentType.getContentDisplayNameScript());
@@ -843,8 +834,6 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
 
                 publishControls.setCompareStatus(this.contentCompareStatus);
                 publishControls.setLeafContent(!this.getPersistedItem().hasChildren());
-
-                this.managePublishButtonStateForMobile(this.contentCompareStatus);
             });
 
             wizardHeader.setSimplifiedNameGeneration(persistedContent.getType().isDescendantOfMedia());
@@ -1509,48 +1498,6 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
         // case when content was moved
         this.getWizardHeader()
             .setPath(content.getPath().getParentPath().isRoot() ? "/" : content.getPath().getParentPath().toString() + "/");
-    }
-
-    private initPublishButtonForMobile() {
-        var action: api.ui.Action = new api.ui.Action("Publish");
-        action.setIconClass("publish-action");
-        action.onExecuted(() => {
-            this.wizardActions.getPublishAction().execute();
-        });
-
-        this.publishButtonForMobile = new DialogButton(action);
-        this.publishButtonForMobile.addClass("mobile-edit-publish-button");
-
-        this.subscribePublishButtonForMobileToPublishEvents();
-
-        this.appendChild(this.publishButtonForMobile);
-    }
-
-    private managePublishButtonStateForMobile(compareStatus: CompareStatus) {
-        var canBeShown = compareStatus !== CompareStatus.EQUAL;
-        this.publishButtonForMobile.toggleClass("visible", canBeShown);
-        this.publishButtonForMobile.setLabel("Publish " + api.content.CompareStatusFormatter.formatStatus(compareStatus) + " item");
-    }
-
-    private subscribePublishButtonForMobileToPublishEvents() {
-
-        var serverPublishOrUnpublishHandler = (contents: ContentSummaryAndCompareStatus[]) => {
-            contents.forEach(content => {
-                if (this.isCurrentContentId(content.getContentId())) {
-                    this.managePublishButtonStateForMobile(CompareStatus.EQUAL);
-                }
-            });
-        };
-
-
-        let serverEvents = api.content.event.ContentServerEventsHandler.getInstance();
-        serverEvents.onContentPublished(serverPublishOrUnpublishHandler);
-        serverEvents.onContentUnpublished(serverPublishOrUnpublishHandler);
-
-        this.onClosed(() => {
-            serverEvents.unContentPublished(serverPublishOrUnpublishHandler);
-            serverEvents.unContentUnpublished(serverPublishOrUnpublishHandler);
-        });
     }
 
     private openLiveEdit() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbar.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbar.ts
@@ -5,16 +5,17 @@ import CycleButton = api.ui.button.CycleButton;
 import TogglerButton = api.ui.button.TogglerButton;
 
 export interface ContentWizardToolbarParams {
-    saveAction:api.ui.Action;
-    duplicateAction:api.ui.Action;
-    deleteAction:api.ui.Action;
-    publishAction:api.ui.Action;
-    publishTreeAction:api.ui.Action;
-    unpublishAction:api.ui.Action;
-    previewAction:api.ui.Action;
-    showLiveEditAction:api.ui.Action;
-    showFormAction:api.ui.Action;
-    showSplitEditAction:api.ui.Action;
+    saveAction: api.ui.Action;
+    duplicateAction: api.ui.Action;
+    deleteAction: api.ui.Action;
+    publishAction: api.ui.Action;
+    publishTreeAction: api.ui.Action;
+    unpublishAction: api.ui.Action;
+    previewAction: api.ui.Action;
+    showLiveEditAction: api.ui.Action;
+    showFormAction: api.ui.Action;
+    showSplitEditAction: api.ui.Action;
+    publishMobileAction: api.ui.Action;
 }
 
 export class ContentWizardToolbar extends api.ui.toolbar.Toolbar {
@@ -38,7 +39,7 @@ export class ContentWizardToolbar extends api.ui.toolbar.Toolbar {
         this.contextWindowToggler = new TogglerButton("icon-cog", "Show Inspection Panel");
 
         this.contentWizardToolbarPublishControls = new ContentWizardToolbarPublishControls(
-            params.publishAction, params.publishTreeAction, params.unpublishAction
+            params.publishAction, params.publishTreeAction, params.unpublishAction, params.publishMobileAction
         );
 
         super.addElement(this.contentWizardToolbarPublishControls);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbarPublishControls.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbarPublishControls.ts
@@ -5,6 +5,7 @@ import DialogButton = api.ui.dialog.DialogButton;
 import SpanEl = api.dom.SpanEl;
 import CompareStatus = api.content.CompareStatus;
 import MenuButton = api.ui.button.MenuButton;
+import ActionButton = api.ui.button.ActionButton;
 
 export class ContentWizardToolbarPublishControls extends api.dom.DivEl {
 
@@ -12,24 +13,31 @@ export class ContentWizardToolbarPublishControls extends api.dom.DivEl {
     private publishAction: Action;
     private publishTreeAction: Action;
     private unpublishAction: Action;
+    private publishMobileAction:Action;
     private contentStateSpan: SpanEl;
     private contentCanBePublished: boolean = false;
     private userCanPublish: boolean = true;
     private leafContent: boolean = true;
     private contentCompareStatus: CompareStatus;
+    private publishButtonForMobile:ActionButton;
 
-    constructor(publish: Action, publishTree: Action, unpublish: Action) {
+    constructor(publish:Action, publishTree:Action, unpublish:Action, publishMobile:Action) {
         super("toolbar-publish-controls");
 
         this.publishAction = publish;
         this.publishAction.setIconClass("publish-action");
         this.publishTreeAction = publishTree;
         this.unpublishAction = unpublish;
+        this.publishMobileAction = publishMobile;
 
         this.publishButton = new MenuButton(publish, [publishTree, unpublish]);
         this.publishButton.addClass("content-wizard-toolbar-publish-button");
 
         this.contentStateSpan = new SpanEl("content-status");
+
+        this.publishButtonForMobile = new ActionButton(publishMobile);
+        this.publishButtonForMobile.addClass("mobile-edit-publish-button");
+        this.publishButtonForMobile.setVisible(false);
 
         this.appendChildren(this.contentStateSpan, this.publishButton);
     }
@@ -62,7 +70,7 @@ export class ContentWizardToolbarPublishControls extends api.dom.DivEl {
         }
     }
 
-    public refreshState() {
+    private refreshState() {
         let canBePublished = !this.isOnline() && this.contentCanBePublished && this.userCanPublish;
         let canTreeBePublished = !this.leafContent && this.contentCanBePublished && this.userCanPublish;
         let canBeUnpublished = this.contentCompareStatus != CompareStatus.NEW && this.contentCompareStatus != CompareStatus.UNKNOWN &&
@@ -71,8 +79,12 @@ export class ContentWizardToolbarPublishControls extends api.dom.DivEl {
         this.publishAction.setEnabled(canBePublished);
         this.publishTreeAction.setEnabled(canTreeBePublished);
         this.unpublishAction.setEnabled(canBeUnpublished);
+        this.publishMobileAction.setEnabled(canBePublished);
+        this.publishMobileAction.setVisible(canBePublished);
 
         this.contentStateSpan.setHtml(this.getContentStateValueForSpan(this.contentCompareStatus), false);
+        this.publishButtonForMobile.setLabel("Publish " + api.content.CompareStatusFormatter.formatStatus(this.contentCompareStatus) +
+            " item");
     }
 
     public isOnline(): boolean {
@@ -98,5 +110,9 @@ export class ContentWizardToolbarPublishControls extends api.dom.DivEl {
         }
         status.setHtml(api.content.CompareStatusFormatter.formatStatus(compareStatus));
         return "Item is " + status.toString();
+    }
+
+    public getPublishButtonForMobile():ActionButton {
+        return this.publishButtonForMobile;
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/action/ContentWizardActions.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/action/ContentWizardActions.ts
@@ -31,6 +31,8 @@ export class ContentWizardActions extends api.app.wizard.WizardActions<api.conte
 
     private unpublish: api.ui.Action;
 
+    private publishMobile:api.ui.Action;
+
     private preview: api.ui.Action;
 
     private showLiveEditAction: api.ui.Action;
@@ -54,7 +56,8 @@ export class ContentWizardActions extends api.app.wizard.WizardActions<api.conte
             new ShowLiveEditAction(wizardPanel),
             new ShowFormAction(wizardPanel),
             new ShowSplitEditAction(wizardPanel),
-            new SaveAndCloseAction(wizardPanel)
+            new SaveAndCloseAction(wizardPanel),
+            new PublishAction(wizardPanel)
         );
 
         this.save = this.getActions()[0];
@@ -69,6 +72,7 @@ export class ContentWizardActions extends api.app.wizard.WizardActions<api.conte
         this.showFormAction = this.getActions()[9];
         this.showSplitEditAction = this.getActions()[10];
         this.saveAndClose = this.getActions()[11];
+        this.publishMobile = this.getActions()[12];
     }
 
     enableActionsForNew() {
@@ -93,6 +97,8 @@ export class ContentWizardActions extends api.app.wizard.WizardActions<api.conte
         this.duplicate.setEnabled(!valueOn);
         this.publish.setEnabled(!valueOn);
         this.unpublish.setEnabled(!valueOn);
+        this.publishMobile.setEnabled(!valueOn);
+        this.publishMobile.setVisible(!valueOn);
 
         if (valueOn) {
             this.enableDeleteIfAllowed(content);
@@ -132,6 +138,8 @@ export class ContentWizardActions extends api.app.wizard.WizardActions<api.conte
                 this.publish.setEnabled(false);
                 this.unpublish.setEnabled(false);
                 this.publishTree.setEnabled(false);
+                this.publishMobile.setEnabled(false);
+                this.publishMobile.setVisible(false);
             } else {
                 // check if already published to show unpublish button
                 api.content.resource.ContentSummaryAndCompareStatusFetcher.fetchByContent(existing)
@@ -140,8 +148,6 @@ export class ContentWizardActions extends api.app.wizard.WizardActions<api.conte
                         var status = contentAndCompare.getCompareStatus();
                         var isPublished = status !== api.content.CompareStatus.NEW &&
                                           status != api.content.CompareStatus.UNKNOWN;
-
-                        this.unpublish.setVisible(isPublished);
                     });
             }
 
@@ -218,5 +224,9 @@ export class ContentWizardActions extends api.app.wizard.WizardActions<api.conte
 
     getShowSplitEditAction(): api.ui.Action {
         return this.showSplitEditAction;
+    }
+
+    getPublishMobileAction():api.ui.Action {
+        return this.publishMobile;
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
@@ -148,10 +148,6 @@
     }
   }
 
-  .@{_COMMON_PREFIX}button.mobile-edit-publish-button {
-    display: none;
-  }
-
   &._0-240, &._240-360, &._360-540 {
     .@{_COMMON_PREFIX}button.mobile-edit-publish-button {
       .button(@form-button-font, @admin-green, @form-button-font, lighten(@admin-green, 30%));
@@ -161,11 +157,6 @@
       height: 40px;
       width: 100%;
       opacity: 0.9;
-      display: none;
-
-      &.visible {
-        display: inherit;
-      }
 
       &.spinner {
         font-family: 'xp-admin-font-icon';
@@ -183,10 +174,14 @@
 
   &._540-720, &._720-960, &._960-1200, &._1200-1380, &._1380-1620, &._1620-1920, &._1920-Infinity {
 
+    .@{_COMMON_PREFIX}button.mobile-edit-publish-button {
+      display: none !important;
+    }
+
     .toolbar {
 
       .unpublish-button {
-        display: none;
+        display: none !important;
       }
 
       .toolbar-publish-controls {


### PR DESCRIPTION
… mode

- In order to simplify and align enabling/hiding of mobile publish button , it was moved to ContentWizardPublishControls class where mobile publish button's state is managed along with regular publish button. !NB, that mobile button is not appended to the ContentWizardPublishControls element, but to WizardPanel so that we don't need to manage their visibility separately
- Made unpublish button to be always shown in wizard panel - its state is managed via publish controls