### PR TITLE
XP-4850 Content Wizard - settings are not refreshed, when a content version was changed

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/SettingsWizardStepForm.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/SettingsWizardStepForm.ts
@@ -78,7 +78,7 @@ export class SettingsWizardStepForm extends api.app.wizard.WizardStepForm {
 
     update(content: api.content.Content, unchangedOnly: boolean = true) {
         this.updateUnchangedOnly = unchangedOnly;
-        this.model.setOwner(content.getOwner(), true).setLanguage(content.getLanguage(), true);
+        this.model.setOwner(content.getOwner()).setLanguage(content.getLanguage());
     }
 
     reset() {


### PR DESCRIPTION
…age that is  related to the fragment was removed