### PR TITLE
Attachmentuploader in part config creates error message when "upload"…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/contextwindow/ContextWindow.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/page/contextwindow/ContextWindow.ts
@@ -204,6 +204,7 @@ export class ContextWindow extends api.ui.panel.DockedPanel {
         this.animationTimer = setTimeout(() => {
             this.contextWindowState = ContextWindowState.SHOWN;
             this.updateFrameSize();
+            this.show(); // to notify listeners that elements are shown
             this.animationTimer = null;
         }, 100);
     }


### PR DESCRIPTION
… button is clicked #4748

-Uploader is initialized when uploaderEl gets shown, but that was not happening when selecting part with uploader while context window is hidden; if you open context window after selecting part it slides in from out of frame and 'show' event not triggered; Thus triggering show() on context window when slide in occurs to notify all listeners that context window and it's children are shown