### PR TITLE
XP-4167 Impossible to save changes and close the Wizard after an imag…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -617,6 +617,10 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
                 liveFormPanel.loadPage(false);
             }
 
+            if (content.getType().isImage()) {
+                this.updateWizard(content);
+            }
+
             return content;
         }).finally(() => {
             this.contentUpdateDisabled = false;


### PR DESCRIPTION
…e was croped

-When editing image via ImageEditor wizard is not updated, thus when pressing close button on tab hasUnsavedChanges always returns true