### PR TITLE
XP-4766 Incorrect validation of content in the Publish Dialog

### DIFF
--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CheckContentsValidCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CheckContentsValidCommand.java
@@ -24,6 +24,11 @@ public class CheckContentsValidCommand
 
     public boolean execute()
     {
+        if ( this.contentIds.getSize() == 0 )
+        {
+            return true;
+        }
+
         final ContentQuery query = ContentQuery.create().
             queryFilter( ValueFilter.create().
                 fieldName( ContentPropertyNames.VALID ).

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/CheckContentValidCommandTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/CheckContentValidCommandTest.java
@@ -1,7 +1,0 @@
-package com.enonic.xp.core.content;
-
-public class CheckContentValidCommandTest
-{
-
-
-}

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/ContentServiceImplTest_isValidContent.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/ContentServiceImplTest_isValidContent.java
@@ -10,12 +10,14 @@ import com.enonic.xp.content.CreateContentParams;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.form.Input;
 import com.enonic.xp.inputtype.InputTypeName;
+import com.enonic.xp.repo.impl.node.NodeServiceImpl;
 import com.enonic.xp.schema.content.ContentType;
 import com.enonic.xp.schema.content.ContentTypeName;
 import com.enonic.xp.schema.content.ContentTypeService;
 import com.enonic.xp.schema.content.GetContentTypeParams;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.times;
 
 public class ContentServiceImplTest_isValidContent
     extends AbstractContentServiceTest
@@ -106,5 +108,16 @@ public class ContentServiceImplTest_isValidContent
             build() );
 
         assertFalse( this.contentService.isValidContent( ContentIds.from( content.getId(), content2.getId() ) ) );
+    }
+
+    @Test
+    public void test_empty_content_ids_returns_true()
+        throws Exception
+    {
+
+        NodeServiceImpl nodeService = Mockito.spy( this.nodeService );
+        Mockito.verify( nodeService, times( 0 ) ).findByQuery( Mockito.any() );
+
+        assertTrue( this.contentService.isValidContent( ContentIds.empty() ) );
     }
 }


### PR DESCRIPTION
- Adjusted CheckContentsValidCommand to return true right away for empty contentIds
- Added test for case above
- Removed redundant CheckContentValidCommandTest test file