### PR TITLE
XP-4777 Changing back and forth between options in optionset that con…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/set/optionset/FormOptionSetOptionView.ts
@@ -322,7 +322,9 @@ module api.form {
             this.disableFormItems();
 
             var array = this.getOptionItemsPropertyArray(this.parentDataSet);
-            array.getSet(0).reset();
+            array.getSet(0).forEach((property) => {
+                array.getSet(0).removeProperty(property.getName(), property.getIndex());
+            });
             this.update(this.parentDataSet);
         }
 


### PR DESCRIPTION
…tains RadioButton makes <default> value not work

- Replaced call to PropertySet.reset() of option set upon unchecking option with removing property set's properties - this forces input views to populate property set with default values when option is selected back again.