### PR TITLE
XP-4687 Principals with an uppercase letter in the name cannot be del…

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/CreateNodeParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/CreateNodeParams.java
@@ -226,7 +226,7 @@ public class CreateNodeParams
 
         public Builder setNodeId( final NodeId nodeId )
         {
-            this.nodeId = nodeId;
+            this.nodeId = nodeId != null ? NodeId.from( nodeId.toString().toLowerCase() ) : null;
             return this;
         }
 


### PR DESCRIPTION
…eted

Setting lowercase nodeId when creating nodes to prevent more case-sensitive nodes beeing created.