### PR TITLE
Fix messages in notifications about User Store actions #5170

### DIFF
--- a/modules/app/app-contentstudio/src/main/js/app/wizard/ContentWizardToolbarPublishControls.ts
+++ b/modules/app/app-contentstudio/src/main/js/app/wizard/ContentWizardToolbarPublishControls.ts
@@ -92,6 +92,7 @@ export class ContentWizardToolbarPublishControls
         this.createIssueAction.setEnabled(canCreateIssue);
         this.unpublishAction.setEnabled(canBeUnpublished);
         this.publishMobileAction.setEnabled(canBePublished);
+        this.publishMobileAction.setVisible(canBePublished);
 
         this.contentStateSpan.setHtml(this.getContentStateValueForSpan(this.content), false);
         this.publishButtonForMobile.setLabel(

--- a/modules/app/app-users/src/main/resources/admin/i18n/phrases.properties
+++ b/modules/app/app-users/src/main/resources/admin/i18n/phrases.properties
@@ -34,13 +34,13 @@ field.authentication = Authentication
 #
 # Notify
 #
-notify.delete.principal = Principal [{0}] deleted
-notify.delete.userstore = UserStore [{0}] deleted
+notify.delete.principal = Principal "{0}" is deleted
+notify.delete.userstore = User Store "{0}" is deleted
 notify.change.password = Password was changed
 notify.create.user = User was created
 notify.create.group = Group was created
 notify.create.role = Role was created
-notify.update.any = {0} '{1}' was updated
+notify.update.any = {0} "{1}" was updated
 
 notify.empty.name = Name can not be empty.
 notify.empty.email = Email can not be empty.

--- a/modules/app/app-users/src/main/resources/admin/i18n/phrases_no.properties
+++ b/modules/app/app-users/src/main/resources/admin/i18n/phrases_no.properties
@@ -34,13 +34,13 @@ field.authentication = Autentisering
 #
 # Notify
 #
-notify.delete.principal = Principal [{0}] slettet
-notify.delete.userstore = Brukerlager [{0}] slettet
+notify.delete.principal = Principal "{0}" slettet
+notify.delete.userstore = Brukerlager "{0}" slettet
 notify.change.password = Passord ble endret
 notify.create.user = Bruker ble lagret
 notify.create.group = Gruppe ble lagret
 notify.create.role = Rolle ble lagert
-notify.update.any = {0} '{1}' ble oppdatert!
+notify.update.any = {0} "{1}" ble oppdatert
 
 notify.empty.name = Navn må være utfullt.
 notify.empty.email = Epost må være utfullt.


### PR DESCRIPTION
Update localized notifications for User Store and Principals.

Restored line, mistakenly removed in #5151