### PR TITLE
Auto-expand move dialog's treegrid dropdown down to selected item

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentMoveComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentMoveComboBox.ts
@@ -44,6 +44,7 @@ export class ContentMoveComboBox extends api.ui.selector.combobox.RichComboBox<C
     setFilterContents(contents: ContentSummary[]) {
         this.getLoader().setFilterContentPaths(contents.map((content) => content.getPath()));
         this.readonlyChecker.setFilterContentIds(contents.map((content) => content.getContentId()));
+        this.getComboBox().getComboBoxDropdownGrid().presetDefaultOption(contents[0]);
     }
 
     setFilterContentTypes(contentTypes: api.schema.content.ContentType[]) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentSummaryOptionDataHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/browse/ContentSummaryOptionDataHelper.ts
@@ -17,4 +17,8 @@ export class ContentSummaryOptionDataHelper implements OptionDataHelper<ContentS
     getDataId(data: ContentSummary): string {
         return data ? data.getId() : '';
     }
+
+    isDescendingPath(childOption: ContentSummary, parentOption: ContentSummary) {
+        return childOption.getPath().isDescendantOf(parentOption.getPath());
+    }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownGrid.ts
@@ -67,6 +67,10 @@ module api.ui.selector {
             return;
         }
 
+        presetDefaultOption(data: OPTION_DISPLAY_VALUE) {
+            return;
+        }
+
         protected initGridAndData() {
             throw new Error('Must be implemented by inheritors');
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownTreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownTreeGrid.ts
@@ -53,6 +53,10 @@ module api.ui.selector {
             this.optionsTreeGrid.setReadonlyChecker(checker);
         }
 
+        presetDefaultOption(data: OPTION_DISPLAY_VALUE) {
+            this.optionsTreeGrid.presetDefaultOption(data);
+        }
+
         setOptions(options: Option<OPTION_DISPLAY_VALUE>[]) {
             this.optionsTreeGrid.setOptions(options);
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/OptionDataHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/OptionDataHelper.ts
@@ -7,5 +7,7 @@ module api.ui.selector {
         hasChildren(data: DATA): boolean;
 
         getDataId(data: DATA): string;
+
+        isDescendingPath(childOption: DATA, parentOption: DATA);
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/OptionsTreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/OptionsTreeGrid.ts
@@ -10,7 +10,9 @@ module api.ui.selector {
         private loader: OptionDataLoader<OPTION_DISPLAY_VALUE>;
         private treeDataHelper: OptionDataHelper<OPTION_DISPLAY_VALUE>;
         private readonlyChecker: (optionToCheck: OPTION_DISPLAY_VALUE) => boolean;
-        private isSelfManaging: boolean;
+        private isSelfLoading: boolean;
+        private defaultOption: OPTION_DISPLAY_VALUE;
+        private isDefaultOptionActive: boolean;
 
         constructor(columns: api.ui.grid.GridColumn<any>[],
                     gridOptions: api.ui.grid.GridOptions<any>,
@@ -34,14 +36,14 @@ module api.ui.selector {
             super(builder);
             this.loader = loader;
             this.treeDataHelper = treeDataHelper;
-            this.isSelfManaging = true;
+            this.isSelfLoading = true;
             this.highlightingEnabled = false;
 
             this.initEventHandlers();
         }
 
         setOptions(options: Option<OPTION_DISPLAY_VALUE>[]) {
-            this.isSelfManaging = false;
+            this.isSelfLoading = false;
             this.getGrid().getDataView().setItems(this.dataToTreeNodes(options, this.getRoot().getCurrentRoot()), 'dataId');
         }
 
@@ -53,6 +55,15 @@ module api.ui.selector {
             let gridClasses = (' ' + this.getGrid().getEl().getClass()).replace(/\s/g, '.');
             let viewport = api.dom.Element.fromString(gridClasses + ' .slick-viewport', false);
             return viewport;
+        }
+
+        reload(parentNodeData?: Option<OPTION_DISPLAY_VALUE>): wemQ.Promise<void> {
+            return super.reload(parentNodeData).then(() => {
+                if (this.defaultOption && !this.isDefaultOptionActive) {
+                    this.scrollToDefaultOption(this.getRoot().getCurrentRoot(), 0);
+                    this.isDefaultOptionActive = true;
+                }
+            });
         }
 
         private initEventHandlers() {
@@ -73,7 +84,7 @@ module api.ui.selector {
         }
 
         hasChildren(option: Option<OPTION_DISPLAY_VALUE>): boolean {
-            if (!this.isSelfManaging) {
+            if (!this.isSelfLoading) {
                 return false;
             }
             return this.treeDataHelper.hasChildren(option.displayValue);
@@ -94,7 +105,7 @@ module api.ui.selector {
         }
 
         fetchChildren(parentNode?: TreeNode<Option<OPTION_DISPLAY_VALUE>>): wemQ.Promise<Option<OPTION_DISPLAY_VALUE>[]> {
-            this.isSelfManaging = true;
+            this.isSelfLoading = true;
             parentNode = parentNode ? parentNode : this.getRoot().getCurrentRoot();
 
             let from = parentNode.getChildren().length;
@@ -104,13 +115,13 @@ module api.ui.selector {
             }
 
             return this.loader.fetchChildren(parentNode, from, OptionsTreeGrid.MAX_FETCH_SIZE).then(
-                (loadedeData: OptionDataLoaderData<OPTION_DISPLAY_VALUE>) => {
-                    let newOptions = this.optionsDataToTreeNodeOption(loadedeData.getData());
+                (loadedData: OptionDataLoaderData<OPTION_DISPLAY_VALUE>) => {
+                    let newOptions = this.optionsDataToTreeNodeOption(loadedData.getData());
                     let options = parentNode.getChildren().map((el) => el.getData()).slice(0, from).concat(newOptions);
 
-                    parentNode.setMaxChildren(loadedeData.getTotalHits());
+                    parentNode.setMaxChildren(loadedData.getTotalHits());
 
-                    return this.loader.checkReadonly(loadedeData.getData()).then((readonlyIds: string[]) => {
+                    return this.loader.checkReadonly(loadedData.getData()).then((readonlyIds: string[]) => {
                         newOptions.forEach((option: Option<OPTION_DISPLAY_VALUE>) => {
                             const markedReadonly = readonlyIds.some((id: string) => {
                                 if (this.treeDataHelper.getDataId(option.displayValue) === id) {
@@ -125,12 +136,56 @@ module api.ui.selector {
                             }
                         });
 
-                        if (from + loadedeData.getHits() < loadedeData.getTotalHits()) {
+                        if (from + loadedData.getHits() < loadedData.getTotalHits()) {
                             options.push(this.makeEmptyData());
                         }
                         return options;
                     });
                 });
+        }
+
+        presetDefaultOption(data: OPTION_DISPLAY_VALUE) {
+            this.defaultOption = data;
+            this.isDefaultOptionActive = false;
+        }
+
+        private scrollToDefaultOption(parentNode: TreeNode<Option<OPTION_DISPLAY_VALUE>>, startFrom: number) {
+            const length = parentNode.getChildren().length;
+            const defaultOptionId = this.treeDataHelper.getDataId(this.defaultOption);
+            for (let i = startFrom; i < length; i++) {
+                const child = parentNode.getChildren()[i];
+                const childOption = child.getData().displayValue;
+                if (childOption) {
+                    if (this.treeDataHelper.getDataId(childOption) == defaultOptionId) {
+                        this.scrollToRow(this.getGrid().getDataView().getRowById(child.getId()), true); // found target data node
+                        return;
+                    }
+                    if (this.treeDataHelper.isDescendingPath(this.defaultOption, childOption)) {
+                        // found ancestor of target data node
+                        this.expandNode(child).then(() => {
+                            this.scrollToDefaultOption(child, 0); // expand target data node ancestor and keep searching
+                        });
+                        return;
+                    }
+                }
+            }
+
+            // if reached here  - no matches were found, need to load more children
+            this.fetchBatchOfChildren(parentNode);
+        }
+
+        private fetchBatchOfChildren(parentNode: TreeNode<Option<OPTION_DISPLAY_VALUE>>) {
+            const length = parentNode.getChildren().length;
+            const from = parentNode.getChildren()[length - 1].getData().displayValue ? length : length - 1;
+            if (from < parentNode.getMaxChildren()) {
+                this.fetchChildren(parentNode).then((children: Option<OPTION_DISPLAY_VALUE>[]) => {
+                    let fetchedChildrenNodes = this.dataToTreeNodes(children, parentNode);
+                    parentNode.setChildren(fetchedChildrenNodes);
+                    this.initData(this.getRoot().getCurrentRoot().treeToList());
+
+                    this.scrollToDefaultOption(parentNode, from);
+                });
+            }
         }
 
         private optionsDataToTreeNodeOption(data: OPTION_DISPLAY_VALUE[]): Option<OPTION_DISPLAY_VALUE>[] {
@@ -158,7 +213,12 @@ module api.ui.selector {
             }
 
             if (node.getData().readOnly) {
-                return {cssClasses: "readonly' title='This content is read-only'"};
+                if (this.treeDataHelper.getDataId(node.getData().displayValue) !=
+                    this.treeDataHelper.getDataId(this.defaultOption)) {
+                    return {cssClasses: "readonly' title='This content is read-only'"};
+                } else {
+                    return {cssClasses: "active readonly' title='This content is read-only'"};
+                }
             }
 
             return null;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/selector/dropdown/dropdown.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/selector/dropdown/dropdown.less
@@ -102,10 +102,8 @@
     }
     .toggle.icon {
       margin-right: 0px;
-      &.expand, &.collapse {
-        padding-left: 10px;
-        margin-right: 10px;
-      }
+      padding-left: 10px;
+      margin-right: 10px;
     }
   }
 }


### PR DESCRIPTION
- Added dataToExpandOnReload field to OptionsTreeGrid which will be used as target when searching for node within grid
- Added method to OptionsTreeGrid that expands node till dataToExpandOnReload node
- Updated combobox classes to use new method that sets dataToExpandOnReload