### PR TITLE
XP-4769 Images imported to XP with plus character in filename not ren…

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ImageUrlBuilder.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ImageUrlBuilder.java
@@ -1,5 +1,8 @@
 package com.enonic.xp.portal.impl.url;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
 import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.Charsets;
@@ -65,7 +68,15 @@ final class ImageUrlBuilder
 
     private String resolveName( final Media media )
     {
-        final String name = media.getName().toString();
+        String name = media.getName().toString();
+
+        try
+        {
+            name = URLEncoder.encode( name, "UTF-8" );
+        }
+        catch ( final UnsupportedEncodingException e )
+        {
+        }
 
         if ( this.params.getFormat() != null )
         {

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/url/ImageUrlBuilderTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/url/ImageUrlBuilderTest.java
@@ -73,6 +73,18 @@ public class ImageUrlBuilderTest
     }
 
     @Test
+    public void testPlusSignInNameConverted()
+    {
+        final StringBuilder stringBuilder = new StringBuilder( "test/" );
+
+        Mockito.when( media.getName() ).thenReturn( ContentName.from( "test+Name.png" ) );
+
+        urlBuilder.buildUrl( stringBuilder, HashMultimap.create() );
+        assertEquals( "test/draft/context/path/_/image/testID:e57c6588d59c360d2464a5eabdaa24c78f7d1ed6/testScale/test%252BName.png",
+                      stringBuilder.toString() );
+    }
+
+    @Test
     public void testWithFormatParam()
     {
         final StringBuilder stringBuilder = new StringBuilder( "test/" );


### PR DESCRIPTION
…dered

- In PortalUrlBuilder, UrlEscapers.urlPathSegmentEscaper().escape(...) call of appendPart() method treats "+" char as ok char and does not encode it in anyway, whereas  in WebDispatcherServlet URLDecoder decoded url with a little different approach, where '+' gets converted into space char. I believe, that it's a UrlBuilder job's responsibility to build url in a right way, hence I added URLEncoder.encode call for image name resolving. I could not reproduce this problem with other content types, so I adjusted ImageUrlBuilder only