### PR TITLE
SessionData cannot be serialized (#6331)

### DIFF
--- a/modules/core/core-ignite/src/main/java/com/enonic/xp/ignite/impl/config/ConfigurationFactory.java
+++ b/modules/core/core-ignite/src/main/java/com/enonic/xp/ignite/impl/config/ConfigurationFactory.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.apache.ignite.configuration.AddressResolver;
 import org.apache.ignite.configuration.BasicAddressResolver;
 import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.marshaller.optimized.OptimizedMarshaller;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +45,7 @@ public class ConfigurationFactory
         config.setConsistentId( clusterConfig.name().toString() );
         config.setIgniteHome( resolveIgniteHome() );
         config.setAddressResolver( getAddressResolver() );
+        config.setMarshaller( new OptimizedMarshaller().setRequireSerializable( true ) );
 
         config.setDataStorageConfiguration( DataStorageConfigFactory.create( this.igniteSettings ) );
 

--- a/modules/core/core-ignite/src/main/java/com/enonic/xp/ignite/impl/config/ConfigurationFactory.java
+++ b/modules/core/core-ignite/src/main/java/com/enonic/xp/ignite/impl/config/ConfigurationFactory.java
@@ -45,7 +45,7 @@ public class ConfigurationFactory
         config.setConsistentId( clusterConfig.name().toString() );
         config.setIgniteHome( resolveIgniteHome() );
         config.setAddressResolver( getAddressResolver() );
-        config.setMarshaller( new OptimizedMarshaller().setRequireSerializable( true ) );
+        config.setMarshaller( new OptimizedMarshaller( true ) );
 
         config.setDataStorageConfiguration( DataStorageConfigFactory.create( this.igniteSettings ) );
 


### PR DESCRIPTION
This change removes the warning, by forcing to always use OptimizedMarshaller.

According to the javadocs there are some consequences: 

> Some Ignite features will not work if non-null marshaller is set (IgniteCache.withKeepBinary(), .NET, CPP, ODBC)

I think we do not currently use any of those features.