### PR TITLE
Application fails to update properly under load #7978

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/app/ApplicationListener.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/app/ApplicationListener.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.app;
 
+@Deprecated
 public interface ApplicationListener
 {
     void activated( Application app );

--- a/modules/core/core-api/src/main/java/com/enonic/xp/app/ApplicationService.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/app/ApplicationService.java
@@ -41,6 +41,7 @@ public interface ApplicationService
     @Deprecated
     void invalidate( ApplicationKey key );
 
+    @Deprecated
     void invalidate( ApplicationKey key, ApplicationInvalidationLevel level );
 
     @Deprecated

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationListenerHub.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationListenerHub.java
@@ -5,83 +5,27 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.BundleEvent;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.util.tracker.BundleTracker;
-import org.osgi.util.tracker.BundleTrackerCustomizer;
 
 import com.enonic.xp.app.Application;
-import com.enonic.xp.app.ApplicationInvalidationLevel;
-import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.app.ApplicationListener;
-import com.enonic.xp.app.ApplicationService;
 
-@Component(immediate = true)
+@Component(service = ApplicationListenerHub.class)
 public final class ApplicationListenerHub
-    implements BundleTrackerCustomizer<Application>
 {
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
-    private ApplicationService applicationService;
-
     private final List<ApplicationListener> listeners = new CopyOnWriteArrayList<>();
 
-    private BundleTracker<Application> tracker;
-
-    @Activate
-    public void activate( final BundleContext context )
-    {
-        this.tracker = new BundleTracker<>( context, Bundle.ACTIVE, this );
-        this.tracker.open();
-    }
-
-    @Deactivate
-    public void deactivate()
-    {
-        this.tracker.close();
-    }
-
-    @Override
-    public Application addingBundle( final Bundle bundle, final BundleEvent event )
-    {
-        if ( !ApplicationHelper.isApplication( bundle ) )
-        {
-            return null;
-        }
-
-        return activated( applicationService.getInstalledApplication( ApplicationKey.from( bundle ) ) );
-    }
-
-    @Override
-    public void modifiedBundle( final Bundle bundle, final BundleEvent event, final Application object )
-    {
-        // Do nothing
-    }
-
-    @Override
-    public void removedBundle( final Bundle bundle, final BundleEvent event, final Application app )
-    {
-        if ( app != null )
-        {
-            deactivated( app );
-            applicationService.invalidate( app.getKey(), ApplicationInvalidationLevel.FULL );
-        }
-    }
-
-    private Application activated( final Application app )
+    public void activated( final Application app )
     {
         this.executor.submit( () -> notifyActivated( app ) );
-        return app;
     }
 
-    private void deactivated( final Application app )
+    public void deactivated( final Application app )
     {
         this.executor.submit( () -> notifyDeactivated( app ) );
     }
@@ -111,11 +55,5 @@ public final class ApplicationListenerHub
     public void removeListener( final ApplicationListener listener )
     {
         this.listeners.remove( listener );
-    }
-
-    @Reference
-    public void setApplicationService( final ApplicationService applicationService )
-    {
-        this.applicationService = applicationService;
     }
 }

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/config/ApplicationConfigInvalidator.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/config/ApplicationConfigInvalidator.java
@@ -14,6 +14,8 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.util.tracker.BundleTracker;
 import org.osgi.util.tracker.BundleTrackerCustomizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.core.impl.app.ApplicationConfigService;
@@ -23,6 +25,8 @@ import com.enonic.xp.core.impl.app.ApplicationHelper;
 public class ApplicationConfigInvalidator
     implements BundleTrackerCustomizer<ServiceRegistration<ManagedService>>
 {
+    private final static Logger LOG = LoggerFactory.getLogger( ApplicationConfigInvalidator.class );
+
     private ApplicationConfigService applicationConfigService;
 
     private BundleTracker<ServiceRegistration<ManagedService>> tracker;
@@ -60,6 +64,7 @@ public class ApplicationConfigInvalidator
     @Override
     public void removedBundle( final Bundle bundle, final BundleEvent event, final ServiceRegistration<ManagedService> object )
     {
+        LOG.debug( "Unregister app config reloader for bundle {}", bundle.getBundleId() );
         object.unregister();
     }
 
@@ -72,6 +77,7 @@ public class ApplicationConfigInvalidator
         final Hashtable<String, Object> props = new Hashtable<>();
         props.put( Constants.SERVICE_PID, bundle.getSymbolicName() );
 
+        LOG.debug( "Register app {} config reloader for bundle {}", key, bundle.getBundleId() );
         return context.registerService( ManagedService.class, reloader, props );
     }
 

--- a/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/ApplicationServiceImplTest.java
+++ b/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/ApplicationServiceImplTest.java
@@ -61,6 +61,7 @@ public class ApplicationServiceImplTest
         this.service.setRepoService( this.repoService );
         this.eventPublisher = mock( EventPublisher.class );
         this.service.setEventPublisher( this.eventPublisher );
+        this.service.setApplicationListenerHub( new ApplicationListenerHub() );
     }
 
     @Test

--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/executor/ScriptExecutorManager.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/executor/ScriptExecutorManager.java
@@ -1,7 +1,11 @@
 package com.enonic.xp.script.impl.executor;
 
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 
 import com.enonic.xp.app.Application;
 import com.enonic.xp.app.ApplicationKey;
@@ -41,12 +45,17 @@ public final class ScriptExecutorManager
             throw new ApplicationNotFoundException( key );
         }
 
+        final Bundle bundle = application.getBundle();
+
         final ClassLoader classLoader = application.getClassLoader();
+        final BundleContext bundleContext = Objects.requireNonNull( bundle.getBundleContext(),
+                                                                    String.format( "application bundle %s context must not be null",
+                                                                                   bundle.getBundleId() ) );
 
         final ScriptExecutorImpl executor = new ScriptExecutorImpl();
         executor.setScriptSettings( this.scriptSettings );
         executor.setClassLoader( classLoader );
-        executor.setServiceRegistry( new ServiceRegistryImpl( application.getBundle().getBundleContext() ) );
+        executor.setServiceRegistry( new ServiceRegistryImpl( bundleContext ) );
         executor.setResourceService( this.resourceService );
         executor.setApplication( application );
         executor.setRunMode( RunMode.get() );


### PR DESCRIPTION
`ApplicationListener` got deprecated as it was never used. `ApplicationListenerHub` responsible for `ApplicationListener`s notification is kept but no longer able to catch all application bundle events because it is now controlled by `ApplicationServiceImpl` which has no fully synchronous control over bundle/application binding . It was the main cause of issue: `ApplicationListenerHub` could invalidate Application instance too early (while it was still in STOPPING state), causing other threads to re-capture reference to a dying bundle.

`ApplicationService` invalidate method got deprecated. It is unreliable and can cause deadlocks.

Fallback to ConfigAdmin is kept is branch 7.2 to simplify PR readability, but will be removed in master.

`ScriptExecutorManager` now verifies `BundleContext` before creating an ScriptExecutor. Without such a check any frontend request could create an executor with `null` `BundleContext`, even if new Application Bundle was correctly captured (`applicationService.getInstalledApplication` may return Application even if bundle is just INSTALLED, but in such state bundles don't have context yet)