### PR TITLE
Check if node exists when checking if content has unpublished children

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/task/PublishRunnableTaskResult.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/task/PublishRunnableTaskResult.java
@@ -8,12 +8,10 @@ import com.google.common.collect.Lists;
 import com.enonic.xp.content.ContentIds;
 import com.enonic.xp.content.ContentPath;
 
-
 public class PublishRunnableTaskResult
     extends RunnableTaskResult
 {
     private final List<ContentPath> deleted;
-
 
     private PublishRunnableTaskResult( Builder builder )
     {

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/task/UnpublishRunnableTask.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/task/UnpublishRunnableTask.java
@@ -78,6 +78,7 @@ public class UnpublishRunnableTask
                 build() );
 
             final ContentIds unpublishedContents = result.getUnpublishedContents();
+            final ContentIds deleted = result.getDeletedContents();
 
             if ( unpublishedContents.getSize() == 1 )
             {
@@ -86,6 +87,14 @@ public class UnpublishRunnableTask
             else
             {
                 resultBuilder.succeeded( result.getUnpublishedContents() );
+            }
+            if ( deleted.getSize() == 1 )
+            {
+                resultBuilder.deleted( result.getContentPath() );
+            }
+            else
+            {
+                resultBuilder.deleted( deleted );
             }
         }
         catch ( Exception e )

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/task/UnpublishRunnableTaskResult.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/task/UnpublishRunnableTaskResult.java
@@ -1,12 +1,28 @@
 package com.enonic.xp.admin.impl.rest.resource.content.task;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
+
+import com.enonic.xp.content.ContentIds;
+import com.enonic.xp.content.ContentPath;
+
 public class UnpublishRunnableTaskResult
     extends RunnableTaskResult
 {
+    private final List<ContentPath> deleted;
 
     private UnpublishRunnableTaskResult( Builder builder )
     {
         super( builder );
+        this.deleted = builder.deleted;
+    }
+
+
+    public List<ContentPath> getDeleted()
+    {
+        return deleted;
     }
 
     @Override
@@ -23,9 +39,23 @@ public class UnpublishRunnableTaskResult
     public static class Builder
         extends RunnableTaskResult.Builder<Builder>
     {
+        private List<ContentPath> deleted = Lists.newArrayList();
+
         private Builder()
         {
             super();
+        }
+
+        public UnpublishRunnableTaskResult.Builder deleted( ContentPath item )
+        {
+            this.deleted.add( item );
+            return this;
+        }
+
+        public UnpublishRunnableTaskResult.Builder deleted( ContentIds items )
+        {
+            this.deleted.addAll( items.stream().map( i -> ContentPath.from( i.toString() ) ).collect( Collectors.toList() ) );
+            return this;
         }
 
         public UnpublishRunnableTaskResult build()

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/task/UnpublishTaskMessageGenerator.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/task/UnpublishTaskMessageGenerator.java
@@ -1,5 +1,9 @@
 package com.enonic.xp.admin.impl.rest.resource.content.task;
 
+import java.util.List;
+
+import com.enonic.xp.content.ContentPath;
+
 class UnpublishTaskMessageGenerator
     extends TaskMessageGenerator<UnpublishRunnableTaskResult>
 {
@@ -21,12 +25,27 @@ class UnpublishTaskMessageGenerator
 
     void appendMessageForSingleSuccess( final StringBuilder builder, final UnpublishRunnableTaskResult result )
     {
-        builder.append( String.format( "Item \"%s\" is unpublished.", result.getSucceeded().get( 0 ).getName() ) );
+        final List<ContentPath> deleted = result.getDeleted();
+        final List<ContentPath> unpublished = result.getSucceeded();
+        if ( deleted != null && deleted.size() == 1 )
+        {
+            builder.append( String.format( "Item \"%s\" is deleted.", deleted.get( 0 ).getName() ) );
+        }
+        else if ( unpublished != null && unpublished.size() == 1 )
+        {
+            builder.append( String.format( "Item \"%s\" is unpublished.", unpublished.get( 0 ).getName() ) );
+        }
     }
 
     void appendMessageForMultipleSuccess( final StringBuilder builder, final UnpublishRunnableTaskResult result )
     {
+        final List<ContentPath> deleted = result.getDeleted();
         builder.append( String.format( "%s items are unpublished", result.getSuccessCount() ) );
+        if ( deleted.size() > 0 )
+        {
+            builder.append( String.format( " ( %s deleted )", getNameOrSize( deleted ) ) );
+        }
+        builder.append( "." );
     }
 
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/UnpublishContentsResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/UnpublishContentsResult.java
@@ -10,11 +10,14 @@ public class UnpublishContentsResult
 {
     private final ContentIds unpublishedContents;
 
+    private final ContentIds deletedContents;
+
     private final ContentPath contentPath;
 
     private UnpublishContentsResult( Builder builder )
     {
         this.unpublishedContents = ContentIds.from( builder.unpublishedContents );
+        this.deletedContents = ContentIds.from( builder.deletedContents );
         this.contentPath = builder.contentPath;
     }
 
@@ -28,6 +31,11 @@ public class UnpublishContentsResult
         return unpublishedContents;
     }
 
+    public ContentIds getDeletedContents()
+    {
+        return deletedContents;
+    }
+
     public ContentPath getContentPath()
     {
         return contentPath;
@@ -37,19 +45,35 @@ public class UnpublishContentsResult
     {
         private List<ContentId> unpublishedContents = Lists.newArrayList();
 
+        private List<ContentId> deletedContents = Lists.newArrayList();
+
         private ContentPath contentPath;
 
         private Builder()
         {
         }
 
-        public Builder addUnpublished(final ContentId contentId) {
+        public Builder addUnpublished( final ContentId contentId )
+        {
             this.unpublishedContents.add( contentId );
             return this;
         }
 
-        public Builder addUnpublished(final ContentIds contentIds) {
+        public Builder addUnpublished( final ContentIds contentIds )
+        {
             this.unpublishedContents.addAll( contentIds.getSet() );
+            return this;
+        }
+
+        public Builder addDeleted( final ContentId contentId )
+        {
+            this.deletedContents.add( contentId );
+            return this;
+        }
+
+        public Builder addDeleted( final ContentIds contentIds )
+        {
+            this.deletedContents.addAll( contentIds.getSet() );
             return this;
         }
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/HasUnpublishedChildrenCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/HasUnpublishedChildrenCommand.java
@@ -28,6 +28,11 @@ public class HasUnpublishedChildrenCommand
     {
         final Node parentNode = doGetById( parent );
 
+        if ( parentNode == null )
+        {
+            return false;
+        }
+
         final SearchResult result = nodeSearchService.query( NodeVersionDiffQuery.create().
             source( ContextAccessor.current().getBranch() ).
             target( target ).

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/HasUnpublishedChildrenCommandTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/node/HasUnpublishedChildrenCommandTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.enonic.xp.node.Node;
+import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodePath;
 
 import static junit.framework.TestCase.assertTrue;
@@ -28,12 +29,14 @@ public class HasUnpublishedChildrenCommandTest
         final Node node1 = createNode( NodePath.ROOT, "node1" );
         final Node node1_1 = createNode( node1.path(), "node1_1" );
         final Node node1_1_1 = createNode( node1_1.path(), "node1_1_1" );
+        final Node nodeWithoutParent = Node.create( NodeId.from( "node0" ) ).build();
 
         refresh();
 
         assertTrue( resolve( node1 ) );
         assertTrue( resolve( node1_1 ) );
         assertFalse( resolve( node1_1_1 ) );
+        assertFalse( resolve( nodeWithoutParent ) );
     }
 
     @Test


### PR DESCRIPTION
* Updated `HasUnpublishedChildrenCommand` to return `false`, if the parent node is absent.
* Updated unpublish command message when content is deleted.