### PR TITLE
NPE on import targeting a manually sorted node #4636

### DIFF
--- a/modules/core/core-export/build.gradle
+++ b/modules/core/core-export/build.gradle
@@ -2,7 +2,10 @@ apply from: "$rootDir/gradle/osgi.gradle"
 
 dependencies {
     compile project( ':core:core-api' )
+    testCompile project( ':core:core-repo' )
     testCompile project( path: ':core:core-api', configuration: 'testOutput' )
+    testCompile project( path: ':core:core-repo', configuration: 'testOutput' )
+    testCompile project( path: ':core:core-blobstore', configuration: 'testOutput' )
 }
 
 bundle {

--- a/modules/core/core-export/src/main/java/com/enonic/xp/core/impl/export/NodeImporter.java
+++ b/modules/core/core-export/src/main/java/com/enonic/xp/core/impl/export/NodeImporter.java
@@ -83,9 +83,17 @@ public final class NodeImporter
     {
         this.result.dryRun( this.dryRun );
 
-        verifyImportRoot();
-
-        processNodeFolder( this.exportRoot, ProcessNodeSettings.create() );
+        if ( !isNodeFolder( this.exportRoot ) )
+        {
+            importFromDirectoryLayout( this.exportRoot );
+        }
+        else
+        {
+            // Export root contains a node definition - should be created as the node
+            // given as importRoot
+            verifyImportRoot();
+            processNodeFolder( this.exportRoot, ProcessNodeSettings.create() );
+        }
 
         nodeService.refresh( RefreshMode.ALL );
 
@@ -178,6 +186,11 @@ public final class NodeImporter
 
     }
 
+    private boolean isNodeFolder( final VirtualFile folder )
+    {
+        return folder.resolve( folder.getPath().join( "_" ) ).exists();
+    }
+
     private Node processNodeSource( final VirtualFile nodeFolder, final ProcessNodeSettings.Builder processNodeSettings )
     {
         final VirtualFile nodeSource = this.exportReader.getNodeSource( nodeFolder );
@@ -237,9 +250,7 @@ public final class NodeImporter
             importPermissions( this.importPermissions ).
             build();
 
-        final ImportNodeResult importNodeResult = this.nodeService.importNode( importNodeParams );
-
-        return importNodeResult;
+        return this.nodeService.importNode( importNodeParams );
     }
 
     private List<String> processBinarySource( final VirtualFile nodeFolder )

--- a/modules/core/core-export/src/test/resources/com/enonic/xp/core/impl/export/node_manual_ordered.xml
+++ b/modules/core/core-export/src/test/resources/com/enonic/xp/core/impl/export/node_manual_ordered.xml
@@ -24,7 +24,6 @@
     </property-set>
   </data>
   <indexConfigs>
-    <analyzer>myAnalyzer</analyzer>
     <defaultConfig>
       <decideByType>false</decideByType>
       <enabled>true</enabled>

--- a/modules/core/core-export/src/test/resources/com/enonic/xp/core/impl/export/node_timestamp.xml
+++ b/modules/core/core-export/src/test/resources/com/enonic/xp/core/impl/export/node_timestamp.xml
@@ -1,7 +1,6 @@
 <node>
   <childOrder>_name DESC</childOrder>
   <nodeType>content</nodeType>
-  <id>1234</id>
   <timestamp>2014-01-01T10:00:00Z</timestamp>
   <permissions/>
   <data>
@@ -26,7 +25,6 @@
     </property-set>
   </data>
   <indexConfigs>
-    <analyzer>myAnalyzer</analyzer>
     <defaultConfig>
       <decideByType>false</decideByType>
       <enabled>true</enabled>

--- a/modules/core/core-export/src/test/resources/com/enonic/xp/core/impl/export/node_unordered.xml
+++ b/modules/core/core-export/src/test/resources/com/enonic/xp/core/impl/export/node_unordered.xml
@@ -24,7 +24,6 @@
     </property-set>
   </data>
   <indexConfigs>
-    <analyzer>myAnalyzer</analyzer>
     <defaultConfig>
       <decideByType>false</decideByType>
       <enabled>true</enabled>

--- a/modules/core/core-export/src/test/resources/com/enonic/xp/core/impl/export/node_with_appref.xml
+++ b/modules/core/core-export/src/test/resources/com/enonic/xp/core/impl/export/node_with_appref.xml
@@ -29,7 +29,6 @@
     </property-set>
   </data>
   <indexConfigs>
-    <analyzer>myAnalyzer</analyzer>
     <defaultConfig>
       <decideByType>false</decideByType>
       <enabled>true</enabled>

--- a/modules/core/core-export/src/test/resources/com/enonic/xp/core/impl/export/node_with_binary.xml
+++ b/modules/core/core-export/src/test/resources/com/enonic/xp/core/impl/export/node_with_binary.xml
@@ -25,7 +25,6 @@
     </property-set>
   </data>
   <indexConfigs>
-    <analyzer>myAnalyzer</analyzer>
     <defaultConfig>
       <decideByType>false</decideByType>
       <enabled>true</enabled>

--- a/modules/core/core-export/src/test/resources/com/enonic/xp/core/impl/export/node_with_id_1234.xml
+++ b/modules/core/core-export/src/test/resources/com/enonic/xp/core/impl/export/node_with_id_1234.xml
@@ -25,7 +25,6 @@
     </property-set>
   </data>
   <indexConfigs>
-    <analyzer>myAnalyzer</analyzer>
     <defaultConfig>
       <decideByType>false</decideByType>
       <enabled>true</enabled>

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ResolveInsertOrderValueCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ResolveInsertOrderValueCommand.java
@@ -31,7 +31,7 @@ public class ResolveInsertOrderValueCommand
             execute();
 
         final ChildOrder childOrder =
-            insertManualStrategy.equals( InsertManualStrategy.LAST ) ? ChildOrder.reverseManualOrder() : ChildOrder.manualOrder();
+            InsertManualStrategy.LAST.equals( insertManualStrategy ) ? ChildOrder.reverseManualOrder() : ChildOrder.manualOrder();
 
         final FindNodesByParentResult findNodesByParentResult = doFindNodesByParent( FindNodesByParentParams.create().
             parentPath( parentPath ).

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/AbstractNodeTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/AbstractNodeTest.java
@@ -124,6 +124,8 @@ public abstract class AbstractNodeTest
 
     private BlobStore blobStore;
 
+    protected NodeServiceImpl nodeService;
+
     @Before
     public void setUp()
         throws Exception
@@ -191,7 +193,7 @@ public abstract class AbstractNodeTest
 
     private void setUpRepositoryServices()
     {
-        NodeServiceImpl nodeService = new NodeServiceImpl();
+        nodeService = new NodeServiceImpl();
         nodeService.setIndexServiceInternal( indexServiceInternal );
         nodeService.setNodeStorageService( this.storageService );
         nodeService.setNodeSearchService( this.searchService );
@@ -214,6 +216,9 @@ public abstract class AbstractNodeTest
         this.repositoryService.setIndexServiceInternal( this.indexServiceInternal );
         this.repositoryService.setNodeRepositoryService( nodeRepositoryService );
         this.repositoryService.setNodeStorageService( this.storageService );
+
+        this.nodeService.setRepositoryService( this.repositoryService );
+
     }
 
     void createRepository( final Repository repository )
@@ -250,9 +255,13 @@ public abstract class AbstractNodeTest
 
     protected Node createDefaultRootNode()
     {
-        final AccessControlList rootPermissions =
-            AccessControlList.of( AccessControlEntry.create().principal( TEST_DEFAULT_USER.getKey() ).allowAll().build() );
-        final CreateRootNodeParams createRootParams = CreateRootNodeParams.create().permissions( rootPermissions ).
+        final AccessControlList rootPermissions = AccessControlList.of( AccessControlEntry.create().
+            principal( TEST_DEFAULT_USER.getKey() ).
+            allowAll().
+            build() );
+
+        final CreateRootNodeParams createRootParams = CreateRootNodeParams.create().
+            permissions( rootPermissions ).
             build();
 
         return CreateRootNodeCommand.create().


### PR DESCRIPTION
Checking if initial folder contains a node definition or not, acts accordingly.
Refactored tests to integration tests since its so hard testing this properly without a real backend.
Fixed issue with NPE on insert in manual ordered parent.