### PR TITLE
XP-4571 Time-based publishing - Content Studio - Publish status

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/CompareContentResultJson.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/CompareContentResultJson.java
@@ -8,10 +8,13 @@ public class CompareContentResultJson
 
     private final String id;
 
-    public CompareContentResultJson( final CompareContentResult compareContentResult )
+    private final PublishStatus publishStatus;
+
+    public CompareContentResultJson( final CompareContentResult compareContentResult, final PublishStatus publishStatus )
     {
         this.compareStatus = compareContentResult.getCompareStatus().name();
         this.id = compareContentResult.getContentId().toString();
+        this.publishStatus = publishStatus;
     }
 
     @SuppressWarnings("UnusedDeclaration")
@@ -24,5 +27,10 @@ public class CompareContentResultJson
     public String getId()
     {
         return id;
+    }
+
+    public PublishStatus getPublishStatus()
+    {
+        return publishStatus;
     }
 }

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/CompareContentResultsJson.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/CompareContentResultsJson.java
@@ -11,15 +11,22 @@ public class CompareContentResultsJson
 {
     private final Set<CompareContentResultJson> compareContentResults = Sets.newHashSet();
 
-    public CompareContentResultsJson( final CompareContentResults compareContentResults )
+    public CompareContentResultsJson( final CompareContentResults compareContentResults,
+                                      final GetPublishStatusResultsJson getPublishStatusResultsJson )
     {
         for ( final CompareContentResult compareContentResult : compareContentResults )
         {
-            this.compareContentResults.add( new CompareContentResultJson( compareContentResult ) );
+            PublishStatus publishStatus = getPublishStatusResultsJson.getGetPublishStatusResults().stream().
+                filter( publishStatusJson -> publishStatusJson.getId().equals( compareContentResult.getContentId().toString() ) ).
+                map( publishStatusJson -> publishStatusJson.getPublishStatus() ).
+                findFirst().
+                orElse( null );
+
+            this.compareContentResults.add( new CompareContentResultJson( compareContentResult, publishStatus ) );
         }
     }
 
-    @SuppressWarnings( "UnusedDeclaration" )
+    @SuppressWarnings("UnusedDeclaration")
     public Set<CompareContentResultJson> getCompareContentResults()
     {
         return compareContentResults;

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/GetPublishStatusResultJson.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/json/content/GetPublishStatusResultJson.java
@@ -4,18 +4,18 @@ import com.enonic.xp.content.ContentId;
 
 public class GetPublishStatusResultJson
 {
-    private final String publishStatus;
+    private final PublishStatus publishStatus;
 
     private final String id;
 
     public GetPublishStatusResultJson( final PublishStatus publishStatus, final ContentId contentId )
     {
-        this.publishStatus = publishStatus.toString();
+        this.publishStatus = publishStatus;
         this.id = contentId.toString();
     }
 
     @SuppressWarnings("UnusedDeclaration")
-    public String getPublishStatus()
+    public PublishStatus getPublishStatus()
     {
         return publishStatus;
     }

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -1201,7 +1201,12 @@ public final class ContentResource
         final CompareContentResults compareResults =
             contentService.compare( new CompareContentsParams( contentIds, ContentConstants.BRANCH_MASTER ) );
 
-        return new CompareContentResultsJson( compareResults );
+        final GetPublishStatusesJson getPublishStatusesJson = new GetPublishStatusesJson();
+        getPublishStatusesJson.setIds( params.getIds() );
+
+        final GetPublishStatusResultsJson publishStatusesJson = getPublishStatuses( getPublishStatusesJson );
+
+        return new CompareContentResultsJson( compareResults, publishStatusesJson );
     }
 
     @POST

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -25,6 +25,7 @@ import ContentId = api.content.ContentId;
 import ContentPath = api.content.ContentPath;
 import ContentSummaryAndCompareStatus = api.content.ContentSummaryAndCompareStatus;
 import CompareStatus = api.content.CompareStatus;
+import PublishStatus = api.content.PublishStatus;
 import ContentBuilder = api.content.ContentBuilder;
 import Thumbnail = api.thumb.Thumbnail;
 import ContentName = api.content.ContentName;
@@ -692,16 +693,20 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
                 if (this.isCurrentContentId(content.getContentId())) {
 
                     this.persistedContentCompareStatus = this.currentContentCompareStatus = content.getCompareStatus();
-                    this.getContentWizardToolbarPublishControls().setCompareStatus(this.currentContentCompareStatus);
+                    this.getContentWizardToolbarPublishControls().setPublishStatus(content.getPublishStatus()).setCompareStatus(
+                        this.currentContentCompareStatus);
 
                     this.getWizardHeader().disableNameGeneration(this.currentContentCompareStatus === CompareStatus.EQUAL);
                 }
             });
         };
 
-        var updateHandler = (contentId: ContentId, compareStatus?: CompareStatus) => {
+        var updateHandler = (contentId: ContentId, compareStatus?: CompareStatus, publishStatus?: PublishStatus) => {
 
             if (this.isCurrentContentId(contentId)) {
+                if (publishStatus) {
+                    this.getContentWizardToolbarPublishControls().setPublishStatus(publishStatus);
+                }
                 if (compareStatus != undefined) {
                     this.persistedContentCompareStatus = this.currentContentCompareStatus = compareStatus;
                     this.getContentWizardToolbarPublishControls().setCompareStatus(compareStatus);
@@ -745,7 +750,8 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
                 return this.isCurrentContentId(sorted.getContentId());
             });
             if (wasSorted) {
-                this.getContentWizardToolbarPublishControls().setCompareStatus(data[indexOfCurrentContent].getCompareStatus());
+                this.getContentWizardToolbarPublishControls().setPublishStatus(
+                    data[indexOfCurrentContent].getPublishStatus()).setCompareStatus(data[indexOfCurrentContent].getCompareStatus());
             }
         };
 
@@ -755,14 +761,14 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
             });
 
             if (wasMoved) {
-                updateHandler(this.getPersistedItem().getContentId(), data[0].getCompareStatus());
+                updateHandler(this.getPersistedItem().getContentId(), data[0].getCompareStatus(), data[0].getPublishStatus());
             }
         };
 
         var contentUpdatedHandler = (data: ContentSummaryAndCompareStatus[]) => {
             if (!this.contentUpdateDisabled) {
                 data.forEach((updated: ContentSummaryAndCompareStatus) => {
-                    updateHandler(updated.getContentId(), updated.getCompareStatus());
+                    updateHandler(updated.getContentId(), updated.getCompareStatus(), updated.getPublishStatus());
                 });
             }
         };
@@ -870,8 +876,8 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
 
                 wizardHeader.disableNameGeneration(this.currentContentCompareStatus !== CompareStatus.NEW);
 
-                publishControls.setCompareStatus(this.currentContentCompareStatus);
-                publishControls.setLeafContent(!this.getPersistedItem().hasChildren());
+                publishControls.setPublishStatus(summaryAndStatus.getPublishStatus()).setCompareStatus(
+                    this.currentContentCompareStatus).setLeafContent(!this.getPersistedItem().hasChildren());
             });
 
             wizardHeader.setSimplifiedNameGeneration(persistedContent.getType().isDescendantOfMedia());

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbarPublishControls.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbarPublishControls.ts
@@ -4,6 +4,7 @@ import Action = api.ui.Action;
 import DialogButton = api.ui.dialog.DialogButton;
 import SpanEl = api.dom.SpanEl;
 import CompareStatus = api.content.CompareStatus;
+import PublishStatus = api.content.PublishStatus;
 import MenuButton = api.ui.button.MenuButton;
 import ActionButton = api.ui.button.ActionButton;
 
@@ -19,6 +20,7 @@ export class ContentWizardToolbarPublishControls extends api.dom.DivEl {
     private userCanPublish: boolean = true;
     private leafContent: boolean = true;
     private contentCompareStatus: CompareStatus;
+    private publishStatus: PublishStatus;
     private publishButtonForMobile:ActionButton;
 
     constructor(publish:Action, publishTree:Action, unpublish:Action, publishMobile:Action) {
@@ -42,32 +44,41 @@ export class ContentWizardToolbarPublishControls extends api.dom.DivEl {
         this.appendChildren(this.contentStateSpan, this.publishButton);
     }
 
-    public setCompareStatus(compareStatus: CompareStatus, refresh: boolean = true) {
+    public setCompareStatus(compareStatus: CompareStatus, refresh: boolean = true): ContentWizardToolbarPublishControls {
         this.contentCompareStatus = compareStatus;
         if (refresh) {
             this.refreshState();
         }
+        return this;
     }
 
-    public setContentCanBePublished(value: boolean, refresh: boolean = true) {
+    setPublishStatus(publishStatus: PublishStatus): ContentWizardToolbarPublishControls {
+        this.publishStatus = publishStatus;
+        return this;
+    }
+
+    public setContentCanBePublished(value: boolean, refresh: boolean = true): ContentWizardToolbarPublishControls {
         this.contentCanBePublished = value;
         if (refresh) {
             this.refreshState();
         }
+        return this;
     }
 
-    public setUserCanPublish(value: boolean, refresh: boolean = true) {
+    public setUserCanPublish(value: boolean, refresh: boolean = true): ContentWizardToolbarPublishControls {
         this.userCanPublish = value;
         if (refresh) {
             this.refreshState();
         }
+        return this;
     }
 
-    public setLeafContent(leafContent: boolean, refresh: boolean = true) {
+    public setLeafContent(leafContent: boolean, refresh: boolean = true): ContentWizardToolbarPublishControls {
         this.leafContent = leafContent;
         if (refresh) {
             this.refreshState();
         }
+        return this;
     }
 
     private refreshState() {
@@ -108,7 +119,13 @@ export class ContentWizardToolbarPublishControls extends api.dom.DivEl {
         if (compareStatus === CompareStatus.EQUAL) {
             status.addClass("online");
         }
-        status.setHtml(api.content.CompareStatusFormatter.formatStatus(compareStatus));
+        if (this.publishStatus && (this.publishStatus == PublishStatus.PENDING || this.publishStatus == PublishStatus.EXPIRED)) {
+            status.addClass(api.content.PublishStatusFormatter.formatStatus(this.publishStatus).toLowerCase())
+            status.setHtml(api.content.CompareStatusFormatter.formatStatus(compareStatus) + ' (' +
+                           api.content.PublishStatusFormatter.formatStatus(this.publishStatus) + ')');
+        } else {
+            status.setHtml(api.content.CompareStatusFormatter.formatStatus(compareStatus));
+        }
         return "Item is " + status.toString();
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatus.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatus.ts
@@ -10,6 +10,8 @@ module api.content {
 
         private compareStatus: CompareStatus;
 
+        private publishStatus: PublishStatus;
+
         constructor() {
         }
 
@@ -17,8 +19,10 @@ module api.content {
             return new ContentSummaryAndCompareStatus().setContentSummary(contentSummary);
         }
 
-        public static fromContentAndCompareStatus(contentSummary: ContentSummary, compareStatus: CompareStatus) {
-            return new ContentSummaryAndCompareStatus().setContentSummary(contentSummary).setCompareStatus(compareStatus);
+        public static fromContentAndCompareAndPublishStatus(contentSummary: ContentSummary, compareStatus: CompareStatus,
+                                                            publishStatus: PublishStatus) {
+            return new ContentSummaryAndCompareStatus().setContentSummary(contentSummary).setCompareStatus(compareStatus).setPublishStatus(
+                publishStatus);
         }
 
         public static fromUploadItem(item: UploadItem<ContentSummary>): ContentSummaryAndCompareStatus {
@@ -40,6 +44,15 @@ module api.content {
 
         setCompareStatus(status: CompareStatus): ContentSummaryAndCompareStatus {
             this.compareStatus = status;
+            return this;
+        }
+
+        getPublishStatus(): PublishStatus {
+            return this.publishStatus;
+        }
+
+        setPublishStatus(publishStatus: PublishStatus): ContentSummaryAndCompareStatus {
+            this.publishStatus = publishStatus;
             return this;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/PublishStatus.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/PublishStatus.ts
@@ -1,0 +1,33 @@
+module api.content {
+
+    export enum PublishStatus {
+        ONLINE, PENDING, EXPIRED
+    }
+
+    export class PublishStatusFormatter {
+        public static formatStatus(publishStatus: PublishStatus): string {
+
+            var status;
+
+            switch (publishStatus) {
+            case PublishStatus.ONLINE:
+                status = "Online";
+                break;
+            case PublishStatus.PENDING:
+                status = "Pending";
+                break;
+            case PublishStatus.EXPIRED:
+                status = "Expired";
+                break;
+            default:
+                status = "Unknown"
+            }
+
+            if (!!CompareStatus[status]) {
+                return "Unknown";
+            }
+
+            return status;
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/_module.ts
@@ -12,6 +12,7 @@
 
 ///<reference path='ContentComboBox.ts' />
 ///<reference path='CompareStatus.ts' />
+///<reference path='PublishStatus.ts' />
 ///<reference path='Branch.ts' />
 ///<reference path='ContentSummaryAndCompareStatus.ts' />
 ///<reference path='ContentSummaryAndCompareStatusViewer.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/GetPublishStatusResultJson.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/GetPublishStatusResultJson.ts
@@ -1,8 +1,6 @@
 module api.content.json {
 
-    export interface CompareContentResultJson {
-
-        compareStatus: string;
+    export interface GetPublishStatusResultJson {
 
         publishStatus: string;
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/GetPublishStatusesResultJson.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/GetPublishStatusesResultJson.ts
@@ -1,0 +1,8 @@
+module api.content.json {
+
+    export interface GetPublishStatusesResultJson {
+
+        publishStatuses: GetPublishStatusResultJson[];
+    }
+
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/_module.ts
@@ -34,3 +34,5 @@
 ///<reference path='ContentsExistJson.ts' />
 ///<reference path='MoveContentResultJson.ts' />///<reference path='UnpublishContentJson.ts' />
 ///<reference path='ContentPublishTimeRangeJson.ts' />
+///<reference path='GetPublishStatusResultJson.ts' />
+///<reference path='GetPublishStatusesResultJson.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/ContentSummaryAndCompareStatusFetcher.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/ContentSummaryAndCompareStatusFetcher.ts
@@ -116,7 +116,8 @@ module api.content.resource {
             var list: ContentSummaryAndCompareStatus[] = [];
             contentSummaries.forEach((contentSummary: ContentSummary) => {
                 var compareResult: api.content.resource.result.CompareContentResult = compareResults.get(contentSummary.getId());
-                var newEntry = ContentSummaryAndCompareStatus.fromContentAndCompareStatus(contentSummary, compareResult.getCompareStatus());
+                var newEntry = ContentSummaryAndCompareStatus.fromContentAndCompareAndPublishStatus(
+                    contentSummary, compareResult.getCompareStatus(), compareResult.getPublishStatus());
                 list.push(newEntry)
             });
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/GetPublishStatusesRequest.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/GetPublishStatusesRequest.ts
@@ -1,0 +1,34 @@
+module api.content.resource {
+
+    import GetPublishStatusesResult = api.content.resource.result.GetPublishStatusesResult;
+    export class GetPublishStatusesRequest extends ContentResourceRequest<api.content.json.GetPublishStatusesResultJson, GetPublishStatusesResult> {
+
+        private ids: string[];
+
+        constructor(ids: string[]) {
+            super();
+            super.setMethod("POST");
+            this.ids = ids;
+        }
+
+        getParams(): Object {
+            return {
+                ids: this.ids
+            };
+        }
+
+        getRequestPath(): api.rest.Path {
+            return api.rest.Path.fromParent(super.getResourcePath(), "getPublishStatuses");
+        }
+
+        sendAndParse(): wemQ.Promise<GetPublishStatusesResult> {
+            return this.send().then((response: api.rest.JsonResponse<api.content.json.GetPublishStatusesResultJson>) => {
+                return this.fromJsonToGetPublishStatusesResult(response.getResult());
+            });
+        }
+
+        fromJsonToGetPublishStatusesResult(json: api.content.json.GetPublishStatusesResultJson): GetPublishStatusesResult {
+            return GetPublishStatusesResult.fromJson(json);
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/_module.ts
@@ -34,6 +34,7 @@
 ///<reference path='ResolvePublishRequestedContentsRequest.ts' />
 ///<reference path='ResolvePublishDependenciesRequest.ts' />
 ///<reference path='CompareContentRequest.ts' />
+///<reference path='GetPublishStatusesRequest.ts' />
 ///<reference path='ContentSummaryAndCompareStatusFetcher.ts' />
 ///<reference path='GetActiveContentVersionsRequest.ts' />
 ///<reference path='GetContentVersionsRequest.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/result/CompareContentResult.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/result/CompareContentResult.ts
@@ -1,16 +1,18 @@
 module api.content.resource.result {
 
-
     export class CompareContentResult implements api.Equitable {
 
-        compareStatus: api.content.CompareStatus;
+        compareStatus: CompareStatus;
 
         id: string;
 
-        constructor(id: string, compareStatus: CompareStatus) {
+        publishStatus: PublishStatus;
+
+        constructor(id: string, compareStatus: CompareStatus, publishStatus: PublishStatus) {
 
             this.compareStatus = compareStatus;
             this.id = id;
+            this.publishStatus = publishStatus;
         }
 
         getId(): string {
@@ -19,6 +21,10 @@ module api.content.resource.result {
 
         getCompareStatus(): CompareStatus {
             return this.compareStatus;
+        }
+
+        getPublishStatus(): PublishStatus {
+            return this.publishStatus;
         }
 
         equals(o: api.Equitable): boolean {
@@ -38,9 +44,10 @@ module api.content.resource.result {
 
         static fromJson(json: api.content.json.CompareContentResultJson): CompareContentResult {
 
-            var status: CompareStatus = <CompareStatus>CompareStatus[json.compareStatus];
+            var compareStatus: CompareStatus = <CompareStatus>CompareStatus[json.compareStatus],
+                publishStatus: PublishStatus = <PublishStatus>PublishStatus[json.publishStatus];
 
-            return new CompareContentResult(json.id, status);
+            return new CompareContentResult(json.id, compareStatus, publishStatus);
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/result/GetPublishStatusResult.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/result/GetPublishStatusResult.ts
@@ -1,0 +1,49 @@
+module api.content.resource.result {
+
+    export class GetPublishStatusResult implements api.Equitable {
+
+        publishStatus: api.content.PublishStatus;
+
+        id: string;
+
+        constructor(id: string, publishStatus: PublishStatus) {
+
+            this.publishStatus = publishStatus;
+            this.id = id;
+        }
+
+        getId(): string {
+            return this.id;
+        }
+
+        getPublishStatus(): PublishStatus {
+            return this.publishStatus;
+        }
+
+        equals(o: api.Equitable): boolean {
+
+            if (!api.ObjectHelper.iFrameSafeInstanceOf(o, GetPublishStatusResult)) {
+                return false;
+            }
+
+            var other = <GetPublishStatusResult>o;
+
+            if (!api.ObjectHelper.stringEquals(this.id.toString(), other.id.toString())) {
+                return false;
+            }
+
+            if (!api.ObjectHelper.objectEquals(this.publishStatus, other.publishStatus)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        static fromJson(json: api.content.json.GetPublishStatusResultJson): GetPublishStatusResult {
+
+            var status: PublishStatus = <PublishStatus>PublishStatus[json.publishStatus];
+
+            return new GetPublishStatusResult(json.id, status);
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/result/GetPublishStatusesResult.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/result/GetPublishStatusesResult.ts
@@ -1,0 +1,40 @@
+module api.content.resource.result {
+
+    export class GetPublishStatusesResult {
+
+        private getPublishStatusesResult: GetPublishStatusResult[] = [];
+
+        constructor(getPublishStatusesResult: GetPublishStatusResult[]) {
+            this.getPublishStatusesResult = getPublishStatusesResult;
+        }
+
+        get(contentId: string): GetPublishStatusResult {
+
+            var getPublishStatusResult: GetPublishStatusResult = null;
+
+            this.getPublishStatusesResult.forEach((result: GetPublishStatusResult) => {
+
+                if (result.getId() == contentId) {
+                    getPublishStatusResult = result;
+                }
+            });
+
+            return getPublishStatusResult;
+        }
+
+        getAll(): GetPublishStatusResult[] {
+            return this.getPublishStatusesResult;
+        }
+
+        static fromJson(json: api.content.json.GetPublishStatusesResultJson): GetPublishStatusesResult {
+
+            var list: GetPublishStatusResult[] = [];
+
+            json.publishStatuses.forEach((getPublishStatusResult: api.content.json.GetPublishStatusResultJson) => {
+                list.push(GetPublishStatusResult.fromJson(getPublishStatusResult));
+            });
+
+            return new GetPublishStatusesResult(list);
+        }
+    }
+}

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/result/_module.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/result/_module.ts
@@ -7,3 +7,5 @@
 ///<reference path='CompareContentResults.ts' />
 ///<reference path='CompareContentResult.ts' />
 ///<reference path='ContentsExistResult.ts' />
+///<reference path='GetPublishStatusResult.ts' />
+///<reference path='GetPublishStatusesResult.ts' />

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-tree-grid.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-tree-grid.less
@@ -10,8 +10,8 @@
       padding-left: 0px;
     }
     .shifted .toggle.icon {
-        width: 45px;
-        margin-right: 0;
+      width: 45px;
+      margin-right: 0;
     }
   }
 
@@ -19,19 +19,34 @@
     line-height: 37px;
   }
 
-  .slick-cell {
-    &:not(.selected) {
-      &.status .equal {
-        color: @admin-green;
+  .grid .slick-row {
+    .slick-cell {
+      &:not(.selected) {
+        &.status .equal {
+          color: @admin-green;
+          &.pending {
+            color: darkorange;
+          }
+          &.expired {
+            color: @admin-red;
+          }
+        }
       }
-    }
 
-    &.order .sort-dialog-trigger:before {
-      margin-left: 6px;
-    }
+      &.status {
+        text-align: center;
+        div:not(.online) {
+          line-height: 18px;
+        }
+      }
 
-    &.slick-cell-checkboxsel:last-child {
-      padding-right: 20px;
+      &.order .sort-dialog-trigger:before {
+        margin-left: 6px;
+      }
+
+      &.slick-cell-checkboxsel:last-child {
+        padding-right: 20px;
+      }
     }
   }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
@@ -210,6 +210,12 @@
             color: @admin-black;
             &.online {
               color: @admin-green;
+              &.pending {
+                color: darkorange;
+              }
+              &.expired {
+                color: @admin-red;
+              }
             }
           }
         }


### PR DESCRIPTION
- Adjusted ContentResource.compare method to return publish status as well - as this method is used by treegrid so that we don't need to do subsequent call to getPublishStatuses. Changed appropriate json classes on back-end and front-end
- Adjusted ContentSummaryAndCompareStatus.ts to store publishResult field
- Adjusted statusFormatter of ContentRowFormatter so that it displays 'pending' and 'expired' publish statuses along with compare status in TreeGird
- Adjusted ContentWizardToolbarPublishControls to manage publishStatus along with compareStatus. Adjusted WizardPanel to set publish status into it.
- Added GetPublishStatusesRequest.ts and appropriate json and wrapper classes
- Adjusted styles