### PR TITLE
XP-4253 More robust handling of unknown item types

### DIFF
--- a/modules/core/core-schema/src/main/java/com/enonic/xp/core/impl/schema/content/ContentTypeRegistry.java
+++ b/modules/core/core-schema/src/main/java/com/enonic/xp/core/impl/schema/content/ContentTypeRegistry.java
@@ -40,7 +40,14 @@ final class ContentTypeRegistry
             return this.builtInTypes.getAll().getContentType( name );
         }
 
-        return new ContentTypeLoader( this.resourceService ).get( name );
+        try
+        {
+            return new ContentTypeLoader( this.resourceService ).get( name );
+        }
+        catch ( final Exception e )
+        {
+            return null;
+        }
     }
 
     public ContentTypes getByApplication( final ApplicationKey key )


### PR DESCRIPTION
- Added catch for get ContentTypeLoader.get() call that catches XMLException that is thrown when there is a content type in schema that is not described in schema.xsd