### PR TITLE
Auto-expand move dialog's treegrid dropdown down to selected item

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentMoveComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentMoveComboBox.ts
@@ -44,6 +44,7 @@ export class ContentMoveComboBox extends api.ui.selector.combobox.RichComboBox<C
     setFilterContents(contents: ContentSummary[]) {
         this.getLoader().setFilterContentPaths(contents.map((content) => content.getPath()));
         this.readonlyChecker.setFilterContentIds(contents.map((content) => content.getContentId()));
+        this.getComboBox().getComboBoxDropdownGrid().expandToDataOnReload(contents[0]);
     }
 
     setFilterContentTypes(contentTypes: api.schema.content.ContentType[]) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentSummaryOptionDataHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentSummaryOptionDataHelper.ts
@@ -17,4 +17,8 @@ export class ContentSummaryOptionDataHelper implements OptionDataHelper<ContentS
     getDataId(data: ContentSummary): string {
         return data ? data.getId() : '';
     }
+
+    isChildAndAncestor(possibleChild: ContentSummary, possibleParent: ContentSummary) {
+        return possibleChild.getPath().isDescendantOf(possibleParent.getPath());
+    }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownGrid.ts
@@ -67,6 +67,10 @@ module api.ui.selector {
             return;
         }
 
+        expandToDataOnReload(data: OPTION_DISPLAY_VALUE) {
+            return;
+        }
+
         protected initGridAndData() {
             throw new Error('Must be implemented by inheritors');
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownTreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownTreeGrid.ts
@@ -53,6 +53,10 @@ module api.ui.selector {
             this.optionsTreeGrid.setReadonlyChecker(checker);
         }
 
+        expandToDataOnReload(data: OPTION_DISPLAY_VALUE) {
+            this.optionsTreeGrid.expandToDataOnReload(data);
+        }
+
         setOptions(options: Option<OPTION_DISPLAY_VALUE>[]) {
             this.optionsTreeGrid.setOptions(options);
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/OptionDataHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/OptionDataHelper.ts
@@ -7,5 +7,7 @@ module api.ui.selector {
         hasChildren(data: DATA): boolean;
 
         getDataId(data: DATA): string;
+
+        isChildAndAncestor(possibleChild: DATA, possibleParent: DATA);
     }
 }


### PR DESCRIPTION
- Added dataToExpandOnReload field to OptionsTreeGrid which will be used as target when searching for node within grid
- Added method to OptionsTreeGrid that expands node till dataToExpandOnReload node
- Updated combobox classes to use new method that sets dataToExpandOnReload