### PR TITLE
Page Template Wizard- button 'Edit' in the support-selected option do…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/schema/content/ContentTypeComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/schema/content/ContentTypeComboBox.ts
@@ -48,5 +48,9 @@ module api.schema.content {
             return content.getName();
         }
 
+        protected isEditButtonNeeded(): boolean {
+            return false;
+        }
+
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichSelectedOptionView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/RichSelectedOptionView.ts
@@ -41,13 +41,17 @@ module api.ui.selector.combobox {
             if (this.draggable) {
                 buttons.push(new api.dom.DivEl('drag-control'));
             }
-            if (this.isEditable()) {
+            if (this.isEditButtonNeeded()) {
                 buttons.push(this.createEditButton(content));
             }
             if (this.removable) {
                 buttons.push(this.createRemoveButton());
             }
             return buttons;
+        }
+
+        protected isEditButtonNeeded(): boolean {
+            return this.isEditable();
         }
 
         protected createView(content: T): api.dom.Element {


### PR DESCRIPTION
…es not open the content in new wizard tab #4745

-Removing edit button for ContentTypeSelectedOptionView because can't edit content type