### PR TITLE
XP-4472 Error appears in the browser console, when a background image…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelector.ts
@@ -315,7 +315,7 @@ module api.content.form.inputtype.image {
 
         update(propertyArray: PropertyArray, unchangedOnly?: boolean): wemQ.Promise<void> {
             return super.update(propertyArray, unchangedOnly).then(() => {
-                if (!unchangedOnly || !this.contentComboBox.isDirty()) {
+                if ((!unchangedOnly || !this.contentComboBox.isDirty()) && this.contentComboBox.isRendered()) {
                     this.contentComboBox.setValue(this.getValueFromPropertyArray(propertyArray));
                 }
             });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorSelectedOptionView.ts
@@ -63,7 +63,6 @@ module api.content.site.inputtype.siteconfigurator {
             };
 
             this.formView = this.createFormView(this.siteConfig);
-            this.formView.layout();
 
             if (this.application.getForm().getFormItems().length > 0) {
                 header.appendChild(this.createEditButton());


### PR DESCRIPTION
… was selected in the SiteConfigurator dialog

- When user pressed save, an update for all site dialog inputs was triggered, including image selector, but to the moment when it reached imageselector's combobox setValue() (due to a few asynch calls)  a dialog had already been removed, causing doRender() method to be not reached in ImageSelectorSelectedOptionView...
- ... hence, adjusted update() method of ImageSelector to check if underlying combobox is rendered before calling its setValue()
- in SiteConfiguratorSelectedOptionView removed formView.layout() from doRender() as given form view refers to view that is shown in the Site Dialog, which is triggered by edit button, that in turns calls formview.layout()