### PR TITLE
Page Editor - Image and Part components have unneeded margins #5432

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/item-view.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/item-view.less
@@ -16,10 +16,6 @@
     .@{_CLS_PREFIX}item-placeholder {
       height: @placeholder-height;
     }
-
-    //& figure {
-    //  margin: 0;
-    //}
   }
 
   &[data-portal-placeholder-error=true] {

--- a/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/item-view.less
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/live-edit/styles/less/partials/item-view.less
@@ -16,6 +16,10 @@
     .@{_CLS_PREFIX}item-placeholder {
       height: @placeholder-height;
     }
+
+    //& figure {
+    //  margin: 0;
+    //}
   }
 
   &[data-portal-placeholder-error=true] {
@@ -75,6 +79,10 @@
         content: '';
       }
     }
+  }
+
+  & figure.empty {
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
-ImageComponentView is wrapped on backend into Figure tag which has margins diffrent from div; setting margin to zero for empty ImageComponentView and letting it be as it is when image is selected