### PR TITLE
SelectionController checkbox doesn't change state after content was l…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -1444,7 +1444,14 @@ module api.ui.treegrid {
         }
 
         isAllSelected(): boolean {
-            return this.grid.isAllSelected();
+            return this.grid.isAllSelected() || this.thereIsOneUnselectedEmptyLoadNode();
+        }
+
+        private thereIsOneUnselectedEmptyLoadNode(): boolean {
+            return this.grid.getDataLength() - this.grid.getSelectedRows().length == 1
+                   && this.grid.getDataView().getItems().some((data: TreeNode<DATA>) => {
+                    return data && data.getDataId() === '';
+                });
         }
 
         protected updateExpanded() {


### PR DESCRIPTION
…azy loaded

- Adjusted isAllSelected() method to check case when there is mock load node within treegrid, which don't get selected (by default behavior)