### PR TITLE
Fix undefined principal key in RoleKeys static functions

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/security/RoleKeys.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/security/RoleKeys.ts
@@ -39,23 +39,23 @@ module api.security {
         /* */
 
         public static isContentAdmin(principalKey: PrincipalKey): boolean {
-            return RoleKeys.contentAdminRoles.some(roleId => principalKey.getId() === roleId);
+            return !!principalKey && RoleKeys.contentAdminRoles.some(roleId => principalKey.getId() === roleId);
         }
 
         public static isUserAdmin(principalKey: PrincipalKey): boolean {
-            return RoleKeys.userAdminRoles.some(roleId => principalKey.getId() === roleId);
+            return !!principalKey && RoleKeys.userAdminRoles.some(roleId => principalKey.getId() === roleId);
         }
 
         public static isContentExpert(principalKey: PrincipalKey): boolean {
-            return RoleKeys.contentExpertRoles.some(roleId => principalKey.getId() === roleId);
+            return !!principalKey && RoleKeys.contentExpertRoles.some(roleId => principalKey.getId() === roleId);
         }
 
         public static isAdmin(principalKey: PrincipalKey): boolean {
-            return RoleKeys.ROLE_ADMIN === principalKey.getId();
+            return !!principalKey && RoleKeys.ROLE_ADMIN === principalKey.getId();
         }
 
         public static isEveryone(principalKey: PrincipalKey): boolean {
-            return RoleKeys.ROLE_EVERYONE === principalKey.getId();
+            return !!principalKey && RoleKeys.ROLE_EVERYONE === principalKey.getId();
         }
     }
 }


### PR DESCRIPTION
Added check for `truthy` principal key value to prevent error, when passing undefined key. This bug prevented some wizards to create steps properly.

_Related to issue #5466._