### PR TITLE
XP-4953 Uploading new image to image content results in hang and cras…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveEditPageProxy.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveEditPageProxy.ts
@@ -1,7 +1,7 @@
-import "../../../api.ts";
-import {ShowContentFormEvent} from "../ShowContentFormEvent";
-import {ShowLiveEditEvent} from "../ShowLiveEditEvent";
-import {ShowSplitEditEvent} from "../ShowSplitEditEvent";
+import '../../../api.ts';
+import {ShowContentFormEvent} from '../ShowContentFormEvent';
+import {ShowLiveEditEvent} from '../ShowLiveEditEvent';
+import {ShowSplitEditEvent} from '../ShowSplitEditEvent';
 
 declare var CONFIG;
 
@@ -314,6 +314,8 @@ export class LiveEditPageProxy {
         }
 
         if (liveEditWindow) {
+            this.liveEditWindow = liveEditWindow;
+            
             if (liveEditWindow.wemjq) {
                 if (LiveEditPageProxy.debug) {
                     console.debug("LiveEditPageProxy.setting config for", liveEditWindow.document, CONFIG);
@@ -326,8 +328,6 @@ export class LiveEditPageProxy {
                 if (this.liveEditWindow) {
                     this.stopListening(this.liveEditWindow);
                 }
-
-                this.liveEditWindow = liveEditWindow;
 
                 this.listenToPage(this.liveEditWindow);
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveFormPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/LiveFormPanel.ts
@@ -1,21 +1,21 @@
-import "../../../api.ts";
-import {ContentWizardPanel} from "../ContentWizardPanel";
-import {DefaultModels} from "./DefaultModels";
-import {EmulatorPanel} from "./contextwindow/EmulatorPanel";
-import {LiveEditPageProxy} from "./LiveEditPageProxy";
-import {TextInspectionPanel} from "./contextwindow/inspect/region/TextInspectionPanel";
-import {ContentInspectionPanel} from "./contextwindow/inspect/ContentInspectionPanel";
-import {RegionInspectionPanel} from "./contextwindow/inspect/region/RegionInspectionPanel";
-import {ImageInspectionPanel} from "./contextwindow/inspect/region/ImageInspectionPanel";
-import {LayoutInspectionPanel} from "./contextwindow/inspect/region/LayoutInspectionPanel";
-import {FragmentInspectionPanel} from "./contextwindow/inspect/region/FragmentInspectionPanel";
-import {PartInspectionPanel} from "./contextwindow/inspect/region/PartInspectionPanel";
-import {PageInspectionPanel} from "./contextwindow/inspect/page/PageInspectionPanel";
-import {InspectionsPanel, InspectionsPanelConfig} from "./contextwindow/inspect/InspectionsPanel";
-import {InsertablesPanel} from "./contextwindow/insert/InsertablesPanel";
-import {ContextWindowController} from "./contextwindow/ContextWindowController";
-import {ContextWindow, ContextWindowConfig} from "./contextwindow/ContextWindow";
-import {ShowContentFormEvent} from "../ShowContentFormEvent";
+import '../../../api.ts';
+import {ContentWizardPanel} from '../ContentWizardPanel';
+import {DefaultModels} from './DefaultModels';
+import {EmulatorPanel} from './contextwindow/EmulatorPanel';
+import {LiveEditPageProxy} from './LiveEditPageProxy';
+import {TextInspectionPanel} from './contextwindow/inspect/region/TextInspectionPanel';
+import {ContentInspectionPanel} from './contextwindow/inspect/ContentInspectionPanel';
+import {RegionInspectionPanel} from './contextwindow/inspect/region/RegionInspectionPanel';
+import {ImageInspectionPanel} from './contextwindow/inspect/region/ImageInspectionPanel';
+import {LayoutInspectionPanel} from './contextwindow/inspect/region/LayoutInspectionPanel';
+import {FragmentInspectionPanel} from './contextwindow/inspect/region/FragmentInspectionPanel';
+import {PartInspectionPanel} from './contextwindow/inspect/region/PartInspectionPanel';
+import {PageInspectionPanel} from './contextwindow/inspect/page/PageInspectionPanel';
+import {InspectionsPanel, InspectionsPanelConfig} from './contextwindow/inspect/InspectionsPanel';
+import {InsertablesPanel} from './contextwindow/insert/InsertablesPanel';
+import {ContextWindowController} from './contextwindow/ContextWindowController';
+import {ContextWindow, ContextWindowConfig} from './contextwindow/ContextWindow';
+import {ShowContentFormEvent} from '../ShowContentFormEvent';
 
 import PageTemplate = api.content.page.PageTemplate;
 import PageTemplateKey = api.content.page.PageTemplateKey;
@@ -129,6 +129,8 @@ export class LiveFormPanel extends api.ui.panel.Panel {
 
     private liveEditPageProxy: LiveEditPageProxy;
 
+    private contentEventListener;
+
     constructor(config: LiveFormPanelConfig) {
         super("live-form-panel");
         this.contentWizardPanel = config.contentWizardPanel;
@@ -141,6 +143,10 @@ export class LiveFormPanel extends api.ui.panel.Panel {
         this.liveEditPageProxy = new LiveEditPageProxy();
 
         this.contextWindow = this.createContextWindow(this.liveEditPageProxy, this.liveEditModel);
+
+        this.contentEventListener = (event) => {
+            this.propagateEvent(event);
+        };
 
         // constructor to listen to live edit events during wizard rendering
         this.contextWindowController = new ContextWindowController(
@@ -362,15 +368,18 @@ export class LiveFormPanel extends api.ui.panel.Panel {
             this.contentWizardPanel.getContextWindowToggler().setActive(false, true);
         });
 
-        var contentEventListener = (event) => {
-            this.propagateEvent(event);
-        }
+        this.handleContentUpdatedEvent();
+    }
 
-        ContentDeletedEvent.on(contentEventListener);
-        ContentUpdatedEvent.on(contentEventListener);
+    private handleContentUpdatedEvent() {
+        ContentDeletedEvent.un(this.contentEventListener);
+        ContentUpdatedEvent.un(this.contentEventListener);
+        ContentDeletedEvent.on(this.contentEventListener);
+        ContentUpdatedEvent.on(this.contentEventListener);
+
         this.onRemoved(() => {
-            ContentDeletedEvent.un(contentEventListener);
-            ContentUpdatedEvent.un(contentEventListener);
+            ContentDeletedEvent.un(this.contentEventListener);
+            ContentUpdatedEvent.un(this.contentEventListener);
         });
     }
 


### PR DESCRIPTION
…h of content studio

- Fixed handleIFrameLoadedEvent() method of  LiveEditPageProxy to set liveEditWindow field correctly - for contents without live edit it caused incorrect event propagation
- Adjusted update event unsubscribing in FragmentInspectionPanel and  LiveFormPanel