### PR TITLE
Resolving component name fails when attached content is not found #8080

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ComponentNameResolverImpl.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/content/ComponentNameResolverImpl.java
@@ -3,6 +3,7 @@ package com.enonic.xp.admin.impl.rest.resource.content;
 import org.osgi.service.component.annotations.Reference;
 
 import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ContentNotFoundException;
 import com.enonic.xp.content.ContentService;
 import com.enonic.xp.region.Component;
 import com.enonic.xp.region.ComponentName;
@@ -70,8 +71,16 @@ public final class ComponentNameResolverImpl
     {
         if ( component.hasImage() )
         {
-            final Content content = contentService.getById( component.getImage() );
-            return ComponentName.from( content.getDisplayName() );
+            try
+            {
+                final Content content = contentService.getById( component.getImage() );
+                return ComponentName.from( content.getDisplayName() );
+            }
+            catch ( final ContentNotFoundException e )
+            {
+                return component.getName();
+            }
+
         }
         return component.getName();
     }
@@ -80,8 +89,15 @@ public final class ComponentNameResolverImpl
     {
         if ( component.getFragment() != null )
         {
-            final Content content = contentService.getById( component.getFragment() );
-            return ComponentName.from( content.getDisplayName() );
+            try
+            {
+                final Content content = contentService.getById( component.getFragment() );
+                return ComponentName.from( content.getDisplayName() );
+            }
+            catch ( final ContentNotFoundException e )
+            {
+                return component.getName();
+            }
         }
         return component.getName();
     }

--- a/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/content/ComponentNameResolverImplTest.java
+++ b/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/content/ComponentNameResolverImplTest.java
@@ -1,0 +1,125 @@
+package com.enonic.xp.admin.impl.rest.resource.content;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ContentId;
+import com.enonic.xp.content.ContentNotFoundException;
+import com.enonic.xp.content.ContentPath;
+import com.enonic.xp.content.ContentService;
+import com.enonic.xp.region.ComponentName;
+import com.enonic.xp.region.FragmentComponent;
+import com.enonic.xp.region.ImageComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ComponentNameResolverImplTest
+{
+    private ComponentNameResolverImpl componentNameResolver;
+
+    private ContentService contentService;
+
+    @BeforeEach
+    public void init()
+    {
+        componentNameResolver = new ComponentNameResolverImpl();
+        contentService = Mockito.mock( ContentService.class );
+
+        componentNameResolver.setContentService( contentService );
+    }
+
+    @Test
+    public void testResolveEmptyImageComponent()
+        throws Exception
+    {
+        final ImageComponent imageComponent = ImageComponent.create().build();
+
+        final ComponentName result = componentNameResolver.resolve( imageComponent );
+
+        assertEquals( imageComponent.getName(), result );
+    }
+
+    @Test
+    public void testResolveImageComponent()
+        throws Exception
+    {
+        final Content imageContent = createContent();
+        final ImageComponent imageComponent = ImageComponent.create().image( ContentId.from( "id" ) ).build();
+
+        Mockito.when( contentService.getById( imageComponent.getImage() ) ).thenReturn( imageContent );
+
+        final ComponentName result = componentNameResolver.resolve( imageComponent );
+
+        assertEquals( imageContent.getDisplayName(), result.toString() );
+    }
+
+    @Test
+    public void testResolveMissingImageComponent()
+        throws Exception
+    {
+        final ContentId imageComponentId = ContentId.from( "imageCompId" );
+        final ImageComponent imageComponent = ImageComponent.create().image( imageComponentId ).build();
+
+        Mockito.when( contentService.getById( imageComponent.getImage() ) ).thenThrow(
+            new ContentNotFoundException( imageComponentId, null ) );
+
+        final ComponentName result = componentNameResolver.resolve( imageComponent );
+
+        assertEquals( imageComponent.getName(), result );
+    }
+
+    @Test
+    public void testResolveEmptyFragmentComponent()
+        throws Exception
+    {
+        final FragmentComponent fragmentComponent = FragmentComponent.create().build();
+
+        final ComponentName result = componentNameResolver.resolve( fragmentComponent );
+
+        assertEquals( fragmentComponent.getName(), result );
+    }
+
+    @Test
+    public void testResolveFragmentComponent()
+        throws Exception
+    {
+        final Content fragmentContent = createContent();
+        final FragmentComponent fragmentComponent = FragmentComponent.create().fragment( ContentId.from( "id" ) ).build();
+
+        Mockito.when( contentService.getById( fragmentComponent.getFragment() ) ).thenReturn( fragmentContent );
+
+        final ComponentName result = componentNameResolver.resolve( fragmentComponent );
+
+        assertEquals( fragmentContent.getDisplayName(), result.toString() );
+    }
+
+    @Test
+    public void testResolveMissingFragmentComponent()
+        throws Exception
+    {
+        final ContentId fragmentComponentId = ContentId.from( "fragmentCompId" );
+        final FragmentComponent fragmentComponent = FragmentComponent.create().fragment( fragmentComponentId ).build();
+
+        Mockito.when( contentService.getById( fragmentComponent.getFragment() ) ).thenThrow(
+            new ContentNotFoundException( fragmentComponentId, null ) );
+
+        final ComponentName result = componentNameResolver.resolve( fragmentComponent );
+
+        assertEquals( fragmentComponent.getName(), result );
+    }
+
+    private Content createContent()
+    {
+        final Content.Builder builder = Content.create();
+
+        builder.id( ContentId.from( "123456" ) );
+        builder.name( "someName" );
+        builder.parentPath( ContentPath.ROOT );
+        builder.displayName( "displayName" );
+
+        return builder.build();
+    }
+
+}


### PR DESCRIPTION
- Returning component type name when attached content removed
- Using try-catch clause to define if attached content is there or not (not using contentExists since it fetches node with try-catch itself)