### PR TITLE
Use ISO datetime as standard logback config #5263

### DIFF
--- a/modules/distro/src/home/config/logback.xml
+++ b/modules/distro/src/home/config/logback.xml
@@ -16,7 +16,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
Setting ISO date as STDOUT format