### PR TITLE
Problem with size of app icon in issue email #5293

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/issue/IssueMailMessageGenerator.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/issue/IssueMailMessageGenerator.java
@@ -16,6 +16,7 @@ import com.google.common.io.Resources;
 
 import com.enonic.xp.content.CompareStatus;
 import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ContentId;
 import com.enonic.xp.issue.IssueStatus;
 import com.enonic.xp.mail.MailMessage;
 import com.enonic.xp.security.User;
@@ -136,12 +137,32 @@ public abstract class IssueMailMessageGenerator<P extends IssueMailMessageParams
         final Map itemParams = Maps.newHashMap();
         itemParams.put( "displayName", item.getDisplayName() );
         itemParams.put( "path", item.getPath() );
-        itemParams.put( "icon", params.getIcons().getOrDefault( item.getId(), "" ) );
+        itemParams.put( "icon", getIcon( item.getId() ) );
         itemParams.put( "status", status.getFormattedStatus() );
         itemParams.put( "bgcolor", even ? "#f5f5f5" : "initial" );
         itemParams.put( "statusColor", isOnline ? "#609e24" : "initial" );
 
         return new StrSubstitutor( itemParams ).replace( template );
+    }
+
+    private String getIcon( final ContentId id )
+    {
+        final String icon = params.getIcons().get( id );
+
+        if ( icon == null )
+        {
+            return "";
+        }
+
+        final boolean isSvg = icon.contains( "<svg" );
+
+        if ( isSvg )
+        {
+            return icon.replaceFirst( "(\\s+)(width=\")(.+?)(\")", " width=\"100%\"" ).
+                replaceFirst( "(\\s+)(height=\")(.+?)(\")"," height=\"auto\"" );
+        }
+
+        return icon;
     }
 
     private String generateApproversHtml()

--- a/modules/admin/admin-impl/src/main/resources/com/enonic/xp/admin/impl/rest/resource/issue/item.html
+++ b/modules/admin/admin-impl/src/main/resources/com/enonic/xp/admin/impl/rest/resource/issue/item.html
@@ -1,5 +1,5 @@
 <div style="display: flex; align-items: center;">
-    <div style="flex-basis: 34px; margin-right: 8px; color: initial">
+    <div style="flex-basis: 34px; margin-right: 8px; color: initial; max-width: 40px; max-height: 40px">
         ${icon}
     </div>
     <div style="padding: 4px 8px; width: 100%;">


### PR DESCRIPTION
-When svg icon contains width and height attributes it overrides all container width and height values and takes space according to svg width and height; CSS can't help, thus replacing svg's attributes with required values that will restrict icon size to container's size