### PR TITLE
Endless loop when calling application market #8159

### DIFF
--- a/modules/runtime/src/bin/security.properties
+++ b/modules/runtime/src/bin/security.properties
@@ -1,0 +1,1 @@
+jdk.tls.disabledAlgorithms=TLSv1.3

--- a/modules/runtime/src/bin/server.bat
+++ b/modules/runtime/src/bin/server.bat
@@ -47,5 +47,5 @@ if "%JAVA_DEBUG_OPTS%" == "" set JAVA_DEBUG_OPTS=%DEFAULT_JAVA_DEBUG_OPTS%
 IF "%1"=="debug" set JAVA_OPTS=%JAVA_OPTS% %JAVA_DEBUG_OPTS%
 
 :execute
-"%JAVA_EXE%" %JAVA_OPTS% -Dxp.install="%XP_INSTALL%" -Dfile.encoding=UTF8 -Dnashorn.args="--no-deprecation-warning" %XP_OPTS% -Dmapper.allow_dots_in_name=true --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED -classpath "%XP_INSTALL%\lib\*" com.enonic.xp.launcher.LauncherMain %ARGS%
+"%JAVA_EXE%" -Djava.security.properties="%DIRNAME%\security.properties" %JAVA_OPTS% -Dxp.install="%XP_INSTALL%" -Dfile.encoding=UTF8 -Dnashorn.args="--no-deprecation-warning" %XP_OPTS% -Dmapper.allow_dots_in_name=true --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED -classpath "%XP_INSTALL%\lib\*" com.enonic.xp.launcher.LauncherMain %ARGS%
 endlocal

--- a/modules/runtime/src/bin/server.sh
+++ b/modules/runtime/src/bin/server.sh
@@ -88,7 +88,7 @@ init() {
 }
 
 run() {
-    exec "$JAVACMD" $JAVA_OPTS -Dxp.install="$XP_INSTALL" -Dfile.encoding=UTF8 -Dnashorn.args="--no-deprecation-warning" $XP_OPTS -Dmapper.allow_dots_in_name=true --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED -classpath "$XP_INSTALL/lib/*" com.enonic.xp.launcher.LauncherMain "${ARGS[@]}"
+    exec "$JAVACMD" -Djava.security.properties="%DIRNAME%/security.properties" $JAVA_OPTS -Dxp.install="$XP_INSTALL" -Dfile.encoding=UTF8 -Dnashorn.args="--no-deprecation-warning" $XP_OPTS -Dmapper.allow_dots_in_name=true --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED -classpath "$XP_INSTALL/lib/*" com.enonic.xp.launcher.LauncherMain "${ARGS[@]}"
 }
 
 main() {


### PR DESCRIPTION
Endless loop caused by a bug in JDK 11.0.7 TLSv1.3 implementation
adding a file `security.properties` with `jdk.tls.disabledAlgorithms=TLSv1.3` and referencing it via `-Djava.security.properties="%DIRNAME%/security.properties"` turns off TLSv1.3