### PR TITLE
Incorrect validation of OptionSet-content in the grid #4830

### DIFF
--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ValidateContentDataCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ValidateContentDataCommand.java
@@ -81,7 +81,8 @@ final class ValidateContentDataCommand
     {
         final PropertyTree contentData = this.contentData;
         final ContentTypeName contentTypeName = this.contentType;
-        final ContentType contentType = contentTypeService.getByName( new GetContentTypeParams().contentTypeName( contentTypeName ) );
+        final ContentType contentType =
+            contentTypeService.getByName( new GetContentTypeParams().contentTypeName( contentTypeName ).inlineMixinsToFormItems( true ) );
 
         Preconditions.checkArgument( contentType != null, "ContentType [%s] not found", contentTypeName );
 

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/AbstractContentServiceTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/AbstractContentServiceTest.java
@@ -52,6 +52,7 @@ import com.enonic.xp.data.PropertySet;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.extractor.BinaryExtractor;
 import com.enonic.xp.extractor.ExtractedData;
+import com.enonic.xp.form.Form;
 import com.enonic.xp.form.FormItemSet;
 import com.enonic.xp.form.Input;
 import com.enonic.xp.inputtype.InputTypeName;
@@ -239,6 +240,7 @@ public class AbstractContentServiceTest
         this.nodeService.initialize();
 
         this.mixinService = Mockito.mock( MixinService.class );
+        Mockito.when( mixinService.inlineFormItems( Mockito.isA( Form.class ) ) ).thenReturn( Form.create().build() );
 
         Map<String, List<String>> metadata = Maps.newHashMap();
         metadata.put( HttpHeaders.CONTENT_TYPE, Lists.newArrayList( "image/jpg" ) );


### PR DESCRIPTION
-Updated validation command to fetch form items for inline mixins so they could be validated, otherwise ContentType's form contains form item of type InlineMixin that can't be validated