### PR TITLE
XP-4653 In Content Studio, Browse view triggers parts twice

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/ContentItemPreviewPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/ContentItemPreviewPanel.ts
@@ -168,7 +168,7 @@ export class ContentItemPreviewPanel extends api.app.view.ItemPreviewPanel {
                     this.setPreviewType(PREVIEW_TYPE.PAGE);
                     var src = api.rendering.UriHelper.getPortalUri(item.getPath(), RenderingMode.PREVIEW, api.content.Branch.DRAFT);
                     // test if it returns no error( like because of used app was deleted ) first and show no preview otherwise
-                    wemjq.get(src).done(() => this.frame.setSrc(src)).fail(() => this.setPreviewType(PREVIEW_TYPE.FAILED));
+                    this.frame.setSrc(src);
                 } else {
                     this.setPreviewType(PREVIEW_TYPE.EMPTY);
                 }


### PR DESCRIPTION
- Removed extra check (that doubles same request) made by jquery that checks if portal may render preview - firstly, this is a job for isRenderable() check which stands above, secondly, XP-3126 is not reproduced anymore