### PR TITLE
XP-4892 Fix content tree grid panels to not blink upon first item sel…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/BrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/browse/BrowsePanel.ts
@@ -53,6 +53,9 @@ module api.app.browse {
                     return;
                 }
                 let browseItems: api.app.browse.BrowseItem<M>[] = this.treeNodesToBrowseItems(fullSelection);
+                if(currentSelection.length <= 1) {
+                    this.getBrowseItemPanel().getPanelShown().hide();
+                }
                 let changes = this.getBrowseItemPanel().setItems(browseItems, true);
                 this.getBrowseActions().updateActionsEnabledState(this.getBrowseItemPanel().getItems(), changes)
                     .then(() => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -235,7 +235,7 @@ module api.ui.treegrid {
         };
 
         private bindClickEvents() {
-            this.grid.subscribeOnClick((event, data) => {
+            var clickHandler = api.util.AppHelper.debounce(((event, data) => {
                 if (!this.isActive()) {
                     return;
                 }
@@ -290,7 +290,9 @@ module api.ui.treegrid {
                 if (!elem.hasClass('sort-dialog-trigger')) {
                     new TreeGridItemClickedEvent(!!this.highlightedNode || this.grid.getSelectedRows().length > 0).fire();
                 }
-            });
+            }).bind(this), 50, false);
+
+            this.grid.subscribeOnClick(clickHandler);
         }
 
         private onClickWithShift(event: any, data: Slick.OnClickEventData) {


### PR DESCRIPTION
…ection.

- Made TreeGrid clickHandler to be debounced as shit+click on highlighted row triggers two subsequent calls to it
- Adjusted BrowseItemPanel to hide panel that is currently shown on selection change so that user does not see panel until updateDisplayedPanel() call