### PR TITLE
XP-4695 Update TSLint minor rules and fix errors

### DIFF
--- a/modules/admin/admin-ui/gulp/util/git.js
+++ b/modules/admin/admin-ui/gulp/util/git.js
@@ -37,10 +37,10 @@ function mergeBase() {
     });
 }
 
-// git diff --name-only origin/master..HEAD
-//   Outputs modified files from all commits that are not in master yet
+// git diff --name-only origin/master
+//   Outputs modified files from all commits that are not in master yet and indexed files
 function diff(branch = 'origin/master', extension = '') {
-    const options = ['--name-only', `${branch}..HEAD`];
+    const options = ['--name-only', `${branch}`];
     return new Promise((resolve) => {
         git.diff(options, (err, result) => {
             const files = !result ? [] : result.trim().split('\n');

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/applications/js/app/browse/ApplicationBrowseActions.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/applications/js/app/browse/ApplicationBrowseActions.ts
@@ -21,7 +21,7 @@ export class ApplicationBrowseActions implements TreeGridActions<Application> {
     private static INSTANCE: ApplicationBrowseActions;
 
     static init(applicationTreeGrid: ApplicationTreeGrid): ApplicationBrowseActions {
-        new ApplicationBrowseActions(applicationTreeGrid);
+        ApplicationBrowseActions.INSTANCE = new ApplicationBrowseActions(applicationTreeGrid);
         return ApplicationBrowseActions.INSTANCE;
     }
 
@@ -39,8 +39,6 @@ export class ApplicationBrowseActions implements TreeGridActions<Application> {
         this.INSTALL_APPLICATION.setEnabled(true);
 
         this.allActions.push(this.START_APPLICATION, this.STOP_APPLICATION, this.UNINSTALL_APPLICATION);
-
-        ApplicationBrowseActions.INSTANCE = this;
     }
 
     getAllActions(): api.ui.Action[] {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
@@ -234,12 +234,12 @@ export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
 
         let visibleItems = [];
 
-        for (let key in items) {
-            let position = items[key].getEl().getOffsetTop();
+        items.forEach((item) => {
+            let position = item.getEl().getOffsetTop();
             if (position >= start && position <= end) {
-                visibleItems.push(items[key]);
+                visibleItems.push(item);
             }
-        }
+        });
 
         lastVisible = items.indexOf(visibleItems[visibleItems.length - 1]);
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -1122,17 +1122,20 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
 
             return wemQ.all(metadataMixinPromises);
         }).then((mixins: Mixin[]) => {
-            var activeMixinsNames = api.schema.mixin.MixinNames.create().fromMixins(mixins).build();
+            const activeMixinsNames = api.schema.mixin.MixinNames.create().fromMixins(mixins).build();
 
-            var panelNamesToRemoveBuilder = MixinNames.create();
+            const panelNamesToRemoveBuilder = MixinNames.create();
 
-            for (var key in this.metadataStepFormByName) {// check all old mixin panels
-                var mixinName = new MixinName(key);
-                if (!activeMixinsNames.contains(mixinName)) {
-                    panelNamesToRemoveBuilder.addMixinName(mixinName);
+            const meta = this.metadataStepFormByName;
+            for (const name in meta) { // check all old mixin panels
+                if (meta.hasOwnProperty(name)) {
+                    const mixinName = new MixinName(name);
+                    if (!activeMixinsNames.contains(mixinName)) {
+                        panelNamesToRemoveBuilder.addMixinName(mixinName);
+                    }
                 }
             }
-            var panelNamesToRemove = panelNamesToRemoveBuilder.build();
+            const panelNamesToRemove = panelNamesToRemoveBuilder.build();
             panelNamesToRemove.forEach((panelName: MixinName) => {
                 this.removeStepWithForm(this.metadataStepFormByName[panelName.toString()]);
                 delete this.metadataStepFormByName[panelName.toString()];

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsTreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/PageComponentsTreeGrid.ts
@@ -98,7 +98,7 @@ export class PageComponentsTreeGrid extends TreeGrid<ItemView> {
 
     fetch(node: TreeNode<ItemView>, dataId?: string): Q.Promise<ItemView> {
         var deferred = wemQ.defer<ItemView>();
-        var itemViewId = dataId ? new api.liveedit.ItemViewId(parseInt(dataId)) : node.getData().getItemId();
+        var itemViewId = dataId ? new api.liveedit.ItemViewId(parseInt(dataId, 10)) : node.getData().getItemId();
         deferred.resolve(this.pageView.getItemViewById(itemViewId));
         return deferred.promise;
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/main.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/main.ts
@@ -121,7 +121,7 @@ function updateFavicon(content: Content, iconUrlResolver: ContentIconUrlResolver
         let sizes = link.getAttribute('sizes').split('x');
         if (sizes.length > 0) {
             try {
-                resolver.setSize(parseInt(sizes[0]));
+                resolver.setSize(parseInt(sizes[0], 10));
             } catch (e) { }
         }
         link.setAttribute('href', resolver.resolve());

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/main.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/main.ts
@@ -65,29 +65,38 @@ function startLostConnectionDetector() {
 }
 
 function initToolTip() {
-    var ID = api.StyleHelper.getCls("tooltip", api.StyleHelper.COMMON_PREFIX),
-        CLS_ON = "tooltip_ON", FOLLOW = true,
-        DATA = "_tooltip", OFFSET_X = 0, OFFSET_Y = 20,
-        pageX = 0, pageY = 0,
-        showAt = function (e) {
-            var ntop = pageY + OFFSET_Y, nleft = pageX + OFFSET_X;
-            var tooltipText = api.util.StringHelper.escapeHtml(wemjq(e.currentTarget || e.target).data(DATA));
-            if (!tooltipText) { //if no text then probably hovering over children of original element that has title attr
-                return;
-            }
 
-            var tooltipWidth = tooltipText.length * 7.5;
-            var windowWidth = wemjq(window).width();
-            if (nleft + tooltipWidth >= windowWidth) {
-                nleft = windowWidth - tooltipWidth;
-            }
-            wemjq("#" + ID).html(tooltipText).css({
-                position: "absolute", top: ntop, left: nleft
-            }).show();
+    const ID = api.StyleHelper.getCls("tooltip", api.StyleHelper.COMMON_PREFIX);
+    const CLS_ON = "tooltip_ON";
+    const FOLLOW = true;
+    const DATA = "_tooltip";
+    const OFFSET_X = 0;
+    const OFFSET_Y = 20;
+
+    let pageX = 0;
+    let pageY = 0;
+
+    const showAt = function (e) {
+        const top = pageY + OFFSET_Y;
+        let left = pageX + OFFSET_X;
+
+        const tooltipText = api.util.StringHelper.escapeHtml(wemjq(e.currentTarget || e.target).data(DATA));
+        if (!tooltipText) { //if no text then probably hovering over children of original element that has title attr
+            return;
+        }
+
+        const tooltipWidth = tooltipText.length * 7.5;
+        const windowWidth = wemjq(window).width();
+        if (left + tooltipWidth >= windowWidth) {
+            left = windowWidth - tooltipWidth;
+        }
+        wemjq("#" + ID).html(tooltipText).css({
+            position: "absolute", top, left
+        }).show();
         };
     wemjq(document).on("mouseenter", "*[title]", function (e) {
-        wemjq(this).data(DATA, wemjq(this).attr("title"));
-        wemjq(this).removeAttr("title").addClass(CLS_ON);
+        wemjq(window).data(DATA, wemjq(window).attr("title"));
+        wemjq(window).removeAttr("title").addClass(CLS_ON);
         wemjq("<div id='" + ID + "' />").appendTo("body");
         if (e.pageX) {
             pageX = e.pageX;
@@ -98,10 +107,10 @@ function initToolTip() {
         showAt(e);
     });
     wemjq(document).on("mouseleave click", "." + CLS_ON, function (e) {
-        if (wemjq(this).data(DATA)) {
-            wemjq(this).attr("title", wemjq(this).data(DATA));
+        if (wemjq(window).data(DATA)) {
+            wemjq(window).attr("title", wemjq(window).data(DATA));
         }
-        wemjq(this).removeClass(CLS_ON);
+        wemjq(window).removeClass(CLS_ON);
         wemjq("#" + ID).remove();
     });
     if (FOLLOW) { wemjq(document).on("mousemove", "." + CLS_ON, showAt); }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ObjectHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ObjectHelper.ts
@@ -147,16 +147,16 @@ module api {
                 return false;
             }
 
-            for (var keyA  in keysA) {
+            return keysA.every((keyA: string) => {
                 var valueA: Equitable = mapA[keysA[keyA]];
                 var valueB: Equitable = mapB[keysA[keyA]];
 
                 if (!ObjectHelper.equals(valueA, valueB)) {
                     return false;
                 }
-            }
 
-            return true;
+                return true;
+            });
         }
 
         static stringEquals(a: string, b: string) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/AppManager.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/AppManager.ts
@@ -1,7 +1,7 @@
 module api.app {
 
     export class AppManager {
-        private static _instance: api.app.AppManager = null;
+        private static INSTANCE: api.app.AppManager = null;
 
         private connectionLostListeners: {():void}[] = [];
 
@@ -10,7 +10,7 @@ module api.app {
         private showLauncherListeners: {():void}[] = [];
 
         constructor() {
-            api.app.AppManager._instance = this;
+            api.app.AppManager.INSTANCE = this;
 
         }
 
@@ -47,19 +47,19 @@ module api.app {
         }
 
         static instance(): api.app.AppManager {
-            if (api.app.AppManager._instance) {
-                return api.app.AppManager._instance;
+            if (api.app.AppManager.INSTANCE) {
+                return api.app.AppManager.INSTANCE;
             } else if (window !== window.parent) {
                 // look for instance in parent frame
                 var apiAppModule = (<any> window.parent).api.app;
                 if (apiAppModule && apiAppModule.AppManager) {
-                    var parentAppManager = <api.app.AppManager> apiAppModule.AppManager._instance;
+                    var parentAppManager = <api.app.AppManager> apiAppModule.AppManager.INSTANCE;
                     if (parentAppManager) {
-                        api.app.AppManager._instance = parentAppManager;
+                        api.app.AppManager.INSTANCE = parentAppManager;
                     }
                 }
             }
-            return api.app.AppManager._instance;
+            return api.app.AppManager.INSTANCE;
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/bar/AppBarTabMenu.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/bar/AppBarTabMenu.ts
@@ -172,15 +172,13 @@ module api.app.bar {
         }
 
         private makeTabFirst(tab: AppBarTabMenuItem) {
-            var canBeMoved;
+            const menuWithTab = menuTab => this.getMenuEl().hasChild(menuTab) ? this.getMenuEl() : null;
+            const barWithTab = barTab => this.barEl.hasChild(barTab) ? this.barEl : null;
 
-            if (canBeMoved = this.getMenuEl().hasChild(tab)) {
-                this.getMenuEl().removeChild(tab);
-            } else if (canBeMoved = this.barEl.hasChild(tab)) {
-                this.barEl.removeChild(tab);
-            }
+            const elemWithTab = menuWithTab(tab) || barWithTab(tab);
 
-            if (canBeMoved) {
+            if (elemWithTab) {
+                elemWithTab.removeChild(tab);
                 this.barEl.prependChild(tab);
                 this.moveTabs();
             }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/application/MarketApplication.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/application/MarketApplication.ts
@@ -31,9 +31,11 @@ module api.application {
         }
 
         static fromJsonArray(appsObj: Object): MarketApplication[] {
-            var array: MarketApplication[] = [];
-            for (var property in appsObj) {
-                array.push(MarketApplication.fromJson(property, <api.application.json.MarketApplicationJson>appsObj[property]));
+            const array: MarketApplication[] = [];
+            for (const name in appsObj) {
+                if (appsObj.hasOwnProperty(name)) {
+                    array.push(MarketApplication.fromJson(name, <api.application.json.MarketApplicationJson>appsObj[name]));
+                }
             }
             return array;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
@@ -26,7 +26,7 @@ module api.content.form.inputtype.image {
 
         private removeSelectedOptionsListeners: {(option: SelectedOption<ImageSelectorDisplayValue>[]): void}[] = [];
 
-        private mouseClickListener: {(MouseEvent): void};
+        private mouseClickListener: (event: MouseEvent) => void;
 
         private clickDisabled: boolean = false;
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorSelectedOptionsView.ts
@@ -131,6 +131,7 @@ module api.content.form.inputtype.image {
                 this.notifyOptionSelected(new SelectedOptionEvent(selectedOption, keyCode));
             }
 
+            // tslint:disable-next-line:no-unused-new
             new Tooltip(optionView, isMissingContent ? option.value : option.displayValue.getPath(), 1000);
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/image/ImageUploaderEl.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/image/ImageUploaderEl.ts
@@ -94,13 +94,13 @@ module api.content.image {
                 metaData = content.getContentData().getProperty('metadata');
 
             if (metaData && api.data.ValueTypes.DATA.equals(metaData.getType())) {
-                value = parseInt(metaData.getPropertySet().getProperty(propertyName).getString());
+                value = parseInt(metaData.getPropertySet().getProperty(propertyName).getString(), 10);
             }
             else {
                 var allExtraData = content.getAllExtraData();
                 allExtraData.forEach((extraData: ExtraData) => {
                     if (!value && extraData.getData().getProperty(propertyName)) {
-                        value = parseInt(extraData.getData().getProperty(propertyName).getValue().getString());
+                        value = parseInt(extraData.getData().getProperty(propertyName).getValue().getString(), 10);
                     }
                 });
             }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/page/region/ComponentPath.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/page/region/ComponentPath.ts
@@ -102,7 +102,7 @@ module api.content.page.region {
             for (var i = 0; i < elements.length - 1; i += 2) {
                 var regionName = elements[i];
                 var componentIndexAsString = elements[i + 1];
-                var regionAndComponent = new ComponentPathRegionAndComponent(regionName, parseInt(componentIndexAsString));
+                var regionAndComponent = new ComponentPathRegionAndComponent(regionName, parseInt(componentIndexAsString, 10));
                 regionAndComponentList.push(regionAndComponent);
             }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/page/region/Regions.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/page/region/Regions.ts
@@ -68,9 +68,10 @@ module api.content.page.region {
 
         getRegions(): Region[] {
             var regions = [];
-            for (var i in this.regionByName) {
-                var region = this.regionByName[i];
-                regions.push(region);
+            for (const name in this.regionByName) {
+                if (this.regionByName.hasOwnProperty(name)) {
+                    regions.push(this.regionByName[name]);
+                }
             }
             return regions;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/data/PropertyPath.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/data/PropertyPath.ts
@@ -149,7 +149,7 @@ module api.data {
                 return new PropertyPathElement(str, 0);
             }
             var name = str.substring(0, str.indexOf("["));
-            var index = parseInt(str.substring(str.indexOf("[") + 1, str.indexOf("]")));
+            var index = parseInt(str.substring(str.indexOf("[") + 1, str.indexOf("]")), 10);
             return new PropertyPathElement(name, index);
         }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/data/PropertySet.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/data/PropertySet.ts
@@ -213,8 +213,9 @@ module api.data {
         }
 
         isEmpty(): boolean {
-            var isEmpty: boolean = true;
-            for (var name in this.propertyArrayByName) {
+            let isEmpty: boolean = true;
+            // tslint:disable-next-line:forin
+            for (const name in this.propertyArrayByName) {
                 if (!isEmpty) {
                     return isEmpty;
                 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/data/PropertySet.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/data/PropertySet.ts
@@ -57,7 +57,7 @@ module api.data {
         /**
          * If true, do not add property if it's value is null.
          */
-        private _ifNotNull: boolean = false;
+        private skipNulls: boolean = false;
 
         private changedListeners: {(event: PropertyEvent): void}[] = [];
 
@@ -137,8 +137,8 @@ module api.data {
 
         addProperty(name: string, value: Value): Property {
 
-            if (this._ifNotNull && value.isNull()) {
-                this._ifNotNull = false;
+            if (this.skipNulls && value.isNull()) {
+                this.skipNulls = false;
                 return null;
             }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/ElementHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/ElementHelper.ts
@@ -710,12 +710,15 @@ module api.dom {
          */
         getSiblingIndex(): number {
 
-            var i = 0;
-            var prev: HTMLElement = this.el;
-            while ((prev = <HTMLElement>prev.previousElementSibling) != null) {
-                i++;
+            const getPrevSibling = (elem) => <HTMLElement>elem.previousElementSibling;
+            let prev: HTMLElement;
+            let index;
+
+            for (index = 0, prev = getPrevSibling(this.el); !!prev; index++) {
+                prev = getPrevSibling(prev);
             }
-            return i;
+
+            return index;
         }
 
         isVisible(): boolean {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/ElementRegistry.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/dom/ElementRegistry.ts
@@ -40,7 +40,7 @@ module api.dom {
 
         public static getElementCountById(id: string): number {
             // Get the counter from the id according to the name notation
-            let count = parseInt(id.slice(id.lastIndexOf('-') + 1)) || 0;
+            let count = parseInt(id.slice(id.lastIndexOf('-') + 1), 10) || 0;
             return count;
         }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/i18n/Messages.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/i18n/Messages.ts
@@ -30,10 +30,8 @@ module api.i18n {
         });
     }
 
+    export function i18n(key: string, ...args: any[]): string {
+        return message(key, args);
+    }
+
 }
-
-// Global i18n message method
-var _i18n = (key: string, ...args: any[]) => api.i18n.message(key, args);
-
-
-

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/DragAndDrop.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/DragAndDrop.ts
@@ -13,7 +13,7 @@ module api.liveedit {
 
         public static debug = false;
 
-        private static _messageCounter: number = 0;
+        private static messageCounter: number = 0;
 
         private static instance: DragAndDrop;
 
@@ -32,15 +32,15 @@ module api.liveedit {
 
         public SORTABLE_ITEMS_SELECTOR: string;
 
-        private _isDragging: boolean = false;
+        private dragging: boolean = false;
 
-        private _wasDropped: boolean = false;
+        private wasDropped: boolean = false;
 
-        private _wasDestroyed: boolean = false;
+        private wasDestroyed: boolean = false;
 
-        private _newItemItemType: ItemType;
+        private newItemItemType: ItemType;
 
-        private _draggedComponentView: ComponentView<Component>;
+        private draggedComponentView: ComponentView<Component>;
 
         private dragStartedListeners: {(componentView: ComponentView<Component>): void}[] = [];
         private dragStoppedListeners: {(componentView: ComponentView<Component>): void}[] = [];
@@ -67,7 +67,7 @@ module api.liveedit {
         }
 
         isDragging(): boolean {
-            return this._isDragging;
+            return this.dragging;
         }
 
         createSortableLayout(component: ItemView) {
@@ -138,7 +138,7 @@ module api.liveedit {
         // Used by the Context Window when dragging above the IFrame
         createDraggable(jq: JQuery) {
 
-            this._newItemItemType = ItemType.fromHTMLElement(jq.get(0));
+            this.newItemItemType = ItemType.fromHTMLElement(jq.get(0));
 
             jq.draggable({
                 connectToSortable: this.REGION_SELECTOR,
@@ -155,7 +155,7 @@ module api.liveedit {
         // Used by the Context Window when dragging above the IFrame
         destroyDraggable(jq: JQuery) {
             jq.draggable("destroy");
-            this._wasDestroyed = true;
+            this.wasDestroyed = true;
         }
 
         /*
@@ -164,12 +164,12 @@ module api.liveedit {
          */
         handleDraggableStart(event: Event, ui: JQueryUI.DraggableEventUIParams) {
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleDraggableStart");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleDraggableStart");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
 
-            this.notifyDragStarted(this._draggedComponentView);
+            this.notifyDragStarted(this.draggedComponentView);
         }
 
         /*
@@ -178,16 +178,16 @@ module api.liveedit {
          */
         handleDraggableStop(event: Event, ui: JQueryUI.DraggableEventUIParams) {
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleDraggableStop");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleDraggableStop");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
 
-            if (!this._wasDropped) {
-                this.notifyCanceled(this._draggedComponentView);
+            if (!this.wasDropped) {
+                this.notifyCanceled(this.draggedComponentView);
             }
 
-            this.notifyDragStopped(this._draggedComponentView);
+            this.notifyDragStopped(this.draggedComponentView);
         }
 
         /*
@@ -196,7 +196,7 @@ module api.liveedit {
         handleSortStart(event: JQueryEventObject, ui: JQueryUI.SortableUIParams): void {
 
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleSortStart");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleSortStart");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
@@ -208,15 +208,15 @@ module api.liveedit {
 
             if (this.isDraggingFromContextWindow()) {
                 // Dragging from context window
-                itemType = this._newItemItemType;
+                itemType = this.newItemItemType;
             } else {
                 // Dragging between sortables
-                this._draggedComponentView = this.getComponentView(ui.item);
+                this.draggedComponentView = this.getComponentView(ui.item);
 
-                this._draggedComponentView.deselect();
-                this._draggedComponentView.setMoving(true);
+                this.draggedComponentView.deselect();
+                this.draggedComponentView.setMoving(true);
 
-                itemType = this._draggedComponentView.getType();
+                itemType = this.draggedComponentView.getType();
             }
 
             // Set it as html first time only
@@ -230,7 +230,7 @@ module api.liveedit {
 
             this.updateScrollSensitivity(event.target);
 
-            this.notifyDragStarted(this._draggedComponentView);
+            this.notifyDragStarted(this.draggedComponentView);
         }
 
         /*
@@ -238,7 +238,7 @@ module api.liveedit {
          */
         handleBeforeStop(event: JQueryEventObject, ui: JQueryUI.SortableUIParams): void {
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleBeforeStop");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleBeforeStop");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
@@ -251,14 +251,14 @@ module api.liveedit {
          */
         handleSortStop(event: JQueryEventObject, ui: JQueryUI.SortableUIParams): void {
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleSortStop");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleSortStop");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
 
-            if (this._wasDestroyed) {
+            if (this.wasDestroyed) {
                 this.cancelDrag(<HTMLElement> event.target);
-                this._wasDestroyed = false;
+                this.wasDestroyed = false;
                 return;
             }
 
@@ -280,35 +280,35 @@ module api.liveedit {
                         this.pageView.setLocked(false);
                     }
                     // Create component and view if we drag from context window
-                    var componentType: ComponentItemType = <ComponentItemType> this._newItemItemType;
+                    var componentType: ComponentItemType = <ComponentItemType> this.newItemItemType;
 
                     var newComponent = regionView.createComponent(componentType.toComponentType());
 
-                    this._draggedComponentView = componentType.createView(new CreateItemViewConfig<RegionView,Component>().
+                    this.draggedComponentView = componentType.createView(new CreateItemViewConfig<RegionView,Component>().
                         setParentView(regionView).
                         setParentElement(regionView).
                         setData(newComponent).
                         setPositionIndex(componentIndex));
 
-                    regionView.addComponentView(this._draggedComponentView, componentIndex, true);
+                    regionView.addComponentView(this.draggedComponentView, componentIndex, true);
 
                 } else {
                     // Move component to other region
-                    if (this._draggedComponentView.hasComponentPath()) {
-                        this._draggedComponentView.moveToRegion(regionView, componentIndex);
+                    if (this.draggedComponentView.hasComponentPath()) {
+                        this.draggedComponentView.moveToRegion(regionView, componentIndex);
                     }
                 }
 
-                this.notifyDropped(this._draggedComponentView, regionView);
+                this.notifyDropped(this.draggedComponentView, regionView);
             }
 
             if (!this.isDraggingFromContextWindow()) {
-                this._draggedComponentView.setMoving(false);
+                this.draggedComponentView.setMoving(false);
             }
 
             regionView.refreshEmptyState();
 
-            this.notifyDragStopped(this._draggedComponentView);
+            this.notifyDragStopped(this.draggedComponentView);
 
             // Cleanup
 
@@ -316,8 +316,8 @@ module api.liveedit {
                 // remove item if dragging from context window
                 ui.item.remove();
             }
-            this._newItemItemType = null;
-            this._draggedComponentView = null;
+            this.newItemItemType = null;
+            this.draggedComponentView = null;
         }
 
         /*
@@ -325,7 +325,7 @@ module api.liveedit {
          */
         handleActivate(event: JQueryEventObject, ui: JQueryUI.SortableUIParams): void {
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleActivate");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleActivate");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
@@ -338,7 +338,7 @@ module api.liveedit {
          */
         handleDeactivate(event: JQueryEventObject, ui: JQueryUI.SortableUIParams): void {
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleDeactivate");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleDeactivate");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
@@ -352,7 +352,7 @@ module api.liveedit {
         handleDragOver(event: JQueryEventObject, ui: JQueryUI.SortableUIParams): void {
 
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleDragOver");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleDragOver");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
@@ -370,7 +370,7 @@ module api.liveedit {
         handleDragOut(event: JQueryEventObject, ui: JQueryUI.SortableUIParams): void {
 
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleDragOut");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleDragOut");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
@@ -394,7 +394,7 @@ module api.liveedit {
          */
         handleSortChange(event: JQueryEventObject, ui: JQueryUI.SortableUIParams): void {
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleSortChange");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleSortChange");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
@@ -406,7 +406,7 @@ module api.liveedit {
          */
         handleSortUpdate(event: JQueryEventObject, ui: JQueryUI.SortableUIParams): void {
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleSortUpdate");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleSortUpdate");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
@@ -418,7 +418,7 @@ module api.liveedit {
          */
         handleRemove(event: JQueryEventObject, ui: JQueryUI.SortableUIParams): void {
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleRemove");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleRemove");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
@@ -432,7 +432,7 @@ module api.liveedit {
          */
         handleReceive(event: JQueryEventObject, ui: JQueryUI.SortableUIParams): void {
             if (DragAndDrop.debug) {
-                console.groupCollapsed((DragAndDrop._messageCounter++) + " DragDropSort.handleReceive");
+                console.groupCollapsed((DragAndDrop.messageCounter++) + " DragDropSort.handleReceive");
                 console.log("Event", event, "\nUI", ui);
                 console.groupEnd();
             }
@@ -446,7 +446,7 @@ module api.liveedit {
 
             wemjq(sortable).sortable('cancel');
 
-            this.notifyCanceled(this._draggedComponentView);
+            this.notifyCanceled(this.draggedComponentView);
         }
 
 
@@ -465,8 +465,8 @@ module api.liveedit {
                 console.log('DragAndDrop.notifyDragStarted', componentView);
             }
 
-            this._isDragging = true;
-            this._wasDropped = false;
+            this.dragging = true;
+            this.wasDropped = false;
             this.dragStartedListeners.forEach((curr) => {
                 curr(componentView);
             });
@@ -489,7 +489,7 @@ module api.liveedit {
                 console.log('DragAndDrop.notifyDragStopped', componentView);
             }
 
-            this._isDragging = false;
+            this.dragging = false;
             DragHelper.get().reset();
             this.dragStoppedListeners.forEach((curr) => {
                 curr(componentView);
@@ -517,7 +517,7 @@ module api.liveedit {
                 curr(componentView, regionView);
             });
 
-            this._wasDropped = true;
+            this.wasDropped = true;
             new ComponentViewDragDroppedEvent(componentView, regionView).fire();
         }
 
@@ -548,8 +548,8 @@ module api.liveedit {
             var helper = DragHelper.get();
             var placeholder = DragPlaceholder.get().setRegionView(enter ? regionView : null);
 
-            helper.setItemName(this._draggedComponentView ?
-                               this._draggedComponentView.getName() : api.util.StringHelper.capitalize(this.getItemType().getShortName()));
+            helper.setItemName(this.draggedComponentView ?
+                               this.draggedComponentView.getName() : api.util.StringHelper.capitalize(this.getItemType().getShortName()));
 
             if (!enter) {
                 helper.setDropAllowed(false);
@@ -564,10 +564,10 @@ module api.liveedit {
 
 
         private getItemType(): ItemType {
-            if (this._draggedComponentView) {
-                return this._draggedComponentView.getType();
-            } else if (this._newItemItemType) {
-                return this._newItemItemType;
+            if (this.draggedComponentView) {
+                return this.draggedComponentView.getType();
+            } else if (this.newItemItemType) {
+                return this.newItemItemType;
             } else {
                 throw new Error('Dragged component and new item type can not be both null');
             }
@@ -575,7 +575,7 @@ module api.liveedit {
 
 
         private isDraggingFromContextWindow(): boolean {
-            return !!this._newItemItemType;
+            return !!this.newItemItemType;
         }
 
 
@@ -584,7 +584,7 @@ module api.liveedit {
             if (!isLayout) {
                 var itemType = this.getItemType();
                 if (api.liveedit.fragment.FragmentItemType.get().equals(itemType)) {
-                    var fragment = <api.liveedit.fragment.FragmentComponentView> this._draggedComponentView;
+                    var fragment = <api.liveedit.fragment.FragmentComponentView> this.draggedComponentView;
                     isLayout = fragment && fragment.containsLayout();
                     if (isLayout && DragAndDrop.debug) {
                         console.log('DragAndDrop.isDraggingLayoutOverLayout - Fragment contains layout');

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/Highlighter.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/Highlighter.ts
@@ -132,7 +132,7 @@ module api.liveedit {
                     screenH = bodyEl.getHeight(),
                     screenW = bodyEl.getWidth();
 
-                strokeW = parseInt(window.getComputedStyle(this.path.getHTMLElement(), null).getPropertyValue("stroke-width"));
+                strokeW = parseInt(window.getComputedStyle(this.path.getHTMLElement(), null).getPropertyValue("stroke-width"), 10);
 
                 this.path.getEl()
                     .setAttribute('d',

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemType.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemType.ts
@@ -2,12 +2,14 @@ module api.liveedit {
 
     import StringHelper = api.util.StringHelper;
 
+    type ShortName = {[shortName: string]: ItemType};
+
     export class ItemType implements api.Equitable {
 
         static ATTRIBUTE_TYPE = "portal-component-type";
         static ATTRIBUTE_REGION_NAME = "portal-region";
 
-        private static shortNameToInstance: {[shortName: string]: ItemType} = {};
+        private static shortNameToInstance: ShortName = {};
 
         private shortName: string;
 
@@ -61,11 +63,13 @@ module api.liveedit {
         }
 
         static getDraggables(): ItemType[] {
-            var draggables: ItemType[] = [];
-            for (var shortName in  ItemType.shortNameToInstance) {
-                var itemType = ItemType.shortNameToInstance[shortName];
-                if (itemType.getConfig().isDraggable()) {
-                    draggables.push(itemType);
+            const draggables: ItemType[] = [];
+            for (const shortName in  ItemType.shortNameToInstance) {
+                if (ItemType.shortNameToInstance.hasOwnProperty(shortName)) {
+                    const itemType = ItemType.shortNameToInstance[shortName];
+                    if (itemType.getConfig().isDraggable()) {
+                        draggables.push(itemType);
+                    }
                 }
             }
             return draggables;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/Action.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/Action.ts
@@ -1,5 +1,7 @@
 module api.ui {
 
+    type ExecutionListener = {(action: Action): wemQ.Promise<any>|void};
+
     export class Action {
 
         private label: string;
@@ -18,7 +20,7 @@ module api.ui {
 
         protected forceExecute: boolean = false;
 
-        private executionListeners: {(action:Action): wemQ.Promise<any>|void}[] = [];
+        private executionListeners: ExecutionListener[] = [];
 
         private propertyChangedListeners: Function[] = [];
 
@@ -146,9 +148,7 @@ module api.ui {
         }
 
         private notifyPropertyChanged() {
-            for (var i in this.propertyChangedListeners) {
-                this.propertyChangedListeners[i](this);
-            }
+            this.propertyChangedListeners.forEach((listener: Function) => listener(this));
         }
 
         hasShortcut(): boolean {
@@ -176,10 +176,7 @@ module api.ui {
                 this.notifyBeforeExecute();
                 this.forceExecute = forceExecute;
 
-                var promises = [];
-                for (var i in this.executionListeners) {
-                    promises.push(this.executionListeners[i](this));
-                }
+                const promises = this.executionListeners.map((listener: ExecutionListener) => listener(this));
 
                 wemQ.all(promises).then(() => {
                     this.forceExecute = false;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/KeyBindings.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/KeyBindings.ts
@@ -125,9 +125,10 @@ module api.ui {
 
             this.activeBindings = {};
             Mousetrap.reset();
-            for (var key in previousMousetraps) {
-                var mousetrap: KeyBinding = <KeyBinding> previousMousetraps[key];
-                this.bindKey(mousetrap);
+            for (const name in previousMousetraps) {
+                if (previousMousetraps.hasOwnProperty(name)) {
+                    this.bindKey(<KeyBinding> previousMousetraps[name]);
+                }
             }
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
@@ -15,7 +15,7 @@ module api.ui.dialog {
 
         private actions: api.ui.Action[] = [];
 
-        private mouseClickListener: {(MouseEvent): void};
+        private mouseClickListener: (event: MouseEvent) => void;
 
         private cancelButton: api.dom.DivEl;
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/geo/GeoPoint.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/geo/GeoPoint.ts
@@ -9,7 +9,7 @@ module api.ui.geo {
 
             this.validUserInput = true;
             this.getEl().setAttribute("title", "latitude,longitude");
-            this.setPlaceholder(_i18n('latitude,longitude'));
+            this.setPlaceholder(api.i18n.i18n('latitude,longitude'));
 
             this.onValueChanged((event: api.ValueChangedEvent) => {
                 var typedGeoPoint = this.getValue();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/GridDragHandler.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/GridDragHandler.ts
@@ -82,30 +82,31 @@ module api.ui.grid {
             if (!this.draggableItem) {
                 this.handleDragStart();
             }
-            var gridClasses = (" " + this.contentGrid.getGrid().getEl().getClass()).replace(/\s/g, "."),
-                children = Element.fromSelector(".tree-grid " + gridClasses + " .grid-canvas .slick-row", false);
+            const gridClasses = (" " + this.contentGrid.getGrid().getEl().getClass()).replace(/\s/g, ".");
+            const children = Element.fromSelector(".tree-grid " + gridClasses + " .grid-canvas .slick-row", false);
 
             if (children && !children[0].getPreviousElement()) {
-                children = children.slice(1);
+                children.shift();
             }
 
-            for (let key in children) {
-                if (data.rows[0] <= data.insertBefore) {//move item down
-                    if (key > data.rows[0].toString() && key <= data.insertBefore.toString()) {
-                        children[key].getEl().setMarginTop("-" + this.rowHeight + "px");
+            const setMarginTop = (element: Element, margin: string) => element.getEl().setMarginTop(margin);
+
+            children.forEach((child: Element, index: number) => {
+                if (data.rows[0] <= data.insertBefore) { //move item down
+                    if (index > data.rows[0].toString() && index <= data.insertBefore.toString()) {
+                        setMarginTop(child, `-${this.rowHeight}px`);
                     } else {
-                        children[key].getEl().setMarginTop(null);
+                        setMarginTop(child, null);
                     }
-                    continue;
-                }
-                if (data.rows[0] >= data.insertBefore) {//move item up
-                    if (key < data.rows[0].toString() && key >= data.insertBefore.toString()) {
-                        children[key].getEl().setMarginTop(this.rowHeight + "px");
+                } else if (data.rows[0] >= data.insertBefore) { //move item up
+                    if (index < data.rows[0].toString() && index >= data.insertBefore.toString()) {
+                        setMarginTop(child, `${this.rowHeight}px`);
                     } else {
-                        children[key].getEl().setMarginTop(null);
+                        setMarginTop(child, null);
                     }
                 }
-            }
+            });
+
             this.contentGrid.scrollToRow(data.insertBefore);
             return true;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/image/ImageEditor.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/image/ImageEditor.ts
@@ -694,6 +694,7 @@ module api.ui.image {
             standbyContainer.appendChildren(resetButton, this.uploadButton);
 
             this.editCropButton = new Button();
+            // tslint:disable-next-line:no-unused-new
             new Tooltip(this.editCropButton, 'Crop Image', 1000);
             this.editCropButton.addClass('button-crop transparent icon-crop').onClicked((event: MouseEvent) => {
                 event.stopPropagation();
@@ -711,6 +712,7 @@ module api.ui.image {
             });
 
             this.editFocusButton = new Button();
+            // tslint:disable-next-line:no-unused-new
             new Tooltip(this.editFocusButton, 'Set Autofocus', 1000);
             this.editFocusButton.addClass('button-focus transparent icon-center_focus_strong').onClicked((event: MouseEvent) => {
                 event.stopPropagation();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/responsive/ResponsiveItem.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/responsive/ResponsiveItem.ts
@@ -25,11 +25,13 @@ module api.ui.responsive {
         }
 
         private fitToRange() {
-            for (var key in ResponsiveRanges) {
-                var range = ResponsiveRanges[key];
-                if (range && (api.ObjectHelper.iFrameSafeInstanceOf(range, ResponsiveRange)) && range.isFit(this.rangeValue)) {
-                    this.rangeSize = range;
-                    break;
+            for (const name in ResponsiveRanges) {
+                if (ResponsiveRanges.hasOwnProperty(name)) {
+                    const range = ResponsiveRanges[name];
+                    if (range && (api.ObjectHelper.iFrameSafeInstanceOf(range, ResponsiveRange)) && range.isFit(this.rangeValue)) {
+                        this.rangeSize = range;
+                        break;
+                    }
                 }
             }
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/TimePicker.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/time/TimePicker.ts
@@ -72,7 +72,7 @@ module api.ui.time {
                     if (parsedTime && parsedTime.length == 1) {
                         var splitTime = parsedTime[0].split(':');
                         this.validUserInput = true;
-                        this.popup.setSelectedTime(parseInt(splitTime[0]), parseInt(splitTime[1]));
+                        this.popup.setSelectedTime(parseInt(splitTime[0], 10), parseInt(splitTime[1], 10));
                         if (!this.popup.isVisible()) {
                             this.popup.show();
                         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -17,6 +17,7 @@ module api.ui.treegrid {
     import TreeGridActions = api.ui.treegrid.actions.TreeGridActions;
     import TreeGridToolbarActions = api.ui.treegrid.actions.TreeGridToolbarActions;
     import GridColumnBuilder = api.ui.grid.GridColumnBuilder;
+    import AppHelper = api.util.AppHelper;
 
     /*
      * There are several methods that should be overridden:
@@ -848,10 +849,9 @@ module api.ui.treegrid {
         }
 
         private deleteRootNode(root: TreeNode<DATA>, data: DATA): void {
-            var dataId = this.getDataId(data),
-                node: TreeNode<DATA>;
+            const dataId = this.getDataId(data);
 
-            while (node = root.findNode(dataId)) {
+            AppHelper.whileTruthy(() => root.findNode(dataId), (node) => {
                 if (node.hasChildren()) {
                     node.getChildren().forEach((child: TreeNode<DATA>) => {
                         this.deleteNode(child.getData());
@@ -861,13 +861,13 @@ module api.ui.treegrid {
                     this.gridData.deleteItem(node.getId());
                 }
 
-                var parent = node.getParent();
+                const parent = node.getParent();
                 if (node && parent) {
                     parent.removeChild(node);
                     parent.setMaxChildren(parent.getMaxChildren() - 1);
                     this.notifyDataChanged(new DataChangedEvent<DATA>([node], DataChangedEvent.DELETED));
                 }
-            }
+            });
 
             this.root.removeSelections([dataId]);
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -1121,9 +1121,9 @@ module api.ui.treegrid {
         }
 
         triggerSelectionChangedListeners() {
-            for (var i in this.selectionChangeListeners) {
-                this.selectionChangeListeners[i](this.root.getCurrentSelection(), this.root.getFullSelection());
-            }
+            this.selectionChangeListeners.forEach((listener: Function) => {
+                listener(this.root.getCurrentSelection(), this.root.getFullSelection());
+            });
         }
 
         onSelectionChanged(listener: (currentSelection: TreeNode<DATA>[], fullSelection: TreeNode<DATA>[]) => void) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/uploader/UploaderEl.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/uploader/UploaderEl.ts
@@ -292,23 +292,19 @@ module api.ui.uploader {
         }
 
         protected appendNewItems(newItemsToAppend: Element[]) {
-            for (var key in newItemsToAppend) {
-                this.getResultContainer().appendChild(newItemsToAppend[key]);
-            }
+            newItemsToAppend.forEach((elem: Element) => this.getResultContainer().appendChild(elem));
         }
 
         protected removeAllChildrenExceptGiven(itemsToKeep: Element[]) {
-            var items = this.getResultContainer().getChildren(),
-                toRemove = [];
+            const items: Element[] = this.getResultContainer().getChildren();
+            const toRemove = [];
 
-            items.forEach((elem) => {
-                if (!itemsToKeep.some((itemToKeep) => itemToKeep == elem)) {
+            items.forEach((elem: Element) => {
+                if (!itemsToKeep.some((itemToKeep: Element) => itemToKeep === elem)) {
                     toRemove.push(elem);
                 }
             });
-            for (var key in toRemove) {
-                toRemove[key].remove();
-            }
+            toRemove.forEach((elem: Element) => elem.remove())
         }
 
         protected refreshExistingItem(existingItem: Element, value: string) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/AppHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/AppHelper.ts
@@ -25,6 +25,15 @@ module api.util {
             };
         }
 
+        // Handles the result of the initialization, while the result is truthy
+        static whileTruthy(initializer: () => any, callback: (value: any) => void) {
+            let result: any;
+
+            for (result = initializer(); !!result; result = initializer()) {
+                callback(result);
+            }
+        }
+
         static preventDragRedirect(message: String = "", element?: api.dom.Element) {
             element = element || api.dom.Body.get();
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/DateTime.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/DateTime.ts
@@ -235,8 +235,9 @@ module api.util {
                 return dateString.substr(0, tzStartIndex);
             } else {
                 tzStartIndex = dateString.toLowerCase().indexOf("z");
-                if(tzStartIndex > 0)
+                if (tzStartIndex > 0) {
                     return dateString.substr(0, tzStartIndex);
+                }
             }
             return dateString;
         }
@@ -291,7 +292,9 @@ module api.util {
         }
 
         public setFractions(value: number): DateTimeBuilder {
-            if (this.seconds && value > 0) this.fractions = value;
+            if (this.seconds && value > 0) {
+                this.fractions = value;
+            }
             return this;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/LocalDateTime.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/LocalDateTime.ts
@@ -204,7 +204,9 @@ module api.util {
         }
 
         public setFractions(value: number): LocalDateTimeBuilder {
-            if (this.seconds && value > 0) this.fractions = value;
+            if (this.seconds && value > 0) {
+                this.fractions = value;
+            }
             return this;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
@@ -177,13 +177,7 @@ module api.util.htmlarea.dialog {
         }
 
         private static validationRequiredEmail(input: api.dom.FormInputEl): string {
-            var isValid;
-
-            if (!(isValid = Validators.required(input))) {
-                isValid = Validators.validEmail(input);
-            }
-
-            return isValid;
+            return Validators.required(input) || Validators.validEmail(input);
         }
 
         private getTarget(isTabSelected: boolean): boolean {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaHelper.ts
@@ -5,11 +5,12 @@ module api.util.htmlarea.editor {
     import LinkModalDialog = api.util.htmlarea.dialog.LinkModalDialog;
     import HtmlAreaAnchor = api.util.htmlarea.dialog.HtmlAreaAnchor;
     import HtmlAreaImage = api.util.htmlarea.dialog.HtmlAreaImage;
+    import StringHelper = api.util.StringHelper;
 
     export class HTMLAreaHelper {
 
         private static getConvertedImageSrc(imgSrc:string):string {
-            var contentId = imgSrc.replace(ImageModalDialog.imagePrefix, api.util.StringHelper.EMPTY_STRING),
+            var contentId = imgSrc.replace(ImageModalDialog.imagePrefix, StringHelper.EMPTY_STRING),
                 imageUrl = new api.content.util.ContentImageUrlResolver().
                     setContentId(new api.content.ContentId(contentId)).
                     setScaleWidth(true).
@@ -43,22 +44,21 @@ module api.util.htmlarea.editor {
         }
 
         public static prepareEditorImageSrcsBeforeSave(editor:HtmlAreaEditor):string {
-            var content = editor.getContent(),
-                processedContent = editor.getContent(),
-                regex = /<img.*?data-src="(.*?)".*?>/g,
-                imgTags, imgTag;
+            const content = editor.getContent();
+            const regex = /<img.*?data-src="(.*?)".*?>/g;
+            let processedContent = editor.getContent();
 
-            while ((imgTags = regex.exec(content)) != null) {
-                imgTag = imgTags[0];
+            AppHelper.whileTruthy(() => regex.exec(content), (imgTags) => {
+                const imgTag = imgTags[0];
+
                 if (imgTag.indexOf("<img ") === 0 && imgTag.indexOf(ImageModalDialog.imagePrefix) > 0) {
-                    var dataSrc = /<img.*?data-src="(.*?)".*?>/.exec(imgTag)[1],
-                        src = /<img.*?src="(.*?)".*?>/.exec(imgTags[0])[1];
+                    const dataSrc = /<img.*?data-src="(.*?)".*?>/.exec(imgTag)[1];
+                    const src = /<img.*?src="(.*?)".*?>/.exec(imgTags[0])[1];
 
-                    var convertedImg = imgTag.replace(src, dataSrc).replace(" data-src=\"" + dataSrc + "\"",
-                        api.util.StringHelper.EMPTY_STRING);
+                    const convertedImg = imgTag.replace(src, dataSrc).replace(` data-src="${dataSrc}"`, StringHelper.EMPTY_STRING);
                     processedContent = processedContent.replace(imgTag, convertedImg);
                 }
-            }
+            });
 
             return processedContent;
         }
@@ -99,10 +99,10 @@ module api.util.htmlarea.editor {
             switch (alignment) {
                 case 'left':
                 case 'right':
-                    styleAttr = api.util.StringHelper.format(styleFormat, alignment, "15px", "40");
+                    styleAttr = StringHelper.format(styleFormat, alignment, "15px", "40");
                     break;
                 case 'center':
-                    styleAttr = api.util.StringHelper.format(styleFormat, "none", "auto", "60");
+                    styleAttr = StringHelper.format(styleFormat, "none", "auto", "60");
                     image.parentElement.classList.add(alignment);
                     break;
             case 'justify':

--- a/modules/admin/admin-ui/tslint.json
+++ b/modules/admin/admin-ui/tslint.json
@@ -1,11 +1,11 @@
 {
   "rules": {
-    "forin": false,
+    "forin": true,
     "label-position": true,
     "no-any": false,
     "no-arg": true,
     "no-bitwise": false,
-    "no-conditional-assignment": false,
+    "no-conditional-assignment": true,
     "no-console": [
       true,
       "time",
@@ -15,13 +15,13 @@
     "no-debugger": true,
     "no-duplicate-variable": false,
     "no-empty": false,
-    "no-invalid-this": false,
+    "no-invalid-this": true,
     "no-string-literal": false,
     "no-unsafe-finally": true,
     "no-unused-expression": true,
-    "no-unused-new": false,
+    "no-unused-new": true,
     "no-use-before-declare": false,
-    "radix": false,
+    "radix": true,
     "switch-default": false,
     "triple-equals": [
       false
@@ -54,11 +54,11 @@
     "typedef": [
       true
     ],
-    "variable-name": false,
+    "variable-name": true,
     "align": [
       false
     ],
-    "curly": false,
+    "curly": true,
     "eofline": false,
     "indent": [
       true,


### PR DESCRIPTION
Updated linter rules
Fixed assignments in conditional expressions error
Disabled `no-unused-new` rule check for tooltip creation
Fixed `variable-name` property: leading underscore is disallowed
Fixed `no-invalid-this` rule errors: `this` was used outside of a class
Fixed `forin` rule errors: for..in cycle should be used with hasOwnProperty check