### PR TITLE
XP-4463 Content Grid - Highlight content items with read-only access

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -523,7 +523,7 @@ public final class ContentResource
             map( aggregation -> new DependenciesAggregationJson( aggregation, this.contentTypeIconUrlResolver ) ).collect(
             Collectors.toList() );
 
-        return new DependenciesJson(inbound, outbound);
+        return new DependenciesJson( inbound, outbound );
     }
 
     @POST
@@ -866,6 +866,31 @@ public final class ContentResource
             build();
 
         return new ContentSummaryListJson( contents, metaData, contentIconUrlResolver );
+    }
+
+    @POST
+    @Path("isReadOnlyContent")
+    public List<String> checkContentsReadOnly( final ContentIdsJson params )
+    {
+        final Contents contents = contentService.getByIds( new GetContentByIdsParams( params.getContentIds() ) );
+
+        final AuthenticationInfo authInfo = ContextAccessor.current().getAuthInfo();
+
+        if ( authInfo.hasRole( RoleKeys.ADMIN ) )
+        {
+            return new ArrayList<>();
+        }
+
+        final List<String> result = new ArrayList<>();
+
+        contents.stream().forEach( content -> {
+            if ( !content.getPermissions().isAllowedFor( authInfo.getPrincipals(), Permission.MODIFY ) )
+            {
+                result.add( content.getId().toString() );
+            }
+        } );
+
+        return result;
     }
 
     @GET

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
@@ -31,6 +31,7 @@ import ResponsiveItem = api.ui.responsive.ResponsiveItem;
 import ContentPath = api.content.ContentPath;
 import ContentServerEventsHandler = api.content.event.ContentServerEventsHandler;
 import DataChangedEvent = api.ui.treegrid.DataChangedEvent;
+import ContentSummaryAndCompareStatusFetcher = api.content.resource.ContentSummaryAndCompareStatusFetcher;
 
 export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummaryAndCompareStatus> {
 
@@ -387,11 +388,11 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
             console.debug("ContentBrowsePanel: updated", data);
         }
 
-        var changed = this.doHandleContentUpdate(data);
+        return this.doHandleContentUpdate(data).then((changed) => {
+            this.updateStatisticsPanel(data);
 
-        this.updateStatisticsPanel(data);
-
-        return this.treeGrid.placeContentNodes(changed);
+            return this.treeGrid.placeContentNodes(changed);
+        });
     }
 
     private handleContentDeleted(paths: ContentPath[]) {
@@ -516,7 +517,7 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
         });
     }
 
-    private doHandleContentUpdate(data: ContentSummaryAndCompareStatus[]): TreeNode<ContentSummaryAndCompareStatus>[] {
+    private doHandleContentUpdate(data: ContentSummaryAndCompareStatus[]): wemQ.Promise<TreeNode<ContentSummaryAndCompareStatus>[]> {
         var changed = this.updateNodes(data);
 
         this.updateDetailsPanel(data);
@@ -524,10 +525,13 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
         this.treeGrid.invalidate();
 
         // Update since CompareStatus changed
-        let changedEvent = new DataChangedEvent<ContentSummaryAndCompareStatus>(changed, DataChangedEvent.UPDATED);
-        this.treeGrid.notifyDataChanged(changedEvent);
+        return ContentSummaryAndCompareStatusFetcher.updateReadOnly(changed.map(node => node.getData())).then(() => {
 
-        return changed;
+            let changedEvent = new DataChangedEvent<ContentSummaryAndCompareStatus>(changed, DataChangedEvent.UPDATED);
+            this.treeGrid.notifyDataChanged(changedEvent);
+
+            return changed;
+        })
     }
 
     private updateNodes(data: ContentSummaryAndCompareStatus[]): TreeNode<ContentSummaryAndCompareStatus>[] {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentTreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentTreeGrid.ts
@@ -126,6 +126,8 @@ export class ContentTreeGrid extends TreeGrid<ContentSummaryAndCompareStatus> {
             // re-set the selection to update selected rows presentation
         };
 
+        this.onDataChanged(this.addTitleAttributeToReadOnlyRows.bind(this));
+
         this.initEventHandlers(updateColumns);
     }
 
@@ -177,13 +179,16 @@ export class ContentTreeGrid extends TreeGrid<ContentSummaryAndCompareStatus> {
             compareRequest.sendAndParse().then((compareResults: CompareContentResults) => {
                 var contents: ContentSummaryAndCompareStatus[] = ContentSummaryAndCompareStatusFetcher.updateCompareStatus(contentSummaries,
                     compareResults);
-                var metadata = contentQueryResult.getMetadata();
-                if (metadata.getTotalHits() > metadata.getHits()) {
-                    contents.push(new ContentSummaryAndCompareStatus());
-                }
-                this.filter(contents);
-                this.getRoot().getCurrentRoot().setMaxChildren(metadata.getTotalHits());
-                this.notifyLoaded();
+                ContentSummaryAndCompareStatusFetcher.updateReadOnly(contents).then(() => {
+                    var metadata = contentQueryResult.getMetadata();
+                    if (metadata.getTotalHits() > metadata.getHits()) {
+                        contents.push(new ContentSummaryAndCompareStatus());
+                    }
+                    this.filter(contents);
+                    this.getRoot().getCurrentRoot().setMaxChildren(metadata.getTotalHits());
+                    this.notifyLoaded();
+                })
+                
             }).catch((reason: any) => {
                 api.DefaultErrorHandler.handle(reason);
             }).done();
@@ -259,16 +264,20 @@ export class ContentTreeGrid extends TreeGrid<ContentSummaryAndCompareStatus> {
                     var contentSummaries = contentQueryResult.getContents();
                     var compareRequest = CompareContentRequest.fromContentSummaries(contentSummaries);
                     return compareRequest.sendAndParse().then((compareResults: CompareContentResults) => {
-                        var list = parentNode.getChildren().map((el) => {
+                        var contents = parentNode.getChildren().map((el) => {
                             return el.getData();
                         }).slice(0, from).concat(ContentSummaryAndCompareStatusFetcher.updateCompareStatus(contentSummaries,
                             compareResults));
-                        var meta = contentQueryResult.getMetadata();
-                        if (from + meta.getHits() < meta.getTotalHits()) {
-                            list.push(new ContentSummaryAndCompareStatus());
-                        }
-                        parentNode.setMaxChildren(meta.getTotalHits());
-                        return list;
+
+                        return ContentSummaryAndCompareStatusFetcher.updateReadOnly(contents).then(() => {
+                            var meta = contentQueryResult.getMetadata();
+                            if (from + meta.getHits() < meta.getTotalHits()) {
+                                contents.push(new ContentSummaryAndCompareStatus());
+                            }
+                            parentNode.setMaxChildren(meta.getTotalHits());
+                            return contents;
+                        });
+
                     });
                 });
         }
@@ -391,6 +400,11 @@ export class ContentTreeGrid extends TreeGrid<ContentSummaryAndCompareStatus> {
             super.selectAll();
             this.getGrid().unmask();
         }, 5);
+    }
+
+    protected collapseNode(node: TreeNode<ContentSummaryAndCompareStatus>) {
+        super.collapseNode(node);
+        this.addTitleAttributeToReadOnlyRows();
     }
 
     findByPaths(paths: api.content.ContentPath[], useParent: boolean = false): TreeNodesOfContentPath[] {
@@ -696,5 +710,32 @@ export class ContentTreeGrid extends TreeGrid<ContentSummaryAndCompareStatus> {
         return wemQ.all(parallelPromises).spread<void>(() => {
             return wemQ(null);
         }).catch((reason: any) => api.DefaultErrorHandler.handle(reason));
+    }
+
+    private addTitleAttributeToReadOnlyRows() {
+        setTimeout(() => {
+            this.getRoot().getCurrentRoot().treeToList().forEach((node: TreeNode<ContentSummaryAndCompareStatus>, i) => {
+                if (node.getData().isReadOnly()) {
+                    let rowEl = wemjq(this.getHTMLElement()).find(".slick-row")[i];
+                    if (rowEl) {
+                        rowEl.title = "Read-only";
+                    }
+                }
+
+            })
+        }, 50);
+    }
+
+    protected handleItemMetadata(row: number) {
+        var node = this.getItem(row);
+        if (this.isEmptyNode(node)) {
+            return {cssClasses: 'empty-node'};
+        }
+
+        if (node.getData().isReadOnly()) {
+            return {cssClasses: 'readonly'};
+        }
+
+        return null;
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/Content.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/Content.ts
@@ -185,6 +185,14 @@ module api.content {
             }
             return new ContentBuilder().fromContentJson(json).build();
         }
+
+        static fromJsonArray(jsonArray: api.content.json.ContentJson[]): Content[] {
+            var array: Content[] = [];
+            jsonArray.forEach((json: api.content.json.ContentJson) => {
+                array.push(Content.fromJson(json));
+            });
+            return array;
+        }
     }
 
     export class ContentBuilder extends ContentSummaryBuilder {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatus.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatus.ts
@@ -10,6 +10,8 @@ module api.content {
 
         private compareStatus: CompareStatus;
 
+        private readOnly: boolean;
+
         constructor() {
         }
 
@@ -110,6 +112,14 @@ module api.content {
             }
 
             return true;
+        }
+
+        setReadOnly(value: boolean) {
+            this.readOnly = value;
+        }
+
+        isReadOnly(): boolean {
+            return this.readOnly;
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/ContentSummaryAndCompareStatusFetcher.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/ContentSummaryAndCompareStatusFetcher.ts
@@ -4,6 +4,7 @@ module api.content.resource {
     import BatchContentRequest = api.content.resource.BatchContentRequest;
     import ContentResponse = api.content.resource.result.ContentResponse;
     import CompareContentResults = api.content.resource.result.CompareContentResults;
+    import resolve = Q.resolve;
 
     export class ContentSummaryAndCompareStatusFetcher {
 
@@ -16,11 +17,16 @@ module api.content.resource {
                 (response: ContentResponse<ContentSummary>)=> {
                     CompareContentRequest.fromContentSummaries(response.getContents()).sendAndParse().then(
                         (compareResults: CompareContentResults) => {
-                            var result = new ContentResponse<ContentSummaryAndCompareStatus>(
-                                ContentSummaryAndCompareStatusFetcher.updateCompareStatus(response.getContents(), compareResults),
-                                response.getMetadata()
-                            );
-                            deferred.resolve(result);
+                            var contents: ContentSummaryAndCompareStatus[] = ContentSummaryAndCompareStatusFetcher.updateCompareStatus(
+                                response.getContents(), compareResults);
+
+                            ContentSummaryAndCompareStatusFetcher.updateReadOnly(contents).then(() => {
+                                var result = new ContentResponse<ContentSummaryAndCompareStatus>(
+                                    contents,
+                                    response.getMetadata()
+                                );
+                                deferred.resolve(result);
+                            })
                         });
                 });
 
@@ -121,6 +127,22 @@ module api.content.resource {
             });
 
             return list;
+        }
+
+        static updateReadOnly(contents: ContentSummaryAndCompareStatus[]): wemQ.Promise<any> {
+            return new isContentReadOnlyRequest(contents.map(content => content.getContentId())).sendAndParse().then(
+                (readOnlyContentIds: string[]) => {
+                    readOnlyContentIds.forEach((id: string) => {
+                        contents.some(content => {
+                            if (content.getId() === id) {
+                                content.setReadOnly(true);
+                                return true;
+                            }
+                        })
+                    });
+
+                    return true;
+                });
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/_module.ts
@@ -22,6 +22,7 @@
 ///<reference path='DuplicateContentRequest.ts' />
 ///<reference path='MoveContentRequest.ts' />
 ///<reference path='ListContentByIdRequest.ts' />
+///<reference path='isContentReadOnlyRequest.ts' />
 ///<reference path='ListContentByPathRequest.ts' />
 ///<reference path='DeleteContentRequest.ts' />
 ///<reference path='BatchContentRequest.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/isContentReadOnlyRequest.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/isContentReadOnlyRequest.ts
@@ -1,0 +1,29 @@
+module api.content.resource {
+
+    export class isContentReadOnlyRequest extends ContentResourceRequest<string[], string[]> {
+
+        private ids: ContentId[];
+
+        constructor(ids: ContentId[]) {
+            super();
+            super.setMethod("POST");
+            this.ids = ids;
+        }
+
+        getParams(): Object {
+            return {
+                contentIds: this.ids.map(id => id.toString())
+            };
+        }
+
+        getRequestPath(): api.rest.Path {
+            return api.rest.Path.fromParent(super.getResourcePath(), 'isReadOnlyContent');
+        }
+
+        sendAndParse(): wemQ.Promise<string[]> {
+            return this.send().then((response: api.rest.JsonResponse<string[]>) => {
+                return response.getResult();
+            });
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/DataView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/DataView.ts
@@ -84,7 +84,7 @@ module api.ui.grid {
             this.slickDataView.onRowCountChanged.subscribe(listener);
         }
 
-        setItemMetadata(metadataHandler) {
+        setItemMetadataHandler(metadataHandler) {
             this.slickDataView.getItemMetadata = metadataHandler;
         }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
@@ -86,7 +86,7 @@ module api.ui.grid {
         }
 
         setItemMetadata(metadataHandler: Function) {
-            this.dataView.setItemMetadata(metadataHandler);
+            this.dataView.setItemMetadataHandler(metadataHandler);
         }
 
         mask() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -81,14 +81,7 @@ module api.ui.treegrid {
             this.gridData.setFilter((node: TreeNode<DATA>) => {
                 return node.isVisible();
             });
-            this.gridData.setItemMetadata((row) => {
-                const node = this.gridData.getItem(row);
-                if (this.isEmptyNode(node)) {
-                    return {cssClasses: 'empty-node'};
-                }
-
-                return null;
-            });
+            this.gridData.setItemMetadataHandler(this.handleItemMetadata.bind(this));
 
             
             this.columns = this.updateColumnsFormatter(builder.getColumns());
@@ -1073,7 +1066,7 @@ module api.ui.treegrid {
             this.grid.selectRow(row);
         }
 
-        private collapseNode(node: TreeNode<DATA>) {
+        protected collapseNode(node: TreeNode<DATA>) {
             node.setExpanded(false);
 
             // Save the selected collapsed rows in cache
@@ -1193,6 +1186,15 @@ module api.ui.treegrid {
         }
 
         sortNodeChildren(node: TreeNode<DATA>) {
+        }
+
+        protected handleItemMetadata(row: number) {
+            const node = this.gridData.getItem(row);
+            if (this.isEmptyNode(node)) {
+                return {cssClasses: 'empty-node'};
+            }
+
+            return null;
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-tree-grid.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-tree-grid.less
@@ -9,6 +9,11 @@
       text-overflow: clip;
       padding-left: 0px;
     }
+
+    &.readonly {
+      opacity: 0.5;
+    }
+
     .shifted .toggle.icon {
         width: 45px;
         margin-right: 0;


### PR DESCRIPTION
-using 'expand' param to have full Content with permissions returned instead of ContentSummary
-added 'readOnly' parameter for ContentSummaryAndCompareStatus to mark content that user can't modify
-using  slickgrid's 'getItemMetadata(row)' method to add readonly css classes
-Setting title attribute with 'Read-only' value on node row via jquery because slickgrid does not provide such a possibilty; used grid's datachange event to trigger title attr update (had to call title attr update also in collapse node because it is not used to trigger datachange event)