### PR TITLE
XP-4949 HTML Area - Modal dialogs must handle close on Esc

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/applications/js/app/installation/InstallAppDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/applications/js/app/installation/InstallAppDialog.ts
@@ -66,12 +66,6 @@ export class InstallAppDialog extends api.ui.dialog.ModalDialog {
                 this.clearButton.addClass('hidden');
             });
 
-            this.applicationInput.onKeyUp((event: KeyboardEvent) => {
-                if (event.keyCode === 27) {
-                    this.getCancelAction().execute();
-                }
-            });
-
             this.applicationInput.onTextValueChanged(() => {
                 this.clearButton.toggleClass('hidden', api.util.StringHelper.isEmpty(this.applicationInput.getValue()));
             });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/MoveContentDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/MoveContentDialog.ts
@@ -69,11 +69,6 @@ export class MoveContentDialog extends api.ui.dialog.ModalDialog {
     private initSearchInput() {
         this.destinationSearchInput = new ContentMoveComboBox();
         this.destinationSearchInput.addClass('content-selector');
-        this.destinationSearchInput.onKeyUp((event: KeyboardEvent) => {
-            if (event.keyCode === 27) {
-                this.getCancelAction().execute();
-            }
-        });
         this.destinationSearchInput.onOptionSelected(() => {
             this.getButtonRow().focusDefaultAction();
         });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/create/NewContentDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/create/NewContentDialog.ts
@@ -103,12 +103,6 @@ export class NewContentDialog extends api.ui.dialog.ModalDialog {
 
             this.allContentTypes.filter(this.fileInput.getValue());
         });
-
-        this.fileInput.onKeyUp((event: KeyboardEvent) => {
-            if (event.keyCode === 27) {
-                this.getCancelAction().execute();
-            }
-        });
     }
 
     private initLoadMask() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ConfirmContentDeleteDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/remove/ConfirmContentDeleteDialog.ts
@@ -87,12 +87,6 @@ export class ConfirmContentDeleteDialog extends api.ui.dialog.ModalDialog {
             }
 
         });
-
-        this.input.onKeyUp((event: KeyboardEvent) => {
-            if (event.keyCode === 27) {
-                this.getCancelAction().execute();
-            }
-        });
     }
 
     private initConfirmationBlock() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
@@ -131,7 +131,7 @@ module api.ui.dialog {
         }
 
         private createDefaultCancelAction() {
-            let cancelAction = new api.ui.Action('Cancel', 'esc');
+            let cancelAction = new api.ui.Action('Cancel', 'esc', true);
             cancelAction.setIconClass('cancel-button-top');
             cancelAction.setLabel('');
             cancelAction.onExecuted(()=> {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -813,6 +813,10 @@ module api.ui.selector.combobox {
             }
 
             if (!this.isDropdownShown()) {
+                if (event.which === 27) { // esc
+                    return;
+                }
+
                 this.showDropdown();
 
                 if (event.which === 40) { // down
@@ -875,6 +879,8 @@ module api.ui.selector.combobox {
                 break;
             case 27: // Esc
                 this.hideDropdown();
+                event.stopPropagation();
+                event.preventDefault();
                 break;
             }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ImageModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ImageModalDialog.ts
@@ -147,14 +147,6 @@ module api.util.htmlarea.dialog {
                 api.ui.responsive.ResponsiveManager.fireResizeEvent();
             });
 
-            imageSelectorComboBox.onKeyDown((e: KeyboardEvent) => {
-                if (api.ui.KeyHelper.isEscKey(e) && !imageSelectorComboBox.isDropdownShown()) {
-                    // Prevent modal dialog from closing on Esc key when dropdown is expanded
-                    e.preventDefault();
-                    e.stopPropagation();
-                }
-            });
-
             return formItem;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
@@ -258,14 +258,6 @@ module api.util.htmlarea.dialog {
 
             const contentSelector = api.content.ContentComboBox.create().setLoader(loader).setMaximumOccurrences(1).build();
 
-            contentSelector.onKeyDown((e: KeyboardEvent) => {
-                if (api.ui.KeyHelper.isEscKey(e) && !contentSelector.getComboBox().isDropdownShown()) {
-                    // Prevent modal dialog from closing on Esc key when dropdown is expanded
-                    e.preventDefault();
-                    e.stopPropagation();
-                }
-            });
-
             this.onAdded(() => {
                 contentSelector.setValue(getValueFn.call(this));
             });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/MacroModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/MacroModalDialog.ts
@@ -79,14 +79,6 @@ module api.util.htmlarea.dialog {
                 api.ui.responsive.ResponsiveManager.fireResizeEvent();
             });
 
-            macroSelectorComboBox.onKeyDown((e: KeyboardEvent) => {
-                if (api.ui.KeyHelper.isEscKey(e) && !macroSelectorComboBox.isDropdownShown()) {
-                    // Prevent modal dialog from closing on Esc key when dropdown is expanded
-                    e.preventDefault();
-                    e.stopPropagation();
-                }
-            });
-
             return formItem;
         }
 


### PR DESCRIPTION
-Making all modal dialogs behave same when 'Esc' was presses on keyboard - closing the dialog immediately; the only exception is combobox that has dropdown shown - it must just hide dropdown after first time 'Esc' pressed, and close dialog after the second time 'Esc' pressed.