### PR TITLE
XP-3998 Replace three details panels with one

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
@@ -5,7 +5,10 @@ import {ContentTreeGrid} from "./ContentTreeGrid";
 import {ContentBrowseFilterPanel} from "./filter/ContentBrowseFilterPanel";
 import {ContentBrowseItemPanel} from "./ContentBrowseItemPanel";
 import {MobileContentItemStatisticsPanel} from "../view/MobileContentItemStatisticsPanel";
-import {DetailsPanel} from "../view/detail/DetailsPanel";
+import {MobileDetailsPanel} from "../view/detail/MobileDetailsSlidablePanel";
+import {FloatingDetailsPanel} from "../view/detail/FloatingDetailsPanel";
+import {DockedDetailsPanel} from "../view/detail/DockedDetailsPanel";
+import {DetailsView} from "../view/detail/DetailsView";
 import {NonMobileDetailsPanelsManager, NonMobileDetailsPanelsManagerBuilder} from "../view/detail/NonMobileDetailsPanelsManager";
 import {Router} from "../Router";
 import {ActiveDetailsPanelManager} from "../view/detail/ActiveDetailsPanelManager";
@@ -52,10 +55,6 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
 
     private mobileContentItemStatisticsPanel: MobileContentItemStatisticsPanel;
 
-    private floatingDetailsPanel: DetailsPanel;
-
-    private defaultDockedDetailsPanel: DetailsPanel;
-
     constructor() {
 
         this.contentTreeGrid = new ContentTreeGrid();
@@ -67,9 +66,6 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
         this.browseActions = <ContentTreeGridActions>this.contentTreeGrid.getContextMenu().getActions();
 
         this.toolbar = new ContentBrowseToolbar(this.browseActions);
-
-        this.defaultDockedDetailsPanel = DetailsPanel.create().setUseSplitter(false).build();
-        this.defaultDockedDetailsPanel.addClass("docked-details-panel");
 
         super({
             browseToolbar: this.toolbar,
@@ -92,8 +88,7 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
             if (event.getType() === 'updated') {
                 let browseItems = this.treeNodesToBrowseItems(event.getTreeNodes());
                 this.getBrowseItemPanel().updateItemViewers(browseItems);
-
-                this.browseActions.updateActionsEnabledState(this.getBrowseItemPanel().getItems());
+                this.browseActions.updateActionsEnabledState(this.treeNodesToBrowseItems(this.contentTreeGrid.getRoot().getFullSelection()));
             }
         });
 
@@ -111,10 +106,12 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
     doRender(): wemQ.Promise<boolean> {
         return super.doRender().then((rendered) => {
 
+            var detailsView = new DetailsView();
+
             var nonMobileDetailsPanelsManagerBuilder = NonMobileDetailsPanelsManager.create();
-            this.initSplitPanelWithDockedDetails(nonMobileDetailsPanelsManagerBuilder);
-            this.initFloatingDetailsPanel(nonMobileDetailsPanelsManagerBuilder);
-            this.initItemStatisticsPanelForMobile();
+            this.initSplitPanelWithDockedDetails(nonMobileDetailsPanelsManagerBuilder, detailsView);
+            this.initFloatingDetailsPanel(nonMobileDetailsPanelsManagerBuilder, detailsView);
+            this.initItemStatisticsPanelForMobile(detailsView);
 
             var nonMobileDetailsPanelsManager = nonMobileDetailsPanelsManagerBuilder.build();
             if (nonMobileDetailsPanelsManager.requiresCollapsedDetailsPanel()) {
@@ -148,11 +145,7 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
 
         this.getTreeGrid().onSelectionChanged((currentSelection: TreeNode<ContentSummaryAndCompareStatus>[],
                                                fullSelection: TreeNode<ContentSummaryAndCompareStatus>[]) => {
-            var browseItems: api.app.browse.BrowseItem<ContentSummaryAndCompareStatus>[] = this.treeNodesToBrowseItems(fullSelection),
-                item: api.app.browse.BrowseItem<ContentSummaryAndCompareStatus> = null;
-            if (browseItems.length > 0) {
-                item = browseItems[0];
-            }
+            var item = this.getFirstSelectedBrowseItem(fullSelection);
             this.doUpdateDetailsPanel(item ? item.getModel() : null);
         });
 
@@ -167,42 +160,45 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
                 ActiveDetailsPanelManager.setActiveDetailsPanel(this.mobileContentItemStatisticsPanel.getDetailsPanel());
             }
         });
-
     }
 
-    private initSplitPanelWithDockedDetails(nonMobileDetailsPanelsManagerBuilder: NonMobileDetailsPanelsManagerBuilder) {
+    private initSplitPanelWithDockedDetails(nonMobileDetailsPanelsManagerBuilder: NonMobileDetailsPanelsManagerBuilder,
+                                            detailsPanelView: DetailsView) {
+
+        var dockedDetailsPanel = new DockedDetailsPanel(detailsPanelView);
 
         var contentPanelsAndDetailPanel: api.ui.panel.SplitPanel = new api.ui.panel.SplitPanelBuilder(this.getFilterAndGridSplitPanel(),
-            this.defaultDockedDetailsPanel).setAlignment(api.ui.panel.SplitPanelAlignment.VERTICAL).setSecondPanelSize(280,
-            api.ui.panel.SplitPanelUnit.PIXEL).setSecondPanelMinSize(280, api.ui.panel.SplitPanelUnit.PIXEL).setAnimationDelay(
-            600).setSecondPanelShouldSlideRight(true).build();
+            dockedDetailsPanel).
+            setAlignment(api.ui.panel.SplitPanelAlignment.VERTICAL).
+            setSecondPanelSize(280, api.ui.panel.SplitPanelUnit.PIXEL).
+            setSecondPanelMinSize(280, api.ui.panel.SplitPanelUnit.PIXEL).
+            setAnimationDelay(600).
+            setSecondPanelShouldSlideRight(true).build();
 
         contentPanelsAndDetailPanel.addClass("split-panel-with-details");
         contentPanelsAndDetailPanel.setSecondPanelSize(280, api.ui.panel.SplitPanelUnit.PIXEL);
 
         nonMobileDetailsPanelsManagerBuilder.setSplitPanelWithGridAndDetails(contentPanelsAndDetailPanel);
-        nonMobileDetailsPanelsManagerBuilder.setDefaultDetailsPanel(this.defaultDockedDetailsPanel);
+        nonMobileDetailsPanelsManagerBuilder.setDefaultDetailsPanel(dockedDetailsPanel);
 
         this.appendChild(contentPanelsAndDetailPanel);
     }
 
-    private initFloatingDetailsPanel(nonMobileDetailsPanelsManagerBuilder: NonMobileDetailsPanelsManagerBuilder) {
+    private initFloatingDetailsPanel(nonMobileDetailsPanelsManagerBuilder: NonMobileDetailsPanelsManagerBuilder, detailsView: DetailsView) {
 
-        this.floatingDetailsPanel = DetailsPanel.create().build();
+        var floatingDetailsPanel = new FloatingDetailsPanel(detailsView);
 
-        this.floatingDetailsPanel.addClass("floating-details-panel");
+        nonMobileDetailsPanelsManagerBuilder.setFloatingDetailsPanel(floatingDetailsPanel);
 
-        nonMobileDetailsPanelsManagerBuilder.setFloatingDetailsPanel(this.floatingDetailsPanel);
-
-        this.appendChild(this.floatingDetailsPanel);
+        this.appendChild(floatingDetailsPanel);
     }
 
-    private initItemStatisticsPanelForMobile() {
-        this.mobileContentItemStatisticsPanel = new MobileContentItemStatisticsPanel(this.browseActions);
+    private initItemStatisticsPanelForMobile(detailsView: DetailsView) {
+        this.mobileContentItemStatisticsPanel = new MobileContentItemStatisticsPanel(this.browseActions, detailsView);
 
         let updatePreviewItem = () => {
             if (this.isSingleItemSelectedInMobileMode()) {
-                var browseItem = this.getBrowseItemPanel().getItems()[0];
+                var browseItem = this.getFirstSelectedBrowseItem();
                 new api.content.page.IsRenderableRequest(new api.content.ContentId(browseItem.getId())).sendAndParse().then(
                     (renderable: boolean) => {
                         var item: api.app.view.ViewItem<ContentSummaryAndCompareStatus> = browseItem.toViewItem();
@@ -212,9 +208,10 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
             }
         };
 
-        this.contentTreeGrid.onSelectionChanged(() => {
+        this.contentTreeGrid.onSelectionChanged((currentSelection: TreeNode<ContentSummaryAndCompareStatus>[],
+                                                 fullSelection: TreeNode<ContentSummaryAndCompareStatus>[]) => {
             if (this.isSingleItemSelectedInMobileMode()) {
-                this.updateMobilePanel();
+                this.updateMobilePanel(fullSelection);
             }
         });
 
@@ -231,13 +228,24 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
         this.appendChild(this.mobileContentItemStatisticsPanel);
     }
 
-    private updateMobilePanel() {
-        this.mobileContentItemStatisticsPanel.setItem(this.getBrowseItemPanel().getItems()[0].toViewItem());
+    private updateMobilePanel(fullSelection?: TreeNode<ContentSummaryAndCompareStatus>[]) {
+        this.mobileContentItemStatisticsPanel.setItem(this.getFirstSelectedBrowseItem(fullSelection).toViewItem());
+    }
+
+    private getFirstSelectedBrowseItem(fullSelection?: TreeNode<ContentSummaryAndCompareStatus>[]): BrowseItem<ContentSummaryAndCompareStatus> {
+        var browseItems: BrowseItem<ContentSummaryAndCompareStatus>[] = this.treeNodesToBrowseItems(!!fullSelection
+                ? fullSelection
+                : this.contentTreeGrid.getRoot().getFullSelection()),
+            item: BrowseItem<ContentSummaryAndCompareStatus> = null;
+        if (browseItems.length > 0) {
+            item = browseItems[0];
+        }
+        return item;
     }
 
     private isSingleItemSelectedInMobileMode(): boolean {
         if (ActiveDetailsPanelManager.getActiveDetailsPanel() == this.mobileContentItemStatisticsPanel.getDetailsPanel()) {
-            return this.getBrowseItemPanel().getItems().length == 1;
+            return this.getFirstSelectedBrowseItem() != null;
         }
         return false;
     }
@@ -250,8 +258,8 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
         }
     }
 
-    treeNodesToBrowseItems(nodes: TreeNode<ContentSummaryAndCompareStatus>[]): BrowseItem<ContentSummaryAndCompareStatus>[] {
-        var browseItems: BrowseItem<ContentSummaryAndCompareStatus>[] = [];
+    treeNodesToBrowseItems(nodes: TreeNode<ContentSummaryAndCompareStatus>[]): ContentBrowseItem[] {
+        var browseItems: ContentBrowseItem[] = [];
 
         // do not proceed duplicated content. still, it can be selected
         nodes.forEach((node: TreeNode<ContentSummaryAndCompareStatus>, index: number) => {
@@ -263,10 +271,12 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
             if (i === index) {
                 var data = node.getData();
                 if (!!data && !!data.getContentSummary()) {
-                    let item = new ContentBrowseItem(data).setId(data.getId()).setDisplayName(
-                        data.getContentSummary().getDisplayName()).setPath(data.getContentSummary().getPath().toString()).setIconUrl(
-                        new api.content.util.ContentIconUrlResolver().setContent(data.getContentSummary()).resolve());
-                    browseItems.push(item);
+                    let item = new ContentBrowseItem(data).
+                        setId(data.getId()).
+                        setDisplayName(data.getContentSummary().getDisplayName()).
+                        setPath(data.getContentSummary().getPath().toString()).
+                        setIconUrl(new api.content.util.ContentIconUrlResolver().setContent(data.getContentSummary()).resolve());
+                    browseItems.push(<ContentBrowseItem> item);
                 }
             }
         });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/MobileContentItemStatisticsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/MobileContentItemStatisticsPanel.ts
@@ -1,17 +1,16 @@
 import "../../api.ts";
 
-import TabMenuItemBuilder = api.ui.tab.TabMenuItemBuilder;
 import ViewItem = api.app.view.ViewItem;
-import ContentSummary = api.content.ContentSummary;
 import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
 import StringHelper = api.util.StringHelper;
 import ResponsiveManager = api.ui.responsive.ResponsiveManager;
 import ResponsiveItem = api.ui.responsive.ResponsiveItem;
-import {DetailsPanel, SLIDE_FROM} from "./detail/DetailsPanel";
+import {MobileDetailsPanel} from "./detail/MobileDetailsSlidablePanel";
 import {ContentItemPreviewPanel} from "./ContentItemPreviewPanel";
 import {MobileDetailsPanelToggleButton} from "./detail/button/MobileDetailsPanelToggleButton";
 import {MobileContentBrowseToolbar} from "../browse/MobileContentBrowseToolbar";
 import {ContentTreeGridActions} from "../browse/action/ContentTreeGridActions";
+import {DetailsView} from "./detail/DetailsView";
 
 export class MobileContentItemStatisticsPanel extends api.app.view.ItemStatisticsPanel<api.content.ContentSummaryAndCompareStatus> {
 
@@ -19,12 +18,12 @@ export class MobileContentItemStatisticsPanel extends api.app.view.ItemStatistic
     private headerLabel: api.dom.SpanEl = new api.dom.SpanEl();
 
     private previewPanel: ContentItemPreviewPanel;
-    private detailsPanel: DetailsPanel;
+    private detailsPanel: MobileDetailsPanel;
     private detailsToggleButton: MobileDetailsPanelToggleButton;
 
     private toolbar: MobileContentBrowseToolbar;
 
-    constructor(browseActions: ContentTreeGridActions) {
+    constructor(browseActions: ContentTreeGridActions, detailsView: DetailsView) {
         super("mobile-content-item-statistics-panel");
 
         this.setDoOffset(false);
@@ -33,7 +32,7 @@ export class MobileContentItemStatisticsPanel extends api.app.view.ItemStatistic
 
         this.initPreviewPanel();
 
-        this.initDetailsPanel();
+        this.initDetailsPanel(detailsView);
 
         this.initDetailsPanelToggleButton();
 
@@ -74,14 +73,8 @@ export class MobileContentItemStatisticsPanel extends api.app.view.ItemStatistic
 
     }
 
-    private initDetailsPanel() {
-        this.detailsPanel = DetailsPanel.create().
-            setUseSplitter(false).
-            setUseViewer(false).
-            setSlideFrom(SLIDE_FROM.BOTTOM).
-            setIsMobile(true).
-            build();
-        this.detailsPanel.addClass("mobile");
+    private initDetailsPanel(detailsView: DetailsView) {
+        this.detailsPanel = new MobileDetailsPanel(detailsView);
         this.appendChild(this.detailsPanel);
     }
 
@@ -101,6 +94,7 @@ export class MobileContentItemStatisticsPanel extends api.app.view.ItemStatistic
     setItem(item: ViewItem<ContentSummaryAndCompareStatus>) {
         if (!this.getItem() || !this.getItem().equals(item)) {
             super.setItem(item);
+            this.detailsPanel.setItem(!!item ? item.getModel() : null);
             if (item) {
                 this.setName(this.makeDisplayName(item));
             }
@@ -115,7 +109,7 @@ export class MobileContentItemStatisticsPanel extends api.app.view.ItemStatistic
             : item.getDisplayName();
     }
 
-    getDetailsPanel(): DetailsPanel {
+    getDetailsPanel(): MobileDetailsPanel {
         return this.detailsPanel;
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/ActiveDetailsPanelManager.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/ActiveDetailsPanelManager.ts
@@ -14,7 +14,6 @@ export class ActiveDetailsPanelManager {
         300, false);
 
     constructor() {
-
     }
 
     static setActiveDetailsPanel(detailsPanelToMakeActive: DetailsPanel) {
@@ -26,22 +25,12 @@ export class ActiveDetailsPanelManager {
     }
 
     private static doSetActiveDetailsPanel(detailsPanelToMakeActive: DetailsPanel) {
-        var activeItem: ContentSummaryAndCompareStatus = null,
-            currentlyActivePanel = ActiveDetailsPanelManager.getActiveDetailsPanel(),
-            currentlyActiveWidget: WidgetView;
-
+        var currentlyActivePanel = ActiveDetailsPanelManager.getActiveDetailsPanel();
         if (currentlyActivePanel == detailsPanelToMakeActive || !detailsPanelToMakeActive) {
             return;
-        } else if (currentlyActivePanel) {
-            activeItem = currentlyActivePanel.getItem();
-            currentlyActiveWidget = currentlyActivePanel.getActiveWidget();
         }
+
         ActiveDetailsPanelManager.activeDetailsPanel = detailsPanelToMakeActive;
-        detailsPanelToMakeActive.getCustomWidgetViewsAndUpdateDropdown().then(() => {
-            detailsPanelToMakeActive.setItem(activeItem);
-            if (currentlyActiveWidget) {
-                detailsPanelToMakeActive.setActiveWidgetWithName(currentlyActiveWidget.getWidgetName());
-            }
-        });
+        ActiveDetailsPanelManager.activeDetailsPanel.setActive();
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/DetailsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/DetailsPanel.ts
@@ -1,582 +1,70 @@
 import "../../../api.ts";
+import {DetailsView} from "./DetailsView";
 import {WidgetView} from "./WidgetView";
-import {WidgetsSelectionRow} from "./WidgetsSelectionRow";
-import {VersionsWidgetItemView} from "./widget/version/VersionsWidgetItemView";
-import {DependenciesWidgetItemView} from "./widget/dependency/DependenciesWidgetItemView";
-import {StatusWidgetItemView} from "./widget/info/StatusWidgetItemView";
-import {PropertiesWidgetItemView} from "./widget/info/PropertiesWidgetItemView";
-import {AttachmentsWidgetItemView} from "./widget/info/AttachmentsWidgetItemView";
-import {UserAccessWidgetItemView} from "./widget/info/UserAccessWidgetItemView";
-
-import ResponsiveManager = api.ui.responsive.ResponsiveManager;
-import ResponsiveItem = api.ui.responsive.ResponsiveItem;
-import ViewItem = api.app.view.ViewItem;
 import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
-import CompareStatus = api.content.CompareStatus;
-import Widget = api.content.Widget;
-import ContentSummaryViewer = api.content.ContentSummaryViewer;
 
 import ContentVersionSetEvent = api.content.event.ActiveContentVersionSetEvent;
 
 export class DetailsPanel extends api.ui.panel.Panel {
 
-    private widgetViews: WidgetView[] = [];
-    private viewer: ContentSummaryViewer;
-    private detailsContainer: api.dom.DivEl = new api.dom.DivEl("details-container");
-    private widgetsSelectionRow: WidgetsSelectionRow;
-
-    private splitter: api.dom.DivEl;
-    private ghostDragger: api.dom.DivEl;
-    private mask: api.ui.mask.DragMask;
-    private loadMask: api.ui.mask.LoadMask;
-    private divForNoSelection: api.dom.DivEl;
-
-    private actualWidth: number;
-    private minWidth: number = 280;
-    private parentMinWidth: number = 15;
-
     private sizeChangedListeners: {() : void}[] = [];
-    private slidedInListeners: {() : void}[] = [];
 
-    private item: ContentSummaryAndCompareStatus;
+    protected detailsView: DetailsView;
 
-    private useViewer: boolean;
-    private useSplitter: boolean;
-    private slideInFunction: () => void;
-    private slideOutFunction: () => void;
+    private detailsViewContainer: api.dom.DivEl;
 
-    private activeWidget: WidgetView;
-    private defaultWidgetView: WidgetView;
-
-    private alreadyFetchedCustomWidgets: boolean;
-
-    private slidedIn: boolean;
-
-    public static debug = false;
-
-    constructor(builder: Builder) {
+    constructor(detailsView: DetailsView) {
         super("details-panel");
+        this.detailsView = detailsView;
         this.setDoOffset(false);
-        this.initSlideFunctions(builder.getSlideFrom());
-        this.useSplitter = builder.isUseSplitter();
-
-        this.appendChild(this.loadMask = new api.ui.mask.LoadMask(this));
-        this.loadMask.addClass("details-panel-mask");
-
-        this.ghostDragger = new api.dom.DivEl("ghost-dragger");
-
-        if (this.useSplitter) {
-            this.splitter = new api.dom.DivEl("splitter");
-            this.appendChild(this.splitter);
-            this.onRendered(() => this.onRenderedHandler());
-        }
-
-        this.initViewer(builder.isUseViewer());
-        this.initDefaultWidgetView();
-        this.initCommonWidgetViews();
-        this.initDivForNoSelection();
-        this.initWidgetsSelectionRow();
-
-        this.appendChild(this.detailsContainer);
-        this.appendChild(this.divForNoSelection);
-
         this.subscribeOnEvents();
-
-        this.layout();
+        this.appendChild(this.detailsViewContainer = new api.dom.DivEl("details-view-container"));
     }
 
-    private subscribeOnEvents() {
-        this.onPanelSizeChanged(() => this.setDetailsContainerHeight());
-
-        this.onSlidedIn(() => !!this.item ? this.updateActiveWidget() : null);
-
-        this.onShown(() => {
-            if (this.isDockedPanel() && !!this.item) {
-                setTimeout(() =>  this.updateActiveWidget(), 250); // small delay so that isVisibleOrAboutToBeVisible() check detects width change
-            }
-        });
-
-        ContentVersionSetEvent.on((event: ContentVersionSetEvent) => {
-            if (this.isVisibleOrAboutToBeVisible() && !!this.activeWidget && this.activeWidget.getWidgetName() == "Version history") {
-                this.updateActiveWidget();
-            }
-        });
+    public setActive() {
+        this.detailsViewContainer.appendChild(this.detailsView);
     }
 
-    private initDivForNoSelection() {
-        this.divForNoSelection = new api.dom.DivEl("no-selection-message");
-        this.divForNoSelection.getEl().setInnerHtml("Select an item - and we'll show you the details!");
-        this.appendChild(this.divForNoSelection);
-    }
-
-    private initWidgetsSelectionRow() {
-        this.widgetsSelectionRow = new WidgetsSelectionRow(this);
-        this.appendChild(this.widgetsSelectionRow);
-        this.widgetsSelectionRow.updateState(this.activeWidget);
-    }
-
-    getCustomWidgetViewsAndUpdateDropdown(): wemQ.Promise<void> {
-        var deferred = wemQ.defer<void>();
-        if (!this.alreadyFetchedCustomWidgets) {
-            this.getAndInitCustomWidgetViews().done(() => {
-                this.widgetsSelectionRow.updateWidgetsDropdown(this.widgetViews);
-                this.updateActiveWidget();
-                this.alreadyFetchedCustomWidgets = true;
-                deferred.resolve(null);
-            });
-        }
-        else {
-            deferred.resolve(null);
-        }
-        return deferred.promise;
-    }
-
-    setActiveWidget(widgetView: WidgetView) {
-        if (this.activeWidget) {
-            this.activeWidget.setInactive();
-        }
-
-        this.activeWidget = widgetView;
-
-        this.widgetsSelectionRow.updateState(this.activeWidget);
-    }
-
-    getActiveWidget(): WidgetView {
-        return this.activeWidget;
-    }
-
-    setActiveWidgetWithName(value: string) {
-        if (this.activeWidget && value == this.activeWidget.getWidgetName()) {
-            return;
-        }
-
-        if (this.activeWidget) {
-            this.activeWidget.setInactive();
-        }
-
-        var widgetFound = false;
-        this.widgetViews.forEach((widgetView: WidgetView) => {
-            if (widgetView.getWidgetName() == value) {
-                widgetView.setActive();
-                widgetFound = true;
-            }
-        });
-
-        if (!widgetFound) {
-            this.activateDefaultWidget();
-        }
-    }
-
-    resetActiveWidget() {
-        this.activeWidget = null;
-    }
-
-    activateDefaultWidget() {
-        var defaultWidget = this.getDefaultWidget();
-        if (defaultWidget) {
-            defaultWidget.setActive();
-        }
-    }
-
-    isDefaultWidget(widgetView: WidgetView): boolean {
-        return widgetView == this.defaultWidgetView;
-    }
-
-    getDefaultWidget(): WidgetView {
-        return this.defaultWidgetView;
-    }
-
-    private initSlideFunctions(slideFrom: SLIDE_FROM) {
-        switch (slideFrom) {
-        case SLIDE_FROM.RIGHT:
-            this.slideInFunction = this.slideInRight;
-            this.slideOutFunction = this.slideOutRight;
-            break;
-        case SLIDE_FROM.LEFT:
-            this.slideInFunction = this.slideInLeft;
-            this.slideOutFunction = this.slideOutLeft;
-            break;
-        case SLIDE_FROM.TOP:
-            this.slideInFunction = this.slideInTop;
-            this.slideOutFunction = this.slideOutTop;
-            break;
-        case SLIDE_FROM.BOTTOM:
-            this.slideInFunction = this.slideInBottom;
-            this.slideOutFunction = this.slideOutBottom;
-            break;
-        default:
-            this.slideInFunction = this.slideInRight;
-            this.slideOutFunction = this.slideOutRight;
-        }
-    }
-
-    private initViewer(useViewer: boolean) {
-        this.useViewer = useViewer;
-
-        if (useViewer) {
-
-            this.viewer = new ContentSummaryViewer();
-            this.viewer.addClass("details-panel-label");
-
-            this.appendChild(this.viewer);
-        }
+    protected subscribeOnEvents() {
     }
 
     public setItem(item: ContentSummaryAndCompareStatus): wemQ.Promise<any> {
-        if (DetailsPanel.debug) {
-            console.debug('DetailsPanel.setItem: ', item);
-        }
-
-        if (!api.ObjectHelper.equals(item, this.item)) {
-            this.item = item;
-            if (item) {
-                this.layout(false);
-                if (this.isVisibleOrAboutToBeVisible() && !!this.activeWidget) {
-                    return this.updateActiveWidget();
-                }
-            } else {
-                this.layout();
-            }
-        }
-        return wemQ<any>(null);
-    }
-
-    getItem(): ContentSummaryAndCompareStatus {
-        return this.item;
+        return this.detailsView.setItem(item);
     }
 
     public isVisibleOrAboutToBeVisible(): boolean {
-        return this.isSlidedIn() || (this.isDockedPanel() && this.getHTMLElement().clientWidth > 0);
+        throw new Error("Must be implemented by inheritors");
     }
 
-    private isDockedPanel(): boolean {
-        return this.hasClass("docked-details-panel");
+    public getActiveWidget(): WidgetView {
+        return this.detailsView.getActiveWidget();
     }
 
-    private getWidgetsInterfaceNames(): string[] {
-        return ["com.enonic.xp.content-manager.context-widget", "contentstudio.detailpanel"];
+    getItem(): ContentSummaryAndCompareStatus {
+        return this.detailsView.getItem();
     }
 
-    private updateActiveWidget(): wemQ.Promise<any> {
-        if (DetailsPanel.debug) {
-            console.debug('DetailsPanel.updateWidgetsForItem');
-        }
-
-        if (!this.activeWidget) {
-            return wemQ<any>(null);
-        }
-
-        this.updateViewer();
-
-        this.showLoadMask();
-
-        return this.activeWidget.updateWidgetItemViews().then(() => {
-            // update active widget's height
-            this.setDetailsContainerHeight();
-            this.activeWidget.slideIn();
-        }).finally(() => this.hideLoadMask());
-    }
-
-    public showLoadMask() {
-        this.loadMask.show();
-    }
-
-    public hideLoadMask() {
-        this.loadMask.hide();
-    }
-
-    private initDefaultWidgetView() {
-        var builder = WidgetView.create()
-            .setName("Info")
-            .setDetailsPanel(this)
-            .setWidgetItemViews([
-                new StatusWidgetItemView(),
-                new UserAccessWidgetItemView(),
-                new PropertiesWidgetItemView(),
-                new AttachmentsWidgetItemView()
-            ]);
-
-        this.detailsContainer.appendChild(this.activeWidget = this.defaultWidgetView = builder.build());
-    }
-
-    private initCommonWidgetViews() {
-
-        var versionsWidgetView = WidgetView.create().setName("Version history").setDetailsPanel(this)
-            .addWidgetItemView(new VersionsWidgetItemView()).build();
-
-        var dependenciesWidgetView = WidgetView.create().setName("Dependencies").setDetailsPanel(this)
-            .addWidgetItemView(new DependenciesWidgetItemView()).build();
-
-        dependenciesWidgetView.addClass("dependency-widget");
-
-        this.addWidgets([versionsWidgetView, dependenciesWidgetView]);
-    }
-
-    private getAndInitCustomWidgetViews(): wemQ.Promise<any> {
-        var getWidgetsByInterfaceRequest = new api.content.resource.GetWidgetsByInterfaceRequest(this.getWidgetsInterfaceNames());
-
-        return getWidgetsByInterfaceRequest.sendAndParse().then((widgets: Widget[]) => {
-            widgets.forEach((widget) => {
-                var widgetView = WidgetView.create().setName(widget.getDisplayName()).setDetailsPanel(this).setWidget(widget).build();
-
-                this.addWidget(widgetView);
-            })
-        }).catch((reason: any) => {
-            if (reason && reason.message) {
-                //api.notify.showError(reason.message);
-            } else {
-                //api.notify.showError('Could not load widget descriptors.');
-            }
-        });
-    }
-
-    private onRenderedHandler() {
-        var initialPos = 0;
-        var splitterPosition = 0;
-        this.actualWidth = this.getEl().getWidth();
-        this.mask = new api.ui.mask.DragMask(this.getParentElement());
-
-        var dragListener = (e: MouseEvent) => {
-            if (this.splitterWithinBoundaries(initialPos - e.clientX)) {
-                splitterPosition = e.clientX;
-                this.ghostDragger.getEl().setLeftPx(e.clientX - this.getEl().getOffsetLeft());
-            }
-        };
-
-        this.splitter.onMouseDown((e: MouseEvent) => {
-            e.preventDefault();
-            initialPos = e.clientX;
-            splitterPosition = e.clientX;
-            this.ghostDragger.insertBeforeEl(this.splitter);
-            this.startDrag(dragListener);
-        });
-
-        this.mask.onMouseUp((e: MouseEvent) => {
-            if (this.ghostDragger.getHTMLElement().parentNode) {
-                this.actualWidth = this.getEl().getWidth() + initialPos - splitterPosition;
-                this.stopDrag(dragListener);
-                this.removeChild(this.ghostDragger);
-                ResponsiveManager.fireResizeEvent();
-            }
-        });
-    }
-
-    private setDetailsContainerHeight() {
-        var panelHeight = this.getEl().getHeight(),
-            panelOffset = this.getEl().getOffsetToParent(),
-            containerHeight = this.detailsContainer.getEl().getHeight(),
-            containerOffset = this.detailsContainer.getEl().getOffsetToParent();
-
-        if (containerOffset.top > 0 && containerHeight !== (panelHeight - panelOffset.top - containerOffset.top)) {
-            this.detailsContainer.getEl().setHeightPx(panelHeight - panelOffset.top - containerOffset.top);
-        }
-    }
-
-    private splitterWithinBoundaries(offset: number) {
-        var newWidth = this.actualWidth + offset;
-        return (newWidth >= this.minWidth) && (newWidth <= this.getParentElement().getEl().getWidth() - this.parentMinWidth);
-    }
-
-    private startDrag(dragListener: {(e: MouseEvent):void}) {
-        this.mask.show();
-        this.addClass("dragging");
-        this.mask.onMouseMove(dragListener);
-        this.ghostDragger.getEl().setLeftPx(this.splitter.getEl().getOffsetLeftRelativeToParent()).setTop(null);
-    }
-
-    private stopDrag(dragListener: {(e: MouseEvent):void}) {
-        this.getEl().setWidthPx(this.actualWidth);
-        this.removeClass("dragging");
-
-        setTimeout(() => {
-            this.notifyPanelSizeChanged();
-            this.widgetsSelectionRow.render()
-        }, 800); //delay is required due to animation time
-
-        this.mask.hide();
-        this.mask.unMouseMove(dragListener);
-    }
-
-    private addWidget(widget: WidgetView) {
-        this.widgetViews.push(widget);
-        this.detailsContainer.appendChild(widget);
-    }
-
-    private addWidgets(widgetViews: WidgetView[]) {
-        widgetViews.forEach((widget) => {
-            this.addWidget(widget);
-        })
-    }
-
-    setWidthPx(value: number) {
-        this.getEl().setWidthPx(value);
-        this.actualWidth = value;
-    }
-
-    getActualWidth(): number {
-        return this.actualWidth;
-    }
-
-    updateViewer() {
-        if (this.useViewer && this.item) {
-            this.viewer.setObject(this.item.getContentSummary());
-        }
-    }
-
-    slideIn() {
-        this.slideInFunction();
-        this.slidedIn = true;
-        this.notifySlidedIn();
-    }
-
-    slideOut() {
-        this.slideOutFunction();
-        this.slidedIn = false;
-    }
-
-    public isSlidedIn(): boolean {
-        return this.slidedIn;
-    }
-
-    public resetWidgetsWidth() {
-        this.widgetViews.forEach((widgetView: WidgetView) => {
-            widgetView.resetContainerWidth();
-        })
-    }
-
-    private layout(empty: boolean = true) {
-        if (this.widgetsSelectionRow) {
-            this.widgetsSelectionRow.setVisible(!empty);
-        }
-        if (this.viewer) {
-            this.viewer.setVisible(!empty);
-        }
-        this.detailsContainer.setVisible(!empty);
-        this.toggleClass("no-selection", empty);
-    }
-
-    protected slideInRight() {
-        this.getEl().setRightPx(0);
-    }
-
-    protected slideOutRight() {
-        this.getEl().setRightPx(-this.getEl().getWidthWithBorder());
-    }
-
-    protected slideInLeft() {
-        this.getEl().setLeftPx(0);
-    }
-
-    protected slideOutLeft() {
-        this.getEl().setLeftPx(-this.getEl().getWidthWithBorder());
-    }
-
-    protected slideInTop() {
-        this.getEl().setTopPx(36);
-    }
-
-    protected slideOutTop() {
-        this.getEl().setTopPx(-window.outerHeight);
-    }
-
-    protected slideInBottom() {
-        this.getEl().setTopPx(36);
-    }
-
-    protected slideOutBottom() {
-        this.getEl().setTopPx(window.outerHeight);
-    }
-
-    notifyPanelSizeChanged() {
+    public notifyPanelSizeChanged() {
         this.sizeChangedListeners.forEach((listener: ()=> void) => listener());
+        this.detailsView.notifyPanelSizeChanged();
     }
 
-    onPanelSizeChanged(listener: () => void) {
+    public onPanelSizeChanged(listener: () => void) {
         this.sizeChangedListeners.push(listener);
     }
 
-    notifySlidedIn() {
-        this.slidedInListeners.forEach((listener: ()=> void) => listener());
+    public getType(): DETAILS_PANEL_TYPE {
+        throw new Error("Must be implemented by inheritors");
     }
 
-    onSlidedIn(listener: () => void) {
-        this.slidedInListeners.push(listener);
-    }
-
-    static create(): Builder {
-        return new Builder();
+    public isMobile(): boolean {
+        return this.getType() == DETAILS_PANEL_TYPE.MOBILE;
     }
 }
 
-export class MobileDetailsPanel extends DetailsPanel {
+export enum DETAILS_PANEL_TYPE {
 
-    protected slideOutTop() {
-        this.getEl().setTopPx(api.BrowserHelper.isIOS() ? -window.innerHeight : -window.outerHeight);
-    }
-
-    protected slideOutBottom() {
-        this.getEl().setTopPx(api.BrowserHelper.isIOS() ? window.innerHeight : window.outerHeight);
-    }
-}
-
-export class Builder {
-
-    private useViewer: boolean = true;
-    private slideFrom: SLIDE_FROM = SLIDE_FROM.RIGHT;
-    private name: string;
-    private useSplitter: boolean = true;
-    private isMobile: boolean = false;
-
-    public setUseViewer(value: boolean): Builder {
-        this.useViewer = value;
-        return this;
-    }
-
-    public setSlideFrom(value: SLIDE_FROM): Builder {
-        this.slideFrom = value;
-        return this;
-    }
-
-    public setName(value: string): Builder {
-        this.name = value;
-        return this;
-    }
-
-    public setUseSplitter(value: boolean): Builder {
-        this.useSplitter = value;
-        return this;
-    }
-
-    public isUseViewer(): boolean {
-        return this.useViewer;
-    }
-
-    public getSlideFrom(): SLIDE_FROM {
-        return this.slideFrom;
-    }
-
-    public getName(): string {
-        return this.name;
-    }
-
-    public isUseSplitter(): boolean {
-        return this.useSplitter;
-    }
-
-    public setIsMobile(value: boolean): Builder {
-        this.isMobile = value;
-        return this;
-    }
-
-    public build(): DetailsPanel {
-        return this.isMobile ? new MobileDetailsPanel(this) : new DetailsPanel(this);
-    }
-}
-
-export enum SLIDE_FROM {
-
-    LEFT,
-    RIGHT,
-    BOTTOM,
-    TOP,
+    DOCKED,
+    FLOATING,
+    MOBILE
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/DetailsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/DetailsView.ts
@@ -1,0 +1,319 @@
+import "../../../api.ts";
+import {WidgetView} from "./WidgetView";
+import {WidgetsSelectionRow} from "./WidgetsSelectionRow";
+import {VersionsWidgetItemView} from "./widget/version/VersionsWidgetItemView";
+import {DependenciesWidgetItemView} from "./widget/dependency/DependenciesWidgetItemView";
+import {StatusWidgetItemView} from "./widget/info/StatusWidgetItemView";
+import {PropertiesWidgetItemView} from "./widget/info/PropertiesWidgetItemView";
+import {AttachmentsWidgetItemView} from "./widget/info/AttachmentsWidgetItemView";
+import {UserAccessWidgetItemView} from "./widget/info/UserAccessWidgetItemView";
+import {ActiveDetailsPanelManager} from "../../view/detail/ActiveDetailsPanelManager";
+
+import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
+import Widget = api.content.Widget;
+import ContentSummaryViewer = api.content.ContentSummaryViewer;
+
+import ContentVersionSetEvent = api.content.event.ActiveContentVersionSetEvent;
+
+export class DetailsView extends api.dom.DivEl {
+
+    private widgetViews: WidgetView[] = [];
+    private viewer: ContentSummaryViewer;
+    private detailsContainer: api.dom.DivEl = new api.dom.DivEl("details-container");
+    private widgetsSelectionRow: WidgetsSelectionRow;
+
+    private loadMask: api.ui.mask.LoadMask;
+    private divForNoSelection: api.dom.DivEl;
+
+    private item: ContentSummaryAndCompareStatus;
+
+    private activeWidget: WidgetView;
+    private defaultWidgetView: WidgetView;
+
+    private alreadyFetchedCustomWidgets: boolean;
+
+    private sizeChangedListeners: {() : void}[] = [];
+
+    public static debug = false;
+
+    constructor() {
+        super("details-panel-view");
+
+        this.appendChild(this.loadMask = new api.ui.mask.LoadMask(this));
+        this.loadMask.addClass("details-panel-mask");
+
+        this.initViewer();
+        this.initDefaultWidgetView();
+        this.initCommonWidgetViews();
+        this.initDivForNoSelection();
+        this.initWidgetsSelectionRow();
+
+        this.appendChild(this.detailsContainer);
+        this.appendChild(this.divForNoSelection);
+
+        this.subscribeOnEvents();
+
+        this.layout();
+
+        this.getCustomWidgetViewsAndUpdateDropdown();
+    }
+
+    private subscribeOnEvents() {
+        ContentVersionSetEvent.on((event: ContentVersionSetEvent) => {
+            if (ActiveDetailsPanelManager.getActiveDetailsPanel().isVisibleOrAboutToBeVisible() && !!this.activeWidget &&
+                this.activeWidget.getWidgetName() == "Version history") {
+                this.updateActiveWidget();
+            }
+        });
+    }
+
+    private initDivForNoSelection() {
+        this.divForNoSelection = new api.dom.DivEl("no-selection-message");
+        this.divForNoSelection.getEl().setInnerHtml("Select an item - and we'll show you the details!");
+        this.appendChild(this.divForNoSelection);
+    }
+
+    private initWidgetsSelectionRow() {
+        this.widgetsSelectionRow = new WidgetsSelectionRow(this);
+        this.appendChild(this.widgetsSelectionRow);
+        this.widgetsSelectionRow.updateState(this.activeWidget);
+    }
+
+    getWidgetsSelectionRow(): WidgetsSelectionRow {
+        return this.widgetsSelectionRow;
+    }
+
+    public resetWidgetsWidth() {
+        this.widgetViews.forEach((widgetView: WidgetView) => {
+            widgetView.resetContainerWidth();
+        })
+    }
+
+    getCustomWidgetViewsAndUpdateDropdown(): wemQ.Promise<void> {
+        var deferred = wemQ.defer<void>();
+        if (!this.alreadyFetchedCustomWidgets) {
+            this.getAndInitCustomWidgetViews().done(() => {
+                this.widgetsSelectionRow.updateWidgetsDropdown(this.widgetViews);
+                // this.updateActiveWidget();
+                this.alreadyFetchedCustomWidgets = true;
+                deferred.resolve(null);
+            });
+        }
+        else {
+            deferred.resolve(null);
+        }
+        return deferred.promise;
+    }
+
+    setActiveWidget(widgetView: WidgetView) {
+        if (this.activeWidget) {
+            this.activeWidget.setInactive();
+        }
+
+        this.activeWidget = widgetView;
+
+        this.widgetsSelectionRow.updateState(this.activeWidget);
+    }
+
+    getActiveWidget(): WidgetView {
+        return this.activeWidget;
+    }
+
+    /*setActiveWidgetWithName(value: string) {
+     if (this.activeWidget && value == this.activeWidget.getWidgetName()) {
+     return;
+     }
+
+     if (this.activeWidget) {
+     this.activeWidget.setInactive();
+     }
+
+     var widgetFound = false;
+     this.widgetViews.forEach((widgetView: WidgetView) => {
+     if (widgetView.getWidgetName() == value) {
+     widgetView.setActive();
+     widgetFound = true;
+     }
+     });
+
+     if (!widgetFound) {
+     this.activateDefaultWidget();
+     }
+     }*/
+
+    resetActiveWidget() {
+        this.activeWidget = null;
+    }
+
+    activateDefaultWidget() {
+        var defaultWidget = this.getDefaultWidget();
+        if (defaultWidget) {
+            defaultWidget.setActive();
+        }
+    }
+
+    isDefaultWidget(widgetView: WidgetView): boolean {
+        return widgetView == this.defaultWidgetView;
+    }
+
+    getDefaultWidget(): WidgetView {
+        return this.defaultWidgetView;
+    }
+
+    private initViewer() {
+        this.viewer = new ContentSummaryViewer();
+        this.viewer.addClass("details-panel-label");
+
+        this.appendChild(this.viewer);
+    }
+
+    public setItem(item: ContentSummaryAndCompareStatus): wemQ.Promise<any> {
+        if (DetailsView.debug) {
+            console.debug('DetailsView.setItem: ', item);
+        }
+
+        if (!api.ObjectHelper.equals(item, this.item)) {
+            this.item = item;
+            if (item) {
+                this.layout(false);
+                if (ActiveDetailsPanelManager.getActiveDetailsPanel().isVisibleOrAboutToBeVisible() && !!this.activeWidget) {
+                    return this.updateActiveWidget();
+                }
+            } else {
+                this.layout();
+            }
+        }
+        return wemQ<any>(null);
+    }
+
+    getItem(): ContentSummaryAndCompareStatus {
+        return this.item;
+    }
+
+    private getWidgetsInterfaceNames(): string[] {
+        return ["com.enonic.xp.content-manager.context-widget", "contentstudio.detailpanel"];
+    }
+
+    updateActiveWidget(): wemQ.Promise<any> {
+        if (DetailsView.debug) {
+            console.debug('DetailsView.updateWidgetsForItem');
+        }
+
+        if (!this.activeWidget) {
+            return wemQ<any>(null);
+        }
+
+        this.updateViewer();
+
+        this.showLoadMask();
+
+        return this.activeWidget.updateWidgetItemViews().then(() => {
+            // update active widget's height
+            setTimeout(() => {
+                this.setDetailsContainerHeight();
+            }, 400)
+            this.activeWidget.slideIn();
+        }).finally(() => this.hideLoadMask());
+    }
+
+    public showLoadMask() {
+        this.loadMask.show();
+    }
+
+    public hideLoadMask() {
+        this.loadMask.hide();
+    }
+
+    private initDefaultWidgetView() {
+        var builder = WidgetView.create()
+            .setName("Info")
+            .setDetailsView(this)
+            .setWidgetItemViews([
+                new StatusWidgetItemView(),
+                new UserAccessWidgetItemView(),
+                new PropertiesWidgetItemView(),
+                new AttachmentsWidgetItemView()
+            ]);
+
+        this.detailsContainer.appendChild(this.activeWidget = this.defaultWidgetView = builder.build());
+    }
+
+    private initCommonWidgetViews() {
+
+        var versionsWidgetView = WidgetView.create().setName("Version history").setDetailsView(this)
+            .addWidgetItemView(new VersionsWidgetItemView()).build();
+
+        var dependenciesWidgetView = WidgetView.create().setName("Dependencies").setDetailsView(this)
+            .addWidgetItemView(new DependenciesWidgetItemView()).build();
+
+        dependenciesWidgetView.addClass("dependency-widget");
+
+        this.addWidgets([versionsWidgetView, dependenciesWidgetView]);
+    }
+
+    private getAndInitCustomWidgetViews(): wemQ.Promise<any> {
+        var getWidgetsByInterfaceRequest = new api.content.resource.GetWidgetsByInterfaceRequest(this.getWidgetsInterfaceNames());
+
+        return getWidgetsByInterfaceRequest.sendAndParse().then((widgets: Widget[]) => {
+            widgets.forEach((widget) => {
+                var widgetView = WidgetView.create().setName(widget.getDisplayName()).setDetailsView(this).setWidget(widget).build();
+
+                this.addWidget(widgetView);
+            })
+        }).catch((reason: any) => {
+            if (reason && reason.message) {
+                api.notify.showError(reason.message);
+            } else {
+                api.notify.showError('Could not load widget descriptors.');
+            }
+        });
+    }
+
+    setDetailsContainerHeight() {
+        var panelHeight = ActiveDetailsPanelManager.getActiveDetailsPanel().getEl().getHeight(),
+            panelOffset = ActiveDetailsPanelManager.getActiveDetailsPanel().getEl().getOffsetToParent(),
+            containerHeight = this.detailsContainer.getEl().getHeight(),
+            containerOffset = this.detailsContainer.getEl().getOffsetToParent();
+
+        if (containerOffset.top > 0 && containerHeight !== (panelHeight - panelOffset.top - containerOffset.top)) {
+            this.detailsContainer.getEl().setHeightPx(panelHeight - panelOffset.top - containerOffset.top);
+        }
+    }
+
+    private addWidget(widget: WidgetView) {
+        this.widgetViews.push(widget);
+        this.detailsContainer.appendChild(widget);
+    }
+
+    private addWidgets(widgetViews: WidgetView[]) {
+        widgetViews.forEach((widget) => {
+            this.addWidget(widget);
+        })
+    }
+
+    updateViewer() {
+        if (this.item) {
+            this.viewer.setObject(this.item.getContentSummary());
+        }
+    }
+
+    private layout(empty: boolean = true) {
+        if (this.widgetsSelectionRow) {
+            this.widgetsSelectionRow.setVisible(!empty);
+        }
+        if (this.viewer) {
+            this.viewer.setVisible(!empty);
+        }
+        this.detailsContainer.setVisible(!empty);
+        this.toggleClass("no-selection", empty);
+    }
+
+    onPanelSizeChanged(listener: () => void) {
+        this.sizeChangedListeners.push(listener);
+    }
+
+    notifyPanelSizeChanged() {
+        this.sizeChangedListeners.forEach((listener: ()=> void) => listener());
+    }
+}
+

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/DockedDetailsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/DockedDetailsPanel.ts
@@ -1,0 +1,33 @@
+import "../../../api.ts";
+import {DetailsPanel, DETAILS_PANEL_TYPE} from "./DetailsPanel";
+import {DetailsView} from "./DetailsView";
+
+import ResponsiveManager = api.ui.responsive.ResponsiveManager;
+
+export class DockedDetailsPanel extends DetailsPanel {
+
+    constructor(detailsView: DetailsView) {
+        super(detailsView);
+        this.setDoOffset(false);
+        this.addClass("docked-details-panel");
+    }
+
+    protected subscribeOnEvents() {
+        this.onPanelSizeChanged(() => this.detailsView.setDetailsContainerHeight());
+
+        this.onShown(() => {
+            if (!!this.getItem()) {
+                setTimeout(() => this.detailsView.updateActiveWidget(), 250); // small delay so that isVisibleOrAboutToBeVisible() check detects width change
+            }
+        });
+    }
+
+    public isVisibleOrAboutToBeVisible(): boolean {
+        return this.getHTMLElement().clientWidth > 0;
+    }
+
+    public getType(): DETAILS_PANEL_TYPE {
+        return DETAILS_PANEL_TYPE.DOCKED;
+    }
+}
+

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/FloatingDetailsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/FloatingDetailsPanel.ts
@@ -1,0 +1,101 @@
+import "../../../api.ts";
+import {SlidablePanel, SlidablePanelBuilder} from "./SlidablePanel";
+import {DetailsView} from "./DetailsView";
+import {DETAILS_PANEL_TYPE} from "./DetailsPanel";
+
+import ResponsiveManager = api.ui.responsive.ResponsiveManager;
+
+export class FloatingDetailsPanel extends SlidablePanel {
+
+    private splitter: api.dom.DivEl;
+    private ghostDragger: api.dom.DivEl;
+    private mask: api.ui.mask.DragMask;
+
+    private minWidth: number = 280;
+    private parentMinWidth: number = 15;
+    private actualWidth: number;
+
+    constructor(detailsView: DetailsView) {
+        super(new SlidablePanelBuilder(), detailsView);
+        this.addClass("floating-details-panel");
+
+        this.splitter = new api.dom.DivEl("splitter");
+        this.ghostDragger = new api.dom.DivEl("ghost-dragger");
+
+        this.appendChild(this.splitter);
+        this.onRendered(() => this.onRenderedHandler());
+    }
+
+    private onRenderedHandler() {
+        var initialPos = 0;
+        var splitterPosition = 0;
+        this.actualWidth = this.getEl().getWidth();
+        this.mask = new api.ui.mask.DragMask(this.getParentElement());
+
+        var dragListener = (e: MouseEvent) => {
+            if (this.splitterWithinBoundaries(initialPos - e.clientX)) {
+                splitterPosition = e.clientX;
+                this.ghostDragger.getEl().setLeftPx(e.clientX - this.getEl().getOffsetLeft());
+            }
+        };
+
+        this.splitter.onMouseDown((e: MouseEvent) => {
+            e.preventDefault();
+            initialPos = e.clientX;
+            splitterPosition = e.clientX;
+            this.ghostDragger.insertBeforeEl(this.splitter);
+            this.startDrag(dragListener);
+        });
+
+        this.mask.onMouseUp((e: MouseEvent) => {
+            if (this.ghostDragger.getHTMLElement().parentNode) {
+                this.actualWidth = this.getEl().getWidth() + initialPos - splitterPosition;
+                this.stopDrag(dragListener);
+                this.removeChild(this.ghostDragger);
+                ResponsiveManager.fireResizeEvent();
+            }
+        });
+    }
+
+    public resetWidgetsWidth() {
+        this.detailsView.resetWidgetsWidth();
+    }
+
+    public setWidthPx(value: number) {
+        this.getEl().setWidthPx(value);
+        this.actualWidth = value;
+    }
+
+    public getActualWidth(): number {
+        return this.actualWidth;
+    }
+
+    private splitterWithinBoundaries(offset: number) {
+        var newWidth = this.actualWidth + offset;
+        return (newWidth >= this.minWidth) && (newWidth <= this.getParentElement().getEl().getWidth() - this.parentMinWidth);
+    }
+
+    private startDrag(dragListener: {(e: MouseEvent):void}) {
+        this.mask.show();
+        this.addClass("dragging");
+        this.mask.onMouseMove(dragListener);
+        this.ghostDragger.getEl().setLeftPx(this.splitter.getEl().getOffsetLeftRelativeToParent()).setTop(null);
+    }
+
+    private stopDrag(dragListener: {(e: MouseEvent):void}) {
+        this.getEl().setWidthPx(this.actualWidth);
+        this.removeClass("dragging");
+
+        setTimeout(() => {
+            this.notifyPanelSizeChanged();
+            this.detailsView.getWidgetsSelectionRow().render();
+        }, 800); //delay is required due to animation time
+
+        this.mask.hide();
+        this.mask.unMouseMove(dragListener);
+    }
+
+    public getType(): DETAILS_PANEL_TYPE {
+        return DETAILS_PANEL_TYPE.FLOATING;
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/MobileDetailsSlidablePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/MobileDetailsSlidablePanel.ts
@@ -1,0 +1,27 @@
+import "../../../api.ts";
+import {SlidablePanel, SlidablePanelBuilder, SLIDE_FROM} from "./SlidablePanel";
+import {DetailsView} from "./DetailsView";
+import {DETAILS_PANEL_TYPE} from "./DetailsPanel";
+
+import ResponsiveManager = api.ui.responsive.ResponsiveManager;
+
+
+export class MobileDetailsPanel extends SlidablePanel {
+
+    constructor(detailsView: DetailsView) {
+        super(new SlidablePanelBuilder().setSlideFrom(SLIDE_FROM.BOTTOM), detailsView);
+        this.addClass("mobile");
+    }
+
+    protected slideOutTop() {
+        this.getEl().setTopPx(api.BrowserHelper.isIOS() ? -window.innerHeight : -window.outerHeight);
+    }
+
+    protected slideOutBottom() {
+        this.getEl().setTopPx(api.BrowserHelper.isIOS() ? window.innerHeight : window.outerHeight);
+    }
+
+    public getType(): DETAILS_PANEL_TYPE {
+        return DETAILS_PANEL_TYPE.MOBILE;
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/NonMobileDetailsPanelsManager.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/NonMobileDetailsPanelsManager.ts
@@ -1,16 +1,17 @@
 import "../../../api.ts";
 
 import ResponsiveRanges = api.ui.responsive.ResponsiveRanges;
-import ResponsiveItem = api.ui.responsive.ResponsiveItem;
 import {DetailsPanel} from "./DetailsPanel";
+import {FloatingDetailsPanel} from "./FloatingDetailsPanel";
+import {DockedDetailsPanel} from "./DockedDetailsPanel";
 import {NonMobileDetailsPanelToggleButton} from "./button/NonMobileDetailsPanelToggleButton";
 import {ActiveDetailsPanelManager} from "./ActiveDetailsPanelManager";
 
 export class NonMobileDetailsPanelsManager {
 
     private splitPanelWithGridAndDetails: api.ui.panel.SplitPanel;
-    private defaultDockedDetailsPanel: DetailsPanel;
-    private floatingDetailsPanel: DetailsPanel;
+    private dockedDetailsPanel: DockedDetailsPanel;
+    private floatingDetailsPanel: FloatingDetailsPanel;
     private resizeEventMonitorLocked: boolean = false;
     private toggleButton: api.dom.DivEl = new NonMobileDetailsPanelToggleButton();
     private debouncedResizeHandler: () => void = api.util.AppHelper.debounce(this.doHandleResizeEvent, 300, false);
@@ -18,7 +19,7 @@ export class NonMobileDetailsPanelsManager {
     constructor(builder: NonMobileDetailsPanelsManagerBuilder) {
 
         this.splitPanelWithGridAndDetails = builder.getSplitPanelWithGridAndDetails();
-        this.defaultDockedDetailsPanel = builder.getDefaultDetailsPanel();
+        this.dockedDetailsPanel = builder.getDefaultDetailsPanel();
         this.floatingDetailsPanel = builder.getFloatingDetailsPanel();
 
         this.toggleButton.onClicked((event) => {
@@ -27,7 +28,7 @@ export class NonMobileDetailsPanelsManager {
             }
         });
 
-        this.defaultDockedDetailsPanel.onShown(() => {
+        this.dockedDetailsPanel.onShown(() => {
             this.splitPanelWithGridAndDetails.distribute();
         });
     }
@@ -42,7 +43,7 @@ export class NonMobileDetailsPanelsManager {
             if (this.needsSwitchToFloatingMode() || this.needsSwitchToDockedMode()) {
                 this.doPanelAnimation();
             } else if (!this.splitPanelWithGridAndDetails.isSecondPanelHidden()) {
-                this.defaultDockedDetailsPanel.notifyPanelSizeChanged();
+                this.dockedDetailsPanel.notifyPanelSizeChanged();
             }
             else if (this.isFloatingDetailsPanelActive()) {
                 this.floatingDetailsPanel.notifyPanelSizeChanged();
@@ -64,7 +65,7 @@ export class NonMobileDetailsPanelsManager {
     }
 
     private nonMobileDetailsPanelIsActive(): boolean {
-        return ActiveDetailsPanelManager.getActiveDetailsPanel() == this.defaultDockedDetailsPanel ||
+        return ActiveDetailsPanelManager.getActiveDetailsPanel() == this.dockedDetailsPanel ||
                ActiveDetailsPanelManager.getActiveDetailsPanel() == this.floatingDetailsPanel;
     }
 
@@ -95,10 +96,10 @@ export class NonMobileDetailsPanelsManager {
             }
 
             if (canSetActivePanel) {
-                ActiveDetailsPanelManager.setActiveDetailsPanel(this.defaultDockedDetailsPanel);
+                ActiveDetailsPanelManager.setActiveDetailsPanel(this.dockedDetailsPanel);
             }
 
-            this.defaultDockedDetailsPanel.addClass("left-bordered");
+            this.dockedDetailsPanel.addClass("left-bordered");
 
             if (this.isExpanded()) {
                 this.splitPanelWithGridAndDetails.showSecondPanel(false);
@@ -107,10 +108,10 @@ export class NonMobileDetailsPanelsManager {
             }
 
             setTimeout(() => {
-                this.defaultDockedDetailsPanel.removeClass("left-bordered");
+                this.dockedDetailsPanel.removeClass("left-bordered");
                 if (this.isExpanded()) {
                     this.splitPanelWithGridAndDetails.showSplitter();
-                    this.defaultDockedDetailsPanel.notifyPanelSizeChanged();
+                    this.dockedDetailsPanel.notifyPanelSizeChanged();
                 }
             }, 500);
         }
@@ -132,7 +133,7 @@ export class NonMobileDetailsPanelsManager {
     }
 
     getActivePanel(): DetailsPanel {
-        return this.requiresFloatingPanelDueToShortWidth() ? this.floatingDetailsPanel : this.defaultDockedDetailsPanel;
+        return this.requiresFloatingPanelDueToShortWidth() ? this.floatingDetailsPanel : this.dockedDetailsPanel;
     }
 
     private isExpanded(): boolean {
@@ -216,8 +217,8 @@ export class NonMobileDetailsPanelsManager {
 
 export class NonMobileDetailsPanelsManagerBuilder {
     private splitPanelWithGridAndDetails: api.ui.panel.SplitPanel;
-    private defaultDockedDetailsPanel: DetailsPanel;
-    private floatingDetailsPanel: DetailsPanel;
+    private dockedDetailsPanel: DockedDetailsPanel;
+    private floatingDetailsPanel: FloatingDetailsPanel;
 
     constructor() {
     }
@@ -226,11 +227,11 @@ export class NonMobileDetailsPanelsManagerBuilder {
         this.splitPanelWithGridAndDetails = splitPanelWithGridAndDetails;
     }
 
-    setDefaultDetailsPanel(defaultDockedDetailsPanel: DetailsPanel) {
-        this.defaultDockedDetailsPanel = defaultDockedDetailsPanel;
+    setDefaultDetailsPanel(dockedDetailsPanel: DockedDetailsPanel) {
+        this.dockedDetailsPanel = dockedDetailsPanel;
     }
 
-    setFloatingDetailsPanel(floatingDetailsPanel: DetailsPanel) {
+    setFloatingDetailsPanel(floatingDetailsPanel: FloatingDetailsPanel) {
         this.floatingDetailsPanel = floatingDetailsPanel;
     }
 
@@ -238,11 +239,11 @@ export class NonMobileDetailsPanelsManagerBuilder {
         return this.splitPanelWithGridAndDetails;
     }
 
-    getDefaultDetailsPanel(): DetailsPanel {
-        return this.defaultDockedDetailsPanel;
+    getDefaultDetailsPanel(): DockedDetailsPanel {
+        return this.dockedDetailsPanel;
     }
 
-    getFloatingDetailsPanel(): DetailsPanel {
+    getFloatingDetailsPanel(): FloatingDetailsPanel {
         return this.floatingDetailsPanel;
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/SlidablePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/SlidablePanel.ts
@@ -1,0 +1,130 @@
+import "../../../api.ts";
+import {DetailsPanel} from "./DetailsPanel";
+import {DetailsView} from "./DetailsView";
+
+import ContentVersionSetEvent = api.content.event.ActiveContentVersionSetEvent;
+
+export class SlidablePanel extends DetailsPanel {
+
+    private slideInFunction: () => void;
+    private slideOutFunction: () => void;
+
+    private slidedInListeners: {() : void}[];
+    private slidedIn: boolean;
+
+    constructor(builder: SlidablePanelBuilder, detailsView: DetailsView) {
+        this.slidedInListeners = [];
+        super(detailsView);
+        this.setDoOffset(false);
+        this.initSlideFunctions(builder.getSlideFrom());
+    }
+
+    protected subscribeOnEvents() {
+        this.onSlidedIn(() => !!this.getItem() ? this.detailsView.updateActiveWidget() : null);
+    }
+
+    public isVisibleOrAboutToBeVisible(): boolean {
+        return this.isSlidedIn();
+    }
+
+    slideIn() {
+        this.slideInFunction();
+        this.slidedIn = true;
+        this.notifySlidedIn();
+    }
+
+    slideOut() {
+        this.slideOutFunction();
+        this.slidedIn = false;
+    }
+
+    public isSlidedIn(): boolean {
+        return this.slidedIn;
+    }
+
+    private initSlideFunctions(slideFrom: SLIDE_FROM) {
+        switch (slideFrom) {
+        case SLIDE_FROM.RIGHT:
+            this.slideInFunction = this.slideInRight;
+            this.slideOutFunction = this.slideOutRight;
+            break;
+        case SLIDE_FROM.LEFT:
+            this.slideInFunction = this.slideInLeft;
+            this.slideOutFunction = this.slideOutLeft;
+            break;
+        case SLIDE_FROM.TOP:
+            this.slideInFunction = this.slideInTop;
+            this.slideOutFunction = this.slideOutTop;
+            break;
+        case SLIDE_FROM.BOTTOM:
+            this.slideInFunction = this.slideInBottom;
+            this.slideOutFunction = this.slideOutBottom;
+            break;
+        default:
+            this.slideInFunction = this.slideInRight;
+            this.slideOutFunction = this.slideOutRight;
+        }
+    }
+
+    protected slideInRight() {
+        this.getEl().setRightPx(0);
+    }
+
+    protected slideOutRight() {
+        this.getEl().setRightPx(-this.getEl().getWidthWithBorder());
+    }
+
+    protected slideInLeft() {
+        this.getEl().setLeftPx(0);
+    }
+
+    protected slideOutLeft() {
+        this.getEl().setLeftPx(-this.getEl().getWidthWithBorder());
+    }
+
+    protected slideInTop() {
+        this.getEl().setTopPx(36);
+    }
+
+    protected slideOutTop() {
+        this.getEl().setTopPx(-window.outerHeight);
+    }
+
+    protected slideInBottom() {
+        this.getEl().setTopPx(36);
+    }
+
+    protected slideOutBottom() {
+        this.getEl().setTopPx(window.outerHeight);
+    }
+
+    notifySlidedIn() {
+        this.slidedInListeners.forEach((listener: ()=> void) => listener());
+    }
+
+    onSlidedIn(listener: () => void) {
+        this.slidedInListeners.push(listener);
+    }
+}
+
+export class SlidablePanelBuilder {
+
+    private slideFrom: SLIDE_FROM = SLIDE_FROM.RIGHT;
+
+    public setSlideFrom(value: SLIDE_FROM): SlidablePanelBuilder {
+        this.slideFrom = value;
+        return this;
+    }
+
+    public getSlideFrom(): SLIDE_FROM {
+        return this.slideFrom;
+    }
+}
+
+export enum SLIDE_FROM {
+
+    LEFT,
+    RIGHT,
+    BOTTOM,
+    TOP,
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/WidgetView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/WidgetView.ts
@@ -4,8 +4,9 @@ import ViewItem = api.app.view.ViewItem;
 import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
 import RenderingMode = api.rendering.RenderingMode;
 import Widget = api.content.Widget;
-import {DetailsPanel} from "./DetailsPanel";
+import {DetailsView} from "./DetailsView";
 import {WidgetItemView} from "./WidgetItemView";
+import {ActiveDetailsPanelManager} from "../../view/detail/ActiveDetailsPanelManager";
 
 export class WidgetView extends api.dom.DivEl {
 
@@ -13,7 +14,7 @@ export class WidgetView extends api.dom.DivEl {
 
     private widgetItemViews: WidgetItemView[];
 
-    private detailsPanel: DetailsPanel;
+    private detailsView: DetailsView;
 
     private widget: Widget;
 
@@ -30,7 +31,7 @@ export class WidgetView extends api.dom.DivEl {
     constructor(builder: WidgetViewBuilder) {
         super("widget-view " + (builder.widget ? "external-widget" : "internal-widget"));
 
-        this.detailsPanel = builder.detailsPanel;
+        this.detailsView = builder.detailsView;
         this.widgetName = builder.name;
         this.widgetItemViews = builder.widgetItemViews;
         this.widget = builder.widget;
@@ -62,12 +63,12 @@ export class WidgetView extends api.dom.DivEl {
 
     private handleRerenderOnResize() {
         var updateWidgetItemViewsHandler = () => {
-            var containerWidth = this.detailsPanel.getEl().getWidth();
-            if (this.detailsPanel.getItem() && containerWidth !== this.containerWidth) {
+            var containerWidth = this.detailsView.getEl().getWidth();
+            if (this.detailsView.getItem() && containerWidth !== this.containerWidth) {
                 this.updateWidgetItemViews(true);
             }
         }
-        this.detailsPanel.onPanelSizeChanged(() => {
+        this.detailsView.onPanelSizeChanged(() => {
             if (this.isActive()) {
                 updateWidgetItemViewsHandler();
             } else {
@@ -85,7 +86,7 @@ export class WidgetView extends api.dom.DivEl {
     }
 
     private getFullUrl(url: string) {
-        return url + "/" + this.detailsPanel.getEl().getWidth();
+        return url + "/" + this.detailsView.getEl().getWidth();
     }
 
     private updateCustomWidgetItemViews(force: boolean = false): wemQ.Promise<any>[] {
@@ -100,11 +101,11 @@ export class WidgetView extends api.dom.DivEl {
     }
 
     public updateWidgetItemViews(force: boolean = false): wemQ.Promise<any> {
-        var content = this.detailsPanel.getItem(),
+        var content = this.detailsView.getItem(),
             promises = [];
 
         if (this.widgetShouldBeUpdated(force)) {
-            this.detailsPanel.showLoadMask();
+            this.detailsView.showLoadMask();
             this.content = content;
 
             if (this.isUrlBased()) {
@@ -116,19 +117,19 @@ export class WidgetView extends api.dom.DivEl {
             }
         }
 
-        this.containerWidth = this.detailsPanel.getEl().getWidth();
-        return wemQ.all(promises).finally(() => this.detailsPanel.hideLoadMask());
+        this.containerWidth = this.detailsView.getEl().getWidth();
+        return wemQ.all(promises).finally(() => this.detailsView.hideLoadMask());
     }
 
     private widgetShouldBeUpdated(force: boolean = false): boolean {
-        var content = this.detailsPanel.getItem();
-        return content && this.detailsPanel.isVisibleOrAboutToBeVisible() &&
+        var content = this.detailsView.getItem();
+        return content && ActiveDetailsPanelManager.getActiveDetailsPanel().isVisibleOrAboutToBeVisible() &&
                (force || !api.ObjectHelper.equals(this.content, content) || (this.isUrlBased() && this.url !== this.getWidgetUrl()));
     }
 
     private createDefaultWidgetItemView() {
         this.widgetItemViews.push(new WidgetItemView());
-        if (this.detailsPanel.getItem()) {
+        if (this.detailsView.getItem()) {
             this.updateWidgetItemViews();
         }
     }
@@ -145,24 +146,6 @@ export class WidgetView extends api.dom.DivEl {
         });
 
         return wemQ.all(layoutTasks);
-    }
-
-    private calcHeight(): number {
-        var originalHeight = this.getEl().getHeight();
-        if (originalHeight == 0) {
-            // prevent jitter if widget is collapsed
-            this.setVisible(false);
-        }
-        this.getEl().setHeight("auto");
-        var height = this.getEl().getHeight();
-        this.getEl().setHeightPx(originalHeight);
-        if (originalHeight == 0) {
-            this.setVisible(true);
-        }
-        if (WidgetView.debug) {
-            console.debug('WidgetView.calcHeight: ', height, 'originalHeight: ', originalHeight);
-        }
-        return height;
     }
 
     getWidgetName(): string {
@@ -194,7 +177,7 @@ export class WidgetView extends api.dom.DivEl {
         if (this.isActive()) {
             return;
         }
-        this.detailsPanel.setActiveWidget(this);
+        this.detailsView.setActiveWidget(this);
         this.notifyActivated();
         this.slideIn();
     }
@@ -203,12 +186,12 @@ export class WidgetView extends api.dom.DivEl {
         if (WidgetView.debug) {
             console.debug('WidgetView.setInactive: ', this.getWidgetName());
         }
-        this.detailsPanel.resetActiveWidget();
+        this.detailsView.resetActiveWidget();
         this.slideOut();
     }
 
     private isActive() {
-        return this.detailsPanel.getActiveWidget() == this;
+        return this.detailsView.getActiveWidget() == this;
     }
 
     private hasDynamicHeight(): boolean {
@@ -229,10 +212,6 @@ export class WidgetView extends api.dom.DivEl {
 
     private isUrlBased(): boolean {
         return !!this.widget && !!this.widget.getUrl();
-    }
-
-    public getDetailsPanel(): DetailsPanel {
-        return this.detailsPanel;
     }
 
     notifyActivated() {
@@ -258,7 +237,7 @@ export class WidgetViewBuilder {
 
     name: string;
 
-    detailsPanel: DetailsPanel;
+    detailsView: DetailsView;
 
     widgetItemViews: WidgetItemView[] = [];
 
@@ -269,8 +248,8 @@ export class WidgetViewBuilder {
         return this;
     }
 
-    public setDetailsPanel(detailsPanel: DetailsPanel): WidgetViewBuilder {
-        this.detailsPanel = detailsPanel;
+    public setDetailsView(detailsView: DetailsView): WidgetViewBuilder {
+        this.detailsView = detailsView;
         return this;
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/WidgetsSelectionRow.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/WidgetsSelectionRow.ts
@@ -1,6 +1,6 @@
 import "../../../api.ts";
 import {WidgetView} from "./WidgetView";
-import {DetailsPanel} from "./DetailsPanel";
+import {DetailsView} from "./DetailsView";
 import {InfoWidgetToggleButton} from "./button/InfoWidgetToggleButton";
 
 import Dropdown = api.ui.selector.dropdown.Dropdown;
@@ -10,19 +10,19 @@ import OptionSelectedEvent = api.ui.selector.OptionSelectedEvent;
 
 export class WidgetsSelectionRow extends api.dom.DivEl {
 
-    private detailsPanel: DetailsPanel;
+    private detailsView: DetailsView;
 
     private widgetSelectorDropdown: WidgetSelectorDropdown;
     private infoWidgetToggleButton: InfoWidgetToggleButton;
 
-    constructor(detailsPanel: DetailsPanel) {
+    constructor(detailsView: DetailsView) {
         super("widgets-selection-row");
 
-        this.detailsPanel = detailsPanel;
+        this.detailsView = detailsView;
 
-        this.infoWidgetToggleButton = new InfoWidgetToggleButton(detailsPanel);
+        this.infoWidgetToggleButton = new InfoWidgetToggleButton(detailsView);
 
-        this.widgetSelectorDropdown = new WidgetSelectorDropdown(detailsPanel);
+        this.widgetSelectorDropdown = new WidgetSelectorDropdown(detailsView);
         this.widgetSelectorDropdown.addClass("widget-selector");
 
         this.widgetSelectorDropdown.onOptionSelected((event: OptionSelectedEvent<WidgetViewOption>) => {
@@ -41,7 +41,7 @@ export class WidgetsSelectionRow extends api.dom.DivEl {
     }
 
     updateState(widgetView: WidgetView) {
-        if (this.detailsPanel.isDefaultWidget(widgetView)) {
+        if (this.detailsView.isDefaultWidget(widgetView)) {
             this.infoWidgetToggleButton.setActive();
             this.widgetSelectorDropdown.removeClass("non-default-selected");
         } else {
@@ -87,7 +87,7 @@ export class WidgetsSelectionRow extends api.dom.DivEl {
 
 export class WidgetSelectorDropdown extends Dropdown<WidgetViewOption> {
 
-    constructor(detailsPanel: DetailsPanel) {
+    constructor(detailsView: DetailsView) {
         super("widgetSelector", {
             disableFilter: true,
             skipExpandOnClick: true,
@@ -98,7 +98,7 @@ export class WidgetSelectorDropdown extends Dropdown<WidgetViewOption> {
             if (this.isDefaultOptionDisplayValueViewer(event.target)) {
                 if (this.getSelectedOption()) {
                     var widgetView = this.getSelectedOption().displayValue.getWidgetView();
-                    if (widgetView != detailsPanel.getActiveWidget()) {
+                    if (widgetView != detailsView.getActiveWidget()) {
                         widgetView.setActive();
                     }
                     this.hideDropdown();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/button/InfoWidgetToggleButton.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/button/InfoWidgetToggleButton.ts
@@ -1,15 +1,15 @@
 import "../../../../api.ts";
 
-import {DetailsPanel} from "../DetailsPanel";
+import {DetailsView} from "../DetailsView";
 
 export class InfoWidgetToggleButton extends api.dom.DivEl {
 
-    constructor(detailsPanel: DetailsPanel) {
+    constructor(detailsView: DetailsView) {
         super("info-widget-toggle-button");
 
         this.onClicked((event) => {
             this.setActive();
-            detailsPanel.activateDefaultWidget();
+            detailsView.activateDefaultWidget();
         });
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/button/MobileDetailsPanelToggleButton.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/button/MobileDetailsPanelToggleButton.ts
@@ -1,14 +1,14 @@
 import "../../../../api.ts";
 
-import {DetailsPanel} from "../DetailsPanel";
+import {MobileDetailsPanel} from "../MobileDetailsSlidablePanel";
 
 export class MobileDetailsPanelToggleButton extends api.dom.DivEl {
 
-    private detailsPanel: DetailsPanel;
+    private detailsPanel: MobileDetailsPanel;
 
     public static EXPANDED_CLASS: string = "expanded";
 
-    constructor(detailsPanel: DetailsPanel, slideInCallback?: () => void) {
+    constructor(detailsPanel: MobileDetailsPanel, slideInCallback?: () => void) {
         super("mobile-details-panel-toggle-button");
 
         this.detailsPanel = detailsPanel;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/detail/details-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/detail/details-panel.less
@@ -18,16 +18,18 @@
     display: none;
   }
 
-  &.no-selection {
-    .no-selection-message {
-      display: block;
+  .details-panel-view {
+    &.no-selection {
+      .no-selection-message {
+        display: block;
+      }
     }
-  }
 
-  .no-selection-message {
-    display: none;
+    .no-selection-message {
+      display: none;
 
-    .watermark-text();
+      .watermark-text();
+    }
   }
 
   .details-container {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/mobile-content-item-statistics-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/mobile-content-item-statistics-panel.less
@@ -86,6 +86,10 @@
     right: 0px;
     opacity: 0.95;
 
+    .content-summary-viewer {
+      display: none !important;
+    }
+
     > .details-container {
       left: 0px;
     }


### PR DESCRIPTION
- Separated slidable panels implementation from details view that contains widget
- Refactored details panel to separate sliding panels functionality from widgets view functionality
- Renamed DetailsPanel into DetailsView- now details view is responsible only for rendering widgets, not hiding/showing itself