### PR TITLE
XP-4524 Fix sliding effect when opening the preview panel on mobile

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/mobile-content-item-statistics-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/mobile-content-item-statistics-panel.less
@@ -240,9 +240,4 @@ body {
     right: 0px;
     .transition(right 0.3s linear);
   }
-  &.mobile-statistics-panel {
-    .appbar, .split-panel {
-      right: 55px;
-    }
-  }
 }


### PR DESCRIPTION
 - Removed redundant styling. It seems that elements for which I remove styles are not visible when mobile panel is in place.