### PR TITLE
XP-4143 Page Editor - Close text edit mode on a click outside

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemView.ts
@@ -87,6 +87,10 @@ module api.liveedit {
 
         private itemViewIdProducer: ItemViewIdProducer;
 
+        private static isHighlightingAllowed:boolean = true;
+
+        private static isNextClickDisabled:boolean = false;
+
         private placeholder: ItemViewPlaceholder;
 
         private type: ItemType;
@@ -279,7 +283,7 @@ module api.liveedit {
         }
 
         highlight() {
-            if (this.isViewInsideSelectedContainer()) {
+            if (!ItemView.isHighlightingAllowed || this.isViewInsideSelectedContainer()) {
                 return;
             }
             Highlighter.get().highlightItemView(this);
@@ -298,6 +302,10 @@ module api.liveedit {
         }
 
         highlightSelected() {
+            if (!ItemView.isHighlightingAllowed) {
+                return;
+            }
+            
             SelectedHighlighter.get().highlightItemView(this);
         }
 
@@ -489,8 +497,14 @@ module api.liveedit {
         }
 
         handleClick(event: MouseEvent) {
-            let rightClicked = event.which === 3;
             event.stopPropagation();
+
+            if (ItemView.isNextClickDisabled) {
+                ItemView.isNextClickDisabled = false;
+                return;
+            }
+
+            let rightClicked = event.which === 3;
 
             if (rightClicked) { // right click
                 event.preventDefault();
@@ -510,8 +524,15 @@ module api.liveedit {
                 // Also allow selecting the same component again (i.e. to show context menu)
                 if (!selectedView || selectedView == this || !isViewInsideSelectedContainer) {
                     let menuPosition = rightClicked ? null : ItemViewContextMenuPosition.NONE;
-                    //
-                    this.select(clickPosition, menuPosition, false, rightClicked);
+
+                    if (this.getPageView().isTextEditMode()) { // if in text edit mode don't select on first click
+                        this.getPageView().setTextEditMode(false);
+                        this.unhighlight();
+                    }
+                    else {
+                        this.select(clickPosition, menuPosition, false, rightClicked);
+                    }
+
                 }
                 else if (isViewInsideSelectedContainer && rightClicked) {
                     SelectedHighlighter.get().getSelectedView().showContextMenu(clickPosition);
@@ -936,6 +957,14 @@ module api.liveedit {
 
         private isViewInsideSelectedContainer() {
             return SelectedHighlighter.get().isViewInsideSelectedContainer(this);
+        }
+
+        static setHighlightingEnabled(value:boolean) {
+            ItemView.isHighlightingAllowed = value;
+        }
+
+        static setNextClickDisabled(value:boolean) {
+            ItemView.isNextClickDisabled = value;
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
@@ -455,6 +455,7 @@ module api.liveedit {
         }
 
         setTextEditMode(flag: boolean) {
+            ItemView.setHighlightingEnabled(!flag);
             this.toggleClass('text-edit-mode', flag);
 
             var textItemViews = this.getItemViewsByType(api.liveedit.text.TextItemType.get());

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
@@ -287,7 +287,12 @@ module api.liveedit.text {
 
             setTimeout(() => {
                 if (!this.anyEditorHasFocus()) {
-                    this.closePageTextEditMode();
+                    var pageView = this.getPageView();
+                    if (pageView.isTextEditMode()) {
+                        pageView.setTextEditMode(false);
+                        ItemView.setNextClickDisabled(true); // preventing mouse click event that triggered blur from further processing in ItemView
+                        setTimeout(() => ItemView.setNextClickDisabled(false), 200); // enable mouse click handling if click's target was not ItemView
+                    }
                 }
             }, 50);
         }
@@ -410,11 +415,16 @@ module api.liveedit.text {
         }
 
         private startPageTextEditMode() {
-            this.deselect();
             var pageView = this.getPageView();
+
+            if (pageView.hasSelectedView()) {
+                pageView.getSelectedView().deselect();
+            }
+
             if (!pageView.isTextEditMode()) {
                 pageView.setTextEditMode(true);
             }
+
             this.giveFocus();
         }
 


### PR DESCRIPTION
-ItemView's mouse click handler ('handleClick()')'  may be called rather before or after TextComponentView's blur event (non predicatable), so to not process first click on any ItemViews have to introduce static 'isNextClickDisabled' variable that is set to 'true' in onblur handler of TextComponentView; but blur event maybe triggered by clicking on elements different from ItemView, thus using timeout function after setting it to true and setting it to false again after some short period of time to let ItemView's click handler to be called in case blur was triggered by it, in case blur was triggered by some other event let ItemView click