### PR TITLE
XP-4699 Fragment Wizard - "Alert" dialog with Stay or Leave buttons a…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/page/PageModel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/page/PageModel.ts
@@ -431,7 +431,7 @@ module api.content.page {
                 }
             }
             else if (this.mode == PageMode.FRAGMENT) {
-                return new PageBuilder().setRegions(this.regions).setConfig(this.config).setCustomized(this.isCustomized()).setFragment(
+                return new PageBuilder().setRegions(null).setConfig(this.config).setCustomized(this.isCustomized()).setFragment(
                     this.fragment).build();
             }
             else {


### PR DESCRIPTION
…ppears when there are no unsaved changes

-There are no regions in fragment content, so small conflict occured when comparing persisted content and assembled one because one had regions set to null and the other one had empty regions object thus their compraing returned false