### PR TITLE
'New' button should be disabled when nothing is selected in the grid …

### DIFF
--- a/modules/app/app-contentstudio/src/main/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/app/app-contentstudio/src/main/js/app/browse/ContentBrowsePanel.ts
@@ -58,6 +58,8 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
             this.getBrowseActions().TOGGLE_SEARCH_PANEL.setVisible(item.isInRangeOrSmaller(ResponsiveRanges._360_540));
         });
 
+        this.getBrowseActions().updateActionsEnabledState([]); // to enable/disable actions correctly
+
         this.handleGlobalEvents();
     }
 


### PR DESCRIPTION
…and user is not allowed to create content in the root #5188

-Making ContentTreeGridActions updated after panel created