### PR TITLE
XP-4729 Linked figure element (with an image) is not escaped in Page …

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/ItemView.ts
@@ -194,6 +194,10 @@ module api.liveedit {
             this.appendChild(placeholder);
         }
 
+        protected disableLinks() {
+            wemjq(this.getHTMLElement()).find("a").click(e => e.preventDefault());
+        }
+
         public setContextMenuTitle(title: ItemViewContextMenuTitle) {
             this.contextMenuTitle = title;
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/fragment/FragmentComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/fragment/FragmentComponentView.ts
@@ -52,6 +52,7 @@ module api.liveedit.fragment {
             this.loadFragmentContent();
 
             this.parseContentViews(this);
+            this.disableLinks();
 
             this.handleContentRemovedEvent();
             this.handleContentUpdatedEvent();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/part/PartComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/part/PartComponentView.ts
@@ -27,6 +27,7 @@ module api.liveedit.part {
             this.resetHrefForRootLink(builder);
 
             this.parseContentViews(this);
+            this.disableLinks();
         }
 
         private createPlaceholder() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/reset.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/reset.less
@@ -11,9 +11,10 @@ html {
     */
     a {
       pointer-events: none;
+      cursor: move; //IE fix XP-2100; also chrome pointer-events: none not always working
 
-      &[disabled] {
-        cursor: move; //IE fix XP-2100
+      &:active {
+        color: blue; // for chrome
       }
     }
   }


### PR DESCRIPTION
…Editor (changes window url)

-Issue is about default browser behaviour, chrome treats inline anchor tag with a block elements in a special way; FF and IE are OK.