### PR TITLE
Show notification about unconfirmed changes in HTML Area modal dialog…

### DIFF
--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/AnchorModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/AnchorModalDialog.ts
@@ -3,22 +3,32 @@ module api.util.htmlarea.dialog {
     import FormItem = api.ui.form.FormItem;
     import Validators = api.ui.form.Validators;
     import i18n = api.util.i18n;
+    import TextInput = api.ui.text.TextInput;
 
     export class AnchorModalDialog extends ModalDialog {
 
+        private nameField: FormItem;
+
         constructor(editor: HtmlAreaEditor) {
 
-            super(<HtmlAreaModalDialogConfig>{editor: editor, title: i18n('dialog.anchor.title')});
+            super(<HtmlAreaModalDialogConfig>{
+                editor: editor,
+                title: i18n('dialog.anchor.title'),
+                confirmation: {
+                    yesCallback: () => this.getSubmitAction().execute(),
+                    noCallback: () => this.close(),
+                }
+            });
         }
 
         protected getMainFormItems(): FormItem[] {
             let formItemBuilder = new ModalDialogFormItemBuilder('name', i18n('dialog.anchor.formitem.name')).setValidator(
                 Validators.required);
-            let nameField = this.createFormItem(formItemBuilder);
+            this.nameField = this.createFormItem(formItemBuilder);
 
-            this.setFirstFocusField(nameField.getInput());
+            this.setFirstFocusField(this.nameField.getInput());
 
-            return [nameField];
+            return [this.nameField];
         }
 
         protected initializeActions() {
@@ -51,6 +61,10 @@ module api.util.htmlarea.dialog {
         private insertAnchor(): void {
             let anchorEl = this.createAnchorEl();
             this.getEditor().insertContent(anchorEl);
+        }
+
+        isDirty(): boolean {
+            return (<TextInput>this.nameField.getInput()).isDirty();
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/CodeDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/CodeDialog.ts
@@ -3,14 +3,24 @@ module api.util.htmlarea.dialog {
     import FormItem = api.ui.form.FormItem;
     import Validators = api.ui.form.Validators;
     import TextArea = api.ui.text.TextArea;
+    import Action = api.ui.Action;
     import i18n = api.util.i18n;
 
     export class CodeDialog extends ModalDialog {
 
         private textArea: TextArea;
 
+        private okAction: Action;
+
         constructor(editor: HtmlAreaEditor) {
-            super(<HtmlAreaModalDialogConfig>{editor: editor, title: i18n('dialog.sourcecode.title'), cls: 'source-code-modal-dialog'});
+            super(<HtmlAreaModalDialogConfig>{
+                editor: editor,
+                title: i18n('dialog.sourcecode.title'), cls: 'source-code-modal-dialog',
+                confirmation: {
+                    yesCallback: () => this.okAction.execute(),
+                    noCallback: () => this.close(),
+                }
+            });
         }
 
         protected layout() {
@@ -38,9 +48,9 @@ module api.util.htmlarea.dialog {
         }
 
         protected initializeActions() {
-            const okAction: api.ui.Action = new api.ui.Action(i18n('action.ok'));
+            this.okAction = new Action(i18n('action.ok'));
 
-            this.addAction(okAction.onExecuted(() => {
+            this.addAction(this.okAction.onExecuted(() => {
                 this.getEditor().focus();
 
                 this.getEditor().undoManager.transact(() => {
@@ -54,6 +64,10 @@ module api.util.htmlarea.dialog {
             }));
 
             super.initializeActions();
+        }
+
+        isDirty(): boolean {
+            return this.textArea.isDirty();
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ImageModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ImageModalDialog.ts
@@ -49,10 +49,23 @@ module api.util.htmlarea.dialog {
                 editor: config.editor,
                 content: content,
                 title: i18n('dialog.image.title'),
-                cls: 'image-modal-dialog'
+                cls: 'image-modal-dialog',
+                confirmation: {
+                    yesCallback: () => this.getSubmitAction().execute(),
+                    noCallback: () => this.close(),
+                }
             });
 
             this.initLoader();
+
+            if (config.element) {
+                this.imageElement = <HTMLImageElement>config.element;
+
+                this.loadImage();
+
+                this.setImageFieldValues(this.imageCaptionField, this.getCaption());
+                this.setImageFieldValues(this.imageAltTextField, this.getAltText());
+            }
         }
 
         private setImageFieldValues(field: FormItem, value: string) {
@@ -381,15 +394,6 @@ module api.util.htmlarea.dialog {
             this.callback = config.callback;
 
             this.content = params.content;
-
-            if (config.element) {
-                this.imageElement = <HTMLImageElement>params.config.element;
-
-                this.loadImage();
-
-                this.setImageFieldValues(this.imageCaptionField, this.getCaption());
-                this.setImageFieldValues(this.imageAltTextField, this.getAltText());
-            }
         }
 
         protected initializeActions() {
@@ -489,6 +493,10 @@ module api.util.htmlarea.dialog {
 
         private isImageInOriginalSize(image: HTMLElement) {
             return image.getAttribute('data-src').indexOf('keepSize=true') > 0;
+        }
+
+        isDirty(): boolean {
+            return AppHelper.isDirty(this);
         }
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/LinkModalDialog.ts
@@ -9,6 +9,7 @@ module api.util.htmlarea.dialog {
     import DropdownConfig = api.ui.selector.dropdown.DropdownConfig;
     import Option = api.ui.selector.Option;
     import InputAlignment = api.ui.InputAlignment;
+    import TextInput = api.ui.text.TextInput;
     import i18n = api.util.i18n;
 
     export class LinkModalDialog extends ModalDialog {
@@ -29,7 +30,15 @@ module api.util.htmlarea.dialog {
         private static subjectPrefix: string = '?subject=';
 
         constructor(config: HtmlAreaAnchor, content: api.content.ContentSummary) {
-            super(<HtmlAreaModalDialogConfig>{editor: config.editor, title: i18n('dialog.link.title'), cls: 'link-modal-dialog'});
+            super(<HtmlAreaModalDialogConfig>{
+                editor: config.editor,
+                title: i18n('dialog.link.title'),
+                cls: 'link-modal-dialog',
+                confirmation: {
+                    yesCallback: () => this.getSubmitAction().execute(),
+                    noCallback: () => this.close(),
+                }
+            });
 
             this.link = config.element;
             this.linkText = config.text;
@@ -469,6 +478,11 @@ module api.util.htmlarea.dialog {
             });
 
             return formItem;
+        }
+
+        isDirty(): boolean {
+            return (<TextInput>this.textFormItem.getInput()).isDirty() || (<TextInput>this.toolTipFormItem.getInput()).isDirty() ||
+                   AppHelper.isDirty(this.dockedPanel);
         }
     }
 

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/MacroModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/MacroModalDialog.ts
@@ -19,7 +19,15 @@ module api.util.htmlarea.dialog {
         private callback: Function;
 
         constructor(config: HtmlAreaMacro, content: api.content.ContentSummary, applicationKeys: ApplicationKey[]) {
-            super(<HtmlAreaModalDialogConfig>{editor: config.editor, title: i18n('dialog.macro.title'), cls: 'macro-modal-dialog'});
+            super(<HtmlAreaModalDialogConfig>{
+                editor: config.editor,
+                title: i18n('dialog.macro.title'),
+                cls: 'macro-modal-dialog',
+                confirmation: {
+                    yesCallback: () => this.getSubmitAction().execute(),
+                    noCallback: () => this.close(),
+                }
+            });
 
             this.callback = config.callback;
 
@@ -131,6 +139,10 @@ module api.util.htmlarea.dialog {
             let configPanelValid = this.macroDockedPanel.validateMacroForm();
 
             return mainFormValid && configPanelValid;
+        }
+
+        isDirty(): boolean {
+            return this.macroSelector.isDirty();
         }
     }
 }

--- a/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ModalDialog.ts
+++ b/modules/admin/admin-ui/src/main/resources/web/admin/common/js/util/htmlarea/dialog/ModalDialog.ts
@@ -4,6 +4,7 @@ module api.util.htmlarea.dialog {
     import Fieldset = api.ui.form.Fieldset;
     import FormItem = api.ui.form.FormItem;
     import FormItemBuilder = api.ui.form.FormItemBuilder;
+    import ConfirmationConfig = api.ui.dialog.ConfirmationConfig;
 
     export class ModalDialogFormItemBuilder {
 
@@ -54,6 +55,8 @@ module api.util.htmlarea.dialog {
         title: string;
 
         cls?: string;
+
+        confirmation?: ConfirmationConfig;
     }
 
     export class ModalDialog extends api.ui.dialog.ModalDialog {
@@ -68,7 +71,7 @@ module api.util.htmlarea.dialog {
 
         constructor(config: HtmlAreaModalDialogConfig) {
 
-            super(<api.ui.dialog.ModalDialogConfig>{title: config.title});
+            super(<api.ui.dialog.ModalDialogConfig>{title: config.title, confirmation: config.confirmation});
 
             this.editor = config.editor;
 
@@ -81,6 +84,10 @@ module api.util.htmlarea.dialog {
 
         setSubmitAction(action: api.ui.Action) {
             this.submitAction = action;
+        }
+
+        getSubmitAction(): api.ui.Action {
+            return this.submitAction;
         }
 
         protected getEditor(): HtmlAreaEditor {


### PR DESCRIPTION
…s #5497

-Added confirmation dialog for html area dialogs except CharMap dialog and SearchAndReplace dialog (not needed there)
-Fixed issue with ImageModalDialog: error when trying to reopen dialog for previously added image
-ImageModalDialog may need more complicated version of isDirty():  alignment, cropping, keepsize not taken into account