### PR TITLE
Simultaneous app start/stop on all nodes #8360

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/app/ApplicationService.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/app/ApplicationService.java
@@ -36,6 +36,7 @@ public interface ApplicationService
 
     void uninstallApplication( final ApplicationKey key, final boolean triggerEvent );
 
+    @Deprecated
     void publishUninstalledEvent( final ApplicationKey key );
 
     @Deprecated

--- a/modules/core/core-api/src/main/java/com/enonic/xp/event/Event.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/event/Event.java
@@ -67,12 +67,7 @@ public final class Event
 
     public <T> Optional<T> getValueAs( final Class<T> type, final String key )
     {
-        Optional<Object> value = this.getValue( key );
-        if ( value.isPresent() )
-        {
-            return Optional.of( Converters.convert( this.getValue( key ).get(), type ) );
-        }
-        return Optional.empty();
+        return this.getValue( key ).map( o -> Converters.convert( o, type ) );
     }
 
     public boolean isType( final String type )

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationServiceImpl.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationServiceImpl.java
@@ -306,6 +306,10 @@ public final class ApplicationServiceImpl
 
     private void doUninstallApplication( final ApplicationKey applicationKey, final boolean triggerEvent )
     {
+        if ( triggerEvent )
+        {
+            this.eventPublisher.publish( ApplicationClusterEvents.uninstall( applicationKey ) );
+        }
         registry.uninstallApplication( applicationKey );
 
         final boolean wasLocal = localApplicationSet.remove( applicationKey );
@@ -336,6 +340,10 @@ public final class ApplicationServiceImpl
 
     private void doStartApplication( final ApplicationKey applicationKey, final boolean triggerEvent, final boolean throwOnInvalidVersion )
     {
+        if ( triggerEvent )
+        {
+            this.eventPublisher.publish( ApplicationClusterEvents.start( applicationKey ) );
+        }
         final boolean started = this.registry.startApplication( applicationKey, throwOnInvalidVersion );
         if ( started )
         {
@@ -352,6 +360,10 @@ public final class ApplicationServiceImpl
 
     private void doStopApplication( final ApplicationKey applicationKey, final boolean triggerEvent )
     {
+        if ( triggerEvent )
+        {
+            this.eventPublisher.publish( ApplicationClusterEvents.stop( applicationKey ) );
+        }
         this.registry.stopApplication( applicationKey );
 
         this.eventPublisher.publish( ApplicationEvents.stopped( applicationKey ) );

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/event/ApplicationClusterEvents.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/event/ApplicationClusterEvents.java
@@ -12,6 +12,12 @@ public class ApplicationClusterEvents
 
     public static final String INSTALLED = "installed";
 
+    public static final String START = "start";
+
+    public static final String STOP = "stop";
+
+    public static final String UNINSTALL = "uninstall";
+
     public static final String UNINSTALLED = "uninstalled";
 
     public static final String STATE_CHANGE = "state";
@@ -33,32 +39,50 @@ public class ApplicationClusterEvents
 
     public static Event uninstalled( final ApplicationKey applicationKey )
     {
-        return Event.create( EVENT_TYPE ).
-            distributed( true ).
-            value( EVENT_TYPE_KEY, UNINSTALLED ).
-            value( APPLICATION_KEY_PARAM, applicationKey.getName() ).
-            localOrigin( true ).
-            build();
+        return doCreateEvent( applicationKey, UNINSTALLED );
+    }
+
+    public static Event uninstall( final ApplicationKey applicationKey )
+    {
+        return doCreateEvent( applicationKey, UNINSTALL );
+    }
+
+    public static Event start( final ApplicationKey applicationKey )
+    {
+        return doCreateEvent( applicationKey, START );
+    }
+
+    public static Event stop( final ApplicationKey applicationKey )
+    {
+        return doCreateEvent( applicationKey, STOP );
     }
 
     public static Event started( final ApplicationKey applicationKey )
     {
-        return doCreateStateEvent( applicationKey, STATE_CHANGE, true );
+        return doCreateStateEvent( applicationKey, true );
     }
 
     public static Event stopped( final ApplicationKey applicationKey )
     {
-        return doCreateStateEvent( applicationKey, STATE_CHANGE, false );
+        return doCreateStateEvent( applicationKey, false );
     }
 
-    private static Event doCreateStateEvent( final ApplicationKey applicationKey, final String eventType, final boolean value )
+    private static Event doCreateEvent( final ApplicationKey applicationKey, final String eventType )
     {
         return Event.create( EVENT_TYPE ).
             distributed( true ).
             value( EVENT_TYPE_KEY, eventType ).
             value( APPLICATION_KEY_PARAM, applicationKey.getName() ).
+            build();
+    }
+
+    private static Event doCreateStateEvent( final ApplicationKey applicationKey, final boolean value )
+    {
+        return Event.create( EVENT_TYPE ).
+            distributed( true ).
+            value( EVENT_TYPE_KEY, STATE_CHANGE ).
+            value( APPLICATION_KEY_PARAM, applicationKey.getName() ).
             value( STARTED_PARAM, value ).
-            localOrigin( true ).
             build();
     }
 }


### PR DESCRIPTION
Before start/stop/uninstall the initiator node sends a respective event to other nodes in the cluster. Other nodes try to start/stop/uninstall - it happens simultaneously on all nodes.

application install is more complex process, as it needs to persist app first into shared storage. So it still waits for install to finish on initiator node.