### PR TITLE
XP-3993 Inspection Panel should be closed, when 'Page Controller' was…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveFormPanel.ts
@@ -339,6 +339,11 @@ export class LiveFormPanel extends api.ui.panel.Panel {
                 }
             }
         });
+
+        this.pageModel.onReset(() => {
+            this.contextWindow.slideOut();
+            this.contentWizardPanel.getContextWindowToggler().setActive(false, true);
+        });
     }
 
     skipNextReloadConfirmation(skip: boolean) {


### PR DESCRIPTION
… removed (Automatic)

- Added pageModel.onReset listener that slides out context window  and sets toggle button state