### PR TITLE
XP-4350 Dropdowns are misplaced in some of the modal dialogs

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorDialog.ts
@@ -103,15 +103,23 @@ module api.content.site.inputtype.siteconfigurator {
         }
 
         private handleSelectorsDropdowns(formView: FormView) {
-            var comboboxArray = [];
-            formView.getChildren().forEach((element: api.dom.Element) => {
-                this.findItemViewsAndSubscribe(element, comboboxArray);
-            });
+            var comboboxes = this.getComboboxesFromFormView(formView);
+
             this.getContentPanel().onScroll((event) => {
-                comboboxArray.forEach((comboBox: ComboBox<any>) => {
+                comboboxes.forEach((comboBox: ComboBox<any>) => {
                     comboBox.hideDropdown();
                 });
             });
+        }
+
+        private getComboboxesFromFormView(formView: FormView): ComboBox<any>[] {
+            var comboboxArray = [];
+
+            formView.getChildren().forEach((element: api.dom.Element) => {
+                this.findComboboxesInElement(element, comboboxArray);
+            });
+
+            return comboboxArray;
         }
 
         private handleDialogClose(formView: FormView) {
@@ -126,44 +134,25 @@ module api.content.site.inputtype.siteconfigurator {
             });
         }
 
-        private findItemViewsAndSubscribe(element: api.dom.Element, comboboxArray: ComboBox<any>[]) {
+        private findComboboxesInElement(element: api.dom.Element, comboboxArray: ComboBox<any>[]) {
             if (api.ObjectHelper.iFrameSafeInstanceOf(element, InputView)) {
-                this.checkItemViewAndSubscribe(<InputView> element, comboboxArray);
+                this.findComboboxInItemView(<InputView> element, comboboxArray);
             } else if (api.ObjectHelper.iFrameSafeInstanceOf(element, api.form.FieldSetView)) {
                 var fieldSetView: api.form.FieldSetView = <api.form.FieldSetView> element;
                 fieldSetView.getFormItemViews().forEach((formItemView: api.form.FormItemView) => {
-                    this.findItemViewsAndSubscribe(formItemView, comboboxArray);
+                    this.findComboboxesInElement(formItemView, comboboxArray);
                 });
             }
         }
 
-        private checkItemViewAndSubscribe(itemView: api.form.FormItemView, comboboxArray: ComboBox<any>[]) {
+        private findComboboxInItemView(itemView: api.form.FormItemView, comboboxArray: ComboBox<any>[]) {
             var inputView: InputView = <InputView> itemView;
             if (this.isContentOrImageOrPrincipalOrComboSelectorInput(inputView)) {
                 var combobox = this.getComboboxFromSelectorInputView(inputView);
                 if (!!combobox) {
                     comboboxArray.push(combobox);
                 }
-                this.subscribeCombobox(combobox);
             }
-        }
-
-        private subscribeCombobox(comboBox: ComboBox<any>) {
-            if (!!comboBox) {
-                comboBox.onExpanded((event: api.ui.selector.DropdownExpandedEvent) => {
-                    if (event.isExpanded()) {
-                        this.adjustSelectorDropDown(comboBox.getInput(), event.getDropdownElement().getEl());
-                    }
-                });
-            }
-        }
-
-        private adjustSelectorDropDown(inputElement: api.dom.Element, dropDownElement: api.dom.ElementHelper) {
-            var inputPosition = wemjq(inputElement.getHTMLElement()).offset();
-
-            dropDownElement.setMaxWidthPx(inputElement.getEl().getWidthWithBorder() - 2);
-            dropDownElement.setTopPx(inputPosition.top + inputElement.getEl().getHeightWithBorder() - 1);
-            dropDownElement.setLeftPx(inputPosition.left);
         }
 
         private getComboboxFromSelectorInputView(inputView: InputView): ComboBox<any> {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/ElementHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/ElementHelper.ts
@@ -680,7 +680,8 @@ module api.dom {
         }
 
         isScrollable(): boolean {
-            return this.el.style.overflow == "auto" || this.el.style.overflowY == "auto" || this.hasClass("slimScrollDiv");
+            return this.getComputedProperty("overflow") == "auto" || this.getComputedProperty("overflow-y") == "auto" ||
+                   this.hasClass("slimScrollDiv");
         }
 
         getComputedProperty(name: string, pseudoElement: string = null): string {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
@@ -251,11 +251,6 @@ module api.util.htmlarea.dialog {
                 loader.setAllowedContentTypeNames(contentTypeNames);
             }
 
-            contentSelectorComboBox.onExpanded((event: api.ui.selector.DropdownExpandedEvent) => {
-                this.adjustDropDown(contentSelectorComboBox.getInput(), event.getDropdownElement().getEl());
-            });
-
-
             contentSelectorComboBox.onKeyDown((e: KeyboardEvent) => {
                 if (api.ui.KeyHelper.isEscKey(e) && !contentSelectorComboBox.isDropdownShown()) {
                     // Prevent modal dialog from closing on Esc key when dropdown is expanded
@@ -274,23 +269,11 @@ module api.util.htmlarea.dialog {
                 dropDown.addOption(<Option<string>>{value: "#" + anchor, displayValue: anchor});
             });
 
-            dropDown.onExpanded((event: api.ui.selector.DropdownExpandedEvent) => {
-                this.adjustDropDown(dropDown, event.getDropdownElement().getEl());
-            });
-
             if (this.getAnchor()) {
                 dropDown.setValue(this.getAnchor());
             }
 
             return this.createFormItem("anchor", "Anchor", Validators.required, null, <api.dom.FormItemEl>dropDown);
-        }
-
-        private adjustDropDown(inputElement: api.dom.Element, dropDownElement: api.dom.ElementHelper) {
-            var inputPosition = wemjq(inputElement.getHTMLElement()).offset();
-
-            dropDownElement.setMaxWidthPx(inputElement.getEl().getWidthWithBorder());
-            dropDownElement.setTopPx(inputPosition.top + inputElement.getEl().getHeightWithBorder() - 1);
-            dropDownElement.setLeftPx(inputPosition.left);
         }
 
         private validateDockPanel(): boolean {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/application/inputtype/siteconfigurator/site-configurator.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/application/inputtype/siteconfigurator/site-configurator.less
@@ -114,12 +114,6 @@
     }
   }
 
-  .@{_COMMON_PREFIX}combobox, .content-combo-box {
-    .options-container {
-      position: fixed !important;
-    }
-  }
-
   &.masked {
 
     border: 1px solid;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/modal-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/modal-dialog.less
@@ -156,12 +156,6 @@
       margin-bottom: 0;
       padding: 0 !important;
 
-      .content-combo-box {
-        .options-container {
-          position: fixed !important;
-        }
-      }
-
       fieldset:not(:last-child) {
         margin-bottom: 5px;
       }
@@ -337,11 +331,9 @@
       margin-left: 108px;
     }
 
-
-      .options-container {
-        position: fixed !important;
-        top: auto !important;
-      }
+    .dialog-content .panel {
+      overflow: visible;
+    }
 
   }
 


### PR DESCRIPTION
-Updated and refactored Combobox to correctly find first scrollable parent
-Updated ElementHelper.isScrollable() to check computedProperty rather than inline style
-Update LinkModalDialog and SiteConfiguratorDialog to not use redundant logic that was positioning dropdown as fixed and calculating it's position; Instead rely on Combobox to position dropdown below or above depending if it fits area