### PR TITLE
XP-4062 HTML Editor - Changing alignment with icons in the toolbar br…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
@@ -185,8 +185,7 @@ module api.form.inputtype.text {
                 removeButtonEL.addEventListener("mouseleave", () => {
                     isMouseOverRemoveOccurenceButton = false;
                 });
-
-                    HTMLAreaHelper.updateImageAlignmentBehaviour(editor);
+                
                     this.onShown((event) => {
                         // invoke auto resize on shown in case contents have been updated while inactive
                         if (!!editor['contentAreaContainer'] || !!editor['bodyElement']) {
@@ -306,6 +305,7 @@ module api.form.inputtype.text {
             var editor = this.getEditor(editorId);
             if (editor) {
                 editor.setContent(property.hasNonNullValue() ? HTMLAreaHelper.prepareImgSrcsInValueForEdit(property.getString()) : "");
+                HTMLAreaHelper.updateImageAlignmentBehaviour(editor);
             } else {
                 console.log("Editor with id '" + editorId + "' not found")
             }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaHelper.ts
@@ -68,6 +68,7 @@ module api.util.htmlarea.editor {
 
             for (let i = 0; i < imgs.length; i++) {
                 this.changeImageParentAlignmentOnImageAlignmentChange(imgs[i]);
+                this.updateImageParentAlignment(imgs[i])
             }
         }
 
@@ -90,8 +91,10 @@ module api.util.htmlarea.editor {
             }
 
             var styleFormat = "float: {0}; margin: {1};" +
-                (HTMLAreaHelper.isImageInOriginalSize(image) ? "" : "width: {2}%;");
-            var styleAttr = "text-align: " + alignment + ";";
+                              (HTMLAreaHelper.isImageInOriginalSize(image) ? "" : "width: {2}%;"),
+                styleAttr = "";
+
+            image.parentElement.className = "";
 
             switch (alignment) {
                 case 'left':
@@ -99,8 +102,12 @@ module api.util.htmlarea.editor {
                     styleAttr = api.util.StringHelper.format(styleFormat, alignment, "15px", "40");
                     break;
                 case 'center':
-                    styleAttr = styleAttr + api.util.StringHelper.format(styleFormat, "none", "auto", "60");
+                    styleAttr = api.util.StringHelper.format(styleFormat, "none", "auto", "60");
+                    image.parentElement.classList.add(alignment);
                     break;
+            case 'justify':
+                image.parentElement.classList.add(alignment);
+                break;
             }
 
             image.parentElement.setAttribute("style", styleAttr);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
@@ -16,6 +16,10 @@
 
     &.center {
       text-align: center;
+
+      figcaption {
+        text-align: center !important;
+      }
     }
 
     &.justify {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
@@ -13,6 +13,14 @@
     -webkit-margin-before: 0;
     -moz-margin-start: 0;
     -moz-margin-end: 0;
+
+    &.center {
+      text-align: center;
+    }
+
+    &.justify {
+      text-align: justify;
+    }
   }
 
   figcaption:empty:before {


### PR DESCRIPTION
…eaks <figure> element

-Issue was in text-align in figure element, when it was used with any other style options tinymce was breaking and creating one more wrapping figure element around exisiting figure. Source of this problem is unknown, googling problem didn't help. Solved by moving text-align to css styles for 'center' and 'justify' alignment
-Fixed one more issue: after saving content it stopped reacting on alignment changes, that because of's html area images were updated and listeners were not rebind. Now update binds required alignment listeners again.