### PR TITLE
XP-4041 Toolbar is not always visible on the BrowsePanel

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
@@ -137,6 +137,9 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
             this.toolbar.appendChild(contentPublishMenuManager.getPublishMenuButton());
 
             return rendered;
+        }).catch((error) => {
+            console.error("Couldn't render ContentBrowsePanel", error);
+            return true;
         });
     }
 
@@ -175,10 +178,10 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
         contentPanelsAndDetailPanel.addClass("split-panel-with-details");
         contentPanelsAndDetailPanel.setSecondPanelSize(280, api.ui.panel.SplitPanelUnit.PIXEL);
 
-        this.appendChild(contentPanelsAndDetailPanel);
-
         nonMobileDetailsPanelsManagerBuilder.setSplitPanelWithGridAndDetails(contentPanelsAndDetailPanel);
         nonMobileDetailsPanelsManagerBuilder.setDefaultDetailsPanel(this.defaultDockedDetailsPanel);
+
+        this.appendChild(contentPanelsAndDetailPanel);
     }
 
     private initFloatingDetailsPanel(nonMobileDetailsPanelsManagerBuilder: NonMobileDetailsPanelsManagerBuilder) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowseToolbar.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowseToolbar.ts
@@ -5,7 +5,7 @@ export class ContentBrowseToolbar extends api.ui.toolbar.Toolbar {
 
     constructor(actions: ContentTreeGridActions) {
         super();
-        this.addClass("content-browse-toolbar")
+        this.addClass("content-browse-toolbar");
         this.addActions(actions.getAllActionsNoPublish());
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/BrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/BrowsePanel.ts
@@ -111,15 +111,36 @@ module api.app.browse {
 
                 if (this.filterPanel) {
                     this.gridAndToolbarPanel = new api.ui.panel.Panel();
-                    this.gridAndToolbarPanel.appendChildren<any>(this.browseToolbar, this.gridAndItemsSplitPanel);
+
+                    this.gridAndToolbarPanel.onAdded(() => {
+                        this.gridAndItemsSplitPanel.setDoOffset(true);
+                    });
 
                     this.filterAndGridSplitPanel = this.setupFilterPanel();
-                    this.appendChild(this.filterAndGridSplitPanel);
                     if (this.filterPanelIsHiddenByDefault) {
                         this.hideFilterPanel();
                     }
+                    this.appendChild(this.filterAndGridSplitPanel);
+
+                    // Hack: Places the append calls farther in the engine call stack.
+                    // Prevent toolbar and gridPanel not being visible when the width/height
+                    // is requested and elements resize/change position/etc.
+                    setTimeout(() => {
+                        this.gridAndToolbarPanel.appendChild(this.browseToolbar);
+                    });
+                    this.browseToolbar.onRendered(() => {
+                        setTimeout(() => {
+                            this.gridAndToolbarPanel.appendChild(this.gridAndItemsSplitPanel);
+                        });
+                    });
                 } else {
-                    this.appendChildren<any>(this.browseToolbar, this.gridAndItemsSplitPanel);
+                    this.appendChild(this.browseToolbar);
+                    // Hack: Same hack.
+                    this.browseToolbar.onRendered(() => {
+                        setTimeout(() => {
+                            this.appendChild(this.gridAndItemsSplitPanel)
+                        });
+                    });
                 }
                 return rendered;
             });


### PR DESCRIPTION
Resolved the rendering problem with a timeout hack, since the errors occurs only in times, when program was trying to get the height of the toolbar, that was not yet visible.
Made sure, that append calls will be placed farther in the call stack.