### PR TITLE
Mobile resolution - Checkboxes are not right-aligned in the Application app's grid #5235

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/GridColumn.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/grid/GridColumn.ts
@@ -339,6 +339,12 @@ module api.ui.grid {
             this.id = id;
             return this;
         }
+
+        setBoundaryWidth(minWidth: number, maxWidth: number): GridColumn<T> {
+            this.minWidth = minWidth;
+            this.maxWidth = maxWidth;
+            return this;
+        }
         setMaxWidth(maxWidth: number): GridColumn<T> {
             this.maxWidth = maxWidth;
             return this;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGridBuilder.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGridBuilder.ts
@@ -35,6 +35,8 @@ module api.ui.treegrid {
 
         private idPropertyName: string = 'id';
 
+        private columnUpdater: () => void;
+
         constructor(grid?: TreeGrid<NODE>) {
             if (grid) {
                 this.showToolbar = grid.hasToolbar();
@@ -278,6 +280,14 @@ module api.ui.treegrid {
 
         getIdPropertyName() : string {
             return this.idPropertyName;
+        }
+
+        setColumnUpdater(columnUpdater: () => void) {
+            this.columnUpdater = columnUpdater;
+        }
+
+        getColumnUpdater(): () => void {
+            return this.columnUpdater;
         }
 
         private buildColumn(columnConfig: GridColumnConfig) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/treegrid/tree-grid-toolbar.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/treegrid/tree-grid-toolbar.less
@@ -90,7 +90,7 @@
 
     &.@{_CLS_PREFIX}icon-loop {
       float: right;
-      padding: 0 26px 0 14px;
+      padding: 0 14px 0 14px;
 
       &:before {
         left: 0;
@@ -160,15 +160,6 @@ body {
     .tree-grid-toolbar .@{_COMMON_PREFIX}button.selection-toggler {
       float: right;
       padding-right: 50px;
-    }
-  }
-}
-
-.content-grid-and-browse-split-panel.vertical .tree-grid {
-  &._0-240, &._240-360, &._360-540 {
-
-    .@{_CLS_PREFIX}icon-loop {
-      padding: 0 32px 0 14px;
     }
   }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/treegrid/tree-grid.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/ui/treegrid/tree-grid.less
@@ -99,6 +99,10 @@
           background: url("../../../../images/admin-checked.gif") center no-repeat;
         }
 
+        &:last-child {
+          padding-right: 20px;
+        }
+
       }
 
       .toggle {
@@ -184,6 +188,11 @@
           color: @admin-dark-gray;
           .animation(rotate360, .5s, 0s, linear);
         }
+      }
+
+      .shifted .toggle.icon {
+        width: 45px;
+        margin-right: 0;
       }
     }
   }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-tree-grid.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/browse/content-tree-grid.less
@@ -10,11 +10,6 @@
       opacity: 0.5;
     }
 
-    .shifted .toggle.icon {
-      width: 45px;
-      margin-right: 0;
-    }
-
     &:not(.selected) {
       .slick-cell:not(.selected).status {
         .content-status-mixin();
@@ -44,10 +39,6 @@
 
       &.order .sort-dialog-trigger:before {
         margin-left: 6px;
-      }
-
-      &.slick-cell-checkboxsel:last-child {
-        padding-right: 20px;
       }
     }
   }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/module/browse/application-tree-grid.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/module/browse/application-tree-grid.less
@@ -11,6 +11,10 @@
     .toggle.icon {
       display: none;
     }
+
+    &.shifted {
+      padding-left: 15px;
+    }
   }
 
   .application-viewer {

--- a/modules/app/app-applications/src/main/js/app/browse/ApplicationTreeGrid.ts
+++ b/modules/app/app-applications/src/main/js/app/browse/ApplicationTreeGrid.ts
@@ -43,70 +43,46 @@ export class ApplicationTreeGrid extends TreeGrid<Application> {
                 style: {cssClass: 'state', minWidth: 80, maxWidth: 100}
         }]).prependClasses('application-grid');
 
-        super(builder);
-
-        this.setContextMenu(new TreeGridContextMenu(ApplicationBrowseActions.init(this)));
-
-        const columns = builder.getColumns();
+        const columns = builder.getColumns().slice(0);
         const [
             nameColumn,
             versionColumn,
             stateColumn,
-        ] = builder.getColumns().slice(1);
+        ] = columns;
 
-        const updateColumns = (force?: boolean) => {
-            if (force) {
-                let width = this.getEl().getWidth();
-                let checkSelIsMoved = ResponsiveRanges._360_540.isFitOrSmaller(api.dom.Body.get().getEl().getWidth());
+        const updateColumns = () => {
+            let width = this.getEl().getWidth();
+            let checkSelIsMoved = ResponsiveRanges._360_540.isFitOrSmaller(api.dom.Body.get().getEl().getWidth());
 
-                const curClass = nameColumn.getCssClass();
+            const curClass = nameColumn.getCssClass();
 
-                if (checkSelIsMoved) {
-                    nameColumn.setCssClass(curClass || 'shifted');
-                } else if (curClass && curClass.indexOf('shifted') >= 0) {
-                    nameColumn.setCssClass(curClass.replace('shifted', ''));
-                }
+            if (checkSelIsMoved) {
+                nameColumn.setCssClass(curClass || 'shifted');
+            } else if (curClass && curClass.indexOf('shifted') >= 0) {
+                nameColumn.setCssClass(curClass.replace('shifted', ''));
+            }
 
-                if (ResponsiveRanges._240_360.isFitOrSmaller(width)) {
-                    nameColumn.setBoundaryWidth(150, 250);
-                    versionColumn.setBoundaryWidth(50, 70);
-                    stateColumn.setBoundaryWidth(50, 50);
-                } else if (ResponsiveRanges._360_540.isFitOrSmaller(width)) {
-                    nameColumn.setBoundaryWidth(200, 350);
-                    versionColumn.setBoundaryWidth(50, 70);
-                    stateColumn.setBoundaryWidth(50, 70);
-                } else {
-                    nameColumn.setBoundaryWidth(200, 9999);
-                    versionColumn.setBoundaryWidth(50, 130);
-                    stateColumn.setBoundaryWidth(80, 100);
-                }
-                this.setColumns(columns.slice(1), checkSelIsMoved);
-
-                this.getGrid().syncGridSelection(true);
+            if (ResponsiveRanges._240_360.isFitOrSmaller(width)) {
+                nameColumn.setBoundaryWidth(150, 250);
+                versionColumn.setBoundaryWidth(50, 70);
+                stateColumn.setBoundaryWidth(50, 50);
+            } else if (ResponsiveRanges._360_540.isFitOrSmaller(width)) {
+                nameColumn.setBoundaryWidth(200, 350);
+                versionColumn.setBoundaryWidth(50, 70);
+                stateColumn.setBoundaryWidth(50, 70);
             } else {
-                this.getGrid().resizeCanvas();
-                this.highlightCurrentNode();
+                nameColumn.setBoundaryWidth(200, 9999);
+                versionColumn.setBoundaryWidth(50, 130);
+                stateColumn.setBoundaryWidth(80, 100);
             }
+            this.setColumns(columns.slice(0), checkSelIsMoved);
         };
 
-        this.initEventHandlers(updateColumns);
-    }
+        builder.setColumnUpdater(updateColumns);
 
-    private initEventHandlers(updateColumnsHandler: Function) {
-        const onBecameActive = (active: boolean) => {
-            if (active) {
-                updateColumnsHandler(true);
-                this.unActiveChanged(onBecameActive);
-            }
-        };
-        // update columns when grid becomes active for the first time
-        this.onActiveChanged(onBecameActive);
+        super(builder);
 
-        api.ui.responsive.ResponsiveManager.onAvailableSizeChanged(this, (item: ResponsiveItem) => {
-            if (this.isInRenderingView()) {
-                updateColumnsHandler(item.isRangeSizeChanged());
-            }
-        });
+        this.setContextMenu(new TreeGridContextMenu(ApplicationBrowseActions.init(this)));
     }
 
     getDataId(data: Application): string {

--- a/modules/app/app-contentstudio/src/main/js/app/browse/ContentTreeGrid.ts
+++ b/modules/app/app-contentstudio/src/main/js/app/browse/ContentTreeGrid.ts
@@ -85,25 +85,24 @@ export class ContentTreeGrid
 
         this.setContextMenu(new TreeGridContextMenu(new ContentTreeGridActions(this)));
 
-        let columns = builder.getColumns();
-        const nameColumn = columns[1];
-        const compareStatusColumn = columns[2];
-        const orderColumn = columns[3];
-        const modifiedTimeColumn = columns[4];
+        const [
+            nameColumn,
+            compareStatusColumn,
+            orderColumn,
+            modifiedTimeColumn,
+        ] = builder.getColumns().slice(1);
 
-        let updateColumns = (force?: boolean) => {
+        const updateColumns = (force?: boolean) => {
             if (force) {
-                let width = this.getEl().getWidth();
-                let checkSelIsMoved = ResponsiveRanges._360_540.isFitOrSmaller(api.dom.Body.get().getEl().getWidth());
+                const width = this.getEl().getWidth(); //
+                const checkSelIsMoved = ResponsiveRanges._360_540.isFitOrSmaller(api.dom.Body.get().getEl().getWidth());
 
-                let curClass = nameColumn.getCssClass();
+                const curClass = nameColumn.getCssClass();
 
                 if (checkSelIsMoved) {
-                    nameColumn.setCssClass(curClass ? curClass : '' + 'shifted');
-                } else {
-                    if (curClass && curClass.indexOf('shifted') >= 0) {
-                        nameColumn.setCssClass(curClass.replace('shifted', ''));
-                    }
+                    nameColumn.setCssClass(curClass || 'shifted');
+                } else if (curClass && curClass.indexOf('shifted') >= 0) {
+                    nameColumn.setCssClass(curClass.replace('shifted', ''));
                 }
 
                 if (ResponsiveRanges._240_360.isFitOrSmaller(width)) {
@@ -154,7 +153,7 @@ export class ContentTreeGrid
             }
         });
 
-        this.getGrid().subscribeOnClick((event, data) => {
+        this.getGrid().subscribeOnClick((event) => {
             let elem = new ElementHelper(event.target);
             if (elem.hasClass('sort-dialog-trigger')) {
                 new SortContentEvent(this.getSelectedDataList()).fire();


### PR DESCRIPTION
* Moved the checkbox in Users and Applications to the right on small resolutions.

__Refactored:__
* Fixed the columns width on different resolutions in `ApplicationTreeGrid`.
* Removed the hidden date column in `UserItemsTreeGrid`.
* Moved common handlers to TreeGrid from its children.
