### PR TITLE
Adjust notifications bar to not span too high on many notifications (#4472)

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/notify/MessageBus.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/notify/MessageBus.ts
@@ -1,19 +1,19 @@
 module api.notify {
 
-    export function showSuccess(message: string, autoHide: boolean = true): string {
-        return NotifyManager.get().showSuccess(message, autoHide);
+    export function showSuccess(message: string, autoHide: boolean = true) {
+        NotifyManager.get().showSuccess(message, autoHide);
     }
 
-    export function showFeedback(message: string, autoHide: boolean = true): string {
-        return NotifyManager.get().showFeedback(message, autoHide);
+    export function showFeedback(message: string, autoHide: boolean = true) {
+        NotifyManager.get().showFeedback(message, autoHide);
     }
 
-    export function showError(message: string, autoHide: boolean = true): string {
-        return NotifyManager.get().showError(message, autoHide);
+    export function showError(message: string, autoHide: boolean = true) {
+        NotifyManager.get().showError(message, autoHide);
     }
 
-    export function showWarning(message: string, autoHide: boolean = true): string {
-        return NotifyManager.get().showWarning(message, autoHide);
+    export function showWarning(message: string, autoHide: boolean = true) {
+        NotifyManager.get().showWarning(message, autoHide);
     }
 
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/notify/NotificationMessage.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/notify/NotificationMessage.ts
@@ -4,8 +4,11 @@ module api.notify {
 
         private notificationInner: api.dom.DivEl;
 
-        constructor(message: string) {
+        private autoHide: boolean;
+
+        constructor(message: string, autoHide: boolean = false) {
             super('notification');
+            this.autoHide = autoHide;
             this.notificationInner = new api.dom.DivEl('notification-inner');
             let notificationRemove = new api.dom.SpanEl('notification-remove');
             notificationRemove.setHtml('X');
@@ -15,5 +18,8 @@ module api.notify {
             this.appendChild(this.notificationInner);
         }
 
+        isAutoHide(): boolean {
+            return this.autoHide;
+        }
     }
 }


### PR DESCRIPTION
* Added the notification limit to prevent from display too many of them at once.
* Removed return value (id) from notification functions (refactored).

Notifications will be shown until the limit is reached. Each next notification will be placed into the queue. After the notification active is removed, new notification from the queue will be rendered.