### PR TITLE
XP-4943 Content Grid - Preview panel is not updated when a fragment w…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/ContentItemPreviewPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/ContentItemPreviewPanel.ts
@@ -136,8 +136,8 @@ export class ContentItemPreviewPanel extends api.app.view.ItemPreviewPanel {
         this.image.setSrc(imgUrl);
     }
 
-    public setItem(item: ViewItem<ContentSummaryAndCompareStatus>) {
-        if (item && !item.equals(this.item) && !this.skipNextSetItemCall) {
+    public setItem(item: ViewItem<ContentSummaryAndCompareStatus>, force: boolean = false) {
+        if (item && !this.skipNextSetItemCall && (!item.equals(this.item) || force)) {
             if (typeof item.isRenderable() === 'undefined') {
                 return;
             }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/ContentItemStatisticsPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/ContentItemStatisticsPanel.ts
@@ -23,4 +23,7 @@ export class ContentItemStatisticsPanel extends api.app.view.ItemStatisticsPanel
         }
     }
 
+    getPreviewPanel(): ContentItemPreviewPanel {
+        return this.previewPanel;
+    }
 }


### PR DESCRIPTION
…as changed in the wizard

- Added force parameter to setItem() method of ContentItemPreviewPanel to enable forced preview reload
- Adjusted updateStatisticsPanel() method of ContentBrowsePanel to check if updated content is a child fragment of previewed item and update preview and mobile preview then