### PR TITLE
XP-4418 Dropdown is misplaced in site configurator- modal dialogs

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -167,7 +167,7 @@ module api.ui.selector.combobox {
         private doUpdateDropdownTopPositionAndWidth() {
 
             if (this.dropdownOverflowsBottom()) {
-                this.placeDropdownAbove()
+                this.placeDropdownAbove();
             } else {
                 this.placeDropdownBelow();
             }
@@ -235,10 +235,11 @@ module api.ui.selector.combobox {
 
         showDropdown() {
 
-            this.doUpdateDropdownTopPositionAndWidth();
-            this.notifyExpanded(true);
-
             this.comboBoxDropdown.showDropdown(this.getSelectedOptions(), this.isInputEmpty() ? this.noOptionsText : null);
+
+            this.doUpdateDropdownTopPositionAndWidth();
+
+            this.notifyExpanded(true);
 
             this.dropdownHandle.down();
 


### PR DESCRIPTION
Fixed the order of calculations
Combobox should fist adjust dropdown grid height and then position the dropdown.