### PR TITLE
Remove usage of UnsupportedEncodingException where possible #7533

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentMediaResource.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ContentMediaResource.java
@@ -1,7 +1,6 @@
 package com.enonic.xp.admin.impl.rest.resource.content;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
@@ -142,18 +141,10 @@ public final class ContentMediaResource
             throw JaxRsExceptions.notFound( String.format( "Content [%s] was not found", contentId ) );
         }
 
-        try
-        {
-            final String decodedIdentifier =
-                StringUtils.isNotBlank( identifier ) ? URLDecoder.decode( identifier, StandardCharsets.UTF_8.toString() ) : identifier;
+        final String decodedIdentifier =
+            StringUtils.isNotBlank( identifier ) ? URLDecoder.decode( identifier, StandardCharsets.UTF_8 ) : identifier;
 
-            return resolveAttachment( decodedIdentifier, content );
-        }
-        catch ( UnsupportedEncodingException e )
-        {
-            return resolveAttachment( identifier, content );
-        }
-
+        return resolveAttachment( decodedIdentifier, content );
     }
 
     private Attachment resolveAttachment( final String identifier, final Content content )

--- a/modules/core/core-i18n/src/main/java/com/enonic/xp/core/impl/i18n/LocaleServiceImpl.java
+++ b/modules/core/core-i18n/src/main/java/com/enonic/xp/core/impl/i18n/LocaleServiceImpl.java
@@ -1,7 +1,7 @@
 package com.enonic.xp.core.impl.i18n;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.Reader;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -256,7 +256,7 @@ public final class LocaleServiceImpl
 
         if ( resource.exists() )
         {
-            try (InputStream in = resource.openStream())
+            try (Reader in = resource.openReader())
             {
                 properties.load( in );
             }

--- a/modules/core/core-i18n/src/main/java/com/enonic/xp/core/impl/i18n/MessageBundleImpl.java
+++ b/modules/core/core-i18n/src/main/java/com/enonic/xp/core/impl/i18n/MessageBundleImpl.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.i18n;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Map;
 import java.util.Properties;
@@ -17,10 +15,6 @@ import com.enonic.xp.i18n.MessageBundle;
 final class MessageBundleImpl
     implements MessageBundle
 {
-    private static final String UTF_8_ENCODING = "UTF-8";
-
-    private static final String LATIN_1_ENCODING = "ISO-8859-1";
-
     private final Properties properties;
 
     MessageBundleImpl( final Properties properties )
@@ -54,29 +48,7 @@ final class MessageBundleImpl
 
     private String doGetMessage( final String key )
     {
-        return handleGetObject( key ).toString();
-    }
-
-    private Object handleGetObject( String key )
-    {
-        return createUTF8EncodedPhrase( (String) this.properties.get( key ) );
-    }
-
-    private String createUTF8EncodedPhrase( String localizedPhrase )
-    {
-        if ( StringUtils.isBlank( localizedPhrase ) )
-        {
-            return "";
-        }
-
-        try
-        {
-            return new String( localizedPhrase.getBytes( LATIN_1_ENCODING ), StandardCharsets.UTF_8 );
-        }
-        catch ( final UnsupportedEncodingException e )
-        {
-            return localizedPhrase;
-        }
+        return this.properties.getProperty( key, "" );
     }
 
     @Override


### PR DESCRIPTION
Starting from Java 9 .properties support UFT8 So conversion is not needed for "broken" files. They are not broken anymore

Also both places we use UnsupportedEncodingException we can simply provide StandardEncoding