### PR TITLE
XP-4031 Don't open the Details panel after closing the wizard on mobile

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/ContentItemPreviewPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/ContentItemPreviewPanel.ts
@@ -55,11 +55,6 @@ export class ContentItemPreviewPanel extends api.app.view.ItemPreviewPanel {
 
             try {
                 if (frameWindow) {
-                    var pathname: string = frameWindow.location.pathname;
-                    // /blank is for IE
-                    if (pathname && pathname !== 'blank' && pathname !== '/blank') {
-                        new ContentPreviewPathChangedEvent(pathname).fire();
-                    }
                     frameWindow.addEventListener("click", this.frameClickHandler.bind(this));
                 }
             } catch (reason) {}
@@ -80,6 +75,7 @@ export class ContentItemPreviewPanel extends api.app.view.ItemPreviewPanel {
                     new ContentPreviewPathChangedEvent(contentPreviewPath).fire();
                     this.showMask();
                     setTimeout(() => {
+                        this.item = null; // we don't have ref to content under contentPreviewPath and there is no point in figuring it out
                         this.skipNextSetItemCall = false;
                         this.frame.setSrc(clickedLinkRelativePath);
                     }, 500)

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/MobileContentItemStatisticsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/MobileContentItemStatisticsPanel.ts
@@ -101,8 +101,6 @@ export class MobileContentItemStatisticsPanel extends api.app.view.ItemStatistic
     setItem(item: ViewItem<ContentSummaryAndCompareStatus>) {
         if (!this.getItem() || !this.getItem().equals(item)) {
             super.setItem(item);
-            this.previewPanel.setItem(item);
-            this.detailsPanel.setItem(item ? item.getModel() : null);
             if (item) {
                 this.setName(this.makeDisplayName(item));
             }
@@ -119,6 +117,10 @@ export class MobileContentItemStatisticsPanel extends api.app.view.ItemStatistic
 
     getDetailsPanel(): DetailsPanel {
         return this.detailsPanel;
+    }
+
+    getPreviewPanel(): ContentItemPreviewPanel {
+        return this.previewPanel;
     }
 
     setName(name: string) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/NamePrettyfier.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/NamePrettyfier.ts
@@ -136,8 +136,13 @@ module api {
                 result += (replace != null ? replace : character);
             }
 
-            var normalized = (<any>result).normalize('NFD'),
-                nonAsciiCleaned = normalized.replace(this.NOT_ASCII, this.DEFAULT_REPLACE);
+            var normalized = result;
+
+            if ((<any>result).normalize) {
+                normalized = (<any>result).normalize('NFD');
+            }
+
+            var nonAsciiCleaned = normalized.replace(this.NOT_ASCII, this.DEFAULT_REPLACE);
             return nonAsciiCleaned.toLowerCase();
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/view/ItemPreviewPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/view/ItemPreviewPanel.ts
@@ -2,9 +2,9 @@ module api.app.view {
 
     export class ItemPreviewPanel extends api.ui.panel.Panel {
 
-        public frame: api.dom.IFrameEl;
+        protected frame: api.dom.IFrameEl;
 
-        public mask: api.ui.mask.LoadMask;
+        protected mask: api.ui.mask.LoadMask;
 
         constructor(className?: string) {
             super("item-preview-panel" + (className ? " " + className : ""));

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/mobile-content-item-statistics-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/mobile-content-item-statistics-panel.less
@@ -74,7 +74,6 @@
     overflow: hidden;
     display: block;
     cursor: pointer;
-    transform: rotate(180deg);
 
     .icon-trending_neutral();
   }


### PR DESCRIPTION
- Adjusted handling of grid events so that mobile panel does not get triggered too often. Also, adjusted content item preview panel to not trigger ContentPreviewPathChangedEvent too often.
- Removed normalize call for cases when its not supported in NamePrettyfier - Safari and IE do not support it
- Changed orientation of mobile statistics panel arrow