### PR TITLE
Context menu opens and instantly closes again in Page Components View…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -236,7 +236,7 @@ module api.ui.treegrid {
         };
 
         private bindClickEvents() {
-            let clickHandler = api.util.AppHelper.debounce(((event, data) => {
+            let clickHandler = ((event, data) => {
                 if (!this.isActive()) {
                     return;
                 }
@@ -283,7 +283,7 @@ module api.ui.treegrid {
                 if (!elem.hasClass('sort-dialog-trigger')) {
                     new TreeGridItemClickedEvent(!!this.getFirstSelectedOrHighlightedNode()).fire();
                 }
-            }).bind(this), 50, false);
+            });
 
             this.grid.subscribeOnClick(clickHandler);
         }


### PR DESCRIPTION
… #4481

-Removed debounced click listener from TreeGrid and moved it directly to grid; issue occured because TreeGrid's click listener triggers row selection changed listeners which supposed to be called before other grid's click listeners, but because of debounce event order was broken