### PR TITLE
XP-4796 Insert Link Dialog: doesn't get focus when opened in 6.9 B3

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
@@ -46,14 +46,11 @@ module api.util.htmlarea.dialog {
 
             this.onlyTextSelected = config.onlyTextSelected;
             if (this.onlyTextSelected) {
-                this.textFormItem.getInput().giveFocus();
-            }
-            else {
+                this.setFirstFocusField(this.textFormItem.getInput());
+            } else {
                 this.textFormItem.hide();
                 this.textFormItem.removeValidator();
             }
-
-            this.setFirstFocusField(this.textFormItem.getInput());
         }
 
         private getHref(): string {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
@@ -52,6 +52,8 @@ module api.util.htmlarea.dialog {
                 this.textFormItem.hide();
                 this.textFormItem.removeValidator();
             }
+
+            this.setFirstFocusField(this.textFormItem.getInput());
         }
 
         private getHref(): string {


### PR DESCRIPTION
Added `setFirstFocusField` call to the `LinkModal` dialog.