### PR TITLE
XP-4482 Content Wizard toolbar - Fix menu overflow and alignment of the help-text icon

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardPanel.ts
@@ -773,11 +773,11 @@ module api.app.wizard {
         }
 
         showMinimizeEditButton() {
-            this.minimizeEditButton.show();
+            this.addClass("wizard-panel--live");
         }
 
         hideMinimizeEditButton() {
-            this.minimizeEditButton.hide();
+            this.removeClass("wizard-panel--live");
         }
 
         private createSplitPanel(firstPanel: api.ui.panel.Panel, secondPanel: api.ui.panel.Panel): api.ui.panel.SplitPanel {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardPanel.ts
@@ -479,30 +479,45 @@ module api.app.wizard {
         }
 
         updateStickyToolbar() {
-            var scrollTop = this.formPanel.getHTMLElement().scrollTop;
-            var wizardHeaderHeight = this.getWizardHeader().getEl().getHeightWithMargin();
-            var navigationWidth;
-            let mainToolbar = this.getMainToolbar();
-            if (scrollTop > wizardHeaderHeight) {
+            const scrollTop = this.formPanel.getHTMLElement().scrollTop;
+            const wizardNavigatorHeight = this.stepNavigatorAndToolbarContainer.getEl().getHeightWithBorder();
+
+            const stickyHeight = this.getWizardHeader().getEl().getHeightWithMargin();
+            // Height, when navigator soon to become sticky
+            // Can be used to update the position of the elements in it
+            const preStickyHeight = stickyHeight - wizardNavigatorHeight;
+
+            const mainToolbar = this.getMainToolbar();
+
+            if (scrollTop > stickyHeight) {
                 mainToolbar.removeClass("scroll-shadow");
-                var stepNavigatorEl = this.stepNavigatorAndToolbarContainer.getEl().addClass("scroll-stick");
+                this.stepNavigatorAndToolbarContainer.addClass("scroll-stick");
                 if (!this.stepNavigatorPlaceholder) {
+                    const stepNavigatorEl = this.stepNavigatorAndToolbarContainer.getEl();
                     this.stepNavigatorPlaceholder = new api.dom.DivEl('toolbar-placeholder');
                     this.stepNavigatorPlaceholder.insertAfterEl(this.stepNavigatorAndToolbarContainer);
                     this.stepNavigatorPlaceholder.getEl().setWidthPx(stepNavigatorEl.getWidth()).setHeightPx(stepNavigatorEl.getHeight());
                 }
-            } else if (scrollTop < wizardHeaderHeight) {
+            } else if (scrollTop < stickyHeight) {
                 mainToolbar.addClass("scroll-shadow");
                 this.stepNavigatorAndToolbarContainer.removeClass("scroll-stick");
                 if (this.stepNavigatorPlaceholder) {
                     this.stepNavigatorPlaceholder.remove();
-                    this.stepNavigatorPlaceholder = undefined;
+                    this.stepNavigatorPlaceholder = null;
                 }
             }
+
+            if (scrollTop > preStickyHeight) {
+                this.stepNavigatorAndToolbarContainer.addClass("pre-scroll-stick");
+            } else if (scrollTop < preStickyHeight) {
+                this.stepNavigatorAndToolbarContainer.removeClass("pre-scroll-stick");
+            }
+
             if (scrollTop == 0) {
                 mainToolbar.removeClass("scroll-shadow");
             }
 
+            let navigationWidth;
             if (this.minimized) {
                 navigationWidth = this.splitPanel.getEl().getHeight();
             } else {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
@@ -13,7 +13,7 @@
 
     .wizard-step-navigator-and-toolbar.pre-scroll-stick {
       .help-text-button {
-        margin-right: 41px;
+        margin: 0 41px 0 0;
       }
     }
   }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
@@ -11,8 +11,10 @@
       display: block;
     }
 
-    .wizard-step-navigator-and-toolbar .help-text-button {
-      margin-right: 40px;
+    .wizard-step-navigator-and-toolbar.pre-scroll-stick {
+      .help-text-button {
+        margin-right: 40px;
+      }
     }
   }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
@@ -10,6 +10,10 @@
     .split-panel .minimize-edit {
       display: block;
     }
+
+    .wizard-step-navigator-and-toolbar .help-text-button {
+      margin-right: 40px;
+    }
   }
 
   .toolbar {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
@@ -13,7 +13,7 @@
 
     .wizard-step-navigator-and-toolbar.pre-scroll-stick {
       .help-text-button {
-        margin-right: 40px;
+        margin-right: 41px;
       }
     }
   }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-panel.less
@@ -6,6 +6,12 @@
     .opacity(.8);
   }
 
+  &--live {
+    .split-panel .minimize-edit {
+      display: block;
+    }
+  }
+
   .toolbar {
     border-bottom: 1px solid @admin-medium-gray-border;
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
@@ -118,13 +118,15 @@
   }
 
   .help-text-button {
-    display: inline-block;
-    width: 56px;
+    display: inline-flex;
+    align-items: center;
+    height: 40px;
+    margin-right: 15px;
+    float: right;
+    vertical-align: top;
     overflow: hidden;
     z-index: @z-index-mask - 1;
     cursor: pointer;
-    vertical-align: top;
-    margin-top: 9px;
 
 
     &:after {
@@ -154,13 +156,5 @@
 ._0-240, ._240-360, ._360-540, ._540-720, ._720-960 {
   .wizard-step-navigator-and-toolbar {
     padding-left: 0;
-  }
-}
-
-.form-panel {
-  &._0-240, &._240-360, &._360-540 {
-    .help-text-button {
-      width: 45px;
-    }
   }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
@@ -123,7 +123,7 @@
     overflow: hidden;
     z-index: @z-index-mask - 1;
     cursor: pointer;
-
+    transition: 0.3s;
 
     &:after {
       display: block;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
@@ -116,8 +116,10 @@
   .help-text-button {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
+    width: 30px;
     height: 40px;
-    margin-right: 15px;
+    margin-right: 7px;
     float: right;
     vertical-align: top;
     overflow: hidden;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
@@ -60,9 +60,10 @@
 
     .@{_COMMON_PREFIX}dropdown {
       margin-top: 32px;
-      width: 180px;
+      max-width: 180px;
 
       .wizard-step-navigator {
+        width: initial;
         margin-bottom: 0;
         padding-right: 0;
         background-color: @admin-white;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
@@ -13,10 +13,6 @@
     .fold-button {
       display: inline-block;
     }
-    .help-text-button {
-      position: absolute;
-      left: 730px;
-    }
   }
 
   .toolbar {
@@ -121,7 +117,7 @@
     display: inline-flex;
     align-items: center;
     height: 40px;
-    margin-right: 15px;
+    margin-right: 30px;
     float: right;
     vertical-align: top;
     overflow: hidden;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
@@ -125,7 +125,7 @@
     overflow: hidden;
     z-index: @z-index-mask - 1;
     cursor: pointer;
-    transition: 0.3s;
+    transition: all .3s 0s cubic-bezier(0, 0.25, 0.25, 1);
 
     &:after {
       display: block;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
@@ -117,7 +117,7 @@
     display: inline-flex;
     align-items: center;
     height: 40px;
-    margin-right: 30px;
+    margin-right: 15px;
     float: right;
     vertical-align: top;
     overflow: hidden;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator-and-toolbar.less
@@ -120,7 +120,9 @@
     justify-content: center;
     width: 30px;
     height: 40px;
-    margin-right: 7px;
+    // margin left 34px is needed for calculations in js
+    // total width with margin should always be the same
+    margin: 0 7px 0 34px;
     float: right;
     vertical-align: top;
     overflow: hidden;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator.less
@@ -1,5 +1,5 @@
 .wizard-step-navigator {
-  width: calc(~'100% - 70px');
+  width: calc(~'100% - 72px');
   max-width: 635px;
   display: inline-block;
   background-color: @admin-bg-light-gray;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator.less
@@ -1,6 +1,6 @@
 .wizard-step-navigator {
   width: calc(~'100% - 72px');
-  max-width: 635px;
+  max-width: 675px;
   display: inline-block;
   background-color: @admin-bg-light-gray;
   color: @admin-font-gray1;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/wizard-step-navigator.less
@@ -1,5 +1,5 @@
 .wizard-step-navigator {
-  width: calc(~'100% - 56px');
+  width: calc(~'100% - 70px');
   max-width: 635px;
   display: inline-block;
   background-color: @admin-bg-light-gray;
@@ -51,14 +51,6 @@
 
     &:last-of-type {
       margin-right: 10px;
-    }
-  }
-}
-
-.form-panel {
-  &._0-240, &._240-360, &._360-540 {
-    .wizard-step-navigator {
-      width: calc(~'100% - 45px');
     }
   }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
@@ -115,7 +115,7 @@
 
       .minimize-edit {
         position: absolute;
-        left: 34px !important;
+        left: 40px !important;
         top: 0;
         &:before {
           transform: rotate(0deg);
@@ -129,8 +129,8 @@
     position: fixed;
     top: 85px;
     height: 40px;
-    width: 30px;
-    margin-left: -30px;
+    width: 40px;
+    margin-left: -40px;
     text-align: center;
     line-height: 40px;
     overflow: hidden;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
@@ -122,31 +122,31 @@
         }
       }
     }
+  }
 
-    .minimize-edit {
-      position: fixed;
-      top: 85px;
-      height: 40px;
-      width: 30px;
-      margin-left: -30px;
-      text-align: center;
-      line-height: 40px;
-      overflow: hidden;
-      z-index: @z-index-mask - 1;
-      cursor: pointer;
-      color: @admin-font-gray2;
+  .minimize-edit {
+    display: none;
+    position: fixed;
+    top: 85px;
+    height: 40px;
+    width: 30px;
+    margin-left: -30px;
+    text-align: center;
+    line-height: 40px;
+    overflow: hidden;
+    z-index: @z-index-mask - 1;
+    cursor: pointer;
+    color: @admin-font-gray2;
 
-      &:before {
-        display: inline-block;
-        transform: rotate(180deg);
-        .transition(0.3s);
-      }
-
-      &:hover {
-        color: @admin-bg-dark-gray;
-      }
+    &:before {
+      display: inline-block;
+      transform: rotate(180deg);
+      .transition(0.3s);
     }
 
+    &:hover {
+      color: @admin-bg-dark-gray;
+    }
   }
 
   &._0-240, &._240-360, &._360-540 {
@@ -231,7 +231,7 @@
 
 ._0-240, ._240-360, ._360-540, ._540-720, ._720-960, .mce-fullscreen {
   .split-panel .minimize-edit {
-    display: none !important;
+    display: none;
   }
 }
 


### PR DESCRIPTION
Fixed the help text button alignment.
Updated the `.minimize-edit` button to use classes for show / hide.
Added smooth slide effect for help button, when wizard-minimize button starts to overlap it.
Fixed the `WizardStepNavigatorAndToolbar` dropdown styles.
Fixed navigator steps check for `minimize` status.