### PR TITLE
Roles and Groups are incorrectly sorted on the UserItemStatisticsPanel #7021

### DIFF
--- a/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/SecurityServiceImpl.java
+++ b/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/SecurityServiceImpl.java
@@ -296,15 +296,15 @@ public final class SecurityServiceImpl
 
     private PrincipalKeys resolveMemberships( final PrincipalKey userKey )
     {
-        final Set<PrincipalKey> resolvedMemberships = Sets.newHashSet();
+        final Set<PrincipalKey> resolvedMemberships = Sets.newLinkedHashSet();
         final PrincipalKeys directMemberships = queryDirectMemberships( userKey );
         resolvedMemberships.addAll( directMemberships.getSet() );
 
-        final Set<PrincipalKey> queriedMemberships = Sets.newHashSet();
+        final Set<PrincipalKey> queriedMemberships = Sets.newLinkedHashSet();
 
         do
         {
-            final Set<PrincipalKey> newMemberships = Sets.newHashSet();
+            final Set<PrincipalKey> newMemberships = Sets.newLinkedHashSet();
             resolvedMemberships.stream().filter( principal -> !queriedMemberships.contains( principal ) ).forEach( principal -> {
                 final PrincipalKeys indirectMemberships = queryDirectMemberships( principal );
                 newMemberships.addAll( indirectMemberships.getSet() );


### PR DESCRIPTION
* Replaced `HashSet` with the `LinkedHashSet` to prevent the change of the keys order.