### PR TITLE
Hide options "User" and "User Group" in the dialog when a user storeis selected #5472

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/ui/treegrid/TreeGrid.ts
@@ -1347,12 +1347,12 @@ module api.ui.treegrid {
          */
         appendNode(data: DATA, nextToSelection: boolean = false, prepend: boolean = true,
                    stashedParentNode?: TreeNode<DATA>): wemQ.Promise<void> {
-            let parentNode = this.getParentNode(nextToSelection, stashedParentNode);
+            let parentNode = this.getParentNode(nextToSelection, stashedParentNode, data);
             let index = prepend ? 0 : Math.max(0, parentNode.getChildren().length - 1);
             return this.insertNode(data, nextToSelection, index, stashedParentNode);
         }
 
-        getParentNode(nextToSelection: boolean = false, stashedParentNode?: TreeNode<DATA>) {
+        getParentNode(nextToSelection: boolean = false, stashedParentNode?: TreeNode<DATA>, data?: DATA) {
             let root = stashedParentNode || this.root.getCurrentRoot();
             let parentNode: TreeNode<DATA>;
 
@@ -1372,7 +1372,7 @@ module api.ui.treegrid {
                    stashedParentNode?: TreeNode<DATA>): wemQ.Promise<void> {
             let deferred = wemQ.defer<void>();
             let root = stashedParentNode || this.root.getCurrentRoot();
-            let parentNode = this.getParentNode(nextToSelection, stashedParentNode);
+            let parentNode = this.getParentNode(nextToSelection, stashedParentNode, data);
 
             let isRootParentNode: boolean = (parentNode === root);
 
@@ -1559,7 +1559,7 @@ module api.ui.treegrid {
             this.setActive(true);
         }
 
-        private updateSelectedNode(node: TreeNode<DATA>) {
+        protected updateSelectedNode(node: TreeNode<DATA>) {
             this.getGrid().clearSelection();
             this.refreshNode(node);
             let row = this.getRowIndexByNode(node);

--- a/modules/app/app-users/src/main/js/app/browse/ShowNewPrincipalDialogEvent.ts
+++ b/modules/app/app-users/src/main/js/app/browse/ShowNewPrincipalDialogEvent.ts
@@ -1,6 +1,18 @@
 import '../../api.ts';
+import {UserTreeGridItem} from './UserTreeGridItem';
 
 export class ShowNewPrincipalDialogEvent extends api.event.Event {
+
+    private selection: UserTreeGridItem[];
+
+    constructor(selection: UserTreeGridItem[]) {
+        super();
+        this.selection = selection;
+    }
+
+    getSelection(): UserTreeGridItem[] {
+        return this.selection;
+    }
 
     static on(handler: (event: ShowNewPrincipalDialogEvent) => void) {
         api.event.Event.bind(api.ClassHelper.getFullName(this), handler);

--- a/modules/app/app-users/src/main/js/app/browse/UserBrowsePanel.ts
+++ b/modules/app/app-users/src/main/js/app/browse/UserBrowsePanel.ts
@@ -48,7 +48,7 @@ export class UserBrowsePanel extends api.app.browse.BrowsePanel<UserTreeGridItem
 
             let label;
 
-            if (noSelection) {
+            if (noSelection || selection[0].getData().getType() === UserTreeGridItemType.USER_STORE) {
                 label = `${i18n('action.new')}…`;
             } else {
                 const userItem = selection[0].getData();
@@ -68,9 +68,6 @@ export class UserBrowsePanel extends api.app.browse.BrowsePanel<UserTreeGridItem
                 case UserTreeGridItemType.PRINCIPAL:
                     type = i18n(`field.${PrincipalType[userItem.getPrincipal().getType()].toLowerCase()}`);
                     break;
-                case UserTreeGridItemType.USER_STORE:
-                    type = i18n('field.userStore');
-                    break;
                 default:
                     type = '';
                 }
@@ -84,7 +81,7 @@ export class UserBrowsePanel extends api.app.browse.BrowsePanel<UserTreeGridItem
 
         this.treeGrid.onHighlightingChanged((node: TreeNode<UserTreeGridItem>) => changeSelectionStatus(node ? [node] : []));
 
-        this.onShown((event) => {
+        this.onShown(() => {
             Router.setHash('browse');
         });
     }

--- a/modules/app/app-users/src/main/js/app/browse/action/NewPrincipalAction.ts
+++ b/modules/app/app-users/src/main/js/app/browse/action/NewPrincipalAction.ts
@@ -1,6 +1,6 @@
 import '../../../api.ts';
 import {NewPrincipalEvent} from '../NewPrincipalEvent';
-import {UserTreeGridItem} from '../UserTreeGridItem';
+import {UserTreeGridItem, UserTreeGridItemType} from '../UserTreeGridItem';
 import {UserItemsTreeGrid} from '../UserItemsTreeGrid';
 import {ShowNewPrincipalDialogEvent} from '../ShowNewPrincipalDialogEvent';
 
@@ -14,10 +14,10 @@ export class NewPrincipalAction extends Action {
         this.setEnabled(false);
         this.onExecuted(() => {
             const principals: UserTreeGridItem[] = grid.getSelectedDataList();
-            if (principals.length > 0) {
+            if (principals.length > 0 && principals[0].getType() !== UserTreeGridItemType.USER_STORE) {
                 new NewPrincipalEvent(principals).fire();
             } else {
-                new ShowNewPrincipalDialogEvent().fire();
+                new ShowNewPrincipalDialogEvent(principals).fire();
             }
         });
     }

--- a/modules/app/app-users/src/main/js/app/create/NewPrincipalDialog.ts
+++ b/modules/app/app-users/src/main/js/app/create/NewPrincipalDialog.ts
@@ -1,6 +1,7 @@
 import '../../api.ts';
 import {UserItemTypesTreeGrid} from './UserItemTypesTreeGrid';
 import {NewPrincipalEvent} from '../browse/NewPrincipalEvent';
+import {UserTreeGridItem, UserTreeGridItemType} from '../browse/UserTreeGridItem';
 
 import i18n = api.util.i18n;
 import LoadMask = api.ui.mask.LoadMask;
@@ -51,8 +52,17 @@ export class NewPrincipalDialog extends api.ui.dialog.ModalDialog {
         NewPrincipalEvent.on(() => this.isVisible() && this.close());
     }
 
+    setSelection(selection: UserTreeGridItem[]): NewPrincipalDialog {
+        const isUserStore = selection.length > 0 && selection[0].getType() === UserTreeGridItemType.USER_STORE;
+        if (isUserStore) {
+            this.grid.setUserStore(selection[0].getUserStore());
+        }
+        return this;
+    }
+
     open() {
         this.grid.reload(null, null, false);
+        this.grid.getGrid().resizeCanvas();
         super.open();
     }
 

--- a/modules/app/app-users/src/main/js/app/create/UserItemTypesTreeGrid.ts
+++ b/modules/app/app-users/src/main/js/app/create/UserItemTypesTreeGrid.ts
@@ -40,8 +40,9 @@ export class UserItemTypesTreeGrid extends TreeGrid<UserTypeTreeGridItem> {
 
     private userStores: UserStore[];
 
-    constructor() {
+    private manualUserStore: boolean;
 
+    constructor() {
         const builder = new TreeGridBuilder<UserTypeTreeGridItem>().setColumnConfig([{
             name: i18n('field.name'),
             id: 'name',
@@ -56,6 +57,8 @@ export class UserItemTypesTreeGrid extends TreeGrid<UserTypeTreeGridItem> {
             .prependClasses('user-types-tree-grid');
 
         super(builder);
+
+        this.manualUserStore = false;
 
         this.initEventHandlers();
     }
@@ -121,16 +124,18 @@ export class UserItemTypesTreeGrid extends TreeGrid<UserTypeTreeGridItem> {
                     .setKey(new PrincipalKey(UserStoreKey.SYSTEM, PrincipalType.GROUP, 'user-group'))
                     .setDisplayName(i18n('field.userGroup'))
                     .build()).build(),
-            new UserTypeTreeGridItemBuilder()
-                .setUserItem(new UserStoreBuilder()
-                    .setKey(UserStoreKey.SYSTEM.toString())
-                    .setDisplayName(i18n('field.userStore'))
-                    .build()).build(),
-            new UserTypeTreeGridItemBuilder()
-                .setUserItem(new RoleBuilder()
-                    .setKey(new PrincipalKey(UserStoreKey.SYSTEM, PrincipalType.ROLE, 'role'))
-                    .setDisplayName(i18n('field.role'))
-                    .build()).build(),
+            ...(this.manualUserStore ? [] : [
+                    new UserTypeTreeGridItemBuilder()
+                        .setUserItem(new UserStoreBuilder()
+                            .setKey(UserStoreKey.SYSTEM.toString())
+                            .setDisplayName(i18n('field.userStore'))
+                            .build()).build(),
+                    new UserTypeTreeGridItemBuilder()
+                        .setUserItem(new RoleBuilder()
+                            .setKey(new PrincipalKey(UserStoreKey.SYSTEM, PrincipalType.ROLE, 'role'))
+                            .setDisplayName(i18n('field.role'))
+                            .build()).build(),
+                ])
         ]);
     }
 
@@ -157,7 +162,15 @@ export class UserItemTypesTreeGrid extends TreeGrid<UserTypeTreeGridItem> {
         });
     }
 
+    setUserStore(userStore: UserStore) {
+        this.userStores = [userStore];
+        this.manualUserStore = true;
+        this.addClass('flat');
+    }
+
     clearUserStores() {
         this.userStores = null;
+        this.manualUserStore = false;
+        this.removeClass('flat');
     }
 }

--- a/modules/app/app-users/src/main/js/main.ts
+++ b/modules/app/app-users/src/main/js/main.ts
@@ -59,8 +59,8 @@ function startApplication() {
     api.security.event.PrincipalServerEventsHandler.getInstance().start();
 
     const newPrincipalDialog = new NewPrincipalDialog();
-    ShowNewPrincipalDialogEvent.on(() => {
-        newPrincipalDialog.open();
+    ShowNewPrincipalDialogEvent.on((event) => {
+        newPrincipalDialog.setSelection(event.getSelection()).open();
     });
 }
 


### PR DESCRIPTION
Added `NewPrincipalDialog` with two options (User and User Group), when a user clicks on the `New...` button and User Store is selected.
Added manual canvas resize to shrink the dialog on open.