### PR TITLE
Fix jsdoc for "attachmentUrl" in portal lib

### DIFF
--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.js
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.js
@@ -76,7 +76,7 @@ exports.componentUrl = function (params) {
  * @param {string} [params.id] Id to the content holding the attachment.
  * @param {string} [params.path] Path to the content holding the attachment.
  * @param {string} [params.name] Name to the attachment.
- * @param {string} [params.type=source] Label of the attachment.
+ * @param {string} [params.label=source] Label of the attachment.
  * @param {boolean} [params.download=false] Set to true if the disposition header should be set to attachment.
  * @param {string} [params.type=server] URL type. Either `server` (server-relative URL) or `absolute`.
  * @param {object} [params.params] Custom parameters to append to the url.


### PR DESCRIPTION
The key `params.type` was used on both line 79 and 81. It appears that this is a typo, and the correct key on line 79 should be `param.label`.