### PR TITLE
Move dialog dropdown list doesn't expand fully if site in content stu…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownGrid.ts
@@ -41,6 +41,8 @@ module api.ui.selector {
 
         protected multipleSelectionListeners: {(event: DropdownGridMultipleSelectionEvent): void}[];
 
+        protected rowCountChangedListeners: {(): void}[] = [];
+
         protected multipleSelections: boolean;
 
         protected config: DropdownGridConfig<OPTION_DISPLAY_VALUE>;
@@ -367,6 +369,22 @@ module api.ui.selector {
             const event = new DropdownGridMultipleSelectionEvent(rowsSelected);
             this.multipleSelectionListeners.forEach((listener: (event: DropdownGridMultipleSelectionEvent) => void) => {
                 listener(event);
+            });
+        }
+
+        onRowCountChanged(listener: () => void) {
+            this.rowCountChangedListeners.push(listener);
+        }
+
+        unRowCountChanged(listener: () => void) {
+            this.rowCountChangedListeners.filter((currentListener: () => void) => {
+                return listener !== currentListener;
+            });
+        }
+
+        notifyRowCountChanged() {
+            this.rowCountChangedListeners.forEach((listener: () => void) => {
+                listener();
             });
         }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownListGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownListGrid.ts
@@ -20,6 +20,8 @@ module api.ui.selector {
             }
 
             this.grid = new api.ui.grid.Grid<Option<OPTION_DISPLAY_VALUE>>(this.gridData, this.createColumns(), this.createOptions());
+
+            this.gridData.onRowCountChanged(() => this.notifyRowCountChanged());
         }
 
         getElement(): Element {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownTreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/DropdownTreeGrid.ts
@@ -28,6 +28,8 @@ module api.ui.selector {
 
         constructor(config: DropdownGridConfig<OPTION_DISPLAY_VALUE>) {
             super(config);
+
+            this.optionsTreeGrid.getGrid().getDataView().onRowCountChanged(() => this.notifyRowCountChanged());
         }
 
         expandActiveRow() {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/combobox/ComboBox.ts
@@ -324,7 +324,7 @@ module api.ui.selector.combobox {
             this.input.giveFocus();
         }
 
-        getComboBoxDropdownGrid() {
+        getComboBoxDropdownGrid(): DropdownGrid<OPTION_DISPLAY_VALUE> {
             return this.comboBoxDropdown.getDropdownGrid();
         }
 
@@ -809,6 +809,13 @@ module api.ui.selector.combobox {
                     this.handleSelectedOptionMoved();
                 });
             }
+
+            this.comboBoxDropdown.getDropdownGrid().onRowCountChanged(() => {
+                if (this.comboBoxDropdown.isDropdownShown()) {
+                    this.comboBoxDropdown.getDropdownGrid().adjustGridHeight();
+                    this.doUpdateDropdownTopPositionAndWidth();
+                }
+            });
         }
 
         private handleInputValueChanged() {

--- a/modules/app/app-contentstudio/src/main/js/app/browse/ContentMoveComboBox.ts
+++ b/modules/app/app-contentstudio/src/main/js/app/browse/ContentMoveComboBox.ts
@@ -44,7 +44,6 @@ export class ContentMoveComboBox extends api.ui.selector.combobox.RichComboBox<C
     setFilterContents(contents: ContentSummary[]) {
         this.getLoader().setFilterContentPaths(contents.map((content) => content.getPath()));
         this.readonlyChecker.setFilterContentIds(contents.map((content) => content.getContentId()));
-        this.getComboBox().getComboBoxDropdownGrid().presetDefaultOption(contents[0]);
     }
 
     setFilterContentTypes(contentTypes: api.schema.content.ContentType[]) {


### PR DESCRIPTION
…dio was expanded #4924

Disabled `presetDefaultOption()` in `ContentMoveComboBox` to prevent the tree auto-expanding.
Added height adjustment on row count changed.