### PR TITLE
XP-4359 Content Wizard - Status of published fragment won't change to modified after save

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveEditPageProxy.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveEditPageProxy.ts
@@ -47,6 +47,7 @@ import CreateHtmlAreaDialogEvent = api.util.htmlarea.dialog.CreateHtmlAreaDialog
 import LiveEditPageDialogCreatedEvent = api.liveedit.LiveEditPageDialogCreatedEvent;
 import MinimizeWizardPanelEvent = api.app.wizard.MinimizeWizardPanelEvent;
 import PageView = api.liveedit.PageView;
+import FragmentComponentReloadRequiredEvent = api.liveedit.FragmentComponentReloadRequiredEvent;
 
 export class LiveEditPageProxy {
 
@@ -111,6 +112,8 @@ export class LiveEditPageProxy {
     private liveEditPageInitErrorListeners: {(event: LiveEditPageInitializationErrorEvent): void;}[] = [];
 
     private fragmentCreatedListeners: {(event: ComponentFragmentCreatedEvent): void;}[] = [];
+
+    private fragmentLoadedListeners: {(event: FragmentComponentReloadRequiredEvent): void;}[] = [];
 
     private showWarningListeners: {(event: ShowWarningLiveEditEvent): void;}[] = [];
 
@@ -304,7 +307,7 @@ export class LiveEditPageProxy {
         new api.liveedit.SkipLiveEditReloadConfirmationEvent(skip).fire(this.liveEditWindow);
     }
 
-    public propagateContentDeletedEvent(event: api.content.event.ContentDeletedEvent) {
+    public propagateEvent(event: api.event.Event) {
         event.fire(this.liveEditWindow);
     }
 
@@ -434,6 +437,8 @@ export class LiveEditPageProxy {
 
         ComponentFragmentCreatedEvent.un(null, contextWindow);
 
+        FragmentComponentReloadRequiredEvent.un(null, contextWindow);
+
         ShowWarningLiveEditEvent.un(null, contextWindow);
 
         ComponentLoadedEvent.un(null, contextWindow);
@@ -488,6 +493,8 @@ export class LiveEditPageProxy {
         PageInspectedEvent.on(this.notifyPageInspected.bind(this), contextWindow);
 
         ComponentFragmentCreatedEvent.on(this.notifyFragmentCreated.bind(this), contextWindow);
+
+        FragmentComponentReloadRequiredEvent.on(this.notifyFragmentReloadRequired.bind(this), contextWindow);
 
         ShowWarningLiveEditEvent.on(this.notifyShowWarning.bind(this), contextWindow);
 
@@ -798,6 +805,18 @@ export class LiveEditPageProxy {
 
     private notifyFragmentCreated(event: ComponentFragmentCreatedEvent) {
         this.fragmentCreatedListeners.forEach((listener) => listener(event));
+    }
+
+    onFragmentReloadRequired(listener: {(event: FragmentComponentReloadRequiredEvent): void;}) {
+        this.fragmentLoadedListeners.push(listener);
+    }
+
+    unFragmentReloadRequired(listener: {(event: FragmentComponentReloadRequiredEvent): void;}) {
+        this.fragmentLoadedListeners = this.fragmentLoadedListeners.filter((curr) => (curr != listener));
+    }
+
+    private notifyFragmentReloadRequired(event: FragmentComponentReloadRequiredEvent) {
+        this.fragmentLoadedListeners.forEach((listener) => listener(event));
     }
 
     onShowWarning(listener: {(event: ShowWarningLiveEditEvent): void;}) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveFormPanel.ts
@@ -77,6 +77,8 @@ import Panel = api.ui.panel.Panel;
 import LiveEditPageViewReadyEvent = api.liveedit.LiveEditPageViewReadyEvent;
 
 import ContentDeletedEvent = api.content.event.ContentDeletedEvent;
+import ContentUpdatedEvent = api.content.event.ContentUpdatedEvent;
+import FragmentComponentReloadRequiredEvent = api.liveedit.FragmentComponentReloadRequiredEvent;
 
 export interface LiveFormPanelConfig {
 
@@ -357,13 +359,15 @@ export class LiveFormPanel extends api.ui.panel.Panel {
             this.contentWizardPanel.getContextWindowToggler().setActive(false, true);
         });
 
-        var contentDeletedListener = (event) => {
-            this.propagateContentDeletedEvent(event);
+        var contentEventListener = (event) => {
+            this.propagateEvent(event);
         }
 
-        ContentDeletedEvent.on(contentDeletedListener);
-        this.onRemoved((event) => {
-            ContentDeletedEvent.un(contentDeletedListener);
+        ContentDeletedEvent.on(contentEventListener);
+        ContentUpdatedEvent.on(contentEventListener);
+        this.onRemoved(() => {
+            ContentDeletedEvent.un(contentEventListener);
+            ContentUpdatedEvent.un(contentEventListener);
         });
     }
 
@@ -371,8 +375,8 @@ export class LiveFormPanel extends api.ui.panel.Panel {
         this.liveEditPageProxy.skipNextReloadConfirmation(skip);
     }
 
-    propagateContentDeletedEvent(event: api.content.event.ContentDeletedEvent) {
-        this.liveEditPageProxy.propagateContentDeletedEvent(event);
+    propagateEvent(event: api.event.Event) {
+        this.liveEditPageProxy.propagateEvent(event);
     }
 
     loadPage(clearInspection: boolean = true) {
@@ -547,6 +551,25 @@ export class LiveFormPanel extends api.ui.panel.Panel {
 
             var summaryAndStatus = api.content.ContentSummaryAndCompareStatus.fromContentSummary(event.getFragmentContent());
             new api.content.event.EditContentEvent([summaryAndStatus]).fire();
+        });
+
+        this.liveEditPageProxy.onFragmentReloadRequired((event: FragmentComponentReloadRequiredEvent) => {
+            var fragmentView = event.getFragmentComponentView();
+
+            var componentUrl = api.rendering.UriHelper.getComponentUri(this.content.getContentId().toString(),
+                fragmentView.getComponentPath(),
+                RenderingMode.EDIT,
+                api.content.Branch.DRAFT);
+
+            fragmentView.showLoadingSpinner();
+            this.liveEditPageProxy.loadComponent(fragmentView, componentUrl).then(() => {
+                // fragmentView.hideLoadingSpinner();
+            }).catch((errorMessage: any) => {
+                api.DefaultErrorHandler.handle(errorMessage);
+
+                fragmentView.hideLoadingSpinner();
+                fragmentView.showRenderingError(componentUrl, errorMessage);
+            });
         });
 
         this.liveEditPageProxy.onShowWarning((event: ShowWarningLiveEditEvent) => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/FragmentComponentReloadRequiredEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/FragmentComponentReloadRequiredEvent.ts
@@ -1,0 +1,27 @@
+module api.liveedit {
+
+    import Event = api.event.Event;
+    import FragmentComponentView = api.liveedit.fragment.FragmentComponentView;
+
+    export class FragmentComponentReloadRequiredEvent extends Event {
+
+        private fragmentComponentView: FragmentComponentView;
+
+        constructor(fragmentComponentView: FragmentComponentView) {
+            super();
+            this.fragmentComponentView = fragmentComponentView;
+        }
+
+        getFragmentComponentView(): FragmentComponentView {
+            return this.fragmentComponentView;
+        }
+
+        static on(handler: (event: FragmentComponentReloadRequiredEvent) => void, contextWindow: Window = window) {
+            Event.bind(api.ClassHelper.getFullName(this), handler, contextWindow);
+        }
+
+        static un(handler?: (event: FragmentComponentReloadRequiredEvent) => void, contextWindow: Window = window) {
+            Event.unbind(api.ClassHelper.getFullName(this), handler, contextWindow);
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/_module.ts
@@ -55,6 +55,7 @@
 ///<reference path='ComponentLoadedEvent.ts' />
 ///<reference path='FragmentComponentLoadedEvent.ts' />
 ///<reference path='FragmentLoadErrorEvent.ts' />
+///<reference path='FragmentComponentReloadRequiredEvent.ts' />
 ///<reference path='Position.ts' />
 ///<reference path='LiveEditPageViewReadyEvent.ts' />
 ///<reference path='DragAndDrop.ts' />


### PR DESCRIPTION
- Added propagation of content update event to live edit.
- Added FragmentComponentReloadRequiredEvent that liveFormPanel subscribes on in order to reload fragment upon request
- Made fragment to fire FragmentComponentReloadRequiredEvent on appropriate content update request