### PR TITLE
OSGi plugin fails with Java source 9 or higher (#6586)

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.dm.gradle:gradle-bundle-plugin:0.6.3'
+    compile 'org.dm.gradle:gradle-bundle-plugin:0.10.0'
     compile 'com.moowork.gradle:gradle-node-plugin:1.0.1'
     compile 'org.eclipse.jgit:org.eclipse.jgit:3.7.0.201502260915-r'
     compile 'com.netflix.nebula:gradle-extra-configurations-plugin:2.2.2'

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -45,7 +45,7 @@ task sourcesJar( type: Jar ) {
     classifier = 'sources'
 }
 
-sourceCompatibility = '1.8'
+sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = sourceCompatibility
 
 test {


### PR DESCRIPTION
Do not merge in master yet!
Fixed partly, but there is another issue with Gradle.

It looks exactly like this issue, which has been fixed in the Gradle 5 branch.
https://github.com/gradle/gradle/issues/7059

Here is an issue requesting it to be fixed for Gradle 4.10.3
https://github.com/gradle/gradle/issues/7500