### PR TITLE
Handle case of '/content' node and call to controllers with content path '/' (#6506)

### DIFF
--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentAbstractHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentAbstractHandler.java
@@ -22,7 +22,7 @@ public abstract class GetCurrentAbstractHandler
         if ( content == null )
         {
             final ContentPath contentPath = this.request.getContentPath();
-            if ( contentPath != null )
+            if ( contentPath != null && !ContentPath.ROOT.equals( contentPath ) )
             {
                 try
                 {

--- a/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/current/GetCurrentContentScriptTest.java
+++ b/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/current/GetCurrentContentScriptTest.java
@@ -31,6 +31,7 @@ public class GetCurrentContentScriptTest
     {
         final Content content = TestDataFixtures.newContent();
         this.portalRequest.setContent( null );
+        this.portalRequest.setContentPath( content.getPath() );
         Mockito.when( this.contentService.getByPath( Mockito.any() ) ).thenReturn( content );
         runFunction( "/site/test/getCurrentContent-test.js", "currentContent" );
     }

--- a/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/current/GetCurrentSiteConfigScriptTest.java
+++ b/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/current/GetCurrentSiteConfigScriptTest.java
@@ -33,6 +33,7 @@ public class GetCurrentSiteConfigScriptTest
         final Content content = TestDataFixtures.newContent();
         final Site site = TestDataFixtures.newSite();
         this.portalRequest.setContent( null );
+        this.portalRequest.setContentPath( content.getPath() );
         this.portalRequest.setSite( null );
         Mockito.when( this.contentService.getByPath( Mockito.any() ) ).thenReturn( content );
         Mockito.when( this.contentService.getNearestSite( Mockito.any() ) ).thenReturn( site );

--- a/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/current/GetCurrentSiteScriptTest.java
+++ b/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/current/GetCurrentSiteScriptTest.java
@@ -33,6 +33,7 @@ public class GetCurrentSiteScriptTest
         final Content content = TestDataFixtures.newContent();
         final Site site = TestDataFixtures.newSite();
         this.portalRequest.setContent( null );
+        this.portalRequest.setContentPath( content.getPath() );
         this.portalRequest.setSite( null );
         Mockito.when( this.contentService.getByPath( Mockito.any() ) ).thenReturn( content );
         Mockito.when( this.contentService.getNearestSite( Mockito.any() ) ).thenReturn( site );

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/handler/ControllerHandlerWorker.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/handler/ControllerHandlerWorker.java
@@ -61,6 +61,10 @@ public abstract class ControllerHandlerWorker
 
     private Content getContentByPath( final ContentPath contentPath )
     {
+        if ( ContentPath.ROOT.equals( contentPath ) )
+        {
+            return null;
+        }
         try
         {
             return this.contentService.getByPath( contentPath );
@@ -103,7 +107,7 @@ public abstract class ControllerHandlerWorker
     {
         final ContentId contentId = ContentId.from( contentSelector.substring( 1 ) );
         final ContentPath contentPath = ContentPath.from( contentSelector ).asAbsolute();
-        return this.contentService.contentExists( contentId ) || this.contentService.contentExists( contentPath );
+        return this.contentService.contentExists( contentId ) || (!ContentPath.ROOT.equals( contentPath ) && this.contentService.contentExists( contentPath ));
     }
 
     public final void setContentService( final ContentService contentService )


### PR DESCRIPTION
As you see I only fixed for the current content on controllers for now.
I will make an epic task if we judge necessary to fix it at content service level (as it has many impacts: content studio, toolbox CLI interface, ...)