### PR TITLE
Configure CKEditor to work in inline mode #5129

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
@@ -225,6 +225,10 @@ module api.form.inputtype.text {
 
                 this.removeTooltipFromEditorArea(textAreaWrapper);
 
+                this.moveFullScreenButtonToBottomBar(textAreaWrapper);
+
+                this.moveFullSourceButtonToBottomBar(textAreaWrapper);
+
                 const removeButtonEL = wemjq(textAreaWrapper.getParentElement().getParentElement().getHTMLElement()).find(
                     '.remove-button')[0];
                 removeButtonEL.addEventListener('mouseover', () => {
@@ -236,6 +240,17 @@ module api.form.inputtype.text {
 
             });
         }
+
+        private moveFullScreenButtonToBottomBar(inputOccurence: Element): void {
+            wemjq(inputOccurence.getHTMLElement()).find('.cke_button__maximize').appendTo(
+                wemjq(inputOccurence.getHTMLElement()).find('.cke_bottom'));
+        }
+
+        private moveFullSourceButtonToBottomBar(inputOccurence: Element): void {
+            wemjq(inputOccurence.getHTMLElement()).find('.cke_button__code').appendTo(
+                wemjq(inputOccurence.getHTMLElement()).find('.cke_bottom'));
+        }
+
 
         private setFocusOnEditorAfterCreate(inputOccurence: Element, id: string): void {
             inputOccurence.giveFocus = () => {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
@@ -21,7 +21,7 @@ module api.form.inputtype.text {
     import Promise = Q.Promise;
     import ResponsiveManager = api.ui.responsive.ResponsiveManager;
     import AppHelper = api.util.AppHelper;
-    import editor = CKEDITOR.editor;
+    import HTMLAreaEditor = CKEDITOR.editor;
 
     export class HtmlArea extends support.BaseInputTypeNotManagingAdd<string> {
 
@@ -197,7 +197,7 @@ module api.form.inputtype.text {
                 textAreaWrapper.addClass(focusedEditorCls);
             };
 
-            const ckeditor: editor = new HTMLAreaBuilder().setEditorContainerId(id).
+            const editor: HTMLAreaEditor = new HTMLAreaBuilder().setEditorContainerId(id).
                 setAssetsUri(baseUrl).
                 setInline(false).
                 onCreateDialog(createDialogHandler).
@@ -216,7 +216,7 @@ module api.form.inputtype.text {
                 setForcedRootBlock(this.inputConfig['forcedRootBlock'] ? this.inputConfig['forcedRootBlock'][0].value : 'p').
                 setEditableSourceCode(this.editableSourceCode).createEditor();
 
-            ckeditor.on('loaded', () => {
+            editor.on('loaded', () => {
                 this.setEditorContent(id, property);
 
                 if (this.notInLiveEdit()) {
@@ -225,9 +225,8 @@ module api.form.inputtype.text {
 
                 this.removeTooltipFromEditorArea(textAreaWrapper);
 
-                this.moveFullScreenButtonToBottomBar(textAreaWrapper);
-
-                this.moveFullSourceButtonToBottomBar(textAreaWrapper);
+                this.moveButtonToBottomBar(textAreaWrapper, '.cke_button__maximize');
+                this.moveButtonToBottomBar(textAreaWrapper, '.cke_button__code');
 
                 const removeButtonEL = wemjq(textAreaWrapper.getParentElement().getParentElement().getHTMLElement()).find(
                     '.remove-button')[0];
@@ -241,16 +240,10 @@ module api.form.inputtype.text {
             });
         }
 
-        private moveFullScreenButtonToBottomBar(inputOccurence: Element): void {
-            wemjq(inputOccurence.getHTMLElement()).find('.cke_button__maximize').appendTo(
+        private moveButtonToBottomBar(inputOccurence: Element, buttonClass: string): void {
+            wemjq(inputOccurence.getHTMLElement()).find(buttonClass).appendTo(
                 wemjq(inputOccurence.getHTMLElement()).find('.cke_bottom'));
         }
-
-        private moveFullSourceButtonToBottomBar(inputOccurence: Element): void {
-            wemjq(inputOccurence.getHTMLElement()).find('.cke_button__code').appendTo(
-                wemjq(inputOccurence.getHTMLElement()).find('.cke_bottom'));
-        }
-
 
         private setFocusOnEditorAfterCreate(inputOccurence: Element, id: string): void {
             inputOccurence.giveFocus = () => {
@@ -356,7 +349,7 @@ module api.form.inputtype.text {
             }
         }
 
-        private getEditor(editorId: string): editor {
+        private getEditor(editorId: string): HTMLAreaEditor {
             return CKEDITOR.instances[editorId];
         }
 
@@ -367,7 +360,7 @@ module api.form.inputtype.text {
         }
 
         private setEditorContent(editorId: string, property: Property): void {
-            const editor: editor = this.getEditor(editorId);
+            const editor: HTMLAreaEditor = this.getEditor(editorId);
             if (editor) {
                 editor.setData(property.hasNonNullValue() ? HTMLAreaHelper.prepareImgSrcsInValueForEdit(property.getString()) : '');
                 //HTMLAreaHelper.updateImageAlignmentBehaviour(editor);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/form/inputtype/text/HtmlArea.ts
@@ -197,8 +197,7 @@ module api.form.inputtype.text {
                 textAreaWrapper.addClass(focusedEditorCls);
             };
 
-            const ckeditor: editor = new HTMLAreaBuilder().
-                setSelector('textarea.' + id.replace(/\./g, '_')).setTextAreaId(id).
+            const ckeditor: editor = new HTMLAreaBuilder().setEditorContainerId(id).
                 setAssetsUri(baseUrl).
                 setInline(false).
                 onCreateDialog(createDialogHandler).

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/PageView.ts
@@ -275,7 +275,7 @@ module api.liveedit {
 
         appendContainerForTextToolbar() {
             if (!this.hasToolbarContainer()) {
-                this.editorToolbar = new api.dom.DivEl('mce-toolbar-container');
+                this.editorToolbar = new api.dom.DivEl('cke-toolbar-container').setId('cke-toolbar-container').setContentEditable(true);
                 this.appendChild(this.editorToolbar);
                 this.addClass('has-toolbar-container');
             }
@@ -285,8 +285,24 @@ module api.liveedit {
             return this.hasClass('has-toolbar-container');
         }
 
+        getEditorToolbarContainerId(): string {
+            if (this.editorToolbar) {
+                return this.editorToolbar.getId();
+            }
+
+            return null;
+        }
+
         getEditorToolbarHeight(): number {
-            return !!this.editorToolbar ? this.editorToolbar.getEl().getHeightWithMargin() : 0;
+            if (!this.editorToolbar) {
+                return 0;
+            }
+
+            if (!this.editorToolbar.hasClass('visisble')) {
+                return 0;
+            }
+
+            return this.editorToolbar.getEl().getHeightWithMargin();
         }
 
         private setIgnorePropertyChanges(value: boolean) {
@@ -425,8 +441,8 @@ module api.liveedit {
             let target = <HTMLElement> event.target;
             if (!!target) {
                 let parent = <HTMLElement> target.parentElement;
-                return (target.id.indexOf('mce') >= 0 || target.className.indexOf('mce') >= 0 ||
-                        parent.id.indexOf('mce') >= 0 || parent.className.indexOf('mce') >= 0);
+                return (target.id.indexOf('cke') >= 0 || target.className.indexOf('cke') >= 0 ||
+                        parent.id.indexOf('cke') >= 0 || parent.className.indexOf('cke') >= 0);
             }
             return false;
         }
@@ -562,7 +578,7 @@ module api.liveedit {
         }
 
         private getEditorToolbarWidth(): number {
-            return wemjq(`.mce-toolbar-container .mce-tinymce-inline:not([style*='display: none'])`).outerHeight();
+            return wemjq(`.cke-toolbar-container .cke_reset_all:not([style*='display: none']) .cke_top`).outerHeight();
         }
 
         hasTargetWithinTextComponent(target: HTMLElement) {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
@@ -15,7 +15,7 @@ module api.liveedit.text {
     import ModalDialog = api.util.htmlarea.dialog.ModalDialog;
     import Promise = Q.Promise;
     import i18n = api.util.i18n;
-    import editor = CKEDITOR.editor;
+    import HTMLAreaEditor = CKEDITOR.editor;
 
     export class TextComponentViewBuilder extends ComponentViewBuilder<TextComponent> {
         constructor() {
@@ -30,7 +30,7 @@ module api.liveedit.text {
 
         private rootElement: api.dom.Element;
 
-        private htmlAreaEditor: editor;
+        private htmlAreaEditor: HTMLAreaEditor;
 
         private isInitializingEditor: boolean;
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
@@ -418,7 +418,8 @@ module api.liveedit.text {
                 // copy editor raw content (without any processing!) over to the root html element
                 this.rootElement.getHTMLElement().innerHTML = this.htmlAreaEditor.getSnapshot();
                 // but save processed text to the component
-                // this.component.setText(HTMLAreaHelper.prepareEditorImageSrcsBeforeSave(this.htmlAreaEditor.getSnapshot())); // after 5131 merged
+                // this.component.setText(HTMLAreaHelper.prepareEditorImageSrcsBeforeSave(this.htmlAreaEditor.getSnapshot()));
+                // after 5131 merged
                 this.component.setText(this.htmlAreaEditor.getSnapshot());
             }
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
@@ -418,9 +418,7 @@ module api.liveedit.text {
                 // copy editor raw content (without any processing!) over to the root html element
                 this.rootElement.getHTMLElement().innerHTML = this.htmlAreaEditor.getSnapshot();
                 // but save processed text to the component
-                // this.component.setText(HTMLAreaHelper.prepareEditorImageSrcsBeforeSave(this.htmlAreaEditor.getSnapshot()));
-                // after 5131 merged
-                this.component.setText(this.htmlAreaEditor.getSnapshot());
+                this.component.setText(HTMLAreaHelper.prepareEditorImageSrcsBeforeSave(this.htmlAreaEditor.getSnapshot()));
             }
         }
 
@@ -432,11 +430,7 @@ module api.liveedit.text {
         private destroyEditor(): void {
             let editor = this.htmlAreaEditor;
             if (editor) {
-                try {
-                    editor.destroy(false);
-                } catch (e) {
-                    //error thrown in FF on tab close - XP-2624
-                }
+                editor.destroy(false);
             }
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentView.ts
@@ -15,6 +15,7 @@ module api.liveedit.text {
     import ModalDialog = api.util.htmlarea.dialog.ModalDialog;
     import Promise = Q.Promise;
     import i18n = api.util.i18n;
+    import editor = CKEDITOR.editor;
 
     export class TextComponentViewBuilder extends ComponentViewBuilder<TextComponent> {
         constructor() {
@@ -29,7 +30,7 @@ module api.liveedit.text {
 
         private rootElement: api.dom.Element;
 
-        private htmlAreaEditor: HtmlAreaEditor;
+        private htmlAreaEditor: editor;
 
         private isInitializingEditor: boolean;
 
@@ -96,7 +97,7 @@ module api.liveedit.text {
             };
 
             this.onMouseLeave(() => {
-                if (this.getEl().hasClass(TextComponentView.EDITOR_FOCUSED_CLASS)) {
+                if (!!this.htmlAreaEditor && !this.isInitializingEditor && this.getEl().hasClass(TextComponentView.EDITOR_FOCUSED_CLASS)) {
                     this.processEditorValue();
                 }
             });
@@ -267,7 +268,6 @@ module api.liveedit.text {
                     this.processEditorValue();
                 }
                 this.removeClass(TextComponentView.EDITOR_FOCUSED_CLASS);
-                this.triggerEventInActiveEditorForFirefox('blur');
             }
 
             this.toggleClass('edit-mode', flag);
@@ -280,22 +280,12 @@ module api.liveedit.text {
 
                 if (this.component.isEmpty()) {
                     if (this.htmlAreaEditor) {
-                        this.htmlAreaEditor.setContent(TextComponentView.DEFAULT_TEXT);
+                        this.htmlAreaEditor.setData(TextComponentView.DEFAULT_TEXT);
                     }
                     this.rootElement.setHtml(TextComponentView.DEFAULT_TEXT, false);
                     this.selectText();
                 }
 
-                this.triggerEventInActiveEditorForFirefox('focus');
-            }
-        }
-
-        private triggerEventInActiveEditorForFirefox(eventName: string) {
-            if (api.BrowserHelper.isFirefox()) {
-                let activeEditor = tinymce.activeEditor;
-                if (activeEditor) {
-                    activeEditor.fire(eventName);
-                }
             }
         }
 
@@ -305,8 +295,6 @@ module api.liveedit.text {
 
         private onBlurHandler(e: FocusEvent) {
             this.removeClass(TextComponentView.EDITOR_FOCUSED_CLASS);
-
-            this.collapseEditorMenuItems();
 
             setTimeout(() => {
                 if (!this.anyEditorHasFocus()) {
@@ -364,54 +352,45 @@ module api.liveedit.text {
             this.addClass(id);
 
             if (!this.editorContainer) {
-                this.editorContainer = new api.dom.DivEl('tiny-mce-here');
+                this.editorContainer = new api.dom.DivEl('');
+                this.editorContainer.setContentEditable(true).getEl().setAttribute('id', this.getId() + '_editor');
                 this.appendChild(this.editorContainer);
             }
 
-            new HTMLAreaBuilder().
-                setSelector('div.' + id + ' .tiny-mce-here').setTextAreaId(this.getId()).
+            this.htmlAreaEditor = new HTMLAreaBuilder().setEditorContainerId(this.getId() + '_editor').
                 setAssetsUri(assetsUri).
                 setInline(true).
                 onCreateDialog(event => {
                 this.currentDialogConfig = event.getConfig();
             }).setFocusHandler(this.onFocusHandler.bind(this)).setBlurHandler(this.onBlurHandler.bind(this)).setKeydownHandler(
-                this.onKeydownHandler.bind(this)).setFixedToolbarContainer('.mce-toolbar-container').setContent(
+                this.onKeydownHandler.bind(this)).setFixedToolbarContainer(this.getPageView().getEditorToolbarContainerId()).setContent(
                 this.getContent()).setEditableSourceCode(this.editableSourceCode).setContentPath(this.getContentPath()).setApplicationKeys(
-                this.getApplicationKeys()).createEditor();//.then(this.handleEditorCreated.bind(this));
+                this.getApplicationKeys()).createEditor();
+
+            this.htmlAreaEditor.on('instanceReady', this.handleEditorCreated.bind(this));
         }
 
-        private handleEditorCreated(editor: HtmlAreaEditor) {
-            this.htmlAreaEditor = editor;
+        private handleEditorCreated() {
             if (this.component.getText()) {
-                this.htmlAreaEditor.setContent(HTMLAreaHelper.prepareImgSrcsInValueForEdit(this.component.getText()));
+                this.htmlAreaEditor.setData(HTMLAreaHelper.prepareImgSrcsInValueForEdit(this.component.getText()));
             } else {
-                this.htmlAreaEditor.setContent(TextComponentView.DEFAULT_TEXT);
-                this.htmlAreaEditor.selection.select(this.htmlAreaEditor.getBody(), true);
+                this.htmlAreaEditor.setData(TextComponentView.DEFAULT_TEXT);
+                // this.htmlAreaEditor.selection.select(this.htmlAreaEditor.getBody(), true);
             }
+
             if (this.focusOnInit && this.isAdded()) {
-                if (api.BrowserHelper.isFirefox()) {
-                    setTimeout(() => {
-                        this.forceEditorFocus();
-                    }, 100);
-                } else {
-                    this.forceEditorFocus();
-                }
+                this.forceEditorFocus();
             }
             this.focusOnInit = false;
             this.isInitializingEditor = false;
-            HTMLAreaHelper.updateImageAlignmentBehaviour(editor);
+            // HTMLAreaHelper.updateImageAlignmentBehaviour(editor);
         }
 
         private forceEditorFocus() {
             if (this.htmlAreaEditor) {
                 this.htmlAreaEditor.focus();
-                wemjq(this.htmlAreaEditor.getElement()).simulate('click');
             }
             this.startPageTextEditMode();
-        }
-
-        private collapseEditorMenuItems() {
-            wemjq('.mce-menubtn.mce-active').click();
         }
 
         private anyEditorHasFocus(): boolean {
@@ -437,14 +416,15 @@ module api.liveedit.text {
                 this.rootElement.getHTMLElement().innerHTML = TextComponentView.DEFAULT_TEXT;
             } else {
                 // copy editor raw content (without any processing!) over to the root html element
-                this.rootElement.getHTMLElement().innerHTML = this.htmlAreaEditor.getContent({format: 'raw'});
+                this.rootElement.getHTMLElement().innerHTML = this.htmlAreaEditor.getSnapshot();
                 // but save processed text to the component
-                this.component.setText(HTMLAreaHelper.prepareEditorImageSrcsBeforeSave(this.htmlAreaEditor.getContent()));
+                // this.component.setText(HTMLAreaHelper.prepareEditorImageSrcsBeforeSave(this.htmlAreaEditor.getSnapshot())); // after 5131 merged
+                this.component.setText(this.htmlAreaEditor.getSnapshot());
             }
         }
 
         private isEditorEmpty(): boolean {
-            let editorContent = this.htmlAreaEditor.getContent();
+            let editorContent = this.htmlAreaEditor.getSnapshot();
             return editorContent.trim() === '' || editorContent === '<h2>&nbsp;</h2>';
         }
 
@@ -461,7 +441,7 @@ module api.liveedit.text {
 
         private selectText() {
             if (this.htmlAreaEditor) {
-                this.htmlAreaEditor.selection.select(this.htmlAreaEditor.getBody(), true);
+                // this.htmlAreaEditor.selection.select(this.htmlAreaEditor.getBody(), true);
             }
         }
 
@@ -508,10 +488,6 @@ module api.liveedit.text {
         }
 
         extractText(): string {
-            if(this.htmlAreaEditor) {
-                return this.htmlAreaEditor.getContent({format: 'text'}).trim();
-            }
-
             return wemjq(this.getHTMLElement()).text().trim();
         }
     }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/dialog/ModalDialog.ts
@@ -183,7 +183,7 @@ module api.ui.dialog {
         private isIgnoredElementClicked(element: HTMLElement): boolean {
             let ignoredElementClicked = false;
             if (element && element.className && element.className.indexOf) {
-                ignoredElementClicked = element.className.indexOf('mce-') > -1 || element.className.indexOf('html-area-modal-dialog') > -1;
+                ignoredElementClicked = element.className.indexOf('cke-') > -1 || element.className.indexOf('html-area-modal-dialog') > -1;
             }
             ignoredElementClicked = ignoredElementClicked || this.listOfClickIgnoredElements.some((elem: api.dom.Element) => {
                     return elem.getHTMLElement() === element || elem.getEl().contains(element);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/AnchorModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/AnchorModalDialog.ts
@@ -3,11 +3,11 @@ module api.util.htmlarea.dialog {
     import FormItem = api.ui.form.FormItem;
     import Validators = api.ui.form.Validators;
     import i18n = api.util.i18n;
-    import editor = CKEDITOR.editor;
+    import HTMLAreaEditor = CKEDITOR.editor;
 
     export class AnchorModalDialog extends ModalDialog {
 
-        constructor(editor: editor) {
+        constructor(editor: HTMLAreaEditor) {
 
             super(<HtmlAreaModalDialogConfig>{editor: editor, title: i18n('dialog.anchor.title')});
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/AnchorModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/AnchorModalDialog.ts
@@ -3,10 +3,11 @@ module api.util.htmlarea.dialog {
     import FormItem = api.ui.form.FormItem;
     import Validators = api.ui.form.Validators;
     import i18n = api.util.i18n;
+    import editor = CKEDITOR.editor;
 
     export class AnchorModalDialog extends ModalDialog {
 
-        constructor(editor: HtmlAreaEditor) {
+        constructor(editor: editor) {
 
             super(<HtmlAreaModalDialogConfig>{editor: editor, title: i18n('dialog.anchor.title')});
         }
@@ -50,7 +51,7 @@ module api.util.htmlarea.dialog {
 
         private insertAnchor(): void {
             let anchorEl = this.createAnchorEl();
-            this.getEditor().insertContent(anchorEl);
+            //this.getEditor().insertContent(anchorEl);
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/CharMapDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/CharMapDialog.ts
@@ -1,11 +1,11 @@
 module api.util.htmlarea.dialog {
 
     import i18n = api.util.i18n;
-    import editor = CKEDITOR.editor;
+    import HTMLAreaEditor = CKEDITOR.editor;
 
     export class CharMapDialog extends ModalDialog {
 
-        constructor(editor: editor) {
+        constructor(editor: HTMLAreaEditor) {
             super(<HtmlAreaModalDialogConfig>{editor: editor, title: i18n('dialog.charmap.title'), cls: 'special-chars-modal-dialog'});
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/CharMapDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/CharMapDialog.ts
@@ -1,10 +1,11 @@
 module api.util.htmlarea.dialog {
 
     import i18n = api.util.i18n;
+    import editor = CKEDITOR.editor;
 
     export class CharMapDialog extends ModalDialog {
 
-        constructor(editor: HtmlAreaEditor) {
+        constructor(editor: editor) {
             super(<HtmlAreaModalDialogConfig>{editor: editor, title: i18n('dialog.charmap.title'), cls: 'special-chars-modal-dialog'});
         }
 
@@ -103,16 +104,16 @@ module api.util.htmlarea.dialog {
         }
 
         private extendCharMap(charmap: any) {
-            const settings = this.getEditor().settings;
-
-            if (settings.charmap) {
-                charmap = this.getCharsFromSetting(settings.charmap);
-            }
-
-            if (settings.charmap_append) {
-                return [].concat(charmap).concat(this.getCharsFromSetting(settings.charmap_append));
-            }
-
+            // const settings = this.getEditor().settings;
+            //
+            // if (settings.charmap) {
+            //     charmap = this.getCharsFromSetting(settings.charmap);
+            // }
+            //
+            // if (settings.charmap_append) {
+            //     return [].concat(charmap).concat(this.getCharsFromSetting(settings.charmap_append));
+            // }
+            //
             return charmap;
         }
 
@@ -122,7 +123,7 @@ module api.util.htmlarea.dialog {
 
         private insertChar(chr: string) {
             this.getEditor().fire('insertCustomChar', {chr: chr});
-            this.getEditor().execCommand('mceInsertContent', false, chr);
+            //this.getEditor().execCommand('mceInsertContent', false, chr);
         }
 
         private getDefaultCharMap(): any[] {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/CodeDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/CodeDialog.ts
@@ -4,13 +4,13 @@ module api.util.htmlarea.dialog {
     import Validators = api.ui.form.Validators;
     import TextArea = api.ui.text.TextArea;
     import i18n = api.util.i18n;
-    import editor = CKEDITOR.editor;
+    import HTMLAreaEditor = CKEDITOR.editor;
 
     export class CodeDialog extends ModalDialog {
 
         private textArea: TextArea;
 
-        constructor(editor: editor) {
+        constructor(editor: HTMLAreaEditor) {
             super(<HtmlAreaModalDialogConfig>{editor: editor, title: i18n('dialog.sourcecode.title'), cls: 'source-code-modal-dialog'});
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/CodeDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/CodeDialog.ts
@@ -4,12 +4,13 @@ module api.util.htmlarea.dialog {
     import Validators = api.ui.form.Validators;
     import TextArea = api.ui.text.TextArea;
     import i18n = api.util.i18n;
+    import editor = CKEDITOR.editor;
 
     export class CodeDialog extends ModalDialog {
 
         private textArea: TextArea;
 
-        constructor(editor: HtmlAreaEditor) {
+        constructor(editor: editor) {
             super(<HtmlAreaModalDialogConfig>{editor: editor, title: i18n('dialog.sourcecode.title'), cls: 'source-code-modal-dialog'});
         }
 
@@ -23,7 +24,7 @@ module api.util.htmlarea.dialog {
         open() {
             super.open();
 
-            this.textArea.setValue(this.getEditor().getContent({source_view: true}));
+            this.textArea.setValue(this.getEditor().getSnapshot());
             this.getEl().setAttribute('spellcheck', 'false');
             this.resetHeight();
             this.textArea.giveFocus();
@@ -31,8 +32,9 @@ module api.util.htmlarea.dialog {
         }
 
         private resetHeight() {
-            // textarea has 'height' style property updated on focus, shown events etc, overriding it gently
-            const height: number = this.getEditor().getParam('code_dialog_height', Math.min(tinymce.DOM.getViewPort().h - 200, 500));
+            const size: any = CKEDITOR.document.getWindow().getViewPaneSize();
+            const height: number = Math.min(size.height, 500);
+
             this.textArea.getEl().setMinHeightPx(height);
             this.textArea.getEl().setMaxHeightPx(height);
         }
@@ -42,14 +44,7 @@ module api.util.htmlarea.dialog {
 
             this.addAction(okAction.onExecuted(() => {
                 this.getEditor().focus();
-
-                this.getEditor().undoManager.transact(() => {
-                    this.getEditor().setContent(this.textArea.getValue());
-                });
-
-                this.getEditor().selection.setCursorLocation();
-                this.getEditor().nodeChanged();
-
+                this.getEditor().setData(this.textArea.getValue());
                 this.close();
             }));
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/HTMLAreaDialogHandler.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/HTMLAreaDialogHandler.ts
@@ -1,5 +1,6 @@
 module api.util.htmlarea.dialog {
 
+    import editor = CKEDITOR.editor;
     export class HTMLAreaDialogHandler {
 
         private static modalDialog: ModalDialog;
@@ -53,7 +54,7 @@ module api.util.htmlarea.dialog {
             return this.openDialog(new ImageModalDialog(config, content));
         }
 
-        private static openAnchorDialog(editor: HtmlAreaEditor): ModalDialog {
+        private static openAnchorDialog(editor: editor): ModalDialog {
             return this.openDialog(new AnchorModalDialog(editor));
         }
 
@@ -62,15 +63,15 @@ module api.util.htmlarea.dialog {
             return this.openDialog(new MacroModalDialog(config, content, applicationKeys));
         }
 
-        private static openSearchReplaceDialog(editor: HtmlAreaEditor): ModalDialog {
+        private static openSearchReplaceDialog(editor: editor): ModalDialog {
             return this.openDialog(new SearchReplaceModalDialog(editor));
         }
 
-        private static openCodeDialog(editor: HtmlAreaEditor): ModalDialog {
+        private static openCodeDialog(editor: editor): ModalDialog {
             return this.openDialog(new CodeDialog(editor));
         }
 
-        private static openCharMapDialog(editor: HtmlAreaEditor): ModalDialog {
+        private static openCharMapDialog(editor: editor): ModalDialog {
             return this.openDialog(new CharMapDialog(editor));
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/HTMLAreaDialogHandler.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/HTMLAreaDialogHandler.ts
@@ -1,6 +1,7 @@
 module api.util.htmlarea.dialog {
 
-    import editor = CKEDITOR.editor;
+    import HTMLAreaEditor = CKEDITOR.editor;
+
     export class HTMLAreaDialogHandler {
 
         private static modalDialog: ModalDialog;
@@ -54,7 +55,7 @@ module api.util.htmlarea.dialog {
             return this.openDialog(new ImageModalDialog(config, content));
         }
 
-        private static openAnchorDialog(editor: editor): ModalDialog {
+        private static openAnchorDialog(editor: HTMLAreaEditor): ModalDialog {
             return this.openDialog(new AnchorModalDialog(editor));
         }
 
@@ -63,15 +64,15 @@ module api.util.htmlarea.dialog {
             return this.openDialog(new MacroModalDialog(config, content, applicationKeys));
         }
 
-        private static openSearchReplaceDialog(editor: editor): ModalDialog {
+        private static openSearchReplaceDialog(editor: HTMLAreaEditor): ModalDialog {
             return this.openDialog(new SearchReplaceModalDialog(editor));
         }
 
-        private static openCodeDialog(editor: editor): ModalDialog {
+        private static openCodeDialog(editor: HTMLAreaEditor): ModalDialog {
             return this.openDialog(new CodeDialog(editor));
         }
 
-        private static openCharMapDialog(editor: editor): ModalDialog {
+        private static openCharMapDialog(editor: HTMLAreaEditor): ModalDialog {
             return this.openDialog(new CharMapDialog(editor));
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
@@ -433,7 +433,7 @@ module api.util.htmlarea.dialog {
                 this.link.parentElement.replaceChild(linkEl.getHTMLElement(), this.link);
             } else {
                 if (this.onlyTextSelected) {
-                    this.getEditor().insertContent(linkEl.toString());
+                    //this.getEditor().insertContent(linkEl.toString());
                 } else {
                     let linkAttrs = {
                         href: linkEl.getHref(),
@@ -444,7 +444,7 @@ module api.util.htmlarea.dialog {
                         title: linkEl.getTitle()
                     };
 
-                    this.getEditor().execCommand('mceInsertLink', false, linkAttrs);
+                    //this.getEditor().execCommand('mceInsertLink', false, linkAttrs);
                 }
             }
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ModalDialog.ts
@@ -4,7 +4,7 @@ module api.util.htmlarea.dialog {
     import Fieldset = api.ui.form.Fieldset;
     import FormItem = api.ui.form.FormItem;
     import FormItemBuilder = api.ui.form.FormItemBuilder;
-    import editor = CKEDITOR.editor;
+    import HTMLAreaEditor = CKEDITOR.editor;
 
     export class ModalDialogFormItemBuilder {
 
@@ -50,7 +50,7 @@ module api.util.htmlarea.dialog {
 
     export class HtmlAreaModalDialogConfig {
 
-        editor: editor;
+        editor: HTMLAreaEditor;
 
         title: string;
 
@@ -60,7 +60,7 @@ module api.util.htmlarea.dialog {
     export class ModalDialog extends api.ui.dialog.ModalDialog {
         private fields: { [id: string]: api.dom.FormItemEl } = {};
         private validated: boolean = false;
-        private editor: editor;
+        private editor: HTMLAreaEditor;
         private mainForm: Form;
         private firstFocusField: api.dom.Element;
         private submitAction: api.ui.Action;
@@ -84,7 +84,7 @@ module api.util.htmlarea.dialog {
             this.submitAction = action;
         }
 
-        protected getEditor(): editor {
+        protected getEditor(): HTMLAreaEditor {
             return this.editor;
         }
 
@@ -289,7 +289,7 @@ module api.util.htmlarea.dialog {
     }
 
     export interface HtmlAreaAnchor {
-        editor: editor;
+        editor: HTMLAreaEditor;
         element: HTMLElement;
         text: string;
         anchorList: string[];
@@ -297,14 +297,14 @@ module api.util.htmlarea.dialog {
     }
 
     export interface HtmlAreaImage {
-        editor: editor;
+        editor: HTMLAreaEditor;
         element: HTMLElement;
         container: HTMLElement;
         callback: Function;
     }
 
     export interface HtmlAreaMacro {
-        editor: editor;
+        editor: HTMLAreaEditor;
         callback: Function;
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ModalDialog.ts
@@ -4,6 +4,7 @@ module api.util.htmlarea.dialog {
     import Fieldset = api.ui.form.Fieldset;
     import FormItem = api.ui.form.FormItem;
     import FormItemBuilder = api.ui.form.FormItemBuilder;
+    import editor = CKEDITOR.editor;
 
     export class ModalDialogFormItemBuilder {
 
@@ -49,7 +50,7 @@ module api.util.htmlarea.dialog {
 
     export class HtmlAreaModalDialogConfig {
 
-        editor: HtmlAreaEditor;
+        editor: editor;
 
         title: string;
 
@@ -59,7 +60,7 @@ module api.util.htmlarea.dialog {
     export class ModalDialog extends api.ui.dialog.ModalDialog {
         private fields: { [id: string]: api.dom.FormItemEl } = {};
         private validated: boolean = false;
-        private editor: HtmlAreaEditor;
+        private editor: editor;
         private mainForm: Form;
         private firstFocusField: api.dom.Element;
         private submitAction: api.ui.Action;
@@ -83,7 +84,7 @@ module api.util.htmlarea.dialog {
             this.submitAction = action;
         }
 
-        protected getEditor(): HtmlAreaEditor {
+        protected getEditor(): editor {
             return this.editor;
         }
 
@@ -288,7 +289,7 @@ module api.util.htmlarea.dialog {
     }
 
     export interface HtmlAreaAnchor {
-        editor: HtmlAreaEditor;
+        editor: editor;
         element: HTMLElement;
         text: string;
         anchorList: string[];
@@ -296,14 +297,14 @@ module api.util.htmlarea.dialog {
     }
 
     export interface HtmlAreaImage {
-        editor: HtmlAreaEditor;
+        editor: editor;
         element: HTMLElement;
         container: HTMLElement;
         callback: Function;
     }
 
     export interface HtmlAreaMacro {
-        editor: HtmlAreaEditor;
+        editor: editor;
         callback: Function;
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/SearchReplaceModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/SearchReplaceModalDialog.ts
@@ -7,6 +7,7 @@ module api.util.htmlarea.dialog {
     import Checkbox = api.ui.Checkbox;
     import ElementHelper = api.dom.ElementHelper;
     import i18n = api.util.i18n;
+    import editor = CKEDITOR.editor;
 
     export class SearchReplaceModalDialog extends ModalDialog {
 
@@ -24,7 +25,7 @@ module api.util.htmlarea.dialog {
 
         private searchAndReplaceHelper: SearchAndReplaceHelper;
 
-        constructor(editor: HtmlAreaEditor) {
+        constructor(editor: editor) {
             super(<HtmlAreaModalDialogConfig>{editor: editor, title: i18n('dialog.search.title'), cls: 'search-and-replace-modal-dialog'});
             this.searchAndReplaceHelper = new SearchAndReplaceHelper(editor);
 
@@ -168,7 +169,7 @@ module api.util.htmlarea.dialog {
             super.open();
             this.searchAndReplaceHelper.last = {};
 
-            let selectedText: string = tinymce.trim(this.getEditor().selection.getContent({format: 'text'}));
+            let selectedText: string = '';//tinymce.trim(this.getEditor().selection.getContent({format: 'text'}));
             if(selectedText) {
                 this.findInput.setValue(selectedText);
             }
@@ -187,7 +188,7 @@ module api.util.htmlarea.dialog {
 
     class SearchAndReplaceHelper {
 
-        private editor: HtmlAreaEditor;
+        private editor: editor;
 
         private m: any;
         private matches: any;
@@ -206,7 +207,7 @@ module api.util.htmlarea.dialog {
         currentIndex: number = -1;
         last: any = {};
 
-        constructor(editor: HtmlAreaEditor) {
+        constructor(editor: editor) {
             this.editor = editor;
         }
 
@@ -262,7 +263,7 @@ module api.util.htmlarea.dialog {
 
             forward = forward !== false;
 
-            node = this.editor.getBody();
+            // node = this.editor.getBody();
             nodes = tinymce.grep(tinymce.toArray(node.getElementsByTagName('span')), this.isMatchSpan.bind(this));
             for (i = 0; i < nodes.length; i++) {
                 let nodeIndex = this.getElmIndex(nodes[i]);
@@ -295,7 +296,7 @@ module api.util.htmlarea.dialog {
                 }
             }
 
-            this.editor.undoManager.add();
+            //this.editor.undoManager.add();
             this.currentIndex = nextIndex;
 
             if (forward) {
@@ -328,66 +329,66 @@ module api.util.htmlarea.dialog {
         };
 
         private markAllMatches(regex: RegExp) {
-            let node: Element;
-            let marker: Element;
-
-            marker = this.editor.dom.create('span', {
-                'data-mce-bogus': 1
-            });
-
-            marker.className = 'mce-match-marker'; // IE 7 adds class="mce-match-marker" and class=mce-match-marker
-            node = this.editor.getBody();
-
-            this.done(false);
-
-            return this.findAndReplaceDOMText(regex, node, marker, false, this.editor.schema);
+            // let node: Element;
+            // let marker: Element;
+            //
+            // marker = this.editor.dom.create('span', {
+            //     'data-mce-bogus': 1
+            // });
+            //
+            // marker.className = 'mce-match-marker'; // IE 7 adds class="mce-match-marker" and class=mce-match-marker
+            // node = this.editor.getBody();
+            //
+            // this.done(false);
+            //
+            // return this.findAndReplaceDOMText(regex, node, marker, false, this.editor.schema);
         }
 
         done(keepEditorSelection: boolean = false) {
-            let i: number;
-            let nodes: [any];
-            let startContainer: any;
-            let endContainer: any;
-
-            nodes = tinymce.toArray(this.editor.getBody().getElementsByTagName('span'));
-            for (i = 0; i < nodes.length; i++) {
-                let nodeIndex = this.getElmIndex(nodes[i]);
-
-                if (nodeIndex !== null && nodeIndex.length) {
-                    if (nodeIndex === this.currentIndex.toString()) {
-                        if (!startContainer) {
-                            startContainer = nodes[i].firstChild;
-                        }
-
-                        endContainer = nodes[i].firstChild;
-                    }
-
-                    this.unwrap(nodes[i]);
-                }
-            }
-
-            if (startContainer && endContainer) {
-                let rng = this.editor.dom.createRng();
-                rng.setStart(startContainer, 0);
-                rng.setEnd(endContainer, endContainer.data.length);
-
-                if (keepEditorSelection !== false) {
-                    this.editor.selection.setRng(rng);
-                }
-
-                return rng;
-            }
+            // let i: number;
+            // let nodes: [any];
+            // let startContainer: any;
+            // let endContainer: any;
+            //
+            // nodes = tinymce.toArray(this.editor.getBody().getElementsByTagName('span'));
+            // for (i = 0; i < nodes.length; i++) {
+            //     let nodeIndex = this.getElmIndex(nodes[i]);
+            //
+            //     if (nodeIndex !== null && nodeIndex.length) {
+            //         if (nodeIndex === this.currentIndex.toString()) {
+            //             if (!startContainer) {
+            //                 startContainer = nodes[i].firstChild;
+            //             }
+            //
+            //             endContainer = nodes[i].firstChild;
+            //         }
+            //
+            //         this.unwrap(nodes[i]);
+            //     }
+            // }
+            //
+            // if (startContainer && endContainer) {
+            //     let rng = this.editor.dom.createRng();
+            //     rng.setStart(startContainer, 0);
+            //     rng.setEnd(endContainer, endContainer.data.length);
+            //
+            //     if (keepEditorSelection !== false) {
+            //         this.editor.selection.setRng(rng);
+            //     }
+            //
+            //     return rng;
+            // }
         };
 
         private removeNode(node: Node) {
-            let dom = this.editor.dom;
-            let parent = node.parentNode;
-
-            dom.remove(node);
-
-            if (dom.isEmpty(parent)) {
-                dom.remove(parent);
-            }
+            // let dom = this.editor.dom;
+            // let parent = node.parentNode;
+            //
+            // dom.remove(node);
+            //
+            // if (dom.isEmpty(parent)) {
+            //     dom.remove(parent);
+            // }
         }
 
         private notFoundAlert() {
@@ -411,25 +412,25 @@ module api.util.htmlarea.dialog {
         };
 
         private moveSelection(forward: boolean) {
-            let testIndex: number = this.currentIndex;
-            let dom: any = this.editor.dom;
-
-            forward = forward !== false;
-
-            if (forward) {
-                testIndex++;
-            } else {
-                testIndex--;
-            }
-
-            dom.removeClass(this.findSpansByIndex(this.currentIndex), 'mce-match-marker-selected');
-
-            let spans = this.findSpansByIndex(testIndex);
-            if (spans.length) {
-                dom.addClass(this.findSpansByIndex(testIndex), 'mce-match-marker-selected');
-                api.dom.Element.fromHtmlElement(spans[0]).getEl().scrollIntoView();
-                return testIndex;
-            }
+            // let testIndex: number = this.currentIndex;
+            // let dom: any = this.editor.dom;
+            //
+            // forward = forward !== false;
+            //
+            // if (forward) {
+            //     testIndex++;
+            // } else {
+            //     testIndex--;
+            // }
+            //
+            // dom.removeClass(this.findSpansByIndex(this.currentIndex), 'mce-match-marker-selected');
+            //
+            // let spans = this.findSpansByIndex(testIndex);
+            // if (spans.length) {
+            //     dom.addClass(this.findSpansByIndex(testIndex), 'mce-match-marker-selected');
+            //     api.dom.Element.fromHtmlElement(spans[0]).getEl().scrollIntoView();
+            //     return testIndex;
+            // }
 
             return -1;
         }
@@ -438,7 +439,7 @@ module api.util.htmlarea.dialog {
             let nodes: [any];
             let spans: [any] = <any>[];
 
-            nodes = tinymce.toArray(this.editor.getBody().getElementsByTagName('span'));
+            // nodes = tinymce.toArray(this.editor.getBody().getElementsByTagName('span'));
             if (nodes.length) {
                 for (let i = 0; i < nodes.length; i++) {
                     let nodeIndex = this.getElmIndex(nodes[i]);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/SearchReplaceModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/SearchReplaceModalDialog.ts
@@ -7,7 +7,7 @@ module api.util.htmlarea.dialog {
     import Checkbox = api.ui.Checkbox;
     import ElementHelper = api.dom.ElementHelper;
     import i18n = api.util.i18n;
-    import editor = CKEDITOR.editor;
+    import HTMLAreaEditor = CKEDITOR.editor;
 
     export class SearchReplaceModalDialog extends ModalDialog {
 
@@ -25,7 +25,7 @@ module api.util.htmlarea.dialog {
 
         private searchAndReplaceHelper: SearchAndReplaceHelper;
 
-        constructor(editor: editor) {
+        constructor(editor: HTMLAreaEditor) {
             super(<HtmlAreaModalDialogConfig>{editor: editor, title: i18n('dialog.search.title'), cls: 'search-and-replace-modal-dialog'});
             this.searchAndReplaceHelper = new SearchAndReplaceHelper(editor);
 
@@ -188,7 +188,7 @@ module api.util.htmlarea.dialog {
 
     class SearchAndReplaceHelper {
 
-        private editor: editor;
+        private editor: HTMLAreaEditor;
 
         private m: any;
         private matches: any;
@@ -207,7 +207,7 @@ module api.util.htmlarea.dialog {
         currentIndex: number = -1;
         last: any = {};
 
-        constructor(editor: editor) {
+        constructor(editor: HTMLAreaEditor) {
             this.editor = editor;
         }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaBuilder.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaBuilder.ts
@@ -177,7 +177,7 @@ module api.util.htmlarea.editor {
                 removeButtons: this.toolsToExlcude,
                 extraPlugins: this.plugins + (this.inline ? ',sharedspace' : ''),
                 autoGrow_onStartup: true,
-                contentsCss: this.assetsUri + '/common/styles/api/util/htmlarea/html-editor.css',
+                contentsCss: this.assetsUri + '/common/styles/api/util/htmlarea/html-editor.css', // for classic mode only
                 sharedSpaces: this.inline ? {top: this.fixedToolbarContainer} : null
             };
 
@@ -192,7 +192,7 @@ module api.util.htmlarea.editor {
 
             ckeditor.on('focus', (e) => {
                 if (this.focusHandler) {
-                    this.focusHandler(null);
+                    this.focusHandler(<any>e);
                 }
             });
 
@@ -202,7 +202,7 @@ module api.util.htmlarea.editor {
                     this.hasActiveDialog = false;
                 }
                 if (this.blurHandler) {
-                    this.blurHandler(null);
+                    this.blurHandler(<any>e);
                 }
             });
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaBuilder.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaBuilder.ts
@@ -189,21 +189,21 @@ module api.util.htmlarea.editor {
                 }
             });
 
-            // ckeditor.on('focus', (e) => {
-            //     if (this.focusHandler) {
-            //         this.focusHandler(null);
-            //     }
-            // });
-            //
-            // ckeditor.on('blur', (e) => {
-            //     if (this.hasActiveDialog) {
-            //         //e.stopImmediatePropagation();
-            //         this.hasActiveDialog = false;
-            //     }
-            //     if (this.blurHandler) {
-            //         this.blurHandler(null);
-            //     }
-            // });
+            ckeditor.on('focus', (e) => {
+                if (this.focusHandler) {
+                    this.focusHandler(null);
+                }
+            });
+
+            ckeditor.on('blur', (e) => {
+                if (this.hasActiveDialog) {
+                    //e.stopImmediatePropagation();
+                    this.hasActiveDialog = false;
+                }
+                if (this.blurHandler) {
+                    this.blurHandler(null);
+                }
+            });
 
             return ckeditor;
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaBuilder.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaBuilder.ts
@@ -30,8 +30,8 @@ module api.util.htmlarea.editor {
         private toolsToInclude: string[] = [];
 
         private tools: any[] = [
-            { name: 'gr1', items: ['Format', 'Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', 'Code', '-'] },
-            { name: 'gr2', items: [ 'Blockquote', 'CreateDiv', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', '-'] },
+            {name: 'gr1', items: ['Format', 'Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', 'Blockquote', '-']},
+            {name: 'gr2', items: ['JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', '-']},
             { name: 'gr3', items: ['BulletedList', 'NumberedList', 'Outdent', 'Indent', '-'] },
             { name: 'gr4', items: ['SpecialChar', 'Anchor', 'Image', 'Link', 'Unlink', '-'] },
             { name: 'gr5', items: ['Table', '-', 'PasteText', '-', 'Maximize'] }
@@ -177,6 +177,7 @@ module api.util.htmlarea.editor {
                 removeButtons: this.toolsToExlcude,
                 extraPlugins: this.plugins + (this.inline ? ',sharedspace' : ''),
                 autoGrow_onStartup: true,
+                contentsCss: this.assetsUri + '/common/styles/api/util/htmlarea/html-editor.css',
                 sharedSpaces: this.inline ? {top: this.fixedToolbarContainer} : null
             };
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaBuilder.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaBuilder.ts
@@ -2,7 +2,7 @@ module api.util.htmlarea.editor {
 
     import CreateHtmlAreaDialogEvent = api.util.htmlarea.dialog.CreateHtmlAreaDialogEvent;
     import ApplicationKey = api.application.ApplicationKey;
-    import editor = CKEDITOR.editor;
+    import HTMLAreaEditor = CKEDITOR.editor;
     import config = CKEDITOR.config;
 
     export class HTMLAreaBuilder {
@@ -162,7 +162,7 @@ module api.util.htmlarea.editor {
             }
         }
 
-        public createEditor(): editor {
+        public createEditor(): HTMLAreaEditor {
             this.checkRequiredFieldsAreSet();
 
             if (this.editableSourceCode && !this.isToolExcluded('Code')) {
@@ -181,7 +181,7 @@ module api.util.htmlarea.editor {
                 sharedSpaces: this.inline ? {top: this.fixedToolbarContainer} : null
             };
 
-            const ckeditor: editor = this.inline ? CKEDITOR.inline(this.editorContainerId, config) : CKEDITOR.replace(
+            const ckeditor: HTMLAreaEditor = this.inline ? CKEDITOR.inline(this.editorContainerId, config) : CKEDITOR.replace(
                 this.editorContainerId, config);
 
             ckeditor.on('change', (e) => {
@@ -213,10 +213,7 @@ module api.util.htmlarea.editor {
                 }
             });
 
-
             CKEDITOR.plugins.addExternal('code', this.assetsUri + '/common/js/util/htmlarea/plugins/', 'code.js');
-
-
             return ckeditor;
 
             /*            let deferred = wemQ.defer<HtmlAreaEditor>();
@@ -409,7 +406,7 @@ module api.util.htmlarea.editor {
             this.publishCreateDialogEvent(event);
         }
 
-        private notifyCodeDialog(editor: editor) {
+        private notifyCodeDialog(editor: HTMLAreaEditor) {
             let event = CreateHtmlAreaDialogEvent.create().setConfig(editor).setType(
                 api.util.htmlarea.dialog.HtmlAreaDialogType.CODE).build();
             this.publishCreateDialogEvent(event);

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaBuilder.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/editor/HTMLAreaBuilder.ts
@@ -30,14 +30,14 @@ module api.util.htmlarea.editor {
         private toolsToInclude: string[] = [];
 
         private tools: any[] = [
-            {name: 'gr1', items: ['Format', 'Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', 'Blockquote', '-']},
-            {name: 'gr2', items: ['JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock', '-']},
-            { name: 'gr3', items: ['BulletedList', 'NumberedList', 'Outdent', 'Indent', '-'] },
-            { name: 'gr4', items: ['SpecialChar', 'Anchor', 'Image', 'Link', 'Unlink', '-'] },
+            {name: 'gr1', items: ['Format', 'Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', 'Blockquote']},
+            {name: 'gr2', items: ['JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock']},
+            {name: 'gr3', items: ['BulletedList', 'NumberedList', 'Outdent', 'Indent']},
+            {name: 'gr4', items: ['SpecialChar', 'Anchor', 'Image', 'Link', 'Unlink']},
             { name: 'gr5', items: ['Table', '-', 'PasteText', '-', 'Maximize'] }
         ];
 
-        private plugins: string = 'autogrow,codeTag';
+        private plugins: string = 'autogrow,codeTag,code';
 
         setEditableSourceCode(value: boolean): HTMLAreaBuilder {
             this.editableSourceCode = value;
@@ -165,8 +165,8 @@ module api.util.htmlarea.editor {
         public createEditor(): editor {
             this.checkRequiredFieldsAreSet();
 
-            if (this.editableSourceCode && !this.isToolExcluded('Source')) {
-                this.includeTool('Source');
+            if (this.editableSourceCode && !this.isToolExcluded('Code')) {
+                this.includeTool('Code');
             }
 
             this.tools.push({ name: 'custom', items: this.toolsToInclude });
@@ -205,6 +205,17 @@ module api.util.htmlarea.editor {
                     this.blurHandler(<any>e);
                 }
             });
+
+            ckeditor.addCommand('openCodeDialog', {
+                exec: (editor) => {
+                    this.notifyCodeDialog(editor);
+                    return true;
+                }
+            });
+
+
+            CKEDITOR.plugins.addExternal('code', this.assetsUri + '/common/js/util/htmlarea/plugins/', 'code.js');
+
 
             return ckeditor;
 
@@ -398,8 +409,8 @@ module api.util.htmlarea.editor {
             this.publishCreateDialogEvent(event);
         }
 
-        private notifyCodeDialog(config: any) {
-            let event = CreateHtmlAreaDialogEvent.create().setConfig(config).setType(
+        private notifyCodeDialog(editor: editor) {
+            let event = CreateHtmlAreaDialogEvent.create().setConfig(editor).setType(
                 api.util.htmlarea.dialog.HtmlAreaDialogType.CODE).build();
             this.publishCreateDialogEvent(event);
         }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/plugins/code.js
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/plugins/code.js
@@ -1,14 +1,10 @@
-/*global tinymce:true */
+CKEDITOR.plugins.add('code', {
 
-tinymce.PluginManager.add('code', function (editor) {
-    function showDialog() {
-        editor.execCommand("openCodeDialog", editor);
+    init: function (editor) {
+        editor.ui.addButton('Code', {
+            icon: 'code',
+            label: 'Source code',
+            command: 'openCodeDialog'
+        });
     }
-
-    editor.addButton('code', {
-        icon: 'code',
-        tooltip: 'Source code',
-        onclick: showDialog,
-        type: 'button'
-    });
 });

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/lib/ckeditor/plugins/sharedspace/plugin.js
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/lib/ckeditor/plugins/sharedspace/plugin.js
@@ -1,0 +1,152 @@
+/**
+ * @license Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or http://ckeditor.com/license
+ */
+
+(function () {
+
+    'use strict';
+
+    var containerTpl = CKEDITOR.addTemplate('sharedcontainer', '<div' +
+                                                               ' id="cke_{name}"' +
+                                                               ' class="cke {id} cke_reset_all cke_chrome cke_editor_{name} cke_shared cke_detached cke_{langDir} ' +
+                                                               CKEDITOR.env.cssClass + '"' +
+                                                               ' dir="{langDir}"' +
+                                                               ' title="' + ( CKEDITOR.env.gecko ? ' ' : '' ) + '"' +
+                                                               ' lang="{langCode}"' +
+                                                               ' role="presentation"' +
+                                                               '>' +
+                                                               '<div class="cke_inner">' +
+                                                               '<div id="{spaceId}" class="cke_{space}" role="presentation">{content}</div>' +
+                                                               '</div>' +
+                                                               '</div>');
+
+    CKEDITOR.plugins.add('sharedspace', {
+        init: function (editor) {
+            // Create toolbars on #loaded (like themed creator), but do that
+            // with higher priority to block the default scenario.
+            editor.on('loaded', function () {
+                var spaces = editor.config.sharedSpaces;
+
+                if (spaces) {
+                    for (var spaceName in spaces) {
+                        create(editor, spaceName, spaces[spaceName]);
+                    }
+                }
+            }, null, null, 9);
+        }
+    });
+
+    function create(editor, spaceName, target) {
+        var innerHtml, space;
+
+        if (typeof target == 'string') {
+            target = CKEDITOR.document.getById(target);
+        } else {
+            target = new CKEDITOR.dom.element(target);
+        }
+
+        if (target) {
+            // Have other plugins filling the space.
+            innerHtml = editor.fire('uiSpace', {space: spaceName, html: ''}).html;
+
+            if (innerHtml) {
+                // Block the uiSpace handling by others (e.g. themed-ui).
+                editor.on('uiSpace', function (ev) {
+                    if (ev.data.space == spaceName) {
+                        ev.cancel();
+                    }
+                }, null, null, 1);  // Hi-priority
+
+                // Inject the space into the target.
+                space = target.append(CKEDITOR.dom.element.createFromHtml(containerTpl.output({
+                    id: editor.id,
+                    name: editor.name,
+                    langDir: editor.lang.dir,
+                    langCode: editor.langCode,
+                    space: spaceName,
+                    spaceId: editor.ui.spaceId(spaceName),
+                    content: innerHtml
+                })));
+
+                // Only the first container starts visible. Others get hidden.
+                if (target.getCustomData('cke_hasshared')) {
+                    space.hide();
+                } else {
+                    target.setCustomData('cke_hasshared', 1);
+                }
+
+                // There's no need for the space to be selectable.
+                space.unselectable();
+
+                // Prevent clicking on non-buttons area of the space from blurring editor.
+                space.on('mousedown', function (evt) {
+                    evt = evt.data;
+                    if (!evt.getTarget().hasAscendant('a', 1)) {
+                        evt.preventDefault();
+                    }
+                });
+
+                // Register this UI space to the focus manager.
+                editor.focusManager.add(space, 1);
+
+                // When the editor gets focus, show the space container, hiding others.
+                editor.on('focus', function () {
+                    for (var i = 0, sibling, children = target.getChildren(); ( sibling = children.getItem(i) ); i++) {
+                        if (sibling.type == CKEDITOR.NODE_ELEMENT && !sibling.equals(space) &&
+                            sibling.hasClass('cke_shared')) {
+                            sibling.hide();
+                        }
+                    }
+
+                    space.show();
+                });
+
+                editor.on('destroy', function () {
+                    space.remove();
+                });
+            }
+        }
+    }
+})();
+
+/**
+ * Makes it possible to place some of the editor UI blocks, like the toolbar
+ * and the elements path, in any element on the page.
+ *
+ * The elements used to store the UI blocks can be shared among several editor
+ * instances. In that case only the blocks relevant to the active editor instance
+ * will be displayed.
+ *
+ * Read more in the [documentation](#!/guide/dev_sharedspace)
+ * and see the [SDK sample](http://sdk.ckeditor.com/samples/sharedspace.html).
+ *
+ *        // Place the toolbar inside the element with an ID of "someElementId" and the
+ *        // elements path into the element with an  ID of "anotherId".
+ *        config.sharedSpaces = {
+ *			top: 'someElementId',
+ *			bottom: 'anotherId'
+ *		};
+ *
+ *        // Place the toolbar inside the element with an ID of "someElementId". The
+ *        // elements path will remain attached to the editor UI.
+ *        config.sharedSpaces = {
+ *			top: 'someElementId'
+ *		};
+ *
+ *        // (Since 4.5)
+ *        // Place the toolbar inside a DOM element passed by a reference. The
+ *        // elements path will remain attached to the editor UI.
+ *        var htmlElement = document.getElementById( 'someElementId' );
+ *        config.sharedSpaces = {
+ *			top: htmlElement
+ *		};
+ *
+ * **Note:** The [Maximize](http://ckeditor.com/addon/maximize) and [Editor Resize](http://ckeditor.com/addon/resize)
+ * features are not supported in the shared space environment and should be disabled in this context.
+ *
+ *        config.removePlugins = 'maximize,resize';
+ *
+ * @cfg {Object} [sharedSpaces]
+ * @member CKEDITOR.config
+ */

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-area.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-area.less
@@ -4,6 +4,18 @@
     display: none;
   }
 
+  .cke_bottom {
+    padding: 1px 8px 2px;
+  }
+
+  .cke_button__maximize, .cke_button__code {
+    float: right;
+  }
+
+  .cke_path {
+    padding-top: 6px;
+  }
+
   .cke_focus {
     .box-shadow(0px 0px 5px @admin-input-blue);
     .input-border(@admin-input-blue);
@@ -26,4 +38,32 @@
     display: none;
   }
 
+}
+
+.cke_maximized {
+  z-index: 100 !important;
+
+  .cke_bottom {
+    padding: 1px 8px 2px;
+  }
+
+  .cke_button__maximize, .cke_button__code {
+    float: right;
+  }
+
+  .cke_path {
+    padding-top: 6px;
+  }
+
+  .cke_top {
+
+    text-align: center;
+    width: 100% !important;
+
+    .cke_toolbox {
+      display: inline-block;
+      padding-right: 30px;
+      vertical-align: middle;
+    }
+  }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-area.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-area.less
@@ -1,6 +1,6 @@
 .html-area {
 
-  .cke_top {
+  .cke_top, .cke_bottom {
     display: none;
   }
 
@@ -8,7 +8,7 @@
     .box-shadow(0px 0px 5px @admin-input-blue);
     .input-border(@admin-input-blue);
 
-    .cke_top {
+    .cke_top, .cke_bottom {
       display: block;
     }
   }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
@@ -46,7 +46,7 @@
   }
 }
 
-.mce-toolbar-container .mce-panel, .mce-toolbar-grp.mce-panel {
+.cke-toolbar-container .mce-panel, .mce-toolbar-grp.mce-panel {
   background-image: none;
   background-color: @admin-white;
   border: none;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/api/util/htmlarea/html-editor.less
@@ -1,5 +1,6 @@
-.mce-content-body {
+.cke_editable {
   font-family: "Open Sans", sans-serif;
+  margin: 8px;
 
   > *:first-child {
     margin-top: 0px;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/styles/apps/content/wizard/content-wizard-panel.less
@@ -234,8 +234,12 @@
   }
 }
 
-.mce-fullscreen {
+html[style*="z-index: 9995"] { // ckeditor fullscreen mode
   .wizard-step-navigator-and-toolbar {
+    display: none;
+  }
+
+  .launcher-button {
     display: none;
   }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/text-view.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/text-view.less
@@ -48,6 +48,14 @@
     .cke_editable {
       display: block;
       box-sizing: border-box;
+
+      > *:first-child {
+        margin-top: 0px;
+      }
+
+      > *:last-child {
+        margin-bottom: 0px;
+      }
     }
 
     &.editor-focused {
@@ -115,12 +123,13 @@
   width: 100% !important;
   border-bottom: 1px solid #cccccc !important;
   text-align: center !important;
-  padding: 6px 0px 2px !important;
+  padding: 6px 0px 0px !important;
   display: none !important;
 
   .cke_toolbox {
     display: inline-block;
     padding-right: 30px;
+    vertical-align: middle;
 
     a {
       pointer-events: auto;
@@ -190,6 +199,7 @@
   font-size: 26px;
   display: none;
   text-decoration: none;
+  cursor: pointer;
 
   &.active {
     display: inline;

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/text-view.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/text-view.less
@@ -32,7 +32,7 @@
     display: none;
   }
 
-  .mce-content-body {
+  .cke_editable {
     cursor: auto;
     display: none;
     padding: 5px;
@@ -45,7 +45,7 @@
   &.edit-mode {
     min-height: 0px;
 
-    .mce-content-body {
+    .cke_editable {
       display: block;
       box-sizing: border-box;
     }
@@ -97,13 +97,35 @@
 
 }
 
-.mce-toolbar-container {
-  position: fixed;
+.cke-toolbar-container {
+  &.visible .cke_top {
+    display: block !important;
+  }
+
+  .cke_combopanel {
+    z-index: @z-index-mce-toolbar !important;
+  }
+}
+
+.cke_top {
+  position: fixed !important;
   top: 0;
   left: 0;
   z-index: @z-index-mce-toolbar;
-  width: 100%;
-  border-bottom: 1px solid #cccccc;
+  width: 100% !important;
+  border-bottom: 1px solid #cccccc !important;
+  text-align: center !important;
+  padding: 6px 0px 2px !important;
+  display: none !important;
+
+  .cke_toolbox {
+    display: inline-block;
+    padding-right: 30px;
+
+    a {
+      pointer-events: auto;
+    }
+  }
 
   > div {
     display: none;

--- a/modules/app/app-contentstudio/src/main/resources/com/enonic/xp/app/contentstudio/liveEditHeadEnd.html
+++ b/modules/app/app-contentstudio/src/main/resources/com/enonic/xp/app/contentstudio/liveEditHeadEnd.html
@@ -1,2 +1,5 @@
 <!-- Live edit injection -->
 <link id="live-edit-css" rel="stylesheet" href="{{adminUrl}}/live-edit/styles/_all.css"/>
+<script type="text/javascript">
+    var CKEDITOR_BASEPATH = '{{adminUrl}}/common/lib/ckeditor/';
+</script>

--- a/modules/app/app-contentstudio/src/test/resources/com/enonic/xp/app/contentstudio/liveEditInjectionHeadEnd.html
+++ b/modules/app/app-contentstudio/src/test/resources/com/enonic/xp/app/contentstudio/liveEditInjectionHeadEnd.html
@@ -1,2 +1,5 @@
 <!-- Live edit injection -->
 <link id="live-edit-css" rel="stylesheet" href="/admin/live-edit/styles/_all.css"/>
+<script type="text/javascript">
+    var CKEDITOR_BASEPATH = '/admin/common/lib/ckeditor/';
+</script>


### PR DESCRIPTION
Missing features for now:
-source dialog; will be added in other issue
for both inline and classic modes:
-blur/focus handlers commented now; cke wraps natural events with their own events, need to investiage more on this because some listeners expect natural FocusEvent that not present in cke event
-keyboard events handling