### PR TITLE
Error in console and 'Notification warning' when select a page-contro…

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResource.java
@@ -123,6 +123,7 @@ import com.enonic.xp.content.ContentDependencies;
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentIds;
 import com.enonic.xp.content.ContentListMetaData;
+import com.enonic.xp.content.ContentName;
 import com.enonic.xp.content.ContentNotFoundException;
 import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.content.ContentPaths;
@@ -400,7 +401,7 @@ public final class ContentResource
         try
         {
             // in case content with same name and path was created in between content updated and renamed
-            final RenameContentParams renameParams = json.getRenameContentParams();
+            final RenameContentParams renameParams = makeRenameParams( json.getRenameContentParams() );
             final Content renamedContent = contentService.rename( renameParams );
             return new ContentJson( renamedContent, contentIconUrlResolver, principalsResolver );
         }
@@ -411,6 +412,16 @@ public final class ContentResource
                                                 "Content could not be renamed to [%s]. A content with that name already exists",
                                                 json.getRenameContentParams().getNewName().toString() );
         }
+    }
+
+    private RenameContentParams makeRenameParams( final RenameContentParams renameParams )
+    {
+        if ( renameParams.getNewName().isUnnamed() && !renameParams.getNewName().hasUniqueness() )
+        {
+            return RenameContentParams.create().newName( ContentName.uniqueUnnamed() ).contentId( renameParams.getContentId() ).build();
+        }
+
+        return renameParams;
     }
 
     @POST

--- a/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResourceTest.java
+++ b/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/content/ContentResourceTest.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import javax.ws.rs.core.MediaType;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
@@ -96,6 +97,7 @@ import static com.enonic.xp.security.acl.Permission.DELETE;
 import static com.enonic.xp.security.acl.Permission.MODIFY;
 import static com.enonic.xp.security.acl.Permission.READ;
 import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
@@ -552,6 +554,45 @@ public class ContentResourceTest
 
         assertJson( "update_content_success.json", jsonString );
     }
+
+    @Test
+    public void update_content_renamed_to_unnamed()
+        throws Exception
+    {
+        Content content = createContent( "content-id", "content-name", "myapplication:content-type" );
+        Mockito.when( contentService.update( Mockito.isA( UpdateContentParams.class ) ) ).thenReturn( content );
+        Mockito.when( contentService.getById( Mockito.any() ) ).thenReturn( content );
+        Mockito.when( contentService.rename( Mockito.any() ) ).thenReturn( content );
+        Mockito.when( contentService.getByPath( Mockito.any() ) ).thenThrow( ContentNotFoundException.class );
+        Mockito.when( contentService.getPermissionsById( content.getId() ) ).thenReturn( AccessControlList.empty() );
+        String jsonString = request().path( "content/update" ).
+            entity( readFromFile( "update_content_renamed_to_unnamed.json" ), MediaType.APPLICATION_JSON_TYPE ).
+            post().getAsString();
+        ArgumentCaptor<RenameContentParams> argumentCaptor = ArgumentCaptor.forClass( RenameContentParams.class );
+
+        Mockito.verify( contentService, Mockito.times( 1 ) ).rename( argumentCaptor.capture() );
+        assertTrue( argumentCaptor.getValue().getNewName().hasUniqueness() );
+    }
+
+    @Test
+    public void update_content_renamed()
+        throws Exception
+    {
+        Content content = createContent( "content-id", "content-name", "myapplication:content-type" );
+        Mockito.when( contentService.update( Mockito.isA( UpdateContentParams.class ) ) ).thenReturn( content );
+        Mockito.when( contentService.getById( Mockito.any() ) ).thenReturn( content );
+        Mockito.when( contentService.rename( Mockito.any() ) ).thenReturn( content );
+        Mockito.when( contentService.getByPath( Mockito.any() ) ).thenThrow( ContentNotFoundException.class );
+        Mockito.when( contentService.getPermissionsById( content.getId() ) ).thenReturn( AccessControlList.empty() );
+        String jsonString = request().path( "content/update" ).
+            entity( readFromFile( "update_content_renamed.json" ), MediaType.APPLICATION_JSON_TYPE ).
+            post().getAsString();
+        ArgumentCaptor<RenameContentParams> argumentCaptor = ArgumentCaptor.forClass( RenameContentParams.class );
+
+        Mockito.verify( contentService, Mockito.times( 1 ) ).rename( argumentCaptor.capture() );
+        assertTrue( argumentCaptor.getValue().getNewName().toString().equals( "new-name" ) );
+    }
+
 
     @Test
     public void update_content_success_publish_dates_are_updated()

--- a/modules/admin/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/update_content_renamed.json
+++ b/modules/admin/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/update_content_renamed.json
@@ -1,0 +1,7 @@
+{
+  "contentId": "content-id",
+  "contentName": "new-name",
+  "data": [],
+  "meta": [],
+  "displayName": "Content One"
+}

--- a/modules/admin/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/update_content_renamed_to_unnamed.json
+++ b/modules/admin/admin-impl/src/test/resources/com/enonic/xp/admin/impl/rest/resource/content/update_content_renamed_to_unnamed.json
@@ -1,0 +1,7 @@
+{
+  "contentId": "content-id",
+  "contentName": "__unnamed__",
+  "data": [],
+  "meta": [],
+  "displayName": "Content One"
+}


### PR DESCRIPTION
…ller in unnamed template #6334

-Issue is more common: when trying to update unnamed content it's name, consisting of '__unnamed__' + <unique_identifier>, has it's  <unique_identifier> part lost so name after update is just '__unnamed__'. Error is thrown when trying to save 2nd '__unnamed__' content under same path.
Solved by generating <unique_identifier> part for unnamed content's name