### PR TITLE
Fix outline and tab order of items in the toolbar #4492

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/assets/js/home/launcher.js
+++ b/modules/admin/admin-ui/src/main/resources/assets/js/home/launcher.js
@@ -17,6 +17,7 @@ function appendLauncherButton() {
     setTimeout(function() {
         var container = document.querySelector(".appbar") || document.getElementsByTagName("body")[0];
         container.appendChild(launcherButton);
+        launcherButton.focus();
     }, 700);
 }
 
@@ -98,7 +99,7 @@ function createLauncherLink(container) {
 
 function openWindow(windowArr, anchorEl) {
     var windowId = anchorEl.getAttribute("data-id");
-    
+
     if (windowArr[windowId] && !windowArr[windowId].closed) {
         windowArr[windowId].focus();
     }
@@ -111,7 +112,7 @@ function addLongClickHandler(container) {
     var longpress = false;
     var startTime, endTime;
     var toolWindows = [];
-    
+
     var appTiles = container.querySelector('.launcher-app-container').querySelectorAll("a");
     for (var i = 0; i < appTiles.length; i++) {
         appTiles[i].addEventListener("click", function (e) {
@@ -119,7 +120,7 @@ function addLongClickHandler(container) {
                 e.preventDefault();
                 return;
             }
-                
+
             if (longpress) {
                 e.preventDefault();
                 document.location.href = this.href;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentBrowsePanel.ts
@@ -133,8 +133,8 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
 
             let contentPublishMenuButton = new ContentPublishMenuButton(this.getBrowseActions());
 
-            this.browseToolbar.appendChild(nonMobileDetailsPanelsManager.getToggleButton());
             this.browseToolbar.appendChild(contentPublishMenuButton);
+            this.browseToolbar.appendChild(nonMobileDetailsPanelsManager.getToggleButton());
 
             this.subscribeDetailsPanelsOnEvents(nonMobileDetailsPanelsManager, contentPublishMenuButton);
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/button/NonMobileDetailsPanelToggleButton.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/view/detail/button/NonMobileDetailsPanelToggleButton.ts
@@ -1,9 +1,9 @@
 import '../../../../api.ts';
 
-export class NonMobileDetailsPanelToggleButton extends api.dom.DivEl {
+export class NonMobileDetailsPanelToggleButton extends api.dom.ButtonEl {
 
     constructor() {
-        super('button', api.StyleHelper.COMMON_PREFIX);
+        super();
         this.addClass('non-mobile-details-panel-toggle-button');
 
         this.onClicked(() => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbar.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardToolbar.ts
@@ -63,10 +63,10 @@ export class ContentWizardToolbar extends api.ui.toolbar.Toolbar {
             params.publishAction, params.publishTreeAction, params.unpublishAction, params.publishMobileAction
         );
 
-        super.addElement(this.contentWizardToolbarPublishControls);
-        super.addElement(this.componentsViewToggler);
-        super.addElement(this.contextWindowToggler);
         super.addElement(this.cycleViewModeButton);
+        super.addElement(this.contextWindowToggler);
+        super.addElement(this.componentsViewToggler);
+        super.addElement(this.contentWizardToolbarPublishControls);
     }
 
     getCycleViewModeButton(): CycleButton {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/bar/AppBar.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/app/bar/AppBar.ts
@@ -37,9 +37,15 @@ module api.app.bar {
 
             this.addClass('home-button app-icon icon-' + app.getIconUrl());
 
-            this.onClicked((event: MouseEvent) => {
-                action.execute();
-            });
+            // Keep clickable in User Manager only
+            // Should be unclickable for all apps in future
+            if (app.getShortName() === 'UM') {
+                this.onClicked((event: MouseEvent) => {
+                    action.execute();
+                });
+            } else {
+                this.setEnabled(false);
+            }
         }
 
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/toolbar/Toolbar.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/toolbar/Toolbar.ts
@@ -112,7 +112,7 @@ module api.ui.toolbar {
         private getVisibleButtonsWidth(includeFold: boolean = true): number {
             return this.getChildren().reduce((totalWidth: number, element: api.dom.Element) => {
                 return totalWidth + ( element.isVisible() && (includeFold || element !== this.fold) ?
-                                      element.getEl().getWidthWithMargin() : 0 );
+                                      element.getEl().getWidthWithBorder() : 0 );
             }, 0);
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/appbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/appbar.less
@@ -55,6 +55,14 @@
         color: rgba(255,255,255,0.5);
       }
     }
+
+    // Keep clickable and focusable in User Manager only
+    &:not(.icon-user-manager) {
+      &, &:focus {
+        opacity: 1.0 !important;
+        cursor: default;
+      }
+    }
   }
 }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/content-wizard-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/app/wizard/content-wizard-toolbar.less
@@ -1,4 +1,15 @@
 .content-wizard-toolbar {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  align-items: flex-end;
+  align-content: stretch;
+
+  & > * {
+    flex: 0 0 auto;
+  }
+
   padding-right: 1px;
   height: @app-header-height;
   line-height: @app-header-height;
@@ -21,6 +32,7 @@
 
   .toolbar-publish-controls {
     display: none;
+    margin-left: auto;
   }
 
   .cycle-button.icon-medium:before {
@@ -42,6 +54,18 @@
       position: relative;
       top: 0px;
     }
+  }
+
+  .toggle-button.icon-clipboard {
+    order: 1;
+  }
+
+  .toggle-button.icon-cog {
+    order: 2;
+  }
+
+  .cycle-button {
+    order: 3;
   }
 
   &:not(.live) .toggle-button {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/toolbar.less
@@ -10,7 +10,7 @@
   min-width: 200px;
 
   .fold-button {
-    margin-right: 18px;
+    border-right: 18px solid transparent;
 
     .@{_COMMON_PREFIX}dropdown {
       margin-top: 35px;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-browse-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-browse-toolbar.less
@@ -32,12 +32,14 @@ button.icon-toolbar-settings {
 
 .browse-toolbar {
   .non-mobile-details-panel-toggle-button {
+    .button(@admin-font-gray2, transparent, @admin-font-gray3, transparent, true);
     z-index: 2;
     float: right;
     line-height: 22px;
 
     display: block;
     background-color: transparent;
+    border: 0px transparent;
     border-bottom: 1px transparent;
     position: relative;
 
@@ -47,7 +49,6 @@ button.icon-toolbar-settings {
 
     &:focus {
       box-shadow: none;
-      border: 0px transparent;
     }
 
     * {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-browse-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-browse-toolbar.less
@@ -12,7 +12,7 @@
     background-color: @admin-bg-light-gray;
   }
 
-  button, .fold-button, .content-publish-menu {
+  & > * {
     flex: 0 0 auto;
   }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-browse-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-browse-toolbar.less
@@ -1,7 +1,19 @@
 .content-browse-toolbar {
   overflow: visible;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  align-items: flex-end;
+  align-content: stretch;
+
+  overflow: visible;
   .fold-button .@{_COMMON_PREFIX}dropdown .@{_COMMON_PREFIX}:hover {
     background-color: @admin-bg-light-gray;
+  }
+
+  button, .fold-button, .content-publish-menu {
+    flex: 0 0 auto;
   }
 }
 
@@ -34,8 +46,9 @@ button.icon-toolbar-settings {
   .non-mobile-details-panel-toggle-button {
     .button(@admin-font-gray2, transparent, @admin-font-gray3, transparent, true);
     z-index: 2;
-    float: right;
     line-height: 22px;
+
+    order: 1;
 
     display: block;
     background-color: transparent;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-publish-menu-button.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-publish-menu-button.less
@@ -1,5 +1,5 @@
 .content-publish-menu {
-  float: right;
+  margin-left: auto;
 
   .action-button {
     display: inline-block !important;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/launcher/launcher.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/launcher/launcher.less
@@ -282,7 +282,7 @@ body.mobile-statistics-panel {
   cursor: pointer;
   z-index: @z-index-launcher-button;
   line-height: 17px;
-  padding-top: 5px;
+  padding: 6px 5px 3px;
 
   &::-moz-focus-inner {
     border: 0;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/reset.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/reset.less
@@ -61,7 +61,20 @@ input:not([type="radio"]), textarea, select {
 }
 
 input, textarea, select, button {
-  outline-width: 2px;
+  &:focus {
+    outline-width: 2px;
+    outline-style: auto;
+    outline-offset: -2px;
+    -moz-outline-radius: 3px;
+  }
+}
+
+@-moz-document url-prefix() {
+  input, textarea, select, button {
+    &:focus {
+      outline-color: rgba(66, 148, 222, 0.5);
+    }
+  }
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Disabled HomeButton for all apps, except User Manager.
Added autofocus to launcher button on app rendered.
Updated launcher button padding.
Updated outline on focused elements if Firefox to look it same, as in Chrome.
Updated `NonMobileDetailsPanelToggleButton` to inherit from `button``, instead of `div`.
Updated `ContentBrowseToolbar` to use flexbox, instead of float to fix the focus order for `ContentPublishMenuButton`.
Updated `ContentWizardToolbar` to use flexbox, instead of float to fix the focus order.