### PR TITLE
Notification about unclosed issues doesn't disappear after publishing…

### DIFF
--- a/modules/app/app-contentstudio/src/main/js/app/issue/view/ShowIssuesDialogButton.ts
+++ b/modules/app/app-contentstudio/src/main/js/app/issue/view/ShowIssuesDialogButton.ts
@@ -1,9 +1,9 @@
-
 import ActionButton = api.ui.button.ActionButton;
 import {ShowIssuesDialogAction} from '../../browse/action/ShowIssuesDialogAction';
 import {IssueServerEventsHandler} from '../event/IssueServerEventsHandler';
 import {IssueResponse} from '../resource/IssueResponse';
 import {ListIssuesRequest} from '../resource/ListIssuesRequest';
+import {IssueStatus} from '../IssueStatus';
 
 export class ShowIssuesDialogButton extends ActionButton {
 
@@ -28,12 +28,13 @@ export class ShowIssuesDialogButton extends ActionButton {
     }
 
     private updateShowIssuesDialogButton() {
-        new ListIssuesRequest().setAssignedToMe(true).setSize(0).sendAndParse().then((response: IssueResponse) => {
-            this.toggleClass('has-assigned-issues', response.getMetadata().getTotalHits() > 0);
-            this.getEl().setTitle((response.getMetadata().getTotalHits() === 0) ?
-                                  'Publishing Issues' :
-                                  'You have unclosed Publishing Issues');
-        }).catch((reason: any) => {
+        new ListIssuesRequest().setAssignedToMe(true).setIssueStatus(IssueStatus.OPEN).setSize(0).sendAndParse().then(
+            (response: IssueResponse) => {
+                this.toggleClass('has-assigned-issues', response.getMetadata().getTotalHits() > 0);
+                this.getEl().setTitle((response.getMetadata().getTotalHits() === 0) ?
+                                      'Publishing Issues' :
+                                      'You have unclosed Publishing Issues');
+            }).catch((reason: any) => {
             api.DefaultErrorHandler.handle(reason);
         });
     }


### PR DESCRIPTION
… of the last open issue #5300

-When checking issues assigned to user all statuses were fetched instead of only OPEN.