### PR TITLE
XP-4807 Option Set - Form inputs inside itemsets are not cleared when…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/set/FormSetView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/set/FormSetView.ts
@@ -3,6 +3,7 @@ module api.form {
     import PropertySet = api.data.PropertySet;
     import PropertyArray = api.data.PropertyArray;
     import DragHelper = api.ui.DragHelper;
+    import ValueTypes = api.data.ValueTypes;
 
     export class FormSetView<V extends FormSetOccurrenceView> extends FormItemView {
 
@@ -202,7 +203,13 @@ module api.form {
         }
 
         protected getPropertyArray(propertySet: PropertySet): PropertyArray {
-            throw new Error("Must be implemented by inheritor");
+            var propertyArray = propertySet.getPropertyArray(this.formSet.getName());
+            if (!propertyArray) {
+                propertyArray = PropertyArray.create().setType(ValueTypes.DATA).setName(this.formSet.getName()).setParent(
+                    this.parentDataSet).build();
+                propertySet.addPropertyArray(propertyArray);
+            }
+            return propertyArray;
         }
 
         protected initOccurrences(): FormSetOccurrences<V> {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/set/itemset/FormItemSetView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/set/itemset/FormItemSetView.ts
@@ -1,11 +1,6 @@
 module api.form {
 
     import PropertySet = api.data.PropertySet;
-    import Property = api.data.Property;
-    import PropertyArray = api.data.PropertyArray;
-    import Value = api.data.Value;
-    import ValueType = api.data.ValueType;
-    import ValueTypes = api.data.ValueTypes;
 
     export interface FormItemSetViewConfig {
 
@@ -47,16 +42,6 @@ module api.form {
                 parent: this.getParent(),
                 propertyArray: this.getPropertyArray(this.parentDataSet)
             });
-        }
-
-        protected getPropertyArray(propertySet: PropertySet): PropertyArray {
-            var propertyArray = propertySet.getPropertyArray(this.formSet.getName());
-            if (!propertyArray) {
-                propertyArray = PropertyArray.create().setType(ValueTypes.DATA).setName(this.formSet.getName()).setParent(
-                    this.parentDataSet).build();
-                propertySet.addPropertyArray(propertyArray);
-            }
-            return propertyArray;
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/set/optionset/FormOptionSetView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/set/optionset/FormOptionSetView.ts
@@ -1,11 +1,6 @@
 module api.form {
 
     import PropertySet = api.data.PropertySet;
-    import Property = api.data.Property;
-    import PropertyArray = api.data.PropertyArray;
-    import Value = api.data.Value;
-    import ValueType = api.data.ValueType;
-    import ValueTypes = api.data.ValueTypes;
 
     export interface FormOptionSetViewConfig {
 
@@ -46,16 +41,6 @@ module api.form {
                 parent: this.getParent(),
                 propertyArray: this.getPropertyArray(this.parentDataSet)
             });
-        }
-
-        protected getPropertyArray(parentPropertySet: PropertySet): PropertyArray {
-            var propertyArray = parentPropertySet.getPropertyArray(this.formSet.getName());
-            if (!propertyArray) {
-                propertyArray = PropertyArray.create().setType(ValueTypes.DATA).setName(this.formSet.getName()).setParent(
-                    this.parentDataSet).build();
-                parentPropertySet.addPropertyArray(propertyArray);
-            }
-            return propertyArray;
         }
     }
 }


### PR DESCRIPTION
… an option is unselected

- Adjusted FormOptionSetOptionView items reset process on deselect to make it iterate through the whole property set and remove all non-set properties. This forces correct clean of option set descendants and enables default values to be set.
- Adjusted update() process to enforce option view state that may be affected by parent option set option select/deselect
- Made little cleaning in form set classes