### PR TITLE
XP-4254 Content Studio - Slow rendering under Internet Explorer 11

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/assets/js/home/sessionExpiredDetector.js
+++ b/modules/admin/admin-ui/src/main/resources/assets/js/home/sessionExpiredDetector.js
@@ -22,8 +22,8 @@ function doPoll() {
 
 function createGetStatusRequest() {
     var xhr = new XMLHttpRequest();
-    xhr.timeout = 10000;
     xhr.open('GET', statusUrl, true);
+    xhr.timeout = 10000;
 
     return xhr;
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/main.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/main.ts
@@ -9,4 +9,6 @@ declare var Mousetrap:MousetrapStatic;
  */
 api.StyleHelper.setCurrentPrefix(api.StyleHelper.ADMIN_PREFIX);
 
-wemQ.longStackSupport = true;
+if(!api.BrowserHelper.isIE()) { // IE has slow performance if longStackSupport is true
+    wemQ.longStackSupport = true;  //seems to give more readable stacktraces from errors thrown inside a Q Promise
+}


### PR DESCRIPTION
see https://discuss.enonic.com/t/internet-explorer-support-in-admin/693

-fixed error occuring in sessionExpiredDetector, setting XMLHttpRequest.timeout should be done after open() is called on it
-performance issue in IE occured due to q promises' stacktrace handling; when option Q.longStackSupport is true then stack property of Error rejection reasons is rewritten to be traced along asynchronous jumps instead of stopping at the most recent one. This is useful for debugging but lead to somewhat-serious performance and memory overhead. OK in other browsers