### PR TITLE
Export - Content with trailing space in attachment name #6338

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/util/BinaryReference.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/util/BinaryReference.java
@@ -1,5 +1,7 @@
 package com.enonic.xp.util;
 
+import org.apache.commons.lang.StringUtils;
+
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -11,7 +13,7 @@ public class BinaryReference
 
     private BinaryReference( final String value )
     {
-        this.value = value;
+        this.value = sanitizeValue( value );
     }
 
     public static BinaryReference from( final String value )
@@ -24,6 +26,11 @@ public class BinaryReference
     public String toString()
     {
         return this.value;
+    }
+
+    private String sanitizeValue( final String value )
+    {
+        return StringUtils.stripToEmpty( value ).replaceAll( "[\\\\/:\"*?<>|]+", "" );
     }
 
     @Override


### PR DESCRIPTION
It turns out that trailing space was created through JS api, so I sanitized the binary reference for any other invalid chars