### PR TITLE
XP-4730 Wrong feedback in the publishing dialog when invalid contents…

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -714,7 +714,23 @@ public final class ContentResource
             setContainsRemovable( anyRemovable ).
             setRequestedContents( requestedContentIds ).
             setDependentContents( dependentContentIds ).
+            setAllContentsAreValid( this.allContentsAreValid( results ) ).
             build();
+    }
+
+    private boolean allContentsAreValid( final CompareContentResults compareResults )
+    {
+        ContentIds.Builder contentIds = ContentIds.create();
+
+        for ( CompareContentResult compareResult : compareResults )
+        {
+            if ( compareResult.getCompareStatus() != CompareStatus.PENDING_DELETE )
+            {
+                contentIds.add( compareResult.getContentId() );
+            }
+        }
+
+        return contentService.checkAllContentsValid( contentIds.build() );
     }
 
     private Boolean isAnyContentRemovableFromPublish( final ContentIds contentIds )
@@ -748,7 +764,7 @@ public final class ContentResource
                     iconUrl( contentIconUrlResolver.resolve( content ) ).
                     build();
             } ).
-            collect( Collectors.toList() );
+                collect( Collectors.toList() );
     }
 
     @POST

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/ResolvePublishContentResultJson.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/json/ResolvePublishContentResultJson.java
@@ -14,11 +14,14 @@ public class ResolvePublishContentResultJson
 
     private final Boolean containsRemovable;
 
+    private final Boolean allContentsAreValid;
+
     private ResolvePublishContentResultJson( Builder builder )
     {
         requestedContents = builder.requestedContents.stream().map( item -> new ContentIdJson( item ) ).collect( Collectors.toList() );
         dependentContents = builder.dependentContents.stream().map( item -> new ContentIdJson( item ) ).collect( Collectors.toList() );
         containsRemovable = builder.containsRemovable;
+        allContentsAreValid = builder.allContentsAreValid;
     }
 
     @SuppressWarnings("unused")
@@ -33,9 +36,16 @@ public class ResolvePublishContentResultJson
         return dependentContents;
     }
 
+    @SuppressWarnings("unused")
     public Boolean getContainsRemovable()
     {
         return containsRemovable;
+    }
+
+    @SuppressWarnings("unused")
+    public Boolean getAllContentsAreValid()
+    {
+        return allContentsAreValid;
     }
 
     public static Builder create()
@@ -51,6 +61,8 @@ public class ResolvePublishContentResultJson
         private ContentIds dependentContents;
 
         private Boolean containsRemovable;
+
+        private Boolean allContentsAreValid;
 
         private Builder()
         {
@@ -71,6 +83,12 @@ public class ResolvePublishContentResultJson
         public Builder setContainsRemovable( final Boolean containsRemovable )
         {
             this.containsRemovable = containsRemovable;
+            return this;
+        }
+
+        public Builder setAllContentsAreValid( final Boolean allContentsAreValid )
+        {
+            this.allContentsAreValid = allContentsAreValid;
             return this;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/dialog/DependantItemsDialog.ts
@@ -64,7 +64,7 @@ export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
         let itemsChangedListener = (items) => {
             let count = this.itemList.getItemCount();
             if (this.autoUpdateTitle) {
-                this.setTitle(this.dialogName + (count > 1 ? "s" : ''));
+                this.setTitle(this.dialogName + (count > 1 ? "s" : ""));
             }
 
             this.toggleClass("contains-removable", (count > 1));
@@ -77,7 +77,7 @@ export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
         this.dependantList = this.createDependantList();
         this.dependantList.addClass("dependant-list");
 
-        this.dependantsContainer = new api.dom.DivEl('dependants');
+        this.dependantsContainer = new api.dom.DivEl("dependants");
         this.dependantsContainer.appendChildren(this.dependantsHeader, this.dependantList);
 
         let dependantsChangedListener = (items) => {
@@ -161,7 +161,7 @@ export class DependantItemsDialog extends api.ui.dialog.ModalDialog {
     private extendsWindowHeightSize(): boolean {
         if (ResponsiveRanges._540_720.isFitOrBigger(this.getEl().getWidthWithBorder())) {
             var el = this.getEl(),
-                bottomPosition: number = (el.getTopPx() || parseFloat(el.getComputedProperty('top')) || 0) +
+                bottomPosition: number = (el.getTopPx() || parseFloat(el.getComputedProperty("top")) || 0) +
                                          el.getMarginTop() +
                                          el.getHeightWithBorder() +
                                          el.getMarginBottom();

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/publish/ContentPublishDialog.ts
@@ -26,6 +26,8 @@ export class ContentPublishDialog extends ProgressBarDialog {
 
     private childrenLoaded: boolean = false;
 
+    private contentFormsAreValid: boolean = false; // result of back-end check for all the publish candidates that do not pend deletion
+
     // stashes previous checkbox state items, until selected items changed
     private stash: {[checked: string]: ContentSummaryAndCompareStatus[]} = {};
     private stashedCount: {[checked: string]: number} = {};
@@ -46,7 +48,6 @@ export class ContentPublishDialog extends ProgressBarDialog {
 
         this.setAutoUpdateTitle(false);
         this.getEl().addClass("publish-dialog");
-
 
         this.initShowScheduleAction();
         this.initPublishAction();
@@ -182,6 +183,7 @@ export class ContentPublishDialog extends ProgressBarDialog {
 
             this.toggleClass("contains-removable", result.isContainsRemovable());
             this.dependantIds = result.getDependants();
+            this.contentFormsAreValid = result.areAllContentsValid();
             this.setStashedCount(this.dependantIds.length);
             return this.loadDescendants(0, 20).then((dependants: ContentSummaryAndCompareStatus[]) => {
                 if (resetDependantItems) { // just opened or first time loading children
@@ -229,7 +231,6 @@ export class ContentPublishDialog extends ProgressBarDialog {
         this.updateShowScheduleDialogButton();
         this.updateButtonCount("Publish", count);
     }
-
 
     setDependantItems(items: api.content.ContentSummaryAndCompareStatus[]) {
         if (this.isProgressBarEnabled()) {
@@ -380,12 +381,9 @@ export class ContentPublishDialog extends ProgressBarDialog {
     }
 
     private areItemsAndDependantsValid(): boolean {
-        var itemsValid = this.areAllValid(this.getItemList().getItems());
-        if (!itemsValid) {
-            return false;
-        }
-
-        return this.areAllValid(this.getDependantList().getItems());
+        return this.contentFormsAreValid &&
+               this.areAllValid(this.getItemList().getItems()) &&
+               this.areAllValid(this.getDependantList().getItems());
     }
 
     private disableCheckbox() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/ResolvePublishContentResultJson.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/json/ResolvePublishContentResultJson.ts
@@ -5,5 +5,6 @@ module api.content.json {
         dependentContents: ContentIdBaseItemJson[];
         requestedContents: ContentIdBaseItemJson[];
         containsRemovable: boolean;
+        allContentsAreValid: boolean;
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/result/ResolvePublishDependenciesResult.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/resource/result/ResolvePublishDependenciesResult.ts
@@ -8,12 +8,13 @@ module api.content.resource.result {
         dependentContents: ContentId[];
         requestedContents: ContentId[];
         containsRemovable: boolean;
+        allContentsAreValid: boolean;
 
-
-        constructor(dependants: ContentId[], requested: ContentId[], containsRemovable: boolean) {
+        constructor(dependants: ContentId[], requested: ContentId[], containsRemovable: boolean, allContentsAreValid: boolean) {
             this.dependentContents = dependants;
             this.requestedContents = requested;
             this.containsRemovable = containsRemovable;
+            this.allContentsAreValid = allContentsAreValid;
         }
 
         getDependants(): ContentId[] {
@@ -28,13 +29,18 @@ module api.content.resource.result {
             return this.containsRemovable;
         }
 
+        areAllContentsValid(): boolean {
+            return this.allContentsAreValid;
+        }
+
         static fromJson(json: ResolvePublishContentResultJson): ResolvePublishDependenciesResult {
 
             let dependants: ContentId[] = json.dependentContents.map(dependant => new ContentId(dependant.id));
             let requested: ContentId[] = json.requestedContents.map(dependant => new ContentId(dependant.id));
             let containsRemovable: boolean = json.containsRemovable;
+            let allContentsAreValid: boolean = json.allContentsAreValid;
 
-            return new ResolvePublishDependenciesResult(dependants, requested, containsRemovable);
+            return new ResolvePublishDependenciesResult(dependants, requested, containsRemovable, allContentsAreValid);
         }
     }
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ContentService.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ContentService.java
@@ -41,6 +41,8 @@ public interface ContentService
 
     CompareContentResults resolvePublishDependencies( ResolvePublishDependenciesParams params );
 
+    boolean checkAllContentsValid( ContentIds contentIds );
+
     Content duplicate( DuplicateContentParams params );
 
     Content move( MoveContentParams params );

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentServiceImpl.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentServiceImpl.java
@@ -380,6 +380,19 @@ public class ContentServiceImpl
     }
 
     @Override
+    public boolean checkAllContentsValid( ContentIds contentIds )
+    {
+        return CheckContentsValidCommand.create().
+            translator( this.translator ).
+            nodeService( this.nodeService ).
+            eventPublisher( this.eventPublisher ).
+            contentTypeService( this.contentTypeService ).
+            contentIds( contentIds ).
+            build().
+            execute();
+    }
+
+    @Override
     public UnpublishContentsResult unpublishContent( final UnpublishContentParams params )
     {
         return UnpublishContentCommand.create().

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/PublishContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/PublishContentCommand.java
@@ -120,6 +120,10 @@ public class PublishContentCommand
         {
             doPushNodes( pushNodesIds.build() );
         }
+        else
+        {
+            this.resultBuilder.setFailed( pushContentsIds );
+        }
 
         doDeleteNodes( deletedNodesIds.build() );
     }


### PR DESCRIPTION
… prevent publishing

- Added new field 'allContentsAreValid" ' to ResolvePublishContentResultJson class that indicates if all resolved contents that do not pend deletion are valid. Adjusted appropriate response and json handlers on UI
- Added new method checkAllContentsValid() to ContentService that uses CheckContentsValidCommand
- Adjusted ContentResource.resolvePublishContent() to use new service method and set value to new field in response json
- Adjusted PublishContentCommand.pushAndDelete() method to set contentIds that did not pass validity check into failed field of resultBuilder
- Adjusted publishDialog to store back-end validity check result and use it. NB! that on UI we additionally check that resolved items do have display name which is a little inconsistent with back-end check