### PR TITLE
XP-4821 Emulator panel - Screen height won't reset after switch to 'F…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/contextwindow/EmulatorPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/contextwindow/EmulatorPanel.ts
@@ -42,6 +42,8 @@ export class EmulatorPanel extends api.ui.panel.Panel {
 
             if (units === "px") {
                 this.updateLiveEditFrameContainerHeight(height);
+            } else {
+                this.resetParentHeight();
             }
 
         });
@@ -81,6 +83,12 @@ export class EmulatorPanel extends api.ui.panel.Panel {
             frameParent.style.height = height + this.getScrollbarWidth() + "px";
             frameParent.classList.remove("overflow");
         }
+    }
+
+    private resetParentHeight() {
+        var frameParent = this.liveEditPage.getIFrame().getHTMLElement().parentElement;
+        frameParent.style.height = "";
+        frameParent.classList.remove("overflow");
     }
 
     private getScrollbarWidth(): number {


### PR DESCRIPTION
…ull Size' resolution

- Added removal of custom height of frame parent when setting frame to full size - otherwise, custom height property prevents frame from expanding