### PR TITLE
WebDispatcherImpl implementation issues #7523

### DIFF
--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/handler/TestWebHandler.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/handler/TestWebHandler.java
@@ -5,7 +5,7 @@ import com.enonic.xp.web.WebResponse;
 import com.enonic.xp.web.handler.WebHandler;
 import com.enonic.xp.web.handler.WebHandlerChain;
 
-public final class TestWebHandler
+public class TestWebHandler
     implements WebHandler
 {
     protected WebResponse response;
@@ -13,10 +13,22 @@ public final class TestWebHandler
     protected RequestVerifier verifier = req -> {
     };
 
+    private final int order;
+
+    public TestWebHandler()
+    {
+        this( 0 );
+    }
+
+    public TestWebHandler( final int order )
+    {
+        this.order = order;
+    }
+
     @Override
     public int getOrder()
     {
-        return 0;
+        return order;
     }
 
     @Override

--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/handler/WebDispatcherImplTest.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/handler/WebDispatcherImplTest.java
@@ -1,0 +1,48 @@
+package com.enonic.xp.web.impl.handler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.junit.jupiter.api.Test;
+
+import com.enonic.xp.web.handler.WebHandler;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class WebDispatcherImplTest
+{
+    @Test
+    void orderedProperly()
+    {
+        final WebDispatcherImpl dispatcher = new WebDispatcherImpl();
+        TestWebHandler webHandlerMin = new TestWebHandler( WebHandler.MIN_ORDER );
+        dispatcher.add( webHandlerMin );
+        TestWebHandler webHandlerMax = new TestWebHandler( WebHandler.MAX_ORDER );
+        dispatcher.add( webHandlerMax );
+        TestWebHandler webHandler0 = new TestWebHandler( 0 );
+        dispatcher.add( webHandler0 );
+        TestWebHandler webHandler1 = new TestWebHandler( 1 );
+        dispatcher.add( webHandler1 );
+
+        List<WebHandler> list = StreamSupport.stream( dispatcher.spliterator(), false ).collect( Collectors.toList() );
+        assertSame( webHandlerMin, list.get( 0 ) );
+        assertSame( webHandler0, list.get( 1 ) );
+        assertSame( webHandler1, list.get( 2 ) );
+        assertSame( webHandlerMax, list.get( 3 ) );
+    }
+
+    @Test
+    void supportsEqualOderElements()
+    {
+        final WebDispatcherImpl dispatcher = new WebDispatcherImpl();
+        TestWebHandler webHandler0 = new TestWebHandler( 0 );
+        dispatcher.add( webHandler0 );
+        TestWebHandler webHandlerAlso0 = new TestWebHandler( 0 );
+        dispatcher.add( webHandlerAlso0 );
+
+        List<WebHandler> list = StreamSupport.stream( dispatcher.spliterator(), false ).collect( Collectors.toList() );
+        assertSame( webHandler0, list.get( 0 ) );
+        assertSame( webHandlerAlso0, list.get( 1 ) );
+    }
+}


### PR DESCRIPTION
- keep elements with same order. So we need a list, not a set with comparator (initially I tried SkipListSet and it didn't work well)
- avoid synchronized methods. AtomicReference with CAS works great for occasionally happening add/remove, so CopyOnWrite is not needed.
- avoid copying on every dispatch (this is why ImmutableList instead of copyOnwSrite)
- Don't expose mutable iterator. ImmutableList helps here as well.
- fix comparator so now it correctly sorts big integers like MAX_INT and MIN_INT
- also funny the implementation had race condition: add method for a short while was introducing handler at the end of chain regardless of its real order and this change was visible in dispatch. So Order was not always respected.