### PR TITLE
XP-4937 Page Editor - Page controller selector disappears after the s…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/page/GetPageDescriptorsByApplicationRequest.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/page/GetPageDescriptorsByApplicationRequest.ts
@@ -22,14 +22,16 @@ module api.content.page {
 
         sendAndParse(): wemQ.Promise<PageDescriptor[]> {
 
-            let cached = this.cache.getByApplication(this.applicationKey);
-            if (cached) {
-                return wemQ(cached);
-            } else {
-                return this.send().then((response: api.rest.JsonResponse<PageDescriptorsJson>) => {
-                    return this.fromJsonToPageDescriptors(response.getResult());
-                });
+            if (!api.BrowserHelper.isIE()) { // In case frame was reloaded in IE it can't use objects from cache
+                const cached = this.cache.getByApplication(this.applicationKey); // as they are from old unreachable for IE frame
+                if (cached) {
+                    return wemQ(cached);
+                }
             }
+
+            return this.send().then((response: api.rest.JsonResponse<PageDescriptorsJson>) => {
+                return this.fromJsonToPageDescriptors(response.getResult());
+            });
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/reset.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/reset.less
@@ -8,6 +8,8 @@ html {
   box-sizing: border-box;
 
   body {
+    // For IE, in order for an element to have height:100%; all parent elements must have height:100%;
+    height: 100%;
     // for crosshair highlighter to be drawn properly when content is shorter than window
     min-height: 100%;
     margin: 0;


### PR DESCRIPTION
…ite was saved (only on MS Edge)

-Error occured due to usage of cached objects in GetPageDescriptorsByApplicationRequest after live edit frame reloaded because ie can't use objects created in old frame