### PR TITLE
XP-4563 fix content.js so that it is rendered

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -1355,6 +1355,11 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
                         optionSetProperty.removeProperty(option.getName(), 0);
                     }
                 })
+                // remove selection array
+                var selectionArraySize = selectionArray.getSize();
+                for (var i = 0; i < selectionArraySize; i++) {
+                    optionSetProperty.removeProperty("_selected", 0);
+                }
             }
         });
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/set/optionset/FormOptionSetOccurrenceView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/set/optionset/FormOptionSetOccurrenceView.ts
@@ -171,19 +171,17 @@ module api.form {
         }
 
         protected ensureSelectionArrayExists(propertyArraySet: PropertySet) {
-            var selectionPropertyArray = propertyArraySet.getPropertyArray("_selected");
-            if (!selectionPropertyArray) {
-                selectionPropertyArray =
-                    PropertyArray.create().setType(ValueTypes.STRING).setName("_selected").setParent(
-                        propertyArraySet).build();
-                propertyArraySet.addPropertyArray(selectionPropertyArray);
-                this.addDefaultSelectionToSelectionArray(selectionPropertyArray);
-            }
+            var selectionPropertyArray =
+                PropertyArray.create().setType(ValueTypes.STRING).setName("_selected").setParent(
+                    propertyArraySet).build();
+            propertyArraySet.addPropertyArray(selectionPropertyArray);
+            this.addSelectionToSelectionArray(propertyArraySet, selectionPropertyArray);
         }
 
-        private addDefaultSelectionToSelectionArray(selectionPropertyArray: PropertyArray) {
+        private addSelectionToSelectionArray(propertyArraySet: PropertySet, selectionPropertyArray: PropertyArray) {
             this.formOptionSet.getOptions().forEach((option: FormOptionSetOption) => {
-                if (option.isDefaultOption() && selectionPropertyArray.getSize() < this.formOptionSet.getMultiselection().getMaximum()) {
+                if (propertyArraySet.getProperty(option.getName()) &&
+                    selectionPropertyArray.getSize() < this.formOptionSet.getMultiselection().getMaximum()) {
                     selectionPropertyArray.add(new Value(option.getName(), new api.data.ValueTypeString()))
                 }
             });

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/validate/OccurrenceValidatorTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/validate/OccurrenceValidatorTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentPath;
+import com.enonic.xp.data.PropertySet;
 import com.enonic.xp.form.FieldSet;
 import com.enonic.xp.form.FormItemSet;
 import com.enonic.xp.form.FormOptionSet;
@@ -659,25 +660,12 @@ public class OccurrenceValidatorTest
     }
 
     @Test
-    public void given_optionset_with_default_selection_passes_multiselection_check()
-    {
-        contentType.getForm().addFormItem( makeOptionSet( "myOptionSet", 1, 1, 1, 1 ) );
-
-        Content content = Content.create().path( MY_CONTENT_PATH ).type( contentType.getName() ).build();
-        content.getData().setString( "myOptionSet.option1.myUnrequiredData", "1" );
-        DataValidationErrors validationResults = newValidator( contentType ).validate( content.getData().getRoot() );
-        assertFalse( validationResults.hasErrors() );
-    }
-
-    @Test
-    public void given_optionset_with_required_selection_and_empty_selection_array_fails_multiselection_check()
+    public void given_optionset_with_required_selection_and_empty_selection_data_fails_multiselection_check()
     {
         contentType.getForm().addFormItem( makeOptionSet( "myOptionSet", 0, 0, 1, 1 ) );
 
         Content content = Content.create().path( MY_CONTENT_PATH ).type( contentType.getName() ).build();
-        content.getData().setString( "myOptionSet.option1.myUnrequiredData", "1" );
-        content.getData().setString( "myOptionSet._selected", "1" );
-        content.getData().removeProperty( "myOptionSet._selected" );
+        content.getData().setSet( "myOptionSet", new PropertySet() );
         DataValidationErrors validationResults = newValidator( contentType ).validate( content.getData().getRoot() );
         assertTrue( validationResults.hasErrors() );
         assertTrue( validationResults.getFirst() instanceof OptionSetSelectionValidationError );
@@ -685,15 +673,15 @@ public class OccurrenceValidatorTest
     }
 
     @Test
-    public void given_optionset_with_required_selection_selection_array_hast_too_many_selected_options()
+    public void given_optionset_with_required_selection_has_too_many_selected_options()
     {
         contentType.getForm().addFormItem( makeOptionSet( "myOptionSet", 3, 0, 1, 2 ) );
 
         Content content = Content.create().path( MY_CONTENT_PATH ).type( contentType.getName() ).build();
-        content.getData().setString( "myOptionSet.option1.myUnrequiredData", "1" );
-        content.getData().getSet( "myOptionSet" ).addString( "_selected", "option1" );
-        content.getData().getSet( "myOptionSet" ).addString( "_selected", "option2" );
-        content.getData().getSet( "myOptionSet" ).addString( "_selected", "option3" );
+        content.getData().setSet( "myOptionSet", new PropertySet() );
+        content.getData().getSet( "myOptionSet" ).addSet( "option1", new PropertySet() );
+        content.getData().getSet( "myOptionSet" ).addSet( "option2", new PropertySet() );
+        content.getData().getSet( "myOptionSet" ).addSet( "option3", new PropertySet() );
 
         DataValidationErrors validationResults = newValidator( contentType ).validate( content.getData().getRoot() );
         assertTrue( validationResults.hasErrors() );
@@ -702,7 +690,7 @@ public class OccurrenceValidatorTest
     }
 
     @Test
-    public void given_optionset_with_required_selection_selection_array_hast_too_little_selected_options()
+    public void given_optionset_with_required_selection_selection_data_has_too_little_options()
     {
         contentType.getForm().addFormItem( makeOptionSet( "myOptionSet", 3, 0, 3, 3 ) );
 
@@ -718,25 +706,12 @@ public class OccurrenceValidatorTest
     }
 
     @Test
-    public void given_optionset_with_required_selection_and_missing_selection_array_has_too_many_default_options()
-    {
-        contentType.getForm().addFormItem( makeOptionSet( "myOptionSet", 0, 2, 1, 1 ) );
-
-        Content content = Content.create().path( MY_CONTENT_PATH ).type( contentType.getName() ).build();
-        content.getData().setString( "myOptionSet.option1.myUnrequiredData", "1" );
-        DataValidationErrors validationResults = newValidator( contentType ).validate( content.getData().getRoot() );
-        assertTrue( validationResults.hasErrors() );
-        assertTrue( validationResults.getFirst() instanceof OptionSetSelectionValidationError );
-        assertEquals( "OptionSet [myOptionSet] requires min 1 max 1 items selected: 2", validationResults.getFirst().getErrorMessage() );
-    }
-
-    @Test
-    public void given_optionset_with_required_selection_and_missing_selection_array_has_too_little_default_options()
+    public void given_optionset_with_required_selection_and_missing_selection_data_fails()
     {
         contentType.getForm().addFormItem( makeOptionSet( "myOptionSet", 2, 0, 1, 1 ) );
 
         Content content = Content.create().path( MY_CONTENT_PATH ).type( contentType.getName() ).build();
-        content.getData().setString( "myOptionSet.option1.myUnrequiredData", "1" );
+        content.getData().setSet( "myOptionSet", new PropertySet() );
 
         DataValidationErrors validationResults = newValidator( contentType ).validate( content.getData().getRoot() );
         assertTrue( validationResults.hasErrors() );

--- a/modules/core/core-schema/src/main/java/com/enonic/xp/core/impl/form/FormDefaultValuesProcessorImpl.java
+++ b/modules/core/core-schema/src/main/java/com/enonic/xp/core/impl/form/FormDefaultValuesProcessorImpl.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.enonic.xp.data.PropertyPath;
+import com.enonic.xp.data.PropertySet;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.data.Value;
 import com.enonic.xp.form.FieldSet;
@@ -72,11 +73,16 @@ public final class FormDefaultValuesProcessorImpl
                 FormOptionSetOption option = formItem.toFormOptionSetOption();
                 if ( option.isDefaultOption() )
                 {
+                    data.getSet( parentPath ).addSet( option.getName() );
                     processFormItems( option.getFormItems(), data, PropertyPath.from( parentPath, formItem.getName() ) );
                 }
             }
             else if ( formItem.getType() == FORM_OPTION_SET )
             {
+                if ( data.getSet( PropertyPath.from( parentPath, formItem.getName() ) ) == null )
+                {
+                    data.setSet( PropertyPath.from( parentPath, formItem.getName() ), new PropertySet() );
+                }
                 processFormItems( formItem.toFormOptionSet().getFormItems(), data, PropertyPath.from( parentPath, formItem.getName() ) );
             }
         } );

--- a/modules/core/core-schema/src/test/java/com/enonic/xp/core/impl/form/FormDefaultValuesProcessorImplTest.java
+++ b/modules/core/core-schema/src/test/java/com/enonic/xp/core/impl/form/FormDefaultValuesProcessorImplTest.java
@@ -165,4 +165,27 @@ public class FormDefaultValuesProcessorImplTest
         assertEquals( "default", data.getString( "myOptionSet.option1.myInput" ) );
         assertNull( data.getDouble( "myOptionSet.option1.myDouble" ) );
     }
+
+    @Test
+    public void testOptionSetHasDefaultOptionsInData()
+    {
+        FormOptionSet.Builder myOptionSet = FormOptionSet.create().required( false ).name( "myOptionSet" );
+
+        FormOptionSetOption.Builder option1 = FormOptionSetOption.create().name( "option1" ).defaultOption( true );
+        FormOptionSetOption.Builder option2 = FormOptionSetOption.create().name( "option2" );
+
+        myOptionSet.addOptionSetOption( option1.build() );
+        myOptionSet.addOptionSetOption( option2.build() );
+
+        final Form form = Form.create().
+            addFormItem( myOptionSet.build() ).
+            build();
+
+        final FormDefaultValuesProcessor defaultValuesProcessor = new FormDefaultValuesProcessorImpl();
+        final PropertyTree data = new PropertyTree();
+        defaultValuesProcessor.setDefaultValues( form, data );
+
+        assertNotNull( data.getSet( "myOptionSet.option1" ) );
+        assertNull( data.getSet( "myOptionSet.option2" ) );
+    }
 }


### PR DESCRIPTION
- Changed the way option set stores selection - as recently we've made option  set's PropertySet to store only properties of selected items - there is no need for usage of selection array. The fact that option exists in PropertySet means that it is selected, hence, removed its uses from back-end, though on front-end it's still used for user operations.
- Adjusted FormDefaultValuesProcessorImpl to add default options to option set's PropertySet
- Adjusted cleanFormRedundantData() method of ContentWizardPanel to remove selection array property
- Adjusted OccurrenceValidator
- Added and updated test