### PR TITLE
XP-4501 Sort dialog - Fix focusing and keyboard navigation

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentDialog.ts
@@ -121,6 +121,7 @@ export class SortContentDialog extends api.ui.dialog.ModalDialog {
 
         this.sortContentMenu.onSortOrderChanged(() => {
             this.handleOnSortOrderChangedEvent();
+            this.saveButton.giveFocus();
         });
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentDialog.ts
@@ -71,7 +71,7 @@ export class SortContentDialog extends api.ui.dialog.ModalDialog {
     show() {
         api.dom.Body.get().appendChild(this);
         super.show();
-        this.saveButton.giveFocus();
+        this.sortContentMenu.focus();
     }
 
     close() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentDialog.ts
@@ -91,7 +91,7 @@ export class SortContentDialog extends api.ui.dialog.ModalDialog {
         this.contentGrid.getEl().addClass("sort-content-grid");
         this.contentGrid.onLoaded(() => {
             this.contentGrid.render(true);
-
+            this.centerMyself();
             if (this.contentGrid.getContentId()) {
                 this.open();
             }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentTabMenu.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentTabMenu.ts
@@ -40,15 +40,42 @@ export class SortContentTabMenu extends api.ui.tab.TabMenu {
         });
 
         this.dropdownHandle.onKeyDown((event: KeyboardEvent) => {
+            const saveFocus = (e) => {
+                e.stopPropagation();
+                e.preventDefault();
+            };
+
             if (KeyHelper.isArrowDownKey(event)) {
-                this.showMenu();
-            }
-            if (KeyHelper.isArrowUpKey(event)) {
+                if (this.isMenuVisible()) {
+                    this.giveFocusToMenu();
+                } else {
+                    this.showMenu();
+                }
+                saveFocus(event);
+            } else if (KeyHelper.isArrowUpKey(event)) {
                 this.hideMenu();
+                saveFocus(event);
+            } else if (KeyHelper.isApplyKey(event)) {
+                if (this.isMenuVisible()) {
+                    this.hideMenu();
+                } else {
+                    this.showMenu();
+                }
+                saveFocus(event);
             }
-            event.stopPropagation();
-            event.preventDefault();
         });
+    }
+
+    returnFocusFromMenu(): boolean {
+        return this.focus();
+    }
+
+    isKeyNext(event: KeyboardEvent) {
+        return KeyHelper.isArrowDownKey(event);
+    }
+
+    isKeyPrevious(event: KeyboardEvent) {
+        return KeyHelper.isArrowUpKey(event)
     }
 
     protected hideMenu() {
@@ -126,8 +153,8 @@ export class SortContentTabMenu extends api.ui.tab.TabMenu {
         });
     }
 
-    focus() {
-        this.dropdownHandle.giveFocus();
+    focus(): boolean {
+        return this.dropdownHandle.giveFocus();
     }
 
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentTabMenu.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentTabMenu.ts
@@ -7,6 +7,7 @@ import ContentSummary = api.content.ContentSummary;
 import DropdownHandle = api.ui.button.DropdownHandle;
 import ArrayHelper = api.util.ArrayHelper;
 import KeyHelper = api.ui.KeyHelper;
+import AppHelper = api.util.AppHelper;
 
 export class SortContentTabMenu extends api.ui.tab.TabMenu {
 
@@ -40,10 +41,6 @@ export class SortContentTabMenu extends api.ui.tab.TabMenu {
         });
 
         this.dropdownHandle.onKeyDown((event: KeyboardEvent) => {
-            const saveFocus = (e) => {
-                e.stopPropagation();
-                e.preventDefault();
-            };
 
             if (KeyHelper.isArrowDownKey(event)) {
                 if (this.isMenuVisible()) {
@@ -51,17 +48,22 @@ export class SortContentTabMenu extends api.ui.tab.TabMenu {
                 } else {
                     this.showMenu();
                 }
-                saveFocus(event);
+                AppHelper.lockEvent(event);
             } else if (KeyHelper.isArrowUpKey(event)) {
                 this.hideMenu();
-                saveFocus(event);
+                AppHelper.lockEvent(event);
             } else if (KeyHelper.isApplyKey(event)) {
                 if (this.isMenuVisible()) {
                     this.hideMenu();
                 } else {
                     this.showMenu();
                 }
-                saveFocus(event);
+                AppHelper.lockEvent(event);
+            } else if (KeyHelper.isEscKey(event)) {
+                if (this.isMenuVisible()) {
+                    this.hideMenu();
+                    AppHelper.lockEvent(event);
+                }
             }
         });
     }
@@ -87,6 +89,7 @@ export class SortContentTabMenu extends api.ui.tab.TabMenu {
     protected showMenu() {
         super.showMenu();
         this.dropdownHandle.down();
+        this.focus();
     }
 
     selectNavigationItem(tabIndex: number) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentTabMenu.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/SortContentTabMenu.ts
@@ -6,6 +6,7 @@ import ChildOrder = api.content.order.ChildOrder;
 import ContentSummary = api.content.ContentSummary;
 import DropdownHandle = api.ui.button.DropdownHandle;
 import ArrayHelper = api.util.ArrayHelper;
+import KeyHelper = api.ui.KeyHelper;
 
 export class SortContentTabMenu extends api.ui.tab.TabMenu {
 
@@ -25,7 +26,12 @@ export class SortContentTabMenu extends api.ui.tab.TabMenu {
         this.dropdownHandle = new DropdownHandle();
         this.appendChild(this.dropdownHandle);
         this.dropdownHandle.up();
-        this.dropdownHandle.onClicked((event: any) => {
+
+        this.initEventHandlers();
+    }
+
+    initEventHandlers() {
+        this.dropdownHandle.onClicked(() => {
             if (this.isMenuVisible()) {
                 this.hideMenu();
             } else {
@@ -33,6 +39,16 @@ export class SortContentTabMenu extends api.ui.tab.TabMenu {
             }
         });
 
+        this.dropdownHandle.onKeyDown((event: KeyboardEvent) => {
+            if (KeyHelper.isArrowDownKey(event)) {
+                this.showMenu();
+            }
+            if (KeyHelper.isArrowUpKey(event)) {
+                this.hideMenu();
+            }
+            event.stopPropagation();
+            event.preventDefault();
+        });
     }
 
     protected hideMenu() {
@@ -108,6 +124,10 @@ export class SortContentTabMenu extends api.ui.tab.TabMenu {
         this.sortOrderChangedListeners.forEach((listener: () => void) => {
             listener.call(this);
         });
+    }
+
+    focus() {
+        this.dropdownHandle.giveFocus();
     }
 
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/KeyHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/KeyHelper.ts
@@ -46,10 +46,6 @@ module api.ui {
             return event.keyCode === 39;
         }
 
-        static isArrowUpKey(event: KeyboardEvent): boolean {
-            return event.keyCode === 38;
-        }
-
         static isArrowDownKey(event: KeyboardEvent): boolean {
             return event.keyCode === 40;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/KeyHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/KeyHelper.ts
@@ -46,6 +46,10 @@ module api.ui {
             return event.keyCode === 39;
         }
 
+        static isArrowUpKey(event: KeyboardEvent): boolean {
+            return event.keyCode === 38;
+        }
+
         static isArrowDownKey(event: KeyboardEvent): boolean {
             return event.keyCode === 40;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/KeyHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/KeyHelper.ts
@@ -87,5 +87,13 @@ module api.ui {
         static isEnterKey(event: KeyboardEvent): boolean {
             return event.keyCode === 13;
         }
+
+        static isSpaceKey(event: KeyboardEvent): boolean {
+            return event.keyCode === 32;
+        }
+
+        static isApplyKey(event: KeyboardEvent): boolean {
+            return KeyHelper.isEnterKey(event) || KeyHelper.isSpaceKey(event);
+        }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabItem.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabItem.ts
@@ -8,7 +8,7 @@ module api.ui.tab {
 
         private label: string;
 
-        private labelEl: api.dom.SpanEl;
+        private labelEl: api.dom.AEl;
 
         private active: boolean = false;
 
@@ -26,7 +26,7 @@ module api.ui.tab {
 
             super("tab-item" + (!classes ? "" : " " + classes));
 
-            this.labelEl = new api.dom.SpanEl('label');
+            this.labelEl = new api.dom.AEl('label');
             this.appendChild(this.labelEl);
 
             this.setLabel(builder.label, builder.markUnnamed, builder.addLabelTitleAttribute);
@@ -40,7 +40,7 @@ module api.ui.tab {
             }
 
             this.onClicked((event: MouseEvent) => {
-                this.notifySelectedListeners();
+                this.select();
             });
         }
 
@@ -55,6 +55,10 @@ module api.ui.tab {
                 });
                 this.prependChild(this.removeButton);
             }
+        }
+
+        select() {
+            this.notifySelectedListeners();
         }
 
         setIndex(value: number) {
@@ -159,6 +163,10 @@ module api.ui.tab {
             this.closedListeners.forEach((listener: (event: TabItemClosedEvent)=>void) => {
                 listener.call(this, new TabItemClosedEvent(this));
             });
+        }
+
+        giveFocus(): boolean {
+            return this.labelEl.giveFocus();
         }
 
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabMenu.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabMenu.ts
@@ -1,5 +1,6 @@
 module api.ui.tab {
 
+    import AppHelper = api.util.AppHelper;
     export class TabMenu extends api.dom.DivEl implements api.ui.Navigator {
 
         private tabMenuButton: TabMenuButton;
@@ -51,10 +52,8 @@ module api.ui.tab {
         }
 
         private initListeners() {
-            api.dom.Body.get().onClicked((event: MouseEvent) => {
-                if (!this.getEl().contains(<HTMLElement> event.target)) {
-                    this.hideMenu();
-                }
+            AppHelper.focusInOut(this, () => {
+                this.hideMenu();
             });
 
             this.onClicked((e: MouseEvent) => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabMenu.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabMenu.ts
@@ -74,8 +74,12 @@ module api.ui.tab {
                     }
                 }
 
-                event.stopPropagation();
-                event.preventDefault();
+
+                if (KeyHelper.isEscKey(event) && this.isMenuVisible()) {
+                    this.hideMenu();
+                }
+
+                AppHelper.lockEvent(event);
             });
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabMenu.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/tab/TabMenu.ts
@@ -24,6 +24,8 @@ module api.ui.tab {
 
         private enabled: boolean = true;
 
+        private focusIndex: number = -1;
+
         constructor(className?: string) {
             super("tab-menu" + (className ? " " + className : ""));
 
@@ -60,6 +62,64 @@ module api.ui.tab {
                     this.handleClick(e);
                 }
             });
+
+            this.menuEl.onKeyDown((event: KeyboardEvent) => {
+                if (this.isKeyNext(event)) {
+                    this.focusNextTab();
+                } else if (this.isKeyPrevious(event)) {
+                    this.focusPreviousTab();
+                } else if (KeyHelper.isApplyKey(event)) {
+                    const tab = this.tabs[this.focusIndex];
+                    if (tab) {
+                        tab.select();
+                    }
+                }
+
+                event.stopPropagation();
+                event.preventDefault();
+            });
+        }
+
+        giveFocusToMenu(): boolean {
+            const first = this.tabs[0];
+
+            if (first) {
+                this.focusIndex = 0;
+                return first.giveFocus();
+            }
+            return false;
+        }
+
+        returnFocusFromMenu(): boolean {
+            return this.giveFocus();
+        }
+
+        focusNextTab() {
+            const tabIndex = this.focusIndex + 1;
+
+            if (tabIndex < this.tabs.length) {
+                this.tabs[tabIndex].giveFocus();
+                this.focusIndex = tabIndex;
+            }
+        }
+
+        focusPreviousTab() {
+            const tabIndex = this.focusIndex - 1;
+
+            if (tabIndex >= 0) {
+                this.tabs[tabIndex].giveFocus();
+                this.focusIndex = tabIndex;
+            } else {
+                this.returnFocusFromMenu();
+            }
+        }
+
+        isKeyNext(event: KeyboardEvent) {
+            return KeyHelper.isArrowRightKey(event);
+        }
+
+        isKeyPrevious(event: KeyboardEvent) {
+            KeyHelper.isArrowLeftKey(event)
         }
 
         setEnabled(enabled: boolean): TabMenu {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/AppHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/AppHelper.ts
@@ -56,8 +56,8 @@ module api.util {
         }
 
         static focusInOut(element: api.dom.Element, onFocusOut: () => void, wait: number = 50, preventMouseDown: boolean = true) {
-            let target,
-                focusOutTimeout = 0;
+            let focusOutTimeout = 0;
+            let target;
 
             element.onFocusOut((event) => {
                 if(target == event.target) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/AppHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/AppHelper.ts
@@ -79,6 +79,11 @@ module api.util {
                 });
             }
         }
+
+        static lockEvent(event: Event) {
+            event.stopPropagation();
+            event.preventDefault();
+        }
     }
 
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/sort-content-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/sort-content-dialog.less
@@ -157,11 +157,20 @@
     }
     .tab-menu-item {
       display: block;
-      padding: 5px 35px;
-      overflow: hidden;
-      white-space: pre;
-      color: @admin-button-blue2;
-      .ellipsis();
+      padding: 0;
+      .label {
+        display: block;
+        padding: 5px 35px;
+        overflow: hidden;
+        white-space: pre;
+        color: @admin-button-blue2;
+        .ellipsis();
+
+        &:focus {
+          background-color: @admin-bg-light-gray;
+        }
+
+      }
     }
     .@{_COMMON_PREFIX}dropdown-handle {
       z-index: 3;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/tab/tab-item.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/tab/tab-item.less
@@ -1,0 +1,7 @@
+.tab-item {
+  .label {
+    pointer-events: none;
+    text-decoration: none;
+    color: inherit;
+  }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/styles.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/styles.less
@@ -60,6 +60,7 @@
 @import "api/ui/button/menu-button";
 @import "api/ui/button/cycle-button";
 @import "api/ui/tab/tab-menu";
+@import "api/ui/tab/tab-item";
 @import "api/ui/time/calendar";
 @import "api/ui/time/date-picker";
 @import "api/ui/time/time-picker";


### PR DESCRIPTION
Added basic support for keys in `SortContentTabMenu`
Moved onShown focus from Apply button to `SortContentTabMenu` dropdown.
Fixed focus change after sort order was selected.
Replaced old outer click with the new focusInOut event.
Fixed the dialog position after the grid is loaded.