### PR TITLE
Issue List dialog - State of checkboxes in the filter is not kept aft…

### DIFF
--- a/modules/app/app-contentstudio/src/main/js/app/issue/view/IssuesPanel.ts
+++ b/modules/app/app-contentstudio/src/main/js/app/issue/view/IssuesPanel.ts
@@ -80,8 +80,7 @@ export class IssuesPanel extends Panel {
         this.assignedToMeCheckbox.toggleClass('disabled', total === 0);
         this.assignedToMeCheckbox.setLabel(this.makeFilterLabel(i18n('field.assignedToMe'), total));
         if (total === 0) {
-            this.assignedToMeCheckbox.setChecked(false, true);
-            this.issuesList.setLoadAssignedToMe(false);
+            this.assignedToMeCheckbox.setChecked(false);
         }
     }
 
@@ -89,8 +88,7 @@ export class IssuesPanel extends Panel {
         this.myIssuesCheckbox.toggleClass('disabled', total === 0);
         this.myIssuesCheckbox.setLabel(this.makeFilterLabel(i18n('field.myIssues'), total));
         if (total === 0) {
-            this.myIssuesCheckbox.setChecked(false, true);
-            this.issuesList.setLoadMyIssues(false);
+            this.myIssuesCheckbox.setChecked(false);
         }
     }
 


### PR DESCRIPTION
…er the last issue is published #5320

-Reloading issue list after last 'assigned to me' issue was published (list will reload after unchecking checkbox non-silently)