### PR TITLE
XP-4463 Content Grid - Highlight content items with read-only access

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -1,10 +1,92 @@
 package com.enonic.xp.admin.impl.rest.resource.content;
 
-import com.enonic.xp.admin.impl.json.content.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang.StringUtils;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.io.ByteSource;
+
+import com.enonic.xp.admin.impl.json.content.AbstractContentListJson;
+import com.enonic.xp.admin.impl.json.content.CompareContentResultsJson;
+import com.enonic.xp.admin.impl.json.content.ContentIdJson;
+import com.enonic.xp.admin.impl.json.content.ContentIdListJson;
+import com.enonic.xp.admin.impl.json.content.ContentJson;
+import com.enonic.xp.admin.impl.json.content.ContentListJson;
+import com.enonic.xp.admin.impl.json.content.ContentPermissionsJson;
+import com.enonic.xp.admin.impl.json.content.ContentSummaryJson;
+import com.enonic.xp.admin.impl.json.content.ContentSummaryListJson;
+import com.enonic.xp.admin.impl.json.content.ContentsExistJson;
+import com.enonic.xp.admin.impl.json.content.DependenciesAggregationJson;
+import com.enonic.xp.admin.impl.json.content.DependenciesJson;
+import com.enonic.xp.admin.impl.json.content.GetActiveContentVersionsResultJson;
+import com.enonic.xp.admin.impl.json.content.GetContentVersionsForViewResultJson;
+import com.enonic.xp.admin.impl.json.content.GetContentVersionsResultJson;
+import com.enonic.xp.admin.impl.json.content.ReorderChildrenResultJson;
+import com.enonic.xp.admin.impl.json.content.RootPermissionsJson;
 import com.enonic.xp.admin.impl.json.content.attachment.AttachmentJson;
 import com.enonic.xp.admin.impl.json.content.attachment.AttachmentListJson;
 import com.enonic.xp.admin.impl.rest.resource.ResourceConstants;
-import com.enonic.xp.admin.impl.rest.resource.content.json.*;
+import com.enonic.xp.admin.impl.rest.resource.content.json.AbstractContentQueryResultJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ApplyContentPermissionsJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.BatchContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.CompareContentsJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ContentIdsJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ContentIdsPermissionsJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ContentPublishItemJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ContentQueryJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ContentSelectorQueryJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.CreateContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.DeleteAttachmentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.DeleteContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.DuplicateContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.EffectivePermissionAccessJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.EffectivePermissionJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.EffectivePermissionMemberJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.GetContentVersionsJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.GetDescendantsOfContents;
+import com.enonic.xp.admin.impl.rest.resource.content.json.LocaleListJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.MoveContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.MoveContentResultJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.PublishContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ReorderChildJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ReorderChildrenJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ResolvePublishContentResultJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.ResolvePublishDependenciesJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.SetActiveVersionJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.SetChildOrderJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.TaskResultJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.UnpublishContentJson;
+import com.enonic.xp.admin.impl.rest.resource.content.json.UpdateContentJson;
 import com.enonic.xp.admin.impl.rest.resource.schema.content.ContentTypeIconResolver;
 import com.enonic.xp.admin.impl.rest.resource.schema.content.ContentTypeIconUrlResolver;
 import com.enonic.xp.attachment.Attachment;
@@ -12,7 +94,52 @@ import com.enonic.xp.attachment.AttachmentNames;
 import com.enonic.xp.attachment.CreateAttachment;
 import com.enonic.xp.attachment.CreateAttachments;
 import com.enonic.xp.branch.Branches;
-import com.enonic.xp.content.*;
+import com.enonic.xp.content.ApplyContentPermissionsParams;
+import com.enonic.xp.content.CompareContentResult;
+import com.enonic.xp.content.CompareContentResults;
+import com.enonic.xp.content.CompareContentsParams;
+import com.enonic.xp.content.CompareStatus;
+import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ContentAlreadyExistsException;
+import com.enonic.xp.content.ContentConstants;
+import com.enonic.xp.content.ContentDependencies;
+import com.enonic.xp.content.ContentId;
+import com.enonic.xp.content.ContentIds;
+import com.enonic.xp.content.ContentListMetaData;
+import com.enonic.xp.content.ContentNotFoundException;
+import com.enonic.xp.content.ContentPath;
+import com.enonic.xp.content.ContentPaths;
+import com.enonic.xp.content.ContentQuery;
+import com.enonic.xp.content.ContentService;
+import com.enonic.xp.content.Contents;
+import com.enonic.xp.content.CreateMediaParams;
+import com.enonic.xp.content.DeleteContentParams;
+import com.enonic.xp.content.DeleteContentsResult;
+import com.enonic.xp.content.DuplicateContentParams;
+import com.enonic.xp.content.FindContentByParentParams;
+import com.enonic.xp.content.FindContentByParentResult;
+import com.enonic.xp.content.FindContentIdsByParentResult;
+import com.enonic.xp.content.FindContentIdsByQueryResult;
+import com.enonic.xp.content.FindContentVersionsParams;
+import com.enonic.xp.content.FindContentVersionsResult;
+import com.enonic.xp.content.GetActiveContentVersionsParams;
+import com.enonic.xp.content.GetActiveContentVersionsResult;
+import com.enonic.xp.content.GetContentByIdsParams;
+import com.enonic.xp.content.MoveContentException;
+import com.enonic.xp.content.MoveContentParams;
+import com.enonic.xp.content.PublishContentResult;
+import com.enonic.xp.content.PushContentParams;
+import com.enonic.xp.content.RenameContentParams;
+import com.enonic.xp.content.ReorderChildContentsParams;
+import com.enonic.xp.content.ReorderChildContentsResult;
+import com.enonic.xp.content.ReorderChildParams;
+import com.enonic.xp.content.ResolvePublishDependenciesParams;
+import com.enonic.xp.content.SetActiveContentVersionResult;
+import com.enonic.xp.content.SetContentChildOrderParams;
+import com.enonic.xp.content.UnpublishContentParams;
+import com.enonic.xp.content.UnpublishContentsResult;
+import com.enonic.xp.content.UpdateContentParams;
+import com.enonic.xp.content.UpdateMediaParams;
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.extractor.BinaryExtractor;
@@ -20,10 +147,23 @@ import com.enonic.xp.extractor.ExtractedData;
 import com.enonic.xp.index.ChildOrder;
 import com.enonic.xp.jaxrs.JaxRsComponent;
 import com.enonic.xp.jaxrs.JaxRsExceptions;
-import com.enonic.xp.query.expr.*;
+import com.enonic.xp.query.expr.CompareExpr;
+import com.enonic.xp.query.expr.ConstraintExpr;
+import com.enonic.xp.query.expr.FieldExpr;
+import com.enonic.xp.query.expr.FieldOrderExpr;
+import com.enonic.xp.query.expr.LogicalExpr;
+import com.enonic.xp.query.expr.OrderExpr;
+import com.enonic.xp.query.expr.QueryExpr;
+import com.enonic.xp.query.expr.ValueExpr;
 import com.enonic.xp.schema.content.ContentTypeService;
 import com.enonic.xp.schema.relationship.RelationshipTypeService;
-import com.enonic.xp.security.*;
+import com.enonic.xp.security.Principal;
+import com.enonic.xp.security.PrincipalKey;
+import com.enonic.xp.security.PrincipalKeys;
+import com.enonic.xp.security.PrincipalQuery;
+import com.enonic.xp.security.PrincipalQueryResult;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.SecurityService;
 import com.enonic.xp.security.acl.AccessControlEntry;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.acl.Permission;
@@ -34,23 +174,6 @@ import com.enonic.xp.task.TaskId;
 import com.enonic.xp.task.TaskService;
 import com.enonic.xp.web.multipart.MultipartForm;
 import com.enonic.xp.web.multipart.MultipartItem;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
-import com.google.common.io.ByteSource;
-import org.apache.commons.lang.StringUtils;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.util.*;
-import java.util.stream.Collectors;
 
 import static java.lang.Math.toIntExact;
 import static org.apache.commons.lang.StringUtils.containsIgnoreCase;
@@ -400,7 +523,7 @@ public final class ContentResource
             map( aggregation -> new DependenciesAggregationJson( aggregation, this.contentTypeIconUrlResolver ) ).collect(
             Collectors.toList() );
 
-        return new DependenciesJson(inbound, outbound);
+        return new DependenciesJson( inbound, outbound );
     }
 
     @POST
@@ -743,6 +866,31 @@ public final class ContentResource
             build();
 
         return new ContentSummaryListJson( contents, metaData, contentIconUrlResolver );
+    }
+
+    @POST
+    @Path("isReadOnlyContent")
+    public List<String> checkContentsReadOnly( final ContentIdsJson params )
+    {
+        final Contents contents = contentService.getByIds( new GetContentByIdsParams( params.getContentIds() ) );
+
+        final AuthenticationInfo authInfo = ContextAccessor.current().getAuthInfo();
+
+        if ( authInfo.hasRole( RoleKeys.ADMIN ) )
+        {
+            return new ArrayList<>();
+        }
+
+        final List<String> result = new ArrayList<>();
+
+        contents.stream().forEach( content -> {
+            if ( !content.getPermissions().isAllowedFor( authInfo.getPrincipals(), Permission.MODIFY ) )
+            {
+                result.add( content.getId().toString() );
+            }
+        } );
+
+        return result;
     }
 
     @GET

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/Content.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/Content.ts
@@ -185,6 +185,14 @@ module api.content {
             }
             return new ContentBuilder().fromContentJson(json).build();
         }
+
+        static fromJsonArray(jsonArray: api.content.json.ContentJson[]): Content[] {
+            var array: Content[] = [];
+            jsonArray.forEach((json: api.content.json.ContentJson) => {
+                array.push(Content.fromJson(json));
+            });
+            return array;
+        }
     }
 
     export class ContentBuilder extends ContentSummaryBuilder {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatus.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatus.ts
@@ -10,6 +10,8 @@ module api.content {
 
         private compareStatus: CompareStatus;
 
+        private readOnly: boolean;
+
         constructor() {
         }
 
@@ -110,6 +112,14 @@ module api.content {
             }
 
             return true;
+        }
+
+        setReadOnly(value: boolean) {
+            this.readOnly = value;
+        }
+
+        isReadOnly(): boolean {
+            return this.readOnly;
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/ContentSummaryAndCompareStatusFetcher.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/ContentSummaryAndCompareStatusFetcher.ts
@@ -4,6 +4,7 @@ module api.content.resource {
     import BatchContentRequest = api.content.resource.BatchContentRequest;
     import ContentResponse = api.content.resource.result.ContentResponse;
     import CompareContentResults = api.content.resource.result.CompareContentResults;
+    import resolve = Q.resolve;
 
     export class ContentSummaryAndCompareStatusFetcher {
 
@@ -16,11 +17,16 @@ module api.content.resource {
                 (response: ContentResponse<ContentSummary>)=> {
                     CompareContentRequest.fromContentSummaries(response.getContents()).sendAndParse().then(
                         (compareResults: CompareContentResults) => {
-                            var result = new ContentResponse<ContentSummaryAndCompareStatus>(
-                                ContentSummaryAndCompareStatusFetcher.updateCompareStatus(response.getContents(), compareResults),
-                                response.getMetadata()
-                            );
-                            deferred.resolve(result);
+                            var contents: ContentSummaryAndCompareStatus[] = ContentSummaryAndCompareStatusFetcher.updateCompareStatus(
+                                response.getContents(), compareResults);
+
+                            ContentSummaryAndCompareStatusFetcher.updateReadOnly(contents).then(() => {
+                                var result = new ContentResponse<ContentSummaryAndCompareStatus>(
+                                    contents,
+                                    response.getMetadata()
+                                );
+                                deferred.resolve(result);
+                            })
                         });
                 });
 
@@ -121,6 +127,22 @@ module api.content.resource {
             });
 
             return list;
+        }
+
+        static updateReadOnly(contents: ContentSummaryAndCompareStatus[]): wemQ.Promise<any> {
+            return new isContentReadOnlyRequest(contents.map(content => content.getContentId())).sendAndParse().then(
+                (readOnlyContentIds: string[]) => {
+                    readOnlyContentIds.forEach((id: string) => {
+                        contents.some(content => {
+                            if (content.getId() === id) {
+                                content.setReadOnly(true);
+                                return true;
+                            }
+                        })
+                    });
+
+                    return true;
+                });
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/_module.ts
@@ -22,6 +22,7 @@
 ///<reference path='DuplicateContentRequest.ts' />
 ///<reference path='MoveContentRequest.ts' />
 ///<reference path='ListContentByIdRequest.ts' />
+///<reference path='isContentReadOnlyRequest.ts' />
 ///<reference path='ListContentByPathRequest.ts' />
 ///<reference path='DeleteContentRequest.ts' />
 ///<reference path='BatchContentRequest.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/isContentReadOnlyRequest.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/isContentReadOnlyRequest.ts
@@ -1,0 +1,29 @@
+module api.content.resource {
+
+    export class isContentReadOnlyRequest extends ContentResourceRequest<string[], string[]> {
+
+        private ids: ContentId[];
+
+        constructor(ids: ContentId[]) {
+            super();
+            super.setMethod("POST");
+            this.ids = ids;
+        }
+
+        getParams(): Object {
+            return {
+                contentIds: this.ids.map(id => id.toString())
+            };
+        }
+
+        getRequestPath(): api.rest.Path {
+            return api.rest.Path.fromParent(super.getResourcePath(), 'isReadOnlyContent');
+        }
+
+        sendAndParse(): wemQ.Promise<string[]> {
+            return this.send().then((response: api.rest.JsonResponse<string[]>) => {
+                return response.getResult();
+            });
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/DataView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/DataView.ts
@@ -84,7 +84,7 @@ module api.ui.grid {
             this.slickDataView.onRowCountChanged.subscribe(listener);
         }
 
-        setItemMetadata(metadataHandler) {
+        setItemMetadataHandler(metadataHandler) {
             this.slickDataView.getItemMetadata = metadataHandler;
         }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
@@ -77,7 +77,7 @@ module api.ui.grid {
         }
 
         setItemMetadata(metadataHandler: Function) {
-            this.dataView.setItemMetadata(metadataHandler);
+            this.dataView.setItemMetadataHandler(metadataHandler);
         }
 
         mask() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -83,14 +83,7 @@ module api.ui.treegrid {
             this.gridData.setFilter((node: TreeNode<DATA>) => {
                 return node.isVisible();
             });
-            this.gridData.setItemMetadata((row) => {
-                const node = this.gridData.getItem(row);
-                if (this.isEmptyNode(node)) {
-                    return {cssClasses: 'empty-node'};
-                }
-
-                return null;
-            });
+            this.gridData.setItemMetadataHandler(this.handleItemMetadata.bind(this));
 
             this.columns = this.updateColumnsFormatter(builder.getColumns());
 
@@ -1072,7 +1065,7 @@ module api.ui.treegrid {
             this.grid.selectRow(row);
         }
 
-        private collapseNode(node: TreeNode<DATA>) {
+        protected collapseNode(node: TreeNode<DATA>) {
             node.setExpanded(false);
 
             // Save the selected collapsed rows in cache
@@ -1192,6 +1185,15 @@ module api.ui.treegrid {
         }
 
         sortNodeChildren(node: TreeNode<DATA>) {
+        }
+
+        protected handleItemMetadata(row: number) {
+            const node = this.gridData.getItem(row);
+            if (this.isEmptyNode(node)) {
+                return {cssClasses: 'empty-node'};
+            }
+
+            return null;
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-tree-grid.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-tree-grid.less
@@ -9,6 +9,11 @@
       text-overflow: clip;
       padding-left: 0px;
     }
+
+    &.readonly {
+      opacity: 0.5;
+    }
+
     .shifted .toggle.icon {
         width: 45px;
         margin-right: 0;


### PR DESCRIPTION
-added 'readOnly' parameter for ContentSummaryAndCompareStatus to mark content that user can't modify
-using  slickgrid's 'getItemMetadata(row)' method to add readonly css classes
-Setting title attribute with 'Read-only' value on node row via jquery because slickgrid does not provide such a possibilty; used grid's datachange event to trigger title attr update (had to call title attr update also in collapse node because it is not used to trigger datachange event)