### PR TITLE
XP-4705 Alert dialog always appears, when new image was uploaded in t…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -642,7 +642,7 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
 
         this.updateWizardHeader(content);
         this.updateWizardStepForms(content, unchangedOnly);
-        this.updateMetadataAndMetadataStepForms(content.clone(), unchangedOnly);
+        this.updateMetadataAndMetadataStepForms(content, unchangedOnly);
         this.resetLastFocusedElement();
     }
 
@@ -1046,6 +1046,8 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
                     data.onChanged(this.dataChangedListener);
 
                     formViewLayoutPromises.push(metadataFormView.layout(formContext, data, metadataForm));
+
+                    this.synchPersistedItemWithMixinData(schema.getMixinName(), data);
                 });
 
                 return wemQ.all(formViewLayoutPromises).spread<void>(() => {
@@ -1069,6 +1071,22 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
                 });
             });
         });
+    }
+
+    // synch persisted content extra data with data from mixins
+    // when rendering form - we may add extra fields from mixins; as this is intended action from XP, not user - it should be present in persisted content
+    private synchPersistedItemWithMixinData(mixinName: MixinName, mixinData: PropertyTree) {
+        var persistedContent = this.getPersistedItem(),
+            extraData = persistedContent.getExtraData(mixinName);
+        if (!extraData) { // ensure ExtraData object corresponds to each step form
+            extraData = new ExtraData(mixinName, mixinData.copy());
+            persistedContent.getAllExtraData().push(extraData);
+        } else {
+            var diff = extraData.getData().diff(mixinData);
+            diff.added.forEach((property: api.data.Property) => {
+                extraData.getData().addProperty(property.getName(), property.getValue());
+            });
+        }
     }
 
     private setupWizardLiveEdit() {
@@ -1563,6 +1581,8 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
                 data.onChanged(this.dataChangedListener);
 
                 form.update(data, unchangedOnly);
+
+                this.synchPersistedItemWithMixinData(mixinName, data);
             }
         }
     }


### PR DESCRIPTION
…he wizard but Save was not pressed

- Added synchronization between persisted content extradata and mixins data - while rendering form we intentionally add fields from mixins and populate viewed content with it's data, but persisted content was not aware of mixins  data and caused hasUnsavedChanges() to return true