### PR TITLE
XP-4801 Content type's "Display name scripts" stopped working in 6.9 B3

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/DisplayNameScriptExecutor.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/DisplayNameScriptExecutor.ts
@@ -62,7 +62,7 @@ export class DisplayNameScriptExecutor implements api.app.wizard.DisplayNameGene
 
         try {
             // hide eval, Function, document, window and other things from the script.
-            result = eval('var eval; var Function; var document; var location; ' +
+            result = eval('"strict mode"; var Function; var document; var location; ' +
                           'var window; var parent; var self; var top; ' +
                           script);
         } catch (e) {


### PR DESCRIPTION
- It seems that recent lint changes enforced strict mode that treats 'eval' as a keyword, does not allow assigning it to other variables and makes code evaluated via 'eval' to be always created in a new scope - hiding 'eval' is not needed anymore. Let's just ensure that we are in strict mode.