### PR TITLE
Site.xml with only one input type with foldout doesn't show properly #4914

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorDialog.ts
@@ -13,6 +13,7 @@ module api.content.site.inputtype.siteconfigurator {
     import ComboBox = api.ui.selector.combobox.ComboBox;
     import CreateHtmlAreaDialogEvent = api.util.htmlarea.dialog.CreateHtmlAreaDialogEvent;
     import Application = api.application.Application;
+    import ResponsiveManager = api.ui.responsive.ResponsiveManager;
 
     export class SiteConfiguratorDialog extends api.ui.dialog.ModalDialog {
 
@@ -43,6 +44,21 @@ module api.content.site.inputtype.siteconfigurator {
                     this.removeClass('masked');
                 });
             });
+
+            const availableSizeChangedListener = () => {
+                const content = this.getContentPanel();
+                const contentHeight = content.getEl().getHeightWithoutPadding();
+                const contentChildrenHeight = content.getChildren().reduce((prev, curr) => {
+                    return prev + curr.getEl().getHeightWithMargin();
+                }, 0);
+
+                const isScrollable = contentHeight < contentChildrenHeight;
+
+                this.toggleClass('scrollable', isScrollable);
+            };
+
+            ResponsiveManager.onAvailableSizeChanged(this, availableSizeChangedListener);
+            this.onRemoved(() => ResponsiveManager.unAvailableSizeChanged(this));
         }
 
         doRender(): Q.Promise<boolean> {
@@ -67,6 +83,8 @@ module api.content.site.inputtype.siteconfigurator {
 
                     this.handleSelectorsDropdowns(this.formView);
                     this.handleDialogClose(this.formView);
+
+                    ResponsiveManager.fireResizeEvent();
 
                     return rendered;
                 });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
@@ -224,7 +224,7 @@ module api.ui.dialog {
             return this.buttonRow;
         }
 
-        protected getContentPanel(): ModalDialogContentPanel {
+        getContentPanel(): ModalDialogContentPanel {
             return this.contentPanel;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/application/inputtype/siteconfigurator/site-configurator.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/application/inputtype/siteconfigurator/site-configurator.less
@@ -145,10 +145,15 @@
     }
   }
 
+  &.scrollable {
+    .dialog-content {
+      overflow-y: auto;
+    }
+  }
+
   .dialog-content {
 
     max-height: 500px;
-    overflow-y: auto;
 
     @media screen and (max-height: 720px) {
       max-height: 400px;


### PR DESCRIPTION
Fixed problem with `overflow: auto`, when it prevented dropdown to be rendered outside the parent element in small dialogs without scrolls.