### PR TITLE
XP-4065 Details Panel is empty, when XP opened with FF

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
@@ -69,6 +69,7 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
         this.toolbar = new ContentBrowseToolbar(this.browseActions);
 
         this.defaultDockedDetailsPanel = DetailsPanel.create().setUseSplitter(false).build();
+        this.defaultDockedDetailsPanel.addClass("docked-details-panel");
 
         super({
             browseToolbar: this.toolbar,

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/DetailsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/DetailsPanel.ts
@@ -89,8 +89,8 @@ export class DetailsPanel extends api.ui.panel.Panel {
         this.onSlidedIn(() => !!this.item ? this.updateActiveWidget() : null);
 
         this.onShown(() => {
-            if (!!this.item) {
-                setTimeout(() =>  this.updateActiveWidget(), 50); // small delay so that isVisiblieOrAboutToBeVisible() check detects width change
+            if (this.isDockedPanel() && !!this.item) {
+                setTimeout(() =>  this.updateActiveWidget(), 250); // small delay so that isVisibleOrAboutToBeVisible() check detects width change
             }
         });
     }
@@ -238,7 +238,11 @@ export class DetailsPanel extends api.ui.panel.Panel {
     }
 
     public isVisibleOrAboutToBeVisible(): boolean {
-        return this.isSlidedIn() || (this.isVisible() && this.getHTMLElement().clientWidth > 0);
+        return this.isSlidedIn() || (this.isDockedPanel() && this.getHTMLElement().clientWidth > 0);
+    }
+
+    private isDockedPanel(): boolean {
+        return this.hasClass("docked-details-panel");
     }
 
     private getWidgetsInterfaceNames(): string[] {


### PR DESCRIPTION
- Docked details panel is a child of split panel that does not use slideIn/slideOut methods so in order to detect that panel is displayed we need take in account that there maybe an animation delay in split panel, hence increased timeout time a bit so docked panel width detection may work
- Added check to figure which details panel we work with