### PR TITLE
XP-4953 Uploading new image to image content results in hang and cras…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveEditPageProxy.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveEditPageProxy.ts
@@ -314,6 +314,8 @@ export class LiveEditPageProxy {
         }
 
         if (liveEditWindow) {
+            this.liveEditWindow = liveEditWindow;
+            
             if (liveEditWindow.wemjq) {
                 if (LiveEditPageProxy.debug) {
                     console.debug('LiveEditPageProxy.setting config for', liveEditWindow.document, CONFIG);
@@ -326,8 +328,6 @@ export class LiveEditPageProxy {
                 if (this.liveEditWindow) {
                     this.stopListening(this.liveEditWindow);
                 }
-
-                this.liveEditWindow = liveEditWindow;
 
                 this.listenToPage(this.liveEditWindow);
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveFormPanel.ts
@@ -129,6 +129,8 @@ export class LiveFormPanel extends api.ui.panel.Panel {
 
     private liveEditPageProxy: LiveEditPageProxy;
 
+    private contentEventListener;
+
     constructor(config: LiveFormPanelConfig) {
         super('live-form-panel');
         this.contentWizardPanel = config.contentWizardPanel;
@@ -141,6 +143,10 @@ export class LiveFormPanel extends api.ui.panel.Panel {
         this.liveEditPageProxy = new LiveEditPageProxy();
 
         this.contextWindow = this.createContextWindow(this.liveEditPageProxy, this.liveEditModel);
+
+        this.contentEventListener = (event) => {
+            this.propagateEvent(event);
+        };
 
         // constructor to listen to live edit events during wizard rendering
         this.contextWindowController = new ContextWindowController(
@@ -365,15 +371,18 @@ export class LiveFormPanel extends api.ui.panel.Panel {
             this.contentWizardPanel.getContextWindowToggler().setActive(false, true);
         });
 
-        const contentEventListener = (event) => {
-            this.propagateEvent(event);
-        };
+        this.handleContentUpdatedEvent();
+    }
 
-        ContentDeletedEvent.on(contentEventListener);
-        ContentUpdatedEvent.on(contentEventListener);
+    private handleContentUpdatedEvent() {
+        ContentDeletedEvent.un(this.contentEventListener);
+        ContentUpdatedEvent.un(this.contentEventListener);
+        ContentDeletedEvent.on(this.contentEventListener);
+        ContentUpdatedEvent.on(this.contentEventListener);
+
         this.onRemoved(() => {
-            ContentDeletedEvent.un(contentEventListener);
-            ContentUpdatedEvent.un(contentEventListener);
+            ContentDeletedEvent.un(this.contentEventListener);
+            ContentUpdatedEvent.un(this.contentEventListener);
         });
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/contextwindow/inspect/region/FragmentInspectionPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/contextwindow/inspect/region/FragmentInspectionPanel.ts
@@ -37,10 +37,19 @@ export class FragmentInspectionPanel extends ComponentInspectionPanel<FragmentCo
 
     private componentPropertyChangedEventHandler: (event: ComponentPropertyChangedEvent) => void;
 
+    private contentUpdatedListener;
+
     constructor() {
         super(<ComponentInspectionPanelConfig>{
             iconClass: api.liveedit.ItemViewIconClassResolver.resolveByType('fragment')
         });
+
+        this.contentUpdatedListener = (event: ContentUpdatedEvent) => {
+            // update currently selected option if this is the one updated
+            if (this.fragmentComponent && event.getContentId().equals(this.fragmentComponent.getFragment())) {
+                this.fragmentSelector.getSelectedOption().displayValue = event.getContentSummary();
+            }
+        };
     }
 
     setModel(liveEditModel: LiveEditModel) {
@@ -76,17 +85,11 @@ export class FragmentInspectionPanel extends ComponentInspectionPanel<FragmentCo
     }
 
     private handleContentUpdatedEvent() {
-        let contentUpdatedListener = (event: ContentUpdatedEvent) => {
-            // update currently selected option if this is the one updated
-            if (this.fragmentComponent && event.getContentId().equals(this.fragmentComponent.getFragment())) {
-                this.fragmentSelector.getSelectedOption().displayValue = event.getContentSummary();
-            }
-        };
-
-        ContentUpdatedEvent.on(contentUpdatedListener);
+        ContentUpdatedEvent.un(this.contentUpdatedListener);
+        ContentUpdatedEvent.on(this.contentUpdatedListener);
 
         this.onRemoved((event) => {
-            ContentUpdatedEvent.un(contentUpdatedListener);
+            ContentUpdatedEvent.un(this.contentUpdatedListener);
         });
     }
 


### PR DESCRIPTION
…h of content studio

- Fixed handleIFrameLoadedEvent() method of  LiveEditPageProxy to set liveEditWindow field correctly - for contents without live edit it caused incorrect event propagation
- Adjusted update event unsubscribing in FragmentInspectionPanel and  LiveFormPanel