### PR TITLE
XP-4865 Content Grid - When opening Wizard for several items only one…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/ContentEventsProcessor.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/ContentEventsProcessor.ts
@@ -26,6 +26,10 @@ export class ContentEventsProcessor {
         return window.open(wizardUrl, wizardId);
     }
 
+    static popupBlocked(win: Window) {
+        return !win || win.closed || typeof win.closed == "undefined";
+    }
+
     static handleNew(newContentEvent: NewContentEvent) {
 
         var contentTypeSummary = newContentEvent.getContentType();
@@ -42,10 +46,10 @@ export class ContentEventsProcessor {
 
     static handleEdit(event: api.content.event.EditContentEvent) {
 
-        event.getModels().forEach((content: ContentSummaryAndCompareStatus) => {
+        event.getModels().every((content: ContentSummaryAndCompareStatus) => {
 
             if (!content || !content.getContentSummary()) {
-                return;
+                return true;
             }
 
             var contentSummary = content.getContentSummary(),
@@ -58,7 +62,16 @@ export class ContentEventsProcessor {
                 .setContentTypeName(contentTypeName)
                 .setContentId(contentSummary.getContentId());
 
-            ContentEventsProcessor.openWizardTab(wizardParams, tabId);
+            let win = ContentEventsProcessor.openWizardTab(wizardParams, tabId);
+
+            if (ContentEventsProcessor.popupBlocked(win)) {
+                const message = "Pop-up Blocker is enabled in browser settings! Please add the XP admin to the exception list.";
+                api.notify.showWarning(message, false);
+
+                return false;
+            }
+
+            return true;
         });
     }
 


### PR DESCRIPTION
… tab opens, others are blocked

* Since it's not possible to overcome Chrome's limitation for one tab per user action, show notification about popup blocker when one of the tabs is blocked