### PR TITLE
Broken layout in the Launcher panel when the list of tools is long #5514

### DIFF
--- a/modules/app/app-main/src/main/resources/assets/styles/launcher.less
+++ b/modules/app/app-main/src/main/resources/assets/styles/launcher.less
@@ -155,6 +155,9 @@ body.mobile-statistics-panel {
     .scrollable-content {
       overflow-x: hidden;
       overflow-y: auto;
+      height: 100%;
+      padding-right: 17px;
+      width: 100%;
     }
 
     a {


### PR DESCRIPTION
-set height of tools area to be scrollable
-hiding scrollblar as it looks ugly