### PR TITLE
XP-4524 Fix sliding effect when opening the preview panel on mobile

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/mobile-content-item-statistics-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/view/mobile-content-item-statistics-panel.less
@@ -236,13 +236,13 @@
 
 // Transition when opeining content preview on a mobile
 body {
-  .appbar, .split-panel {
+  .appbar, .split-panel-with-details {
     right: 0px;
     .transition(right 0.3s linear);
   }
   &.mobile-statistics-panel {
-    .appbar, .split-panel {
-      right: 55px;
+    .appbar, .split-panel-with-details {
+      right: 110px;
     }
   }
 }


### PR DESCRIPTION
- Fixed right value. Replaced .split-panel class selector with .split-panel-with-details - so that it affects only single split panel instead of all the split-panels