### PR TITLE
Content Wizard - 'Security Step' is not shown for users with read-only permissions (#4755)

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/apps/content-studio/js/app/wizard/ContentWizardPanel.ts
@@ -140,8 +140,6 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
 
     private contentNamedListeners: {(event: ContentNamedEvent): void}[];
 
-    private isSecurityWizardStepFormAllowed: boolean;
-
     private inMobileViewMode: boolean;
 
     private skipValidation: boolean;
@@ -185,7 +183,6 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
         this.loadData();
 
         this.isContentFormValid = false;
-        this.isSecurityWizardStepFormAllowed = false;
 
         this.requireValid = false;
         this.skipValidation = false;
@@ -602,9 +599,7 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
             this.scheduleWizardStepIndex = steps.length;
             steps.push(this.scheduleWizardStep);
 
-            if (this.isSecurityWizardStepFormAllowed) {
-                steps.push(new WizardStep('Security', this.securityWizardStepForm));
-            }
+            steps.push(new WizardStep('Security', this.securityWizardStepForm));
 
             this.setSteps(steps);
 
@@ -676,7 +671,7 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
 
             if (content.getType().isImage()) {
                 this.updateWizard(content);
-            } else if (this.isSecurityWizardStepFormAllowed) { // update security wizard to have new path/displayName etc.
+            } else { // update security wizard to have new path/displayName etc.
                 this.securityWizardStepForm.update(content);
             }
 
@@ -1118,10 +1113,7 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
                 this.scheduleWizardStepForm.layout(content);
                 this.scheduleWizardStepForm.onPropertyChanged(this.dataChangedListener);
                 this.refreshScheduleWizardStep();
-
-                if (this.isSecurityWizardStepFormAllowed) {
-                    this.securityWizardStepForm.layout(content);
-                }
+                this.securityWizardStepForm.layout(content);
 
                 schemas.forEach((schema: Mixin, index: number) => {
                     let extraData = content.getExtraData(schema.getMixinName());
@@ -1656,20 +1648,8 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
     }
 
     private checkSecurityWizardStepFormAllowed(loginResult: api.security.auth.LoginResult) {
-
-        if (this.getPersistedItem().isAnyPrincipalAllowed(loginResult.getPrincipals(), Permission.WRITE_PERMISSIONS)) {
-            this.isSecurityWizardStepFormAllowed = true;
-        }
-    }
-
-    private isPrincipalPresent(principalKey: api.security.PrincipalKey,
-                               accessEntriesToCheck: AccessControlEntry[]): boolean {
-
-        return accessEntriesToCheck.some((entry: AccessControlEntry) => {
-            if (entry.getPrincipalKey().equals(principalKey)) {
-                return true;
-            }
-        });
+        const noWritePermission = !this.getPersistedItem().isAnyPrincipalAllowed(loginResult.getPrincipals(), Permission.WRITE_PERMISSIONS);
+        this.securityWizardStepForm.toggleClass('no-write-permissions', noWritePermission);
     }
 
     /**
@@ -1720,10 +1700,7 @@ export class ContentWizardPanel extends api.app.wizard.WizardPanel<Content> {
 
         this.settingsWizardStepForm.update(contentCopy, unchangedOnly);
         this.scheduleWizardStepForm.update(contentCopy, unchangedOnly);
-
-        if (this.isSecurityWizardStepFormAllowed) {
-            this.securityWizardStepForm.update(contentCopy, unchangedOnly);
-        }
+        this.securityWizardStepForm.update(contentCopy, unchangedOnly);
     }
 
     private updateWizardHeader(content: Content) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/security-wizard-step-form.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/security-wizard-step-form.less
@@ -1,5 +1,11 @@
 .security-wizard-step-form {
 
+  &.no-write-permissions {
+    .edit-permissions {
+      display: none;
+    }
+  }
+
   .edit-permissions {
     .button(@form-button-font, @form-button-bg);
     display: inline-block;


### PR DESCRIPTION
Made SecurityWizardStepForm visible for users without write permissions.
Hide Edit button in SecurityWizardStepForm for users without write permissions.
Removed obsolete code.