### PR TITLE
XP-4137 HTML Editor: image caption aligned wrong when image is small,…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaHelper.ts
@@ -16,7 +16,7 @@ module api.util.htmlarea.editor {
                     setSize(ImageModalDialog.maxImageWidth).
                     resolve();
 
-            return "src=\"" + imageUrl + "\" data-src=\"" + imgSrc + "\"";
+            return " src=\"" + imageUrl + "\" data-src=\"" + imgSrc + "\"";
         }
 
         public static prepareImgSrcsInValueForEdit(value:string):string {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
@@ -16,10 +16,7 @@
 
     &.center {
       text-align: center;
-
-      figcaption {
-        text-align: center !important;
-      }
+      display: table;
     }
 
     &.justify {


### PR DESCRIPTION
… in original size (keepSize is true) and centered.

-Used display:table for centered image to make caption align left relative to image
-Small fix for image src attribute generation