### PR TITLE
XP-4673 Mobile - Preview panel transition is not entirely smooth in F…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
@@ -219,7 +219,11 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
             return defer.promise;
         };
 
-        const showMobilePanel = () => this.mobileContentItemStatisticsPanel.slideIn();
+        const showMobilePanel = () => {
+            setTimeout(() => {
+                this.mobileContentItemStatisticsPanel.slideIn();
+            }, 400);
+        }
 
         const updateAndShowMobilePanel = () => updateMobilePanel().then(showMobilePanel);
 


### PR DESCRIPTION
…irefox

- Added timeout before sliding mobileContentItemStatisticsPanel for mobile in order to let preview panel render it's content, otherwise, while transitioning, changing dom causes sliding artifacts both in chrome and FF