### PR TITLE
Mobile resolution - "Instantly delete..." checkbox is too wide #5022

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
@@ -100,11 +100,7 @@ module api.ui.dialog {
         }
 
         private initListeners() {
-            ResponsiveManager.onAvailableSizeChanged(this, () => {
-                if (this.isVisible()) {
-                    this.centerMyself();
-                }
-            });
+            ResponsiveManager.onAvailableSizeChanged(this, () => this.centerMyself());
 
             // Set the ResponsiveRanges on first show() call
             const firstTimeResize = () => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/remove/content-delete-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/remove/content-delete-dialog.less
@@ -2,8 +2,12 @@
 
   .instant-delete-check {
     position: absolute;
+    width: calc(~'100% - 240px');
     bottom: 40px;
-    left: 38px;
+    left: 39px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
 
     input[type="checkbox"] + label {
       color: @admin-blue !important;
@@ -34,6 +38,26 @@
 
     .instant-delete-check, .load-mask {
       display: none !important;
+    }
+  }
+
+  &._0-240, &._240-360, &._360-540, &._540-720 {
+    .instant-delete-check {
+
+    }
+  }
+
+  &._0-240, &._240-360 {
+    .instant-delete-check {
+      left: calc(~'2% + 9px');
+      width: calc(~'96% - 190px');
+    }
+  }
+
+  &._360-540 {
+    .instant-delete-check {
+      left: calc(~'3% + 9px');
+      width: calc(~'94% - 190px');
     }
   }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/remove/content-delete-dialog.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/remove/content-delete-dialog.less
@@ -2,7 +2,6 @@
 
   .instant-delete-check {
     position: absolute;
-    width: calc(~'100% - 240px');
     bottom: 40px;
     left: 39px;
     text-overflow: ellipsis;
@@ -41,24 +40,25 @@
     }
   }
 
-  &._0-240, &._240-360, &._360-540, &._540-720 {
-    .instant-delete-check {
+  &._0-240, &._240-360, &._360-540 {
+    .dialog-buttons {
+      margin-top: 58px;
+    }
 
+    .instant-delete-check {
+      bottom: 78px;
     }
   }
 
   &._0-240, &._240-360 {
     .instant-delete-check {
       left: calc(~'2% + 9px');
-      width: calc(~'96% - 190px');
     }
   }
 
   &._360-540 {
     .instant-delete-check {
       left: calc(~'3% + 9px');
-      width: calc(~'94% - 190px');
     }
   }
-
 }


### PR DESCRIPTION
* Made overflowed checkbox label crop and use the ellipsis. Take a note, that it only crop the text, instead of switching between _full_ and _short_ version, because in that case we would need to manage it with JS, wich would be a not a very good idea, in my opinion.

* Fixed the position of the checkbox in mobile mode.