### PR TITLE
SelectionController checkbox doesn't change state after content was l…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -1444,7 +1444,21 @@ module api.ui.treegrid {
         }
 
         isAllSelected(): boolean {
-            return this.grid.isAllSelected();
+            if (this.grid.isAllSelected()) {
+                return true;
+            }
+
+            let selectedNodes = this.grid.getSelectedRows();
+
+            if (!selectedNodes) {
+                return false;
+            }
+
+            let nonEmptyNodes = this.gridData.getItems().filter((data: TreeNode<DATA>) => {
+                return (!!data && data.getDataId() !== '');
+            });
+
+            return nonEmptyNodes.length === selectedNodes.length;
         }
 
         protected updateExpanded() {


### PR DESCRIPTION
…azy loaded

- Adjusted isAllSelected() method to check case when there is mock load node within treegrid, which don't get selected (by default behavior)