### PR TITLE
Mobile resolution - Don't unhighlight grid item and always open Previ…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/OptionsTreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/selector/OptionsTreeGrid.ts
@@ -3,10 +3,10 @@ module api.ui.selector {
     import TreeGrid = api.ui.treegrid.TreeGrid;
     import TreeGridBuilder = api.ui.treegrid.TreeGridBuilder;
     import ResponsiveItem = api.ui.responsive.ResponsiveItem;
+    import SelectionOnClickType = api.ui.treegrid.SelectionOnClickType;
 
     export class OptionsTreeGrid<OPTION_DISPLAY_VALUE> extends TreeGrid<Option<OPTION_DISPLAY_VALUE>> {
 
-        static MAX_FETCH_SIZE: number = 10;
         private loader: OptionDataLoader<OPTION_DISPLAY_VALUE>;
         private treeDataHelper: OptionDataHelper<OPTION_DISPLAY_VALUE>;
         private readonlyChecker: (optionToCheck: OPTION_DISPLAY_VALUE) => boolean;
@@ -23,7 +23,7 @@ module api.ui.selector {
                 new TreeGridBuilder<Option<OPTION_DISPLAY_VALUE>>().setColumns(columns)
                     .setOptions(gridOptions)
                     .setPartialLoadEnabled(true)
-                    .setLoadBufferSize(20)// rows count
+                    .setLoadBufferSize(20)
                     .setAutoLoad(false)
                     .prependClasses('dropdown-tree-grid')
                     .setRowHeight(45)
@@ -37,7 +37,7 @@ module api.ui.selector {
             this.loader = loader;
             this.treeDataHelper = treeDataHelper;
             this.isSelfLoading = true;
-            this.highlightingEnabled = false;
+            this.setSelectionOnClick(SelectionOnClickType.SELECT);
 
             this.initEventHandlers();
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGridItemClickedEvent.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGridItemClickedEvent.ts
@@ -2,15 +2,22 @@ module api.ui.treegrid {
 
     export class TreeGridItemClickedEvent extends api.event.Event {
 
+        private node: TreeNode<any>;
+
         private selection: boolean;
 
-        constructor(selection: boolean = false) {
+        constructor(node: TreeNode<any>, selection: boolean = false) {
             super();
             this.selection = selection;
+            this.node = node;
         }
 
         public hasSelection() {
             return this.selection;
+        }
+
+        public getTreeNode(): TreeNode<any> {
+            return this.node;
         }
 
         static on(handler: (event: TreeGridItemClickedEvent) => void) {

--- a/modules/app/app-contentstudio/src/main/js/app/browse/ContentBrowsePanel.ts
+++ b/modules/app/app-contentstudio/src/main/js/app/browse/ContentBrowsePanel.ts
@@ -37,6 +37,9 @@ import ContentSummaryAndCompareStatusFetcher = api.content.resource.ContentSumma
 import TreeGridItemClickedEvent = api.ui.treegrid.TreeGridItemClickedEvent;
 import GetContentByIdRequest = api.content.resource.GetContentByIdRequest;
 import ActionButton = api.ui.button.ActionButton;
+import SelectionOnClickType = api.ui.treegrid.SelectionOnClickType;
+import ContentIconUrlResolver = api.content.util.ContentIconUrlResolver;
+import IsRenderableRequest = api.content.page.IsRenderableRequest;
 
 export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummaryAndCompareStatus> {
 
@@ -192,8 +195,10 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
                     nonMobileDetailsPanelsManager.setActivePanel();
                     this.mobileContentItemStatisticsPanel.slideAllOut();
                 }
+                this.treeGrid.setSelectionOnClick(SelectionOnClickType.HIGHLIGHT);
             } else {
                 contentPublishMenuButton.minimize();
+                this.treeGrid.setSelectionOnClick(SelectionOnClickType.NONE);
             }
         });
     }
@@ -229,19 +234,17 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
     private initItemStatisticsPanelForMobile(detailsView: DetailsView) {
         this.mobileContentItemStatisticsPanel = new MobileContentItemStatisticsPanel(this.getBrowseActions(), detailsView);
 
-        let updateMobilePanel = () => {
-            const browseItem = this.getFirstSelectedOrHighlightedBrowseItem();
-            const item = browseItem.toViewItem();
+        const updateMobilePanel = (content: ContentSummaryAndCompareStatus, changed: boolean) => {
+            if (changed) {
+                const item = this.toBrowseItem(content, null).toViewItem();
 
-            if (this.itemChanged()) {
                 this.mobileContentItemStatisticsPanel.getPreviewPanel().showMask();
                 this.mobileContentItemStatisticsPanel.setItem(item);
 
                 setTimeout(() => {
                     this.mobileContentItemStatisticsPanel.getPreviewPanel().setBlankFrame();
                     this.mobileContentItemStatisticsPanel.getPreviewPanel().showMask();
-                    new api.content.page.IsRenderableRequest(new api.content.ContentId(browseItem.getId())).sendAndParse().then(
-                        (renderable: boolean) => {
+                    new IsRenderableRequest(content.getContentId()).sendAndParse().then((renderable: boolean) => {
                             item.setRenderable(renderable);
                             this.mobileContentItemStatisticsPanel.getPreviewPanel().setItem(item);
                         });
@@ -250,22 +253,22 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
         };
 
         TreeGridItemClickedEvent.on((event: TreeGridItemClickedEvent) => {
-            if (this.isSomethingSelectedInMobileMode()) {
-                if (this.itemChanged()) {
+            if (this.isMobileMode()) {
+                const summary = event.getTreeNode().getData();
+
+                const prevItem = this.mobileContentItemStatisticsPanel.getPreviewPanel().getItem();
+                const currItem = event.getTreeNode().getData();
+                const changed = !prevItem || !prevItem.getModel() || prevItem.getModel().getId() !== currItem.getId();
+
+                if (changed) {
                     this.mobileContentItemStatisticsPanel.getPreviewPanel().setBlank();
                 }
                 this.mobileContentItemStatisticsPanel.slideIn();
-                updateMobilePanel();
+                updateMobilePanel(summary, changed);
             }
         });
 
         this.appendChild(this.mobileContentItemStatisticsPanel);
-    }
-
-    private itemChanged(): boolean {
-        const prevItem = this.mobileContentItemStatisticsPanel.getPreviewPanel().getItem();
-        const browseItem = this.getFirstSelectedOrHighlightedBrowseItem();
-        return !prevItem || !prevItem.getModel() || prevItem.getModel().getId() !== browseItem.getId();
     }
 
     // tslint:disable-next-line:max-line-length
@@ -295,10 +298,6 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
 
     private isMobileMode(): boolean {
         return this.mobileContentItemStatisticsPanel.isVisible();
-    }
-
-    private isSomethingSelectedInMobileMode(): boolean {
-        return this.isMobileMode() && this.isSomethingSelected();
     }
 
     private setActiveDetailsPanel(nonMobileDetailsPanelsManager: NonMobileDetailsPanelsManager) {
@@ -630,20 +629,11 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
             return;
         }
 
-        let toBrowseItem = (content: ContentSummaryAndCompareStatus, renderable: boolean) => {
-            let item = new BrowseItem<ContentSummaryAndCompareStatus>(content).setId(content.getId()).setDisplayName(
-                content.getDisplayName()).setPath(content.getPath().toString()).setIconUrl(
-                new api.content.util.ContentIconUrlResolver().setContent(content.getContentSummary()).resolve()).setRenderable(
-                renderable);
-
-            return item;
-        };
-
         new GetContentByIdRequest(previewItem.getModel().getContentId()).sendAndParse().then((previewItemContent: Content) => {
             updatedContents.some((content: ContentSummaryAndCompareStatus) => {
                 if (content.getPath().equals(previewItem.getModel().getPath())) {
                     new api.content.page.IsRenderableRequest(content.getContentId()).sendAndParse().then((renderable: boolean) => {
-                        this.getBrowseItemPanel().setStatisticsItem(toBrowseItem(content, renderable));
+                        this.getBrowseItemPanel().setStatisticsItem(this.toBrowseItem(content, renderable));
                     });
                     return true;
                 }
@@ -661,6 +651,14 @@ export class ContentBrowsePanel extends api.app.browse.BrowsePanel<ContentSummar
             });
         });
     }
+
+    private toBrowseItem(content: ContentSummaryAndCompareStatus, renderable: boolean): BrowseItem<ContentSummaryAndCompareStatus> {
+        return new BrowseItem<ContentSummaryAndCompareStatus>(content)
+            .setId(content.getId())
+            .setDisplayName(content.getDisplayName()).setPath(content.getPath().toString())
+            .setIconUrl(new ContentIconUrlResolver().setContent(content.getContentSummary()).resolve())
+            .setRenderable(renderable);
+    };
 
     private forcePreviewRerender() {
         let previewItem = this.getBrowseItemPanel().getStatisticsItem();

--- a/modules/app/app-contentstudio/src/main/js/app/browse/ContentTreeGrid.ts
+++ b/modules/app/app-contentstudio/src/main/js/app/browse/ContentTreeGrid.ts
@@ -179,10 +179,10 @@ export class ContentTreeGrid
             }).done();
         });
 
-        BrowseFilterResetEvent.on((event) => {
+        BrowseFilterResetEvent.on(() => {
             this.resetFilter();
         });
-        BrowseFilterRefreshEvent.on((event) => {
+        BrowseFilterRefreshEvent.on(() => {
             this.notifyLoaded();
         });
         ContentVersionSetEvent.on((event: ContentVersionSetEvent) => {


### PR DESCRIPTION
…ew Panel on click #5019

Disabled the highlighting in mobile mode.
Changed the rendering item of the preview panel in the mobile mode to clicked item.

_The solution, when we keep the highlighting on click and just show the preview panel, has issues with highlight remove and with the root node operations (when nothing is selected)._