### PR TITLE
UserWizard - trim spaces in a password field #5894

### DIFF
--- a/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/ChangePasswordHandler.java
+++ b/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/ChangePasswordHandler.java
@@ -20,7 +20,7 @@ public class ChangePasswordHandler
     {
         final PrincipalKey principalKey = PrincipalKey.from( userKey );
 
-        this.securityService.get().setPassword( principalKey, password );
+        this.securityService.get().setPassword( principalKey, normalize( password ) );
     }
 
     @Override
@@ -37,5 +37,10 @@ public class ChangePasswordHandler
     public void setPassword( final String password )
     {
         this.password = password;
+    }
+
+    private String normalize( final String value )
+    {
+        return value.replaceAll( "\\s", "" );
     }
 }

--- a/modules/lib/lib-auth/src/test/java/com/enonic/xp/lib/auth/ChangePasswordHandlerTest.java
+++ b/modules/lib/lib-auth/src/test/java/com/enonic/xp/lib/auth/ChangePasswordHandlerTest.java
@@ -46,10 +46,11 @@ public class ChangePasswordHandlerTest
     }
 
     @Test
-    public void testFunction()
+    public void testChangePassword()
     {
         runFunction( "/site/test/changePassword-test.js", "changePassword" );
 
-        Mockito.verify( this.securityService ).setPassword( eq( PrincipalKey.from( "user:myUserStore:userId" ) ), eq( "test-password" ) );
+        Mockito.verify( this.securityService ).setPassword( eq( PrincipalKey.from( "user:myUserStore:userId" ) ),
+                                                            eq( "test-password-without-spaces" ) );
     }
 }

--- a/modules/lib/lib-auth/src/test/resources/site/test/changePassword-test.js
+++ b/modules/lib/lib-auth/src/test/resources/site/test/changePassword-test.js
@@ -3,6 +3,6 @@ var auth = require('/lib/xp/auth.js');
 exports.changePassword = function () {
     auth.changePassword({
         userKey: "user:myUserStore:userId",
-        password: "test-password"
+        password: " test-password-   without- spaces  "
     });
 };


### PR DESCRIPTION
Added whitespaces removing from passwords in case client-side validation will fail.