### PR TITLE
Logback - Size and time based (#4940)

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -25,7 +25,7 @@ dependencies {
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.springframework:spring-test:4.1.6.RELEASE'
-    testCompile 'org.slf4j:slf4j-simple:1.7.10'
+    testCompile 'org.slf4j:slf4j-simple:1.7.25'
     testOutput sourceSets.test.output
 }
 

--- a/modules/core/core-api/build.gradle
+++ b/modules/core/core-api/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'org.osgi:osgi.core:6.0.0'
     compile 'org.osgi:osgi.cmpn:6.0.0'
-    compile 'org.slf4j:slf4j-api:1.7.10'
+    compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'javax.mail:mail:1.4.7'
     compile 'io.dropwizard.metrics:metrics-core:3.1.2'
 }

--- a/modules/distro/src/home/config/logback.xml
+++ b/modules/distro/src/home/config/logback.xml
@@ -3,9 +3,11 @@
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <file>${xp.home}/logs/server.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>${xp.home}/logs/server.%d{yyyy-MM-dd}.log</fileNamePattern>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${xp.home}/logs/server.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxFileSize>100MB</maxFileSize>
       <maxHistory>7</maxHistory>
+      <totalSizeCap>3GB</totalSizeCap>
     </rollingPolicy>
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>

--- a/modules/launcher/launcher-impl/build.gradle
+++ b/modules/launcher/launcher-impl/build.gradle
@@ -7,10 +7,10 @@ dependencies {
         transitive = false
     }
     compile 'commons-io:commons-io:2.4'
-    compile 'ch.qos.logback:logback-classic:1.1.2'
-    compile 'org.slf4j:jul-to-slf4j:1.7.10'
-    compile 'org.slf4j:jcl-over-slf4j:1.7.10'
-    compile 'org.slf4j:log4j-over-slf4j:1.7.10'
+    compile 'ch.qos.logback:logback-classic:1.2.3'
+    compile 'org.slf4j:jul-to-slf4j:1.7.25'
+    compile 'org.slf4j:jcl-over-slf4j:1.7.25'
+    compile 'org.slf4j:log4j-over-slf4j:1.7.25'
     compile 'org.fusesource.jansi:jansi:1.11'
     compile 'javax.mail:mail:1.4.7'
 }

--- a/modules/launcher/launcher-impl/src/main/resources/META-INF/config/system.properties
+++ b/modules/launcher/launcher-impl/src/main/resources/META-INF/config/system.properties
@@ -48,7 +48,7 @@ internal.osgi.bootdelegation = \
 internal.osgi.system.packages = \
   sun.misc,\
   org.osgi.service.log;version=1.3,\
-  org.slf4j.*;version=1.7.10,\
+  org.slf4j.*;version=1.7.25,\
   org.apache.commons.logging;version=1.1.1,\
   org.apache.log4j.*;version=1.2.17,\
   javax.activation.*;version=1.1,\

--- a/modules/launcher/launcher-impl/src/test/java/com/enonic/xp/launcher/impl/util/OsgiExportsBuilderTest.java
+++ b/modules/launcher/launcher-impl/src/test/java/com/enonic/xp/launcher/impl/util/OsgiExportsBuilderTest.java
@@ -38,7 +38,7 @@ public class OsgiExportsBuilderTest
     public void expandExports_wildcard()
     {
         final String exports = this.builder.expandExports( "org.slf4j.*" );
-        assertEquals( "org.slf4j,org.slf4j.bridge,org.slf4j.helpers,org.slf4j.impl,org.slf4j.spi", sort( exports ) );
+        assertEquals( "org.slf4j,org.slf4j.bridge,org.slf4j.event,org.slf4j.helpers,org.slf4j.impl,org.slf4j.spi", sort( exports ) );
     }
 
     private String sort( final String str )

--- a/modules/tools/testing/build.gradle
+++ b/modules/tools/testing/build.gradle
@@ -7,5 +7,5 @@ dependencies {
     compile 'junit:junit:4.10'
     compile 'org.mockito:mockito-core:1.10.19'
     compile 'org.hamcrest:hamcrest-library:1.3'
-    compile 'org.slf4j:slf4j-simple:1.7.10'
+    compile 'org.slf4j:slf4j-simple:1.7.25'
 }

--- a/modules/tools/toolbox/build.gradle
+++ b/modules/tools/toolbox/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-databind:2.6.2'
     compile 'org.eclipse.jgit:org.eclipse.jgit:4.0.1.201506240215-r'
     compile project( ':tools:upgrade' )
-    compile 'org.slf4j:slf4j-log4j12:1.7.2'
+    compile 'org.slf4j:slf4j-log4j12:1.7.25'
     testCompile 'com.squareup.okhttp:mockwebserver:2.4.0'
 }
 


### PR DESCRIPTION
Hi Stenl

Just a proposition for Enonic XP 6.11. So that we can use rolling of log file by time and size.
But there may be an impact I do not think about