### PR TITLE
Mobile resolution - ImageEditor dialog doesn't fit the viewport #5023

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/image/ImageUploaderEl.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/content/image/ImageUploaderEl.ts
@@ -160,14 +160,11 @@ module api.content.image {
                 this.notifyEditModeChanged(edit, position, zoom, focus);
                 this.togglePlaceholder(edit);
 
-                let index = -1;
-
                 if (edit) {
-                    index = imageEditor.getSiblingIndex();
                     api.dom.Body.get().appendChild(imageEditor.addClass(ImageUploaderEl.STANDOUT_CLASS));
                     this.positionImageEditor(imageEditor);
                 } else {
-                    this.getResultContainer().insertChild(imageEditor.removeClass(ImageUploaderEl.STANDOUT_CLASS), index);
+                    this.getResultContainer().insertChild(imageEditor.removeClass(ImageUploaderEl.STANDOUT_CLASS), -1);
                 }
             };
             let uploadButtonClickedHandler = () => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/image/ImageEditor.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/image/ImageEditor.ts
@@ -107,7 +107,7 @@ module api.ui.image {
 
             this.image = new ImgEl(null, 'image-bg', true);
 
-            let resizeListener = (item) => {
+            let resizeHandler = () => {
                 if (this.isVisible()) {
                     this.updateImageDimensions(false, true);
                     this.updateStickyToolbar();
@@ -121,7 +121,7 @@ module api.ui.image {
                 this.updateStickyToolbar();
                 this.unShown(updateImageOnShown);
                 if (isFirstLoad) {
-                    api.ui.responsive.ResponsiveManager.onAvailableSizeChanged(this, resizeListener);
+                    api.ui.responsive.ResponsiveManager.onAvailableSizeChanged(this, resizeHandler);
                     isFirstLoad = false;
                 }
             };

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/image/ImageEditor.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/image/ImageEditor.ts
@@ -878,6 +878,7 @@ module api.ui.image {
                 this.setEditMode(true, applyChanges);
             }
 
+            this.updateImageDimensions(false, true);
             this.bindFocusMouseListeners();
             this.updateFocusMaskPosition();
         }
@@ -893,6 +894,7 @@ module api.ui.image {
 
             if (exitEditMode) {
                 this.setEditMode(false, applyChanges);
+                this.updateImageDimensions(false, true);
             }
         }
 
@@ -1197,6 +1199,7 @@ module api.ui.image {
                 this.setEditMode(true, applyChanges);
             }
 
+            this.updateImageDimensions(false, true);
             this.bindCropMouseListeners();
             this.updateCropMaskPosition();
             this.updateZoomPosition();
@@ -1213,6 +1216,7 @@ module api.ui.image {
 
             if (exitEditMode) {
                 this.setEditMode(false, applyChanges);
+                this.updateImageDimensions(false, true);
             }
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/image/image-editor.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/image/image-editor.less
@@ -6,7 +6,7 @@
   &.standout {
     position: absolute; // need to have a position other than static for z-index to have effect
     z-index: @z-index-mask + 1; // to be above image input type mask
-    width: 640px;
+    max-width: 640px;
 
     .sticky-toolbar {
       z-index: @z-index-mask; // to have it on top of zoomed image

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/image/image-editor.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/image/image-editor.less
@@ -213,8 +213,12 @@
           display: none;
         }
 
-        &:before {
+        &::before {
           font-size: 34px;
+        }
+
+        &:focus {
+          border: none !important;
         }
       }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/image/image-editor.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/image/image-editor.less
@@ -7,6 +7,7 @@
     position: absolute; // need to have a position other than static for z-index to have effect
     z-index: @z-index-mask + 1; // to be above image input type mask
     max-width: 640px;
+    width: calc(~'100% - ' 20px);
 
     .sticky-toolbar {
       z-index: @z-index-mask; // to have it on top of zoomed image


### PR DESCRIPTION
Fixed the width of the image editor, since it overflows the screen in mobile mode.
Fixed the resize of the image editor in edit mode.