### PR TITLE
Unable to load class because the bundle wiring is no longer valid #7132

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/app/ApplicationListener.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/app/ApplicationListener.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.app;
 
-@Deprecated
 public interface ApplicationListener
 {
     void activated( Application app );

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationListenerHub.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationListenerHub.java
@@ -2,8 +2,6 @@ package com.enonic.xp.core.impl.app;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -16,18 +14,16 @@ import com.enonic.xp.app.ApplicationListener;
 @Component(service = ApplicationListenerHub.class)
 public final class ApplicationListenerHub
 {
-    private final ExecutorService executor = Executors.newSingleThreadExecutor();
-
     private final List<ApplicationListener> listeners = new CopyOnWriteArrayList<>();
 
     public void activated( final Application app )
     {
-        this.executor.submit( () -> notifyActivated( app ) );
+        notifyActivated( app );
     }
 
     public void deactivated( final Application app )
     {
-        this.executor.submit( () -> notifyDeactivated( app ) );
+        notifyDeactivated( app );
     }
 
     private void notifyActivated( final Application app )

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationServiceImpl.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationServiceImpl.java
@@ -403,9 +403,9 @@ public final class ApplicationServiceImpl
     {
         try
         {
-            application.getBundle().stop();
-
             applicationListenerHub.deactivated( application );
+
+            application.getBundle().stop();
 
             registry.invalidate( application.getKey(), ApplicationInvalidationLevel.FULL );
 
@@ -433,9 +433,9 @@ public final class ApplicationServiceImpl
     {
         try
         {
-            application.getBundle().uninstall();
-
             applicationListenerHub.deactivated( application );
+
+            application.getBundle().uninstall();
 
             registry.invalidate( application.getKey(), ApplicationInvalidationLevel.FULL );
 
@@ -578,10 +578,13 @@ public final class ApplicationServiceImpl
     {
         try
         {
-            final Bundle bundle = this.context.getBundle( applicationKey.getName() );
+            final Application application = this.registry.get( applicationKey );
 
-            if ( bundle != null )
+            if ( application != null )
             {
+                applicationListenerHub.deactivated( application );
+
+                final Bundle bundle = application.getBundle();
                 LOG.debug( "Uninstalling application {} bundle {}", applicationKey, bundle.getBundleId() );
                 bundle.uninstall();
                 LOG.debug( "Uninstalled application {} bundle {}", applicationKey, bundle.getBundleId() );

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImpl.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImpl.java
@@ -6,6 +6,8 @@ import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.enonic.xp.app.Application;
 import com.enonic.xp.app.ApplicationInvalidationLevel;
@@ -24,6 +26,8 @@ import com.enonic.xp.server.RunMode;
 public final class ResourceServiceImpl
     implements ResourceService, ApplicationInvalidator
 {
+    private static final Logger LOG = LoggerFactory.getLogger( ResourceServiceImpl.class );
+
     private static final ApplicationKey SYSTEM_APPLICATION_KEY = ApplicationKey.from( "com.enonic.xp.app.system" );
 
     private final ProcessingCache cache;
@@ -123,6 +127,7 @@ public final class ResourceServiceImpl
     @Override
     public void invalidate( final ApplicationKey key, final ApplicationInvalidationLevel level )
     {
+        LOG.debug( "Cleanup Resource cache for {}", key );
         this.cache.invalidate( key );
     }
 }

--- a/modules/core/core-i18n/src/main/java/com/enonic/xp/core/impl/i18n/LocaleServiceImpl.java
+++ b/modules/core/core-i18n/src/main/java/com/enonic/xp/core/impl/i18n/LocaleServiceImpl.java
@@ -15,6 +15,8 @@ import java.util.regex.Pattern;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.enonic.xp.app.ApplicationInvalidationLevel;
 import com.enonic.xp.app.ApplicationInvalidator;
@@ -35,6 +37,8 @@ import static org.apache.commons.lang.StringUtils.substringBetween;
 public final class LocaleServiceImpl
     implements LocaleService, ApplicationInvalidator
 {
+    private static final Logger LOG = LoggerFactory.getLogger( LocaleServiceImpl.class );
+
     private static final String DELIMITER = "_";
 
     private static final String KEY_SEPARATOR = "|";
@@ -117,6 +121,7 @@ public final class LocaleServiceImpl
 
     private Set<Locale> getAppLocales( final ApplicationKey applicationKey, final String... bundleNames )
     {
+        LOG.debug( "Create app locales for {}", applicationKey );
         final Set<Locale> locales = new LinkedHashSet<>();
         for ( final String bundleName : bundleNames )
         {
@@ -197,6 +202,7 @@ public final class LocaleServiceImpl
 
     private MessageBundle createMessageBundle( final ApplicationKey applicationKey, final Locale locale, final String... bundleNames )
     {
+        LOG.debug( "Create message bundle for {} {}", applicationKey, locale );
         final Properties props = new Properties();
         for ( final String bundleName : bundleNames )
         {
@@ -280,6 +286,7 @@ public final class LocaleServiceImpl
     @Override
     public void invalidate( final ApplicationKey appKey, final ApplicationInvalidationLevel level )
     {
+        LOG.debug( "Cleanup i18n caches for {}", appKey );
         final String cacheKeyPrefix = appKey.toString() + KEY_SEPARATOR;
         bundleCache.keySet().removeIf( ( k ) -> k.startsWith( cacheKeyPrefix ) );
         appLocalesCache.keySet().removeIf( ( k ) -> k.startsWith( cacheKeyPrefix ) );

--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/ScriptRuntimeFactoryDelegate.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/ScriptRuntimeFactoryDelegate.java
@@ -4,16 +4,18 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import com.enonic.xp.app.Application;
 import com.enonic.xp.app.ApplicationInvalidationLevel;
 import com.enonic.xp.app.ApplicationInvalidator;
 import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.app.ApplicationListener;
 import com.enonic.xp.script.runtime.ScriptRuntime;
 import com.enonic.xp.script.runtime.ScriptRuntimeFactory;
 import com.enonic.xp.script.runtime.ScriptSettings;
 
-@Component(immediate = true, service = {ScriptRuntimeFactory.class, ApplicationInvalidator.class})
+@Component(immediate = true, service = {ScriptRuntimeFactory.class, ApplicationInvalidator.class, ApplicationListener.class})
 public final class ScriptRuntimeFactoryDelegate
-    implements ScriptRuntimeFactory, ApplicationInvalidator
+    implements ScriptRuntimeFactory, ApplicationInvalidator, ApplicationListener
 {
     private final static String SWITCH_PROP = "xp.usePurpleJs";
 
@@ -53,6 +55,17 @@ public final class ScriptRuntimeFactoryDelegate
     public void invalidate( final ApplicationKey key, final ApplicationInvalidationLevel level )
     {
         this.provider.invalidate( key );
+    }
+
+    @Override
+    public void activated( final Application app )
+    {
+    }
+
+    @Override
+    public void deactivated( final Application app )
+    {
+        this.provider.runDisposers( app.getKey() );
     }
 
     @Reference(target = "(provider=standard)")

--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/ScriptRuntimeInternal.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/ScriptRuntimeInternal.java
@@ -1,0 +1,10 @@
+package com.enonic.xp.script.impl;
+
+import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.script.runtime.ScriptRuntime;
+
+public interface ScriptRuntimeInternal
+    extends ScriptRuntime
+{
+    void runDisposers( ApplicationKey key );
+}

--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/ScriptRuntimeProvider.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/ScriptRuntimeProvider.java
@@ -9,9 +9,11 @@ import com.enonic.xp.script.runtime.ScriptSettings;
  */
 public interface ScriptRuntimeProvider
 {
-    ScriptRuntime create( ScriptSettings settings );
+    ScriptRuntimeInternal create( ScriptSettings settings );
 
     void dispose( ScriptRuntime runtime );
 
     void invalidate( ApplicationKey key );
+
+    void runDisposers( ApplicationKey key );
 }

--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/event/ScriptEventManagerImpl.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/event/ScriptEventManagerImpl.java
@@ -4,6 +4,8 @@ import java.util.Iterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.enonic.xp.app.ApplicationInvalidationLevel;
 import com.enonic.xp.app.ApplicationInvalidator;
@@ -17,6 +19,8 @@ import com.enonic.xp.script.event.ScriptEventManager;
 public final class ScriptEventManagerImpl
     implements ScriptEventManager, ApplicationInvalidator, EventListener
 {
+    private static final Logger LOG = LoggerFactory.getLogger( ScriptEventManagerImpl.class );
+
     private final CopyOnWriteArrayList<ScriptEventListener> listeners;
 
     public ScriptEventManagerImpl()
@@ -27,6 +31,7 @@ public final class ScriptEventManagerImpl
     @Override
     public void add( final ScriptEventListener listener )
     {
+        LOG.debug( "Add Script Event Listener for {}", listener.getApplication() );
         this.listeners.add( listener );
     }
 
@@ -48,6 +53,7 @@ public final class ScriptEventManagerImpl
     {
         if ( ApplicationInvalidationLevel.FULL == level )
         {
+            LOG.debug( "Remove Script Event Listeners for {}", key );
             this.listeners.removeIf( ( listener ) -> key.equals( listener.getApplication() ) );
         }
     }

--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/purplejs/PurpleJsRuntimeProviderImpl.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/purplejs/PurpleJsRuntimeProviderImpl.java
@@ -3,6 +3,7 @@ package com.enonic.xp.script.impl.purplejs;
 import org.osgi.service.component.annotations.Component;
 
 import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.script.impl.ScriptRuntimeInternal;
 import com.enonic.xp.script.impl.ScriptRuntimeProvider;
 import com.enonic.xp.script.runtime.ScriptRuntime;
 import com.enonic.xp.script.runtime.ScriptRuntimeFactory;
@@ -13,7 +14,7 @@ public final class PurpleJsRuntimeProviderImpl
     implements ScriptRuntimeProvider, ScriptRuntimeFactory
 {
     @Override
-    public ScriptRuntime create( final ScriptSettings settings )
+    public ScriptRuntimeInternal create( final ScriptSettings settings )
     {
         throw new IllegalArgumentException( "Not implemented" );
     }
@@ -25,6 +26,11 @@ public final class PurpleJsRuntimeProviderImpl
 
     @Override
     public void invalidate( final ApplicationKey key )
+    {
+    }
+
+    @Override
+    public void runDisposers( final ApplicationKey key )
     {
     }
 }

--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/standard/ScriptRuntimeFactoryImpl.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/standard/ScriptRuntimeFactoryImpl.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Lists;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.app.ApplicationService;
 import com.enonic.xp.resource.ResourceService;
+import com.enonic.xp.script.impl.ScriptRuntimeInternal;
 import com.enonic.xp.script.impl.ScriptRuntimeProvider;
 import com.enonic.xp.script.runtime.ScriptRuntime;
 import com.enonic.xp.script.runtime.ScriptRuntimeFactory;
@@ -19,7 +20,7 @@ import com.enonic.xp.script.runtime.ScriptSettings;
 public final class ScriptRuntimeFactoryImpl
     implements ScriptRuntimeProvider, ScriptRuntimeFactory
 {
-    private final List<ScriptRuntime> list;
+    private final List<ScriptRuntimeInternal> list;
 
     private ApplicationService applicationService;
 
@@ -31,12 +32,9 @@ public final class ScriptRuntimeFactoryImpl
     }
 
     @Override
-    public ScriptRuntime create( final ScriptSettings settings )
+    public ScriptRuntimeInternal create( final ScriptSettings settings )
     {
-        final ScriptRuntimeImpl runtime = new ScriptRuntimeImpl();
-        runtime.setScriptSettings( settings );
-        runtime.setApplicationService( this.applicationService );
-        runtime.setResourceService( this.resourceService );
+        final ScriptRuntimeImpl runtime = new ScriptRuntimeImpl( applicationService, resourceService, settings );
 
         this.list.add( runtime );
         return runtime;
@@ -52,6 +50,12 @@ public final class ScriptRuntimeFactoryImpl
     public void invalidate( final ApplicationKey key )
     {
         this.list.forEach( runtime -> runtime.invalidate( key ) );
+    }
+
+    @Override
+    public void runDisposers( final ApplicationKey key )
+    {
+        this.list.forEach( runtime -> runtime.runDisposers( key ) );
     }
 
     @Reference

--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/standard/ScriptRuntimeImpl.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/standard/ScriptRuntimeImpl.java
@@ -6,20 +6,21 @@ import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceService;
 import com.enonic.xp.script.ScriptExports;
 import com.enonic.xp.script.ScriptValue;
+import com.enonic.xp.script.impl.ScriptRuntimeInternal;
 import com.enonic.xp.script.impl.executor.ScriptExecutor;
 import com.enonic.xp.script.impl.executor.ScriptExecutorManager;
 import com.enonic.xp.script.impl.util.JsObjectConverter;
-import com.enonic.xp.script.runtime.ScriptRuntime;
 import com.enonic.xp.script.runtime.ScriptSettings;
 
 final class ScriptRuntimeImpl
-    implements ScriptRuntime
+    implements ScriptRuntimeInternal
 {
     private final ScriptExecutorManager executorManager;
 
-    ScriptRuntimeImpl()
+    ScriptRuntimeImpl( final ApplicationService applicationService, final ResourceService resourceService,
+                       final ScriptSettings scriptSettings )
     {
-        this.executorManager = new ScriptExecutorManager();
+        this.executorManager = new ScriptExecutorManager( applicationService, resourceService, scriptSettings );
     }
 
     @Override
@@ -56,18 +57,9 @@ final class ScriptRuntimeImpl
         return new JsObjectConverter( executor.getJavascriptHelper() ).toJs( value );
     }
 
-    void setApplicationService( final ApplicationService applicationService )
+    @Override
+    public void runDisposers( final ApplicationKey key )
     {
-        this.executorManager.setApplicationService( applicationService );
-    }
-
-    void setResourceService( final ResourceService resourceService )
-    {
-        this.executorManager.setResourceService( resourceService );
-    }
-
-    void setScriptSettings( final ScriptSettings scriptSettings )
-    {
-        this.executorManager.setScriptSettings( scriptSettings );
+        this.executorManager.runDisposers( key );
     }
 }


### PR DESCRIPTION
`ApplicationListener` de-deprecated as it can be handy to run some tasks before application gets stopped. But now listeners executed synchronously. Moreover, `deactivated` now called before application gets deactivated (besides the name) - it used to be like this anyway before #7991

With a help of `ApplicationListener` implementation, it is now possible to run `__disposer` methods right before application is stopped.