### PR TITLE
XP-4312 New Content Dialog - have to click content type twice to open the Wizard (only in IE)

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/create/NewContentDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/create/NewContentDialog.ts
@@ -92,7 +92,7 @@ export class NewContentDialog extends api.ui.dialog.ModalDialog {
     private initFileInputEvents() {
         this.fileInput.onUploadStarted(this.closeAndFireEventFromMediaUpload.bind(this));
 
-        this.fileInput.onInput((event: Event) => {
+        this.fileInput.onValueChanged((event) => {
             if (api.util.StringHelper.isEmpty(this.fileInput.getValue())) {
                 this.mostPopularContentTypes.showIfNotEmpty();
             } else {


### PR DESCRIPTION
…any content type for opening a wizard page

-oninput event is triggered unexpectedly in IE on focus and blur; Replaced oninput event with onValueChanged