### PR TITLE
XP-4885 Empty ids in copy executor copies everything

### DIFF
--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentDependenciesResolver.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentDependenciesResolver.java
@@ -1,6 +1,7 @@
 package com.enonic.xp.core.impl.content;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 
 import com.google.common.collect.Maps;
@@ -42,6 +43,11 @@ public class ContentDependenciesResolver
 
     private Collection<ContentDependenciesAggregation> resolveInboundDependenciesAggregation( final ContentId contentId )
     {
+        if ( contentId == null )
+        {
+            return new HashSet<>();
+        }
+
         final FindContentIdsByQueryResult result = this.contentService.find( ContentQuery.create().
             queryFilter( BooleanFilter.create().
                 must( IdFilter.create().

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/SetPublishInfoCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/SetPublishInfoCommand.java
@@ -77,6 +77,11 @@ public class SetPublishInfoCommand
 
     private NodeIds findNodesWithoutPublishInfo( final NodeIds nodesToPush )
     {
+        if ( nodesToPush.isEmpty() )
+        {
+            return NodeIds.empty();
+        }
+
         final NodeQuery query = NodeQuery.create().
             addQueryFilter( BooleanFilter.create().
                 mustNot( ExistsFilter.create().

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/branch/storage/BranchServiceImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/branch/storage/BranchServiceImpl.java
@@ -291,6 +291,11 @@ public class BranchServiceImpl
 
     private NodeBranchEntries getIgnoreOrder( final NodeIds nodeIds, final InternalContext context )
     {
+        if ( nodeIds.isEmpty() )
+        {
+            return NodeBranchEntries.empty();
+        }
+
         final SearchResult results = this.searchDao.search( SearchRequest.create().
             query( NodeBranchQuery.create().
                 addQueryFilter( ValueFilter.create().

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/builder/FilterBuilderFactory.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/builder/FilterBuilderFactory.java
@@ -102,11 +102,6 @@ public class FilterBuilderFactory
 
     private FilterBuilder createIdFilter( final IdFilter idFilter )
     {
-        if ( idFilter.getValues().isEmpty() )
-        {
-            return null;
-        }
-
         final String queryFieldName = IndexFieldNameNormalizer.normalize( idFilter.getFieldName() );
 
         final Set<Object> values = Sets.newHashSet();

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/storage/StorageDaoImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/storage/StorageDaoImpl.java
@@ -196,6 +196,11 @@ public class StorageDaoImpl
     @Override
     public void copy( final CopyRequest request )
     {
+        if ( request.getNodeIds().isEmpty() )
+        {
+            return;
+        }
+
         final IdFilter idFilter = IdFilter.create().
             fieldName( NodeIndexPath.ID.getPath() ).
             values( request.getNodeIds() ).

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodeBranchEntriesByIdCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodeBranchEntriesByIdCommand.java
@@ -53,6 +53,11 @@ public class FindNodeBranchEntriesByIdCommand
 
     private NodeIds getNodeIds( final Context context )
     {
+        if ( this.ids.isEmpty() )
+        {
+            return NodeIds.empty();
+        }
+
         final NodeQuery.Builder queryBuilder = NodeQuery.create().
             addQueryFilters( Filters.create().
                 add( IdFilter.create().

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/NodesHasPermissionResolver.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/NodesHasPermissionResolver.java
@@ -51,6 +51,11 @@ public class NodesHasPermissionResolver
             return true;
         }
 
+        if ( nodeIds.isEmpty() )
+        {
+            return false;
+        }
+
         final NodeQuery query = NodeQuery.create().
             addQueryFilter( IdFilter.create().
                 fieldName( NodeIndexPath.ID.getPath() ).

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/PushNodesCommandTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/PushNodesCommandTest.java
@@ -118,8 +118,10 @@ public class PushNodesCommandTest
         final PushNodesResult result = pushNodes( NodeIds.from( node.id() ), WS_OTHER );
 
         assertEquals( 1, result.getFailed().size() );
+        assertEquals( 0, result.getSuccessful().getSize() );
         assertEquals( PushNodesResult.Reason.ALREADY_EXIST, result.getFailed().iterator().next().getReason() );
     }
+
 
     @Test
     public void push_rename_push_test()
@@ -434,6 +436,13 @@ public class PushNodesCommandTest
         assertTrue( prodNode != null );
     }
 
+
+    @Test
+    public void push_node_exists_in_target()
+        throws Exception
+    {
+
+    }
 
     private void renameNode( final Node node, final String newName )
     {


### PR DESCRIPTION
The id filter usage is a bit scary, this should be fixed later, but for now just make sure that we wont end up getting all results instead of nothing when there is no id's to filter on.