### PR TITLE
ApplicationItemStatisticsPanel should be cleared when an application …

### DIFF
--- a/modules/app/app-applications/src/main/js/app/browse/ApplicationBrowsePanel.ts
+++ b/modules/app/app-applications/src/main/js/app/browse/ApplicationBrowsePanel.ts
@@ -91,6 +91,7 @@ export class ApplicationBrowsePanel extends api.app.browse.BrowsePanel<Applicati
                         let installedApp = this.treeGrid.getByApplicationKey(event.getApplicationKey());
                         let installedAppName = installedApp ? installedApp.getDisplayName() : event.getApplicationKey();
                         api.notify.showFeedback(i18n('notify.installed', installedAppName));
+                        this.treeGrid.refresh();
                     }, 200);
                 });
 


### PR DESCRIPTION
…was uninstalled #4955

Restored selection in applications grid, after app is installed.