### PR TITLE
Implement the possibility to use bountycastle security #5072

### DIFF
--- a/modules/distro/build.gradle
+++ b/modules/distro/build.gradle
@@ -25,6 +25,9 @@ addBundle( 'org.apache.felix:org.apache.felix.eventadmin:1.4.4', 5 )
 addBundle( 'org.apache.felix:org.apache.felix.configadmin:1.8.8', 5 )
 addBundle( 'org.apache.felix:org.apache.felix.scr:2.0.2', 5 )
 
+// Java Cryptography Extension
+addBundle( 'org.bouncycastle:bcprov-jdk15on:1.54', 6 )
+
 // Library dependencies
 addBundle( 'com.google.guava:guava:18.0', 8 )
 addBundle( 'commons-lang:commons-lang:2.4', 8 )


### PR DESCRIPTION
In the libs where it will be used we need to exclude the bountycastle artifact.

build.gradle
```
dependencies {
    compile "org.bouncycastle:bcprov-jdk15on:1.54"
    include( "nl.martijndwars:web-push:3.0.0" ) {
        exclude group: 'com.google.guava', module: 'guava'
        exclude group: 'org.bouncycastle', module: 'bcprov-jdk15on'
    }
}
```

In Java class where is used:
```
import java.security.Security;
import org.bouncycastle.jce.provider.BouncyCastleProvider;

static
{
    if ( Security.getProvider( BouncyCastleProvider.PROVIDER_NAME ) != null )
    {
        Security.removeProvider( BouncyCastleProvider.PROVIDER_NAME );
    }
    Security.addProvider( new BouncyCastleProvider() );
}
```