### PR TITLE
XP-4740 Publish dialog - Endless spinner on the "Publish" button

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
@@ -146,12 +146,12 @@ export class ContentPublishDialog extends ProgressBarDialog {
             return this.reloadPublishDependencies(childrenNotLoadedYet);
         } else {
             // apply the stash to avoid extra heavy request
-            this.lockControls();
+            this.updateSubTitleShowScheduleAndButtonCount();
             this.loadMask.show();
             setTimeout(() => {
                 this.setDependantItems(stashedItems.slice());
                 this.centerMyself();
-                this.unlockControls();
+                this.updateSubTitleShowScheduleAndButtonCount();
                 this.loadMask.hide();
             }, 100);
             return wemQ<void>(null);
@@ -350,6 +350,7 @@ export class ContentPublishDialog extends ProgressBarDialog {
         let canPublish = count > 0 && this.areItemsAndDependantsValid();
 
         this.toggleControls(canPublish);
+        this.toggleClass('no-publish', !canPublish);
         if (canPublish) {
             this.getButtonRow().focusDefaultAction();
             this.updateTabbable();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
@@ -146,7 +146,7 @@ export class ContentPublishDialog extends ProgressBarDialog {
             return this.reloadPublishDependencies(childrenNotLoadedYet);
         } else {
             // apply the stash to avoid extra heavy request
-            this.updateSubTitleShowScheduleAndButtonCount();
+            this.lockControls();
             this.loadMask.show();
             setTimeout(() => {
                 this.setDependantItems(stashedItems.slice());
@@ -349,8 +349,7 @@ export class ContentPublishDialog extends ProgressBarDialog {
 
         let canPublish = count > 0 && this.areItemsAndDependantsValid();
 
-        this.toggleControls(canPublish);
-        this.toggleClass('no-publish', !canPublish);
+        this.togglePublish(canPublish);
         if (canPublish) {
             this.getButtonRow().focusDefaultAction();
             this.updateTabbable();
@@ -401,6 +400,11 @@ export class ContentPublishDialog extends ProgressBarDialog {
 
     protected hasSubDialog(): boolean {
         return true;
+    }
+
+    private togglePublish(enable) {
+        this.toggleControls(enable);
+        this.toggleClass('no-publish', !enable);
     }
 }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/dialog/dependant-items-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/dialog/dependant-items-dialog.less
@@ -32,7 +32,13 @@
         font-family: 'icomoon';
         pointer-events: none;
         opacity: 0.5;
+      }
+    }
+  }
 
+  &.locked:not(.no-publish) {
+    .dialog-buttons {
+      button:not(.cancel-button-bottom) {
         &:after {
           .animation(rotate360, .5s, .0s, linear);
           content: "\e007";


### PR DESCRIPTION
Fixed the stash lock/unlock update.
Added `.no-publish` class to hide spinner, when dialog locked and publish is disabled.