### PR TITLE
Edge specific bug. Fragment wizard- toolbar is not displayed in text …

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/rendering/PageRenderer.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/rendering/PageRenderer.java
@@ -64,7 +64,7 @@ public final class PageRenderer
 
     private PortalResponse renderDefaultFragmentPage( final PortalRequest portalRequest, final Content content )
     {
-        String html = "<html>" +
+        String html = "<!DOCTYPE html>" + "<html>" +
             "<head>" +
             "<meta charset=\"utf-8\"/><title>" + content.getDisplayName() + "</title>" +
             "</head>";

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/rendering/PageRendererTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/rendering/PageRendererTest.java
@@ -95,7 +95,7 @@ public class PageRendererTest
 
         // verify
         final String response =
-            "<html><head><meta charset=\"utf-8\"/><title>My Content</title></head><body data-portal-component-type=\"page\"><!--#COMPONENT fragment--></body></html>";
+            "<!DOCTYPE html><html><head><meta charset=\"utf-8\"/><title>My Content</title></head><body data-portal-component-type=\"page\"><!--#COMPONENT fragment--></body></html>";
         assertEquals( response, portalResponse.getAsString() );
     }
 


### PR DESCRIPTION
…component (CKE) #6341

-When rendering fragment <!DOCTYPE html> was not added to resulting html, thus IE enters Quirks mode -> cke fails