### PR TITLE
XP-4345 Page Component View -  menu icon not present near menu items(…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsView.ts
@@ -73,7 +73,7 @@ export class PageComponentsView extends api.dom.DivEl {
         this.header = new api.dom.H2El('header');
         this.header.setHtml('Components');
 
-        this.appendChildren(closeButton, this.header);
+        this.appendChildren(<api.dom.Element>closeButton, this.header);
 
         this.setModal(false).setFloating(true).setDraggable(true);
 
@@ -129,7 +129,7 @@ export class PageComponentsView extends api.dom.DivEl {
         this.mask.remove();
         this.mask = null;
 
-        if (this.pageView) {
+        if (this.pageView && !api.BrowserHelper.isIE()) { // Live Edit iframe changed, so old pageView object is not reachable in IE
             this.pageView.unPageLocked(this.pageLockedHandler.bind(this));
         }
     }


### PR DESCRIPTION
…only in IE)

-old pageView object was not reachable for IE after frame reload, thus when IE tried to access it error waas thrown.
