### PR TITLE
XP-4535 Delete Content dialog - 'Instantly delete published items' is blinking for published content

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
@@ -266,12 +266,12 @@ export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
     }
 
     protected showLoadingSpinner() {
+        this.addClass("locked");
         this.actionButton.setEnabled(false);
-        this.actionButton.addClass("spinner");
     }
 
     protected hideLoadingSpinner() {
-        this.actionButton.removeClass("spinner");
+        this.removeClass("locked");
         this.actionButton.setEnabled(true);
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
@@ -144,6 +144,7 @@ export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
         this.itemList.clearItems(true);
         this.dependantList.clearItems(true);
         this.dependantsContainer.setVisible(false);
+        this.hideLoadingSpinner();
     }
 
     setAutoUpdateTitle(value: boolean) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
@@ -144,7 +144,7 @@ export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
         this.itemList.clearItems(true);
         this.dependantList.clearItems(true);
         this.dependantsContainer.setVisible(false);
-        this.hideLoadingSpinner();
+        this.unlockControls();
     }
 
     setAutoUpdateTitle(value: boolean) {
@@ -265,12 +265,12 @@ export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
         }
     }
 
-    protected showLoadingSpinner() {
+    protected lockControls() {
         this.addClass("locked");
         this.actionButton.setEnabled(false);
     }
 
-    protected hideLoadingSpinner() {
+    protected unlockControls() {
         this.removeClass("locked");
         this.actionButton.setEnabled(true);
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
@@ -275,6 +275,14 @@ export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
         this.actionButton.setEnabled(true);
     }
 
+    protected toggleControls(enable: boolean) {
+        if (enable) {
+            this.unlockControls();
+        } else {
+            this.lockControls();
+        }
+    }
+
 }
 
 export class DialogItemList extends ListBox<ContentSummaryAndCompareStatus> {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/ProgressBarDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/ProgressBarDialog.ts
@@ -42,7 +42,7 @@ export class ProgressBarDialog extends DependantItemsDialog {
         api.dom.Body.get().addClass(this.isProcessingClass);
 
         MenuButtonProgressBarManager.getProgressBar().setValue(0);
-        this.hideLoadingSpinner();
+        this.unlockControls();
         this.progressBar = this.createProgressBar();
         MenuButtonProgressBarManager.updateProgressHandler(this.processHandler);
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/ProgressBarDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/ProgressBarDialog.ts
@@ -76,10 +76,7 @@ export class ProgressBarDialog extends DependantItemsDialog {
 
         if (this.isVisible()) {
             this.close();
-            return;
         }
-
-        this.hide();
     }
 
     protected pollTask(taskId: api.task.TaskId, elapsed: number = 0) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
@@ -98,7 +98,6 @@ export class ContentPublishDialog extends ProgressBarDialog {
     close() {
         super.close();
         this.childrenCheckbox.setChecked(false);
-        this.hideLoadingSpinner();
     }
 
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
@@ -264,7 +264,7 @@ export class ContentPublishDialog extends ProgressBarDialog {
 
     private doPublish() {
 
-        this.showLoadingSpinner();
+        this.lockControls();
 
         this.setSubTitle(this.countTotal() + " items are being published...");
 
@@ -278,7 +278,7 @@ export class ContentPublishDialog extends ProgressBarDialog {
             .then((taskId: api.task.TaskId) => {
                 this.pollTask(taskId);
             }).catch((reason) => {
-            this.hideLoadingSpinner();
+            this.unlockControls();
                 this.close();
                 if (reason && reason.message) {
                     api.notify.showError(reason.message);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
@@ -46,7 +46,7 @@ export class ContentPublishDialog extends ProgressBarDialog {
         var publishAction = new ContentPublishDialogAction();
         publishAction.onExecuted(this.doPublish.bind(this));
         this.actionButton = this.addAction(publishAction, true, true);
-        this.actionButton.setEnabled(false);
+        this.lockControls();
 
         this.addCancelButtonToBottom();
 
@@ -129,12 +129,12 @@ export class ContentPublishDialog extends ProgressBarDialog {
             return this.reloadPublishDependencies(childrenNotLoadedYet);
         } else {
             // apply the stash to avoid extra heavy request
-            this.actionButton.setEnabled(false);
+            this.lockControls();
             this.loadMask.show();
             setTimeout(() => {
                 this.setDependantItems(stashedItems.slice());
                 this.centerMyself();
-                this.actionButton.setEnabled(true);
+                this.unlockControls();
                 this.loadMask.hide();
             }, 100);
             return wemQ<void>(null);
@@ -145,7 +145,7 @@ export class ContentPublishDialog extends ProgressBarDialog {
         if (this.isProgressBarEnabled()) {
             return wemQ<void>(null);
         }
-        this.actionButton.setEnabled(false);
+        this.lockControls();
         this.loadMask.show();
         this.disableCheckbox();
 
@@ -313,7 +313,7 @@ export class ContentPublishDialog extends ProgressBarDialog {
 
         let canPublish = count > 0 && this.areItemsAndDependantsValid();
 
-        this.actionButton.setEnabled(canPublish);
+        this.toggleControls(canPublish);
         if (canPublish) {
             this.getButtonRow().focusDefaultAction();
             this.updateTabbable();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentUnpublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentUnpublishDialog.ts
@@ -28,10 +28,10 @@ export class ContentUnpublishDialog extends ProgressBarDialog {
 
         this.getEl().addClass("unpublish-dialog");
 
-        var unpublishAction = new ContentUnpublishDialogAction();
+        const unpublishAction = new ContentUnpublishDialogAction();
         unpublishAction.onExecuted(this.doUnpublish.bind(this));
         this.actionButton = this.addAction(unpublishAction, true, true);
-        this.actionButton.setEnabled(false);
+        this.lockControls();
 
         this.addCancelButtonToBottom();
 
@@ -55,7 +55,6 @@ export class ContentUnpublishDialog extends ProgressBarDialog {
 
         this.getDependantList().clearItems();
         this.lockControls();
-        this.actionButton.setEnabled(false);
 
         return this.loadDescendantIds([CompareStatus.EQUAL,CompareStatus.NEWER,CompareStatus.PENDING_DELETE]).then(() => {
             this.loadDescendants(0, 20).
@@ -65,7 +64,6 @@ export class ContentUnpublishDialog extends ProgressBarDialog {
                     // do not set requested contents as they are never going to change
 
                 this.unlockControls();
-                    this.actionButton.setEnabled(true);
                 }).finally(() => {
                     this.loadMask.hide();
                 });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentUnpublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentUnpublishDialog.ts
@@ -54,7 +54,7 @@ export class ContentUnpublishDialog extends ProgressBarDialog {
         }
 
         this.getDependantList().clearItems();
-        this.showLoadingSpinner();
+        this.lockControls();
         this.actionButton.setEnabled(false);
 
         return this.loadDescendantIds([CompareStatus.EQUAL,CompareStatus.NEWER,CompareStatus.PENDING_DELETE]).then(() => {
@@ -64,7 +64,7 @@ export class ContentUnpublishDialog extends ProgressBarDialog {
 
                     // do not set requested contents as they are never going to change
 
-                    this.hideLoadingSpinner();
+                this.unlockControls();
                     this.actionButton.setEnabled(true);
                 }).finally(() => {
                     this.loadMask.hide();
@@ -108,7 +108,7 @@ export class ContentUnpublishDialog extends ProgressBarDialog {
 
     private doUnpublish() {
 
-        this.showLoadingSpinner();
+        this.lockControls();
 
         this.setSubTitle(this.countTotal() + " items are being unpublished...");
 
@@ -121,7 +121,7 @@ export class ContentUnpublishDialog extends ProgressBarDialog {
             .then((taskId: api.task.TaskId) => {
                 this.pollTask(taskId);
             }).catch((reason) => {
-            this.hideLoadingSpinner();
+            this.unlockControls();
             this.close();
             if (reason && reason.message) {
                 api.notify.showError(reason.message);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialog.ts
@@ -143,7 +143,7 @@ export class ContentDeleteDialog extends ProgressBarDialog {
                 this.instantDeleteCheckbox.isChecked() ? this.yesCallback([]) : this.yesCallback();
             }
 
-            this.showLoadingSpinner();
+            this.lockControls();
 
             this.createDeleteRequest()
                 .sendAndParse()

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialog.ts
@@ -58,7 +58,7 @@ export class ContentDeleteDialog extends ProgressBarDialog {
 
     protected manageDescendants() {
         this.loadMask.show();
-        this.actionButton.setEnabled(false);
+        this.lockControls();
 
         return this.loadDescendantIds().then(() => {
             this.loadDescendants(0, 20).
@@ -69,7 +69,7 @@ export class ContentDeleteDialog extends ProgressBarDialog {
                     this.centerMyself();
                 }).finally(() => {
                     this.loadMask.hide();
-                    this.actionButton.setEnabled(true);
+                this.unlockControls();
                 this.actionButton.giveFocus();
                 });
         });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialog.ts
@@ -86,6 +86,11 @@ export class ContentDeleteDialog extends ProgressBarDialog {
         this.instantDeleteCheckbox.setChecked(isChecked, true);
     }
 
+    close() {
+        super.close();
+        this.instantDeleteCheckbox.setChecked(false);
+    }
+
     setContentToDelete(contents: ContentSummaryAndCompareStatus[]): ContentDeleteDialog {
         this.setIgnoreItemsChanged(true);
         this.setListItems(contents);
@@ -115,11 +120,13 @@ export class ContentDeleteDialog extends ProgressBarDialog {
             const deleteRequest = this.createDeleteRequest();
             const content = this.getItemList().getItems().slice(0);
             const descendants = this.getDependantList().getItems().slice(0);
+            const instantDeleteStatus = this.instantDeleteCheckbox.isChecked();
             const yesCallback = () => {
                 this.setContentToDelete(content);
                 this.setDependantItems(descendants);
                 this.countItemsToDeleteAndUpdateButtonCounter();
                 this.open();
+                this.instantDeleteCheckbox.setChecked(instantDeleteStatus);
                 this.doDelete(true);
             };
 
@@ -137,13 +144,13 @@ export class ContentDeleteDialog extends ProgressBarDialog {
                 .sendAndParse()
                 .then((taskId: api.task.TaskId) => {
                     this.pollTask(taskId);
-                }).catch((reason) => {
-                this.hideLoadingSpinner();
-                this.close();
-                if (reason && reason.message) {
-                    api.notify.showError(reason.message);
-                }
-            });
+                })
+                .catch((reason) => {
+                    this.close();
+                    if (reason && reason.message) {
+                        api.notify.showError(reason.message);
+                    }
+                });
         }
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ContentDeleteDialog.ts
@@ -75,6 +75,15 @@ export class ContentDeleteDialog extends ProgressBarDialog {
         });
     }
 
+    manageContentToDelete(contents: ContentSummaryAndCompareStatus[]): ContentDeleteDialog {
+        this.setIgnoreItemsChanged(true);
+        this.setListItems(contents);
+        this.setIgnoreItemsChanged(false);
+        this.updateSubTitle();
+
+        return this;
+    }
+
     private manageInstantDeleteStatus(items: ContentSummaryAndCompareStatus[]) {
         const isHidden = this.isEveryOffline(items);
         const isChecked = isHidden ? false : this.isEveryPendingDelete(items);
@@ -92,13 +101,8 @@ export class ContentDeleteDialog extends ProgressBarDialog {
     }
 
     setContentToDelete(contents: ContentSummaryAndCompareStatus[]): ContentDeleteDialog {
-        this.setIgnoreItemsChanged(true);
-        this.setListItems(contents);
-        this.setIgnoreItemsChanged(false);
-        this.updateSubTitle();
-
+        this.manageContentToDelete(contents);
         this.manageInstantDeleteStatus(contents);
-        
         this.manageDescendants();
 
         return this;
@@ -122,11 +126,12 @@ export class ContentDeleteDialog extends ProgressBarDialog {
             const descendants = this.getDependantList().getItems().slice(0);
             const instantDeleteStatus = this.instantDeleteCheckbox.isChecked();
             const yesCallback = () => {
-                this.setContentToDelete(content);
+                // Manually manage content and dependants without any requests
+                this.manageContentToDelete(content);
                 this.setDependantItems(descendants);
+                this.instantDeleteCheckbox.setChecked(instantDeleteStatus);
                 this.countItemsToDeleteAndUpdateButtonCounter();
                 this.open();
-                this.instantDeleteCheckbox.setChecked(instantDeleteStatus);
                 this.doDelete(true);
             };
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/dialog/dependant-items-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/dialog/dependant-items-dialog.less
@@ -17,6 +17,33 @@
     }
   }
 
+  &.locked {
+
+    .browse-selection-item {
+      .remove {
+        pointer-events: none;
+        opacity: 0.5;
+      }
+    }
+
+    .dialog-buttons {
+
+      button:not(.cancel-button-bottom) {
+        font-family: 'icomoon';
+        pointer-events: none;
+        opacity: 0.5;
+
+        &:after {
+          .animation(rotate360, .5s, .0s, linear);
+          content: "\e007";
+          color: white;
+          display: inline-block;
+          margin-left: 5px;
+        }
+      }
+    }
+  }
+
   .sub-title {
     margin-top: 20px;
   }
@@ -182,27 +209,9 @@
                 display: none;
               }
             }
-
           }
         }
       }
     }
   }
-
-  .dialog-buttons {
-
-    button.spinner {
-      font-family: 'icomoon';
-
-      &:after {
-        .animation(rotate360, .5s, .0s, linear);
-        content: "\e007";
-        color: white;
-        display: inline-block;
-        margin-left: 5px;
-      }
-    }
-
-  }
-
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/dialog/dependant-items-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/dialog/dependant-items-dialog.less
@@ -139,7 +139,7 @@
           }
 
           .dependant-item-viewer {
-            width: calc(~'100% - 90px');
+            width: calc(~'100% - 97px');
 
             &.pending-delete .names-view {
               .main-name, .sub-name {


### PR DESCRIPTION
Fixed endless loading spinner in Delete button bug.
Fixed the instant delete behavior, when published content was not deleted, though it was marked.
Fixed the action button behavior, when it was not disabled when the content was processing.
Fixed styles, when the status of the item in the dependent items list overflows the container.
Disabled the dependent items fetching: items were fetching after there were set manually.
Renamed the show/hide Spinner to more relevant name.
Replaced action button manual enable/disable with more flexible lock/unlock methods.
