### PR TITLE
Error when try to click on 'Save as Template' menu item and '_templat…

### DIFF
--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateContentCommand.java
@@ -196,14 +196,14 @@ final class CreateContentCommand
             if ( !parent.getType().isTemplateFolder() )
             {
                 final ContentPath path = ContentPath.from( params.getParent(), params.getName().toString() );
-                throw new IllegalArgumentException(
+                throw new RuntimeException(
                     "A page template can only be created below a content of type 'template-folder'. Path: " + path );
             }
         }
         catch ( ContentNotFoundException e )
         {
             final ContentPath path = ContentPath.from( params.getParent(), params.getName().toString() );
-            throw new IllegalArgumentException(
+            throw new RuntimeException(
                 "Parent not found; A page template can only be created below a content of type 'template-folder'. Path: " + path, e );
         }
     }

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/CreateContentCommandTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/CreateContentCommandTest.java
@@ -385,7 +385,7 @@ public class CreateContentCommandTest
             command.execute();
             Assert.fail( "Expected exception" );
         }
-        catch ( IllegalArgumentException e )
+        catch ( RuntimeException e )
         {
             assertEquals( "A page template can only be created below a content of type 'template-folder'. Path: /_templates/mytemplate",
                           e.getMessage() );


### PR DESCRIPTION
…es' folder does not exist #6512

-Making template errors to be returned as 5xx errors that will be translated to Errors on ui, rather than 4xx Errors that are translated to Warnings on ui