### PR TITLE
Don't close 'Edit Permissions' dialog without warning, if something is not saved #5120

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/site/inputtype/siteconfigurator/SiteConfiguratorDialog.ts
@@ -16,6 +16,7 @@ module api.content.site.inputtype.siteconfigurator {
     import ResponsiveManager = api.ui.responsive.ResponsiveManager;
     import HtmlAreaResizeEvent = api.form.inputtype.text.HtmlAreaResizeEvent;
     import ModalDialogConfig = api.ui.dialog.ModalDialogConfig;
+    import AppHelper = api.util.AppHelper;
 
     export class SiteConfiguratorDialog extends api.ui.dialog.ModalDialog {
 
@@ -183,7 +184,7 @@ module api.content.site.inputtype.siteconfigurator {
             let inputView: InputView = <InputView> itemView;
             if (this.isContentOrImageOrPrincipalOrComboSelectorInput(inputView)) {
                 let combobox = this.getComboboxFromSelectorInputView(inputView);
-                if (!!combobox) {
+                if (combobox) {
                     comboboxArray.push(combobox);
                 }
             }
@@ -223,7 +224,7 @@ module api.content.site.inputtype.siteconfigurator {
         }
 
         isDirty(): boolean {
-            return this.formView.isDirty();
+            return AppHelper.isDirty(this.formView);
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/FormView.ts
@@ -58,21 +58,6 @@ module api.form {
             this.formItemLayer = new FormItemLayer(context);
         }
 
-        isDirty(): boolean {
-            const checkDirty = (el: api.dom.Element) => {
-                // Check isDirty() on element, except FormView itself to prevent recursion
-                const canCheckForDirty = (!(el instanceof FormView) && typeof el['isDirty'] === 'function');
-                if (canCheckForDirty) {
-                    return el['isDirty']();
-                } else if (el.getChildren().length > 0) {
-                    return el.getChildren().some(checkDirty);
-                }
-                return false;
-            };
-
-            return checkDirty(this);
-        }
-
         /**
          * Lays out the form.
          */

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
@@ -295,7 +295,8 @@ module api.ui.dialog {
 
         protected hasSubDialog(): boolean {
             // html area can spawn sub dialogs so check none is open
-            return !!api.util.htmlarea.dialog.HTMLAreaDialogHandler.getOpenDialog();
+            return !!api.util.htmlarea.dialog.HTMLAreaDialogHandler.getOpenDialog() ||
+                   (this.confirmationDialog && this.confirmationDialog.isVisible());
         }
 
         private hasTabbable(): boolean {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
@@ -94,6 +94,8 @@ module api.ui.dialog {
                 if (noCallback) {
                     this.confirmationDialog.setNoCallback(noCallback);
                 }
+
+                this.confirmationDialog.onClosed(() => this.removeClass('await-confirmation'));
             }
         }
 
@@ -376,6 +378,7 @@ module api.ui.dialog {
         confirmBeforeClose() {
             if (this.confirmationDialog && this.isDirty()) {
                 this.confirmationDialog.open();
+                this.addClass('await-confirmation');
             } else {
                 this.close();
             }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/AppHelper.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/AppHelper.ts
@@ -95,6 +95,22 @@ module api.util {
             event.stopPropagation();
             event.preventDefault();
         }
+
+        static isDirty(element: api.dom.Element): boolean {
+
+            const checkDirty = (el: api.dom.Element) => {
+                // Check isDirty() on element, except root element to prevent recursion
+                const canCheckForDirty = (el !== element && typeof el['isDirty'] === 'function');
+                if (canCheckForDirty) {
+                    return el['isDirty']();
+                } else if (el.getChildren().length > 0) {
+                    return el.getChildren().some(checkDirty);
+                }
+                return false;
+            };
+
+            return checkDirty(element);
+        }
     }
 
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/dialog/modal-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/dialog/modal-dialog.less
@@ -188,10 +188,8 @@
   z-index: @z-index-modal-dialog + 1;
 }
 
-.body-mask.confirmation-dialog-mask + .@{_COMMON_PREFIX}modal-dialog {
-  .cancel-button-top {
-    display: none;
-  }
+.await-confirmation .cancel-button-top {
+  display: none;
 }
 
 body {

--- a/modules/app/app-contentstudio/src/main/js/app/wizard/EditPermissionsDialog.ts
+++ b/modules/app/app-contentstudio/src/main/js/app/wizard/EditPermissionsDialog.ts
@@ -2,6 +2,7 @@ import '../../api.ts';
 import {ContentPermissionsApplyEvent} from './ContentPermissionsApplyEvent';
 
 import Content = api.content.Content;
+import ModalDialogConfig = api.ui.dialog.ModalDialogConfig;
 import AccessControlComboBox = api.ui.security.acl.AccessControlComboBox;
 import AccessControlEntry = api.security.acl.AccessControlEntry;
 import AccessControlList = api.security.acl.AccessControlList;
@@ -43,7 +44,12 @@ export class EditPermissionsDialog extends api.ui.dialog.ModalDialog {
     protected header: EditPermissionsDialogHeader;
 
     constructor() {
-        super();
+        super(<ModalDialogConfig>{
+            confirmation: {
+                yesCallback: () => this.applyAction.execute(),
+                noCallback: () => this.close(),
+            }
+        });
 
         this.addClass('edit-permissions-dialog');
 
@@ -230,6 +236,10 @@ export class EditPermissionsDialog extends api.ui.dialog.ModalDialog {
         } else {
             this.inheritPermissionsCheck.giveFocus();
         }
+    }
+
+    isDirty(): boolean {
+        return this.applyAction.isEnabled();
     }
 }
 


### PR DESCRIPTION
Added confirmation dialog to the `EditPermissionsDialog`.

Moved `isDirty` function to `AppHelper`.
Fixed focus blinking in dialogs with a confirmation dialog, when it was shown.