### PR TITLE
XP-4447 Manually uploaded content isn't sorted correctly

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentTreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentTreeGrid.ts
@@ -491,20 +491,25 @@ export class ContentTreeGrid extends TreeGrid<ContentSummaryAndCompareStatus> {
 
     }
 
-    appendContentNodes(relationships: TreeNodeParentOfContent[],
-                       update: boolean = true): wemQ.Promise<any> {
+    appendContentNodes(relationships: TreeNodeParentOfContent[]): wemQ.Promise<TreeNode<ContentSummaryAndCompareStatus>[]> {
 
-        var parallelPromises: wemQ.Promise<any>[] = [];
+        var deferred = wemQ.defer<TreeNode<ContentSummaryAndCompareStatus>[]>(),
+            parallelPromises: wemQ.Promise<TreeNode<ContentSummaryAndCompareStatus>[]>[] = [],
+            result: TreeNode<ContentSummaryAndCompareStatus>[] = [];
 
         relationships.forEach((relationship) => {
             parallelPromises.push(this.fetchChildrenIds(relationship.getNode()).then((contentIds: ContentId[]) => {
                 relationship.getChildren().forEach((content: ContentSummaryAndCompareStatus) => {
-                    this.appendContentNode(relationship.getNode(), content, contentIds.indexOf(content.getContentId()), false);
+                    result.push(this.appendContentNode(relationship.getNode(), content, contentIds.indexOf(content.getContentId()), false));
                 })
+                return result;
             }));
         });
 
-        return wemQ.allSettled(parallelPromises);
+        wemQ.all(parallelPromises).then(() => {
+            deferred.resolve(result);
+        });
+        return deferred.promise;
     }
 
     placeContentNode(parent: TreeNode<ContentSummaryAndCompareStatus>,


### PR DESCRIPTION
- Adjusted appendContentNodes() method of ContentTreeGrid so that it returns all appended nodes upon resolving parallel promises
- Refactored processContentCreated() method  - removed redundant checks and variables, added call to placeContentNodes so that  created or moved contents are inserted into right place in a grid