### PR TITLE
XP-4653 In Content Studio, Browse view triggers parts twice

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/ContentItemPreviewPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/ContentItemPreviewPanel.ts
@@ -168,7 +168,11 @@ export class ContentItemPreviewPanel extends api.app.view.ItemPreviewPanel {
                     this.setPreviewType(PREVIEW_TYPE.PAGE);
                     var src = api.rendering.UriHelper.getPortalUri(item.getPath(), RenderingMode.PREVIEW, api.content.Branch.DRAFT);
                     // test if it returns no error( like because of used app was deleted ) first and show no preview otherwise
-                    wemjq.get(src).done(() => this.frame.setSrc(src)).fail(() => this.setPreviewType(PREVIEW_TYPE.FAILED));
+                    wemjq.ajax({
+                        type: "HEAD",
+                        async: true,
+                        url: src
+                    }).done(() => this.frame.setSrc(src)).fail(() => this.setPreviewType(PREVIEW_TYPE.FAILED));
                 } else {
                     this.setPreviewType(PREVIEW_TYPE.EMPTY);
                 }


### PR DESCRIPTION
- Replaced ajax.get() with ajax.head request so that we know if content will render without rendering the page and passing back heavy content body