### PR TITLE
XP-4855 Content Wizard - principal is not refreshed from time to time…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -409,14 +409,15 @@ module api.ui.selector.combobox {
             if (this.displayMissingSelectedOptions || this.removeMissingSelectedOptions && missingOptionIds.length > 0) {
                 valueSetPromise = this.selectExistingAndHandleMissing(optionIds, missingOptionIds);
             } else {
-                valueSetPromise = wemQ(this.selectExistingOptions(value));
+                valueSetPromise = wemQ(this.selectExistingOptions(optionIds));
             }
             valueSetPromise.done((options) => this.notifyValueLoaded(options));
         }
 
-        private selectExistingOptions(value: string) {
+        private selectExistingOptions(optionIds: string[]) {
             let selectedOptions = [];
-            this.splitValues(value).forEach((val) => {
+
+            optionIds.forEach((val) => {
                 let option = this.getOptionByValue(val);
                 if (option != null) {
                     selectedOptions.push(option);
@@ -429,17 +430,14 @@ module api.ui.selector.combobox {
         // tslint:disable-next-line:max-line-length
         private selectExistingAndHandleMissing(optionIds: string[], missingOptionIds: string[]): wemQ.Promise<Option<OPTION_DISPLAY_VALUE>[]> {
             let nonExistingIds: string[] = [],
-                selectedOptions = [];
+                selectedOptions = this.selectExistingOptions(optionIds);
 
             return new api.content.resource.ContentsExistRequest(missingOptionIds).sendAndParse()
                 .then((result: api.content.resource.result.ContentsExistResult) => {
 
                     optionIds.forEach((val) => {
                         const option = this.getOptionByValue(val);
-                        if (option != null) {
-                            selectedOptions.push(option);
-                            this.selectOption(option, true);
-                        } else {
+                        if (option == null) {
                             const contentExists = result.contentExists(val);
                             if (this.displayMissingSelectedOptions && (contentExists || !this.removeMissingSelectedOptions)) {
                                 const selectedOption = (<BaseSelectedOptionsView<OPTION_DISPLAY_VALUE>> this.selectedOptionsView)


### PR DESCRIPTION
…, when a content version was changed

-Issue is that async calls are made in doSetValue() of ComboBox, but method invoking it does not know about it and continue processing with values that are not yet updated. This is actual for classes with 'displayMissingSelectedOptions' set to true because they make backend call to check if contents are missing