### PR TITLE
In the Publishing Wizard toggling child items crashes for a modified …

### DIFF
--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ResolveRequiredDependenciesCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ResolveRequiredDependenciesCommand.java
@@ -1,6 +1,7 @@
 package com.enonic.xp.core.impl.content;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -60,16 +61,16 @@ public class ResolveRequiredDependenciesCommand
 
         final Set<ContentId> requiredIds = parentPaths.stream().
             filter( resultPaths::contains ).
-            map( parentPath ->
-                 {
-                     final NodeComparison comparison = nodeComparisons.getBySourcePath( parentPath );
+            map( parentPath -> {
+                final NodeComparison comparison = nodeComparisons.getBySourcePath( parentPath );
 
-                     if ( !CompareStatus.NEWER.equals( comparison.getCompareStatus() ) )
-                     {
-                         return ContentId.from( comparison.getNodeId().toString() );
-                     }
-                     return null;
-                 } ).
+                if ( !CompareStatus.NEWER.equals( comparison.getCompareStatus() ) )
+                {
+                    return ContentId.from( comparison.getNodeId().toString() );
+                }
+                return null;
+            } ).
+            filter( Objects::nonNull ).
             collect( Collectors.toSet() );
 
         return ContentIds.from( requiredIds );


### PR DESCRIPTION
…item

- Added non null filter to content ids stream as further ContentIds.from throws NPE on null entry within node id's set