### PR TITLE
Make sure all data in system-repo:master is deleted before loading da…

### DIFF
--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/executor/BatchedGetChildrenExecutor.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/executor/BatchedGetChildrenExecutor.java
@@ -56,14 +56,14 @@ public class BatchedGetChildrenExecutor
 
         if ( result.isEmpty() )
         {
-            hasMore = false;
+            this.hasMore = false;
         }
         else
         {
-            currentFrom += batchSize;
-            hasMore = true;
-        }
+            this.currentFrom += this.batchSize;
 
+            this.hasMore = currentFrom < result.getTotalHits();
+        }
         return result.getNodeIds();
     }
 

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/executor/BatchedGetChildrenExecutorTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/executor/BatchedGetChildrenExecutorTest.java
@@ -55,6 +55,61 @@ public class BatchedGetChildrenExecutorTest
     }
 
     @Test
+    public void all_yields_only_one_invocation()
+        throws Exception
+    {
+        createNode( NodePath.ROOT, "node1" );
+        createNode( NodePath.ROOT, "node2" );
+        createNode( NodePath.ROOT, "node3" );
+        createNode( NodePath.ROOT, "node4" );
+        createNode( NodePath.ROOT, "node5" );
+
+        final BatchedGetChildrenExecutor executor = BatchedGetChildrenExecutor.create().
+            nodeService( this.nodeService ).
+            parentId( Node.ROOT_UUID ).
+            batchSize( 5 ).
+            build();
+
+        final NodeIds.Builder builder = NodeIds.create();
+
+        while ( executor.hasMore() )
+        {
+            builder.addAll( executor.execute() );
+        }
+
+        final NodeIds result = builder.build();
+        assertEquals( 5, result.getSize() );
+    }
+
+    @Test
+    public void one_larger_than_batch()
+        throws Exception
+    {
+        createNode( NodePath.ROOT, "node1" );
+        createNode( NodePath.ROOT, "node2" );
+        createNode( NodePath.ROOT, "node3" );
+        createNode( NodePath.ROOT, "node4" );
+        createNode( NodePath.ROOT, "node5" );
+        createNode( NodePath.ROOT, "node6" );
+
+        final BatchedGetChildrenExecutor executor = BatchedGetChildrenExecutor.create().
+            nodeService( this.nodeService ).
+            parentId( Node.ROOT_UUID ).
+            batchSize( 5 ).
+            build();
+
+        final NodeIds.Builder builder = NodeIds.create();
+
+        while ( executor.hasMore() )
+        {
+            builder.addAll( executor.execute() );
+        }
+
+        final NodeIds result = builder.build();
+        assertEquals( 6, result.getSize() );
+    }
+
+    @Test
     public void recursive()
         throws Exception
     {
@@ -110,11 +165,11 @@ public class BatchedGetChildrenExecutorTest
         assertEquals( 5, result.getSize() );
 
         final Iterator<NodeId> iterator = result.iterator();
-        assertEquals( iterator.next(), NodeId.from( "a" ));
-        assertEquals( iterator.next(), NodeId.from( "b" ));
-        assertEquals( iterator.next(), NodeId.from( "c" ));
-        assertEquals( iterator.next(), NodeId.from( "d" ));
-        assertEquals( iterator.next(), NodeId.from( "e" ));
+        assertEquals( iterator.next(), NodeId.from( "a" ) );
+        assertEquals( iterator.next(), NodeId.from( "b" ) );
+        assertEquals( iterator.next(), NodeId.from( "c" ) );
+        assertEquals( iterator.next(), NodeId.from( "d" ) );
+        assertEquals( iterator.next(), NodeId.from( "e" ) );
     }
 
 }


### PR DESCRIPTION
…ta (#5209)

Added deletion of all system repo nodes before loading system-repo again. Optimized away one invocation on the batched executor.