### PR TITLE
XP-4413 Site Config - Validation crashes on invalid value with regexp

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionView.ts
@@ -168,6 +168,7 @@ module api.content.site.inputtype.siteconfigurator {
             formView.addClass("site-form");
 
             formView.onLayoutFinished(() => {
+                formView.displayValidationErrors(true);
                 formView.validate(false, true);
                 this.toggleClass("invalid", !formView.isValid());
                 this.notifySiteConfigFormDisplayed(this.application.getApplicationKey());

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/ValidationRecordingViewer.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/ValidationRecordingViewer.ts
@@ -9,19 +9,19 @@ module api.form {
 
         constructor() {
             super('validation-viewer');
+            this.list = new api.dom.UlEl();
         }
 
         doLayout(object: ValidationRecording) {
             super.doLayout(object);
 
-            if (!this.list) {
-                this.list = new api.dom.UlEl();
+            if (!this.list.isRendered()) {
                 this.appendChild(this.list);
             } else {
                 this.list.removeChildren();
             }
 
-            if (object) {
+            if (object && this.list.getChildren().length == 0) {
                 object.breaksMinimumOccurrencesArray.forEach((path: ValidationRecordingPath) => {
                     this.list.appendChild(this.createItemView(path, true));
                 });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/support/BaseInputTypeNotManagingAdd.ts
@@ -196,7 +196,6 @@ module api.form.inputtype.support {
             throw new Error("Must be implemented by inheritor");
         }
 
-
         onFocus(listener: (event: FocusEvent) => void) {
             this.inputOccurrences.onFocus(listener);
         }
@@ -247,8 +246,7 @@ module api.form.inputtype.support {
 
                 var valueFromPropertyArray = this.propertyArray.getValue(occurrenceView.getIndex());
                 if (valueFromPropertyArray) {
-                    var breaksRequiredContract = this.valueBreaksRequiredContract(valueFromPropertyArray);
-                    if (!breaksRequiredContract) {
+                    if (!this.valueBreaksRequiredContract(valueFromPropertyArray) && this.hasValidUserInput()) {
                         numberOfValids++;
                     }
                 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/TextLine.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/TextLine.ts
@@ -39,11 +39,9 @@ module api.form.inputtype.text {
             inputEl.setName(this.getInput().getName() + "-" + index);
 
             inputEl.onValueChanged((event: api.ValueChangedEvent) => {
-                var isValid = this.isValid(event.getNewValue(), inputEl);
-                if (isValid) {
-                    var value = ValueTypes.STRING.newValue(event.getNewValue());
-                    this.notifyOccurrenceValueChanged(inputEl, value);
-                }
+                var isValid = this.isValid(event.getNewValue(), inputEl),
+                    value = isValid ? ValueTypes.STRING.newValue(event.getNewValue()) : this.newInitialValue();
+                this.notifyOccurrenceValueChanged(inputEl, value);
                 inputEl.updateValidationStatusOnUserInput(isValid);
             });
             return inputEl;
@@ -65,10 +63,6 @@ module api.form.inputtype.text {
         }
 
         availableSizeChanged() {
-        }
-
-        private newValue(s: string): Value {
-            return new Value(s, ValueTypes.STRING);
         }
 
         valueBreaksRequiredContract(value: Value): boolean {

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateContentCommand.java
@@ -216,7 +216,7 @@ final class CreateContentCommand
             {
                 InputValidator.
                     create().
-                    contentType( contentType ).
+                    form( contentType.getForm() ).
                     inputTypeResolver( InputTypes.BUILTIN ).
                     build().
                     validate( params.getData() );

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateContentCommand.java
@@ -211,7 +211,7 @@ final class UpdateContentCommand
         {
             InputValidator.
                 create().
-                contentType( contentType ).
+                form( contentType.getForm() ).
                 inputTypeResolver( InputTypes.BUILTIN ).
                 build().
                 validate( editedContent.getData() );

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ValidateContentDataCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ValidateContentDataCommand.java
@@ -9,9 +9,12 @@ import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.content.ExtraData;
 import com.enonic.xp.content.ExtraDatas;
 import com.enonic.xp.core.impl.content.validate.DataValidationErrors;
+import com.enonic.xp.core.impl.content.validate.InputValidator;
 import com.enonic.xp.core.impl.content.validate.OccurrenceValidator;
+import com.enonic.xp.core.impl.content.validate.SiteConfigValidationError;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.form.Form;
+import com.enonic.xp.inputtype.InputTypes;
 import com.enonic.xp.schema.content.ContentType;
 import com.enonic.xp.schema.content.ContentTypeName;
 import com.enonic.xp.schema.content.ContentTypeService;
@@ -102,11 +105,30 @@ final class ValidateContentDataCommand
                         {
                             this.resultBuilder.addAll(
                                 new OccurrenceValidator( siteDescriptor.getForm() ).validate( siteConfig.getConfig().getRoot() ) );
+
+                            validateSiteForm( siteDescriptor.getForm(), siteConfig );
                         }
 
                     }
                 }
             }
+        }
+    }
+
+    private void validateSiteForm( final Form form, final SiteConfig siteConfig )
+    {
+        try
+        {
+            InputValidator.
+                create().
+                form( form ).
+                inputTypeResolver( InputTypes.BUILTIN ).
+                build().
+                validate( siteConfig.getConfig() );
+        }
+        catch ( final Exception e )
+        {
+            this.resultBuilder.add( new SiteConfigValidationError( siteConfig.getApplicationKey().getName() ) );
         }
     }
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/validate/InputValidator.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/validate/InputValidator.java
@@ -5,7 +5,6 @@ import com.google.common.base.Preconditions;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.form.Form;
 import com.enonic.xp.inputtype.InputTypeResolver;
-import com.enonic.xp.schema.content.ContentType;
 
 public final class InputValidator
 {
@@ -15,7 +14,7 @@ public final class InputValidator
 
     private InputValidator( final Builder builder )
     {
-        this.form = builder.contentType.getForm();
+        this.form = builder.form;
         this.inputTypeResolver = builder.inputTypeResolver;
     }
 
@@ -35,13 +34,13 @@ public final class InputValidator
 
     public static class Builder
     {
-        private ContentType contentType;
+        private Form form;
 
         private InputTypeResolver inputTypeResolver;
 
-        public Builder contentType( final ContentType contentType )
+        public Builder form( final Form form )
         {
-            this.contentType = contentType;
+            this.form = form;
             return this;
         }
 
@@ -53,7 +52,7 @@ public final class InputValidator
 
         private void validate()
         {
-            Preconditions.checkNotNull( this.contentType, "ContentType is required" );
+            Preconditions.checkNotNull( this.form, "Form is required" );
             Preconditions.checkNotNull( this.inputTypeResolver, "InputTypeResolver is required" );
         }
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/validate/SiteConfigValidationError.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/validate/SiteConfigValidationError.java
@@ -1,0 +1,10 @@
+package com.enonic.xp.core.impl.content.validate;
+
+public final class SiteConfigValidationError
+    extends DataValidationError
+{
+    public SiteConfigValidationError( final String appName )
+    {
+        super( null, "Data validation error in site config for {0}", appName );
+    }
+}

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/validate/InputValidatorTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/validate/InputValidatorTest.java
@@ -36,7 +36,7 @@ public class InputValidatorTest
         final ContentType contentType = createContentTypeForAllInputTypes( ContentTypeName.audioMedia() );
         this.inputValidator = InputValidator.
             create().
-            contentType( contentType ).
+            form( contentType.getForm() ).
             inputTypeResolver( InputTypes.BUILTIN ).
             build();
     }


### PR DESCRIPTION
- Made site form to display validation errors on show
- Adjusted validateOccurrences() of BaseInputTypeNotManagingAdd to check for input validity before incrementing valid inputs count
- Adjusted TextInput to notify about its change not only when input is valid - the same way other inputs do
- Fixed problem with uninitialized errors container of ValidationRecordingViewer
- Adjusted InputValidatorBuilder to accept Form instead of ContentType, so that SiteConfig and other forms may be passed for validation directly
- Added site form inputs validation in ValidateContentDataCommand
- Added test for broken input in SiteConfig