### PR TITLE
XP-4463 Content Grid - Highlight content items with read-only access

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -1,10 +1,94 @@
 package com.enonic.xp.admin.impl.rest.resource.content;
 
-import com.enonic.xp.admin.impl.json.content.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang.StringUtils;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.io.ByteSource;
+
+import com.enonic.xp.admin.impl.json.content.AbstractContentListJson;
+import com.enonic.xp.admin.impl.json.content.CompareContentResultsJson;
+import com.enonic.xp.admin.impl.json.content.ContentIdJson;
+import com.enonic.xp.admin.impl.json.content.ContentIdListJson;
+import com.enonic.xp.admin.impl.json.content.ContentJson;
+import com.enonic.xp.admin.impl.json.content.ContentListJson;
+import com.enonic.xp.admin.impl.json.content.ContentPermissionsJson;
+import com.enonic.xp.admin.impl.json.content.ContentSummaryJson;
+import com.enonic.xp.admin.impl.json.content.ContentSummaryListJson;
+import com.enonic.xp.admin.impl.json.content.ContentsExistJson;
+import com.enonic.xp.admin.impl.json.content.DependenciesAggregationJson;
+import com.enonic.xp.admin.impl.json.content.DependenciesJson;
+import com.enonic.xp.admin.impl.json.content.GetActiveContentVersionsResultJson;
+import com.enonic.xp.admin.impl.json.content.GetContentVersionsForViewResultJson;
+import com.enonic.xp.admin.impl.json.content.GetContentVersionsResultJson;
+import com.enonic.xp.admin.impl.json.content.ReorderChildrenResultJson;
+import com.enonic.xp.admin.impl.json.content.RootPermissionsJson;
+import com.enonic.xp.admin.impl.json.content.UnpublishContentResultJson;
 import com.enonic.xp.admin.impl.json.content.attachment.AttachmentJson;
 import com.enonic.xp.admin.impl.json.content.attachment.AttachmentListJson;
 import com.enonic.xp.admin.impl.rest.resource.ResourceConstants;
-import com.enonic.xp.admin.impl.rest.resource.content.json.*;
+import com.enonic.xp.admin.impl.rest.resource.content.json.AbstractContentQueryResultJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ApplyContentPermissionsJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.BatchContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.CompareContentsJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ContentIdsJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ContentIdsPermissionsJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ContentPublishItemJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ContentQueryJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ContentSelectorQueryJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.CreateContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.DeleteAttachmentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.DeleteContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.DeleteContentResultJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.DuplicateContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.EffectivePermissionAccessJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.EffectivePermissionJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.EffectivePermissionMemberJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.GetContentVersionsJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.GetDescendantsOfContents;
+import com.enonic.xp.admin.impl.rest.resource.content.json.LocaleListJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.MoveContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.MoveContentResultJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.PublishContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ReorderChildJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ReorderChildrenJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ResolvePublishContentResultJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ResolvePublishDependenciesJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.SetActiveVersionJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.SetChildOrderJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.TaskResultJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.UnpublishContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.UpdateContentJson;
 import com.enonic.xp.admin.impl.rest.resource.schema.content.ContentTypeIconResolver;
 import com.enonic.xp.admin.impl.rest.resource.schema.content.ContentTypeIconUrlResolver;
 import com.enonic.xp.attachment.Attachment;
@@ -12,7 +96,52 @@ import com.enonic.xp.attachment.AttachmentNames;
 import com.enonic.xp.attachment.CreateAttachment;
 import com.enonic.xp.attachment.CreateAttachments;
 import com.enonic.xp.branch.Branches;
-import com.enonic.xp.content.*;
+import com.enonic.xp.content.ApplyContentPermissionsParams;
+import com.enonic.xp.content.CompareContentResult;
+import com.enonic.xp.content.CompareContentResults;
+import com.enonic.xp.content.CompareContentsParams;
+import com.enonic.xp.content.CompareStatus;
+import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ContentAlreadyExistsException;
+import com.enonic.xp.content.ContentConstants;
+import com.enonic.xp.content.ContentDependencies;
+import com.enonic.xp.content.ContentId;
+import com.enonic.xp.content.ContentIds;
+import com.enonic.xp.content.ContentListMetaData;
+import com.enonic.xp.content.ContentNotFoundException;
+import com.enonic.xp.content.ContentPath;
+import com.enonic.xp.content.ContentPaths;
+import com.enonic.xp.content.ContentQuery;
+import com.enonic.xp.content.ContentService;
+import com.enonic.xp.content.Contents;
+import com.enonic.xp.content.CreateMediaParams;
+import com.enonic.xp.content.DeleteContentParams;
+import com.enonic.xp.content.DeleteContentsResult;
+import com.enonic.xp.content.DuplicateContentParams;
+import com.enonic.xp.content.FindContentByParentParams;
+import com.enonic.xp.content.FindContentByParentResult;
+import com.enonic.xp.content.FindContentIdsByParentResult;
+import com.enonic.xp.content.FindContentIdsByQueryResult;
+import com.enonic.xp.content.FindContentVersionsParams;
+import com.enonic.xp.content.FindContentVersionsResult;
+import com.enonic.xp.content.GetActiveContentVersionsParams;
+import com.enonic.xp.content.GetActiveContentVersionsResult;
+import com.enonic.xp.content.GetContentByIdsParams;
+import com.enonic.xp.content.MoveContentException;
+import com.enonic.xp.content.MoveContentParams;
+import com.enonic.xp.content.PublishContentResult;
+import com.enonic.xp.content.PushContentParams;
+import com.enonic.xp.content.RenameContentParams;
+import com.enonic.xp.content.ReorderChildContentsParams;
+import com.enonic.xp.content.ReorderChildContentsResult;
+import com.enonic.xp.content.ReorderChildParams;
+import com.enonic.xp.content.ResolvePublishDependenciesParams;
+import com.enonic.xp.content.SetActiveContentVersionResult;
+import com.enonic.xp.content.SetContentChildOrderParams;
+import com.enonic.xp.content.UnpublishContentParams;
+import com.enonic.xp.content.UnpublishContentsResult;
+import com.enonic.xp.content.UpdateContentParams;
+import com.enonic.xp.content.UpdateMediaParams;
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.extractor.BinaryExtractor;
@@ -20,10 +149,23 @@ import com.enonic.xp.extractor.ExtractedData;
 import com.enonic.xp.index.ChildOrder;
 import com.enonic.xp.jaxrs.JaxRsComponent;
 import com.enonic.xp.jaxrs.JaxRsExceptions;
-import com.enonic.xp.query.expr.*;
+import com.enonic.xp.query.expr.CompareExpr;
+import com.enonic.xp.query.expr.ConstraintExpr;
+import com.enonic.xp.query.expr.FieldExpr;
+import com.enonic.xp.query.expr.FieldOrderExpr;
+import com.enonic.xp.query.expr.LogicalExpr;
+import com.enonic.xp.query.expr.OrderExpr;
+import com.enonic.xp.query.expr.QueryExpr;
+import com.enonic.xp.query.expr.ValueExpr;
 import com.enonic.xp.schema.content.ContentTypeService;
 import com.enonic.xp.schema.relationship.RelationshipTypeService;
-import com.enonic.xp.security.*;
+import com.enonic.xp.security.Principal;
+import com.enonic.xp.security.PrincipalKey;
+import com.enonic.xp.security.PrincipalKeys;
+import com.enonic.xp.security.PrincipalQuery;
+import com.enonic.xp.security.PrincipalQueryResult;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.SecurityService;
 import com.enonic.xp.security.acl.AccessControlEntry;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.acl.Permission;
@@ -34,23 +176,6 @@ import com.enonic.xp.task.TaskId;
 import com.enonic.xp.task.TaskService;
 import com.enonic.xp.web.multipart.MultipartForm;
 import com.enonic.xp.web.multipart.MultipartItem;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
-import com.google.common.io.ByteSource;
-import org.apache.commons.lang.StringUtils;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.*;
-import java.util.stream.Collectors;
 
 import static java.lang.Math.toIntExact;
 import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
@@ -632,7 +757,7 @@ public final class ContentResource
 
     @POST
     @Path("resolveByIds")
-    public ContentSummaryListJson getByIds( final ContentIdsJson params )
+    public ContentListJson getByIds( final ContentIdsJson params )
     {
         final Contents contents = contentService.getByIds( new GetContentByIdsParams( params.getContentIds() ) );
 
@@ -645,7 +770,7 @@ public final class ContentResource
             hits( contents.getSize() ).
             build();
 
-        return new ContentSummaryListJson( contents, metaData, contentIconUrlResolver );
+        return new ContentListJson( contents, metaData, contentIconUrlResolver, principalsResolver );
     }
 
     @GET

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
@@ -381,11 +381,11 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
             console.debug("ContentBrowsePanel: updated", data);
         }
 
-        var changed = this.doHandleContentUpdate(data);
+        return this.doHandleContentUpdate(data).then((changed) => {
+            this.updateStatisticsPanel(data);
 
-        this.updateStatisticsPanel(data);
-
-        return this.contentTreeGrid.placeContentNodes(changed);
+            return this.contentTreeGrid.placeContentNodes(changed);
+        });
     }
 
     private handleContentDeleted(paths: ContentPath[]) {
@@ -510,7 +510,7 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
         });
     }
 
-    private doHandleContentUpdate(data: ContentSummaryAndCompareStatus[]): TreeNode<ContentSummaryAndCompareStatus>[] {
+    private doHandleContentUpdate(data: ContentSummaryAndCompareStatus[]): wemQ.Promise<TreeNode<ContentSummaryAndCompareStatus>[]> {
         var changed = this.updateNodes(data);
 
         this.updateDetailsPanel(data);
@@ -518,10 +518,18 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
         this.contentTreeGrid.invalidate();
 
         // Update since CompareStatus changed
-        let changedEvent = new DataChangedEvent<ContentSummaryAndCompareStatus>(changed, DataChangedEvent.UPDATED);
-        this.contentTreeGrid.notifyDataChanged(changedEvent);
+        return new api.security.auth.IsAuthenticatedRequest().sendAndParse().then((loginResult: api.security.auth.LoginResult) => {
+            changed.forEach((node: TreeNode<ContentSummaryAndCompareStatus>) => {
+                node.getData().setReadOnly(
+                    !(<api.content.Content>node.getData().getContentSummary()).isAnyPrincipalAllowed(loginResult.getPrincipals(),
+                        api.security.acl.Permission.MODIFY));
+            });
 
-        return changed;
+            let changedEvent = new DataChangedEvent<ContentSummaryAndCompareStatus>(changed, DataChangedEvent.UPDATED);
+            this.contentTreeGrid.notifyDataChanged(changedEvent);
+
+            return changed;
+        })
     }
 
     private updateNodes(data: ContentSummaryAndCompareStatus[]): TreeNode<ContentSummaryAndCompareStatus>[] {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/filter/ContentBrowseFilterPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/filter/ContentBrowseFilterPanel.ts
@@ -142,7 +142,7 @@ export class ContentBrowseFilterPanel extends api.app.browse.filter.BrowseFilter
     }
 
     private searchDataAndHandleResponse(contentQuery: ContentQuery) {
-        new ContentQueryRequest<ContentSummaryJson,ContentSummary>(contentQuery).setExpand(api.rest.Expand.SUMMARY).sendAndParse().then(
+        new ContentQueryRequest<ContentSummaryJson,ContentSummary>(contentQuery).setExpand(api.rest.Expand.FULL).sendAndParse().then(
             (contentQueryResult: ContentQueryResult<ContentSummary,ContentSummaryJson>) => {
                 this.handleDataSearchResult(contentQuery, contentQueryResult);
             }).catch((reason: any) => {
@@ -151,7 +151,7 @@ export class ContentBrowseFilterPanel extends api.app.browse.filter.BrowseFilter
     }
 
     private refreshDataAndHandleResponse(contentQuery: ContentQuery) {
-        new ContentQueryRequest<ContentSummaryJson,ContentSummary>(contentQuery).setExpand(api.rest.Expand.SUMMARY).sendAndParse().then(
+        new ContentQueryRequest<ContentSummaryJson,ContentSummary>(contentQuery).setExpand(api.rest.Expand.FULL).sendAndParse().then(
             (contentQueryResult: ContentQueryResult<ContentSummary,ContentSummaryJson>) => {
                 if (contentQueryResult.getMetadata().getTotalHits() > 0) {
                     this.handleDataSearchResult(contentQuery, contentQueryResult);
@@ -214,7 +214,7 @@ export class ContentBrowseFilterPanel extends api.app.browse.filter.BrowseFilter
         }
 
         return new ContentQueryRequest<ContentSummaryJson,ContentSummary>(clonedContentQueryNoContentTypes).setExpand(
-            api.rest.Expand.SUMMARY).sendAndParse().then(
+            api.rest.Expand.FULL).sendAndParse().then(
             (contentQueryResultNoContentTypesSelected: ContentQueryResult<ContentSummary,ContentSummaryJson>) => {
                 return this.combineAggregations(contentQueryResult, contentQueryResultNoContentTypesSelected);
             });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/Content.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/Content.ts
@@ -178,6 +178,14 @@ module api.content {
             }
             return new ContentBuilder().fromContentJson(json).build();
         }
+
+        static fromJsonArray(jsonArray: api.content.json.ContentJson[]): Content[] {
+            var array: Content[] = [];
+            jsonArray.forEach((json: api.content.json.ContentJson) => {
+                array.push(Content.fromJson(json));
+            });
+            return array;
+        }
     }
 
     export class ContentBuilder extends ContentSummaryBuilder {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatus.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatus.ts
@@ -10,6 +10,8 @@ module api.content {
 
         private compareStatus: CompareStatus;
 
+        private readOnly: boolean;
+
         constructor() {
         }
 
@@ -110,6 +112,14 @@ module api.content {
             }
 
             return true;
+        }
+
+        setReadOnly(value: boolean) {
+            this.readOnly = value;
+        }
+
+        isReadOnly(): boolean {
+            return this.readOnly;
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/GetContentSummaryByIds.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/GetContentSummaryByIds.ts
@@ -1,8 +1,8 @@
 module api.content.resource {
 
     import BatchContentResult = api.content.resource.result.BatchContentResult;
-    
-    export class GetContentSummaryByIds extends ContentResourceRequest<BatchContentResult<api.content.json.ContentSummaryJson>, ContentSummary[]> {
+
+    export class GetContentSummaryByIds extends ContentResourceRequest<BatchContentResult<api.content.json.ContentJson>, Content[]> {
 
         private ids: ContentId[];
 
@@ -22,13 +22,13 @@ module api.content.resource {
             return api.rest.Path.fromParent(super.getResourcePath(), 'resolveByIds');
         }
 
-        sendAndParse(): wemQ.Promise<ContentSummary[]> {
+        sendAndParse(): wemQ.Promise<Content[]> {
             if (this.ids && this.ids.length > 0) {
-                return this.send().then((response: api.rest.JsonResponse<BatchContentResult<api.content.json.ContentSummaryJson>>) => {
-                    return ContentSummary.fromJsonArray(response.getResult().contents);
+                return this.send().then((response: api.rest.JsonResponse<BatchContentResult<api.content.json.ContentJson>>) => {
+                    return Content.fromJsonArray(response.getResult().contents);
                 });
             } else {
-                var deferred = wemQ.defer<ContentSummary[]>();
+                var deferred = wemQ.defer<Content[]>();
                 deferred.resolve([]);
                 return deferred.promise;
             }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/DataView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/DataView.ts
@@ -84,7 +84,7 @@ module api.ui.grid {
             this.slickDataView.onRowCountChanged.subscribe(listener);
         }
 
-        setItemMetadata(metadataHandler) {
+        setItemMetadataHandler(metadataHandler) {
             this.slickDataView.getItemMetadata = metadataHandler;
         }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
@@ -77,7 +77,7 @@ module api.ui.grid {
         }
 
         setItemMetadata(metadataHandler: Function) {
-            this.dataView.setItemMetadata(metadataHandler);
+            this.dataView.setItemMetadataHandler(metadataHandler);
         }
 
         mask() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -83,14 +83,7 @@ module api.ui.treegrid {
             this.gridData.setFilter((node: TreeNode<DATA>) => {
                 return node.isVisible();
             });
-            this.gridData.setItemMetadata((row) => {
-                const node = this.gridData.getItem(row);
-                if (this.isEmptyNode(node)) {
-                    return {cssClasses: 'empty-node'};
-                }
-
-                return null;
-            });
+            this.gridData.setItemMetadataHandler(this.handleItemMetadata.bind(this));
 
             this.columns = this.updateColumnsFormatter(builder.getColumns());
 
@@ -1072,7 +1065,7 @@ module api.ui.treegrid {
             this.grid.selectRow(row);
         }
 
-        private collapseNode(node: TreeNode<DATA>) {
+        protected collapseNode(node: TreeNode<DATA>) {
             node.setExpanded(false);
 
             // Save the selected collapsed rows in cache
@@ -1192,6 +1185,15 @@ module api.ui.treegrid {
         }
 
         sortNodeChildren(node: TreeNode<DATA>) {
+        }
+
+        protected handleItemMetadata(row: number) {
+            const node = this.gridData.getItem(row);
+            if (this.isEmptyNode(node)) {
+                return {cssClasses: 'empty-node'};
+            }
+
+            return null;
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-tree-grid.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-tree-grid.less
@@ -9,6 +9,11 @@
       text-overflow: clip;
       padding-left: 0px;
     }
+
+    &.readonly {
+      opacity: 0.5;
+    }
+
     .shifted .toggle.icon {
         width: 45px;
         margin-right: 0;


### PR DESCRIPTION
-using 'expand' param to have full Content with permissions returned instead of ContentSummary
-added 'readOnly' parameter for ContentSummaryAndCompareStatus to mark content that user can't modify
-using  slickgrid's 'getItemMetadata(row)' method to add readonly css classes
-Setting title attribute with 'Read-only' value on node row via jquery because slickgrid does not provide such a possibilty; used grid's datachange event to trigger title attr update (had to call title attr update also in collapse node because it is not used to trigger datachange event)