### PR TITLE
XP-4357 A fragment created from an empty text-component is shown with…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsItemViewer.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsItemViewer.ts
@@ -33,7 +33,7 @@ export class PageComponentsItemViewer extends api.ui.NamesAndIconViewer<ItemView
             let fragmentComponent = fragmentView.getFragmentRootComponent();
             if (fragmentComponent) {
                 if (api.ObjectHelper.iFrameSafeInstanceOf(fragmentComponent, TextComponent)) {
-                    return this.extractTextFromTextComponent(<TextComponent>fragmentComponent);
+                    return this.extractTextFromTextComponent(<TextComponent>fragmentComponent) || fragmentComponent.getName().toString();
                 }
                 return fragmentComponent.getName().toString();
             }


### PR DESCRIPTION
… 'undefined' name in the Page Component window