### PR TITLE
XP-4633 Fragment Wizard -Error appears in the browser console, when s…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsView.ts
@@ -87,6 +87,8 @@ export class PageComponentsView extends api.dom.DivEl {
             }
         });
 
+        this.onAdded(this.initLiveEditEvents.bind(this));
+
         this.responsiveItem = ResponsiveManager.onAvailableSizeChanged(api.dom.Body.get(), (item: ResponsiveItem) => {
             var smallSize = item.isInRangeOrSmaller(ResponsiveRanges._360_540);
             if (!smallSize && this.isVisible()) {
@@ -155,9 +157,7 @@ export class PageComponentsView extends api.dom.DivEl {
         }
     }
 
-    private createTree(content: Content, pageView: PageView) {
-        this.tree = new PageComponentsTreeGrid(content, pageView);
-
+    private initLiveEditEvents() {
         this.liveEditPage.onItemViewSelected((event: ItemViewSelectedEvent) => {
             if (!event.isNew() && !this.pageView.isLocked()) {
                 var selectedItemId = this.tree.getDataId(event.getItemView());
@@ -264,6 +264,10 @@ export class PageComponentsView extends api.dom.DivEl {
 
             this.removeFromInvalidItems(oldDataId);
         });
+    }
+
+    private createTree(content: Content, pageView: PageView) {
+        this.tree = new PageComponentsTreeGrid(content, pageView);
 
         this.clickListener = (event, data) => {
             var elem = new api.dom.ElementHelper(event.target);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ComponentView.ts
@@ -289,7 +289,8 @@ module api.liveedit {
 
         clone(): ComponentView<Component> {
 
-            var index = this.getParentItemView().getComponentViewIndex(this);
+            var isFragmentContent = this.liveEditModel.getContent().getType().isFragment();
+            var index = isFragmentContent ? 0 : this.getParentItemView().getComponentViewIndex(this);
 
             var clone = this.getType().createView(
                 new CreateItemViewConfig<RegionView,Component>().


### PR DESCRIPTION
…elected option was removed in the Inspection Panel

-Clone() method in ComponentView was not handling Fragment correctly
-PageComponentsView is not instantiating tree until PCV is added into page, but live edit events were already bind and on those events errors occur