### PR TITLE
XP-4975 HTML Area/Insert Link dialog - Add ellipsis overflow for long paths

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/image-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/image-dialog.less
@@ -76,6 +76,12 @@
     fieldset.modal-dialog-fieldset {
       margin: 0px;
     }
+
+    @-moz-document url-prefix() { // FF Issue with fieldset width, fix for XP-4975
+      fieldset {
+        display: table-cell;
+      }
+    }
   }
 
   .toolbar {


### PR DESCRIPTION
-FF issue with fieldset width that (minimum width of a fieldset is never less than the intrinsic width of its content. WebKit gives you a way to override this behaviour by specifying it in the default stylesheet, but Gecko goes a step further and enforces it in the rendering engine)