### PR TITLE
XP-4883 Publishing Wizard - X icons are disabled when invalid content…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/dialog/dependant-items-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/dialog/dependant-items-dialog.less
@@ -19,13 +19,6 @@
 
   &.locked {
 
-    .browse-selection-item {
-      .remove {
-        pointer-events: none;
-        opacity: 0.5;
-      }
-    }
-
     .dialog-buttons {
 
       button:not(.cancel-button-bottom) {


### PR DESCRIPTION
… is selected

- Adjusted remove buttons to be enabled even if dialog is locked due to invalid contents