### PR TITLE
Access PortalRequest via script context #8467

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -14,5 +14,5 @@ ext {
     tikaVersion = '1.23'
     resteasyVersion = '3.13.0.Final'
     hazelcastVersion = '3.12.7'
-    mockitoVersion = '3.5.10'
+    mockitoVersion = '3.6.0'
 }

--- a/modules/lib/lib-context/build.gradle
+++ b/modules/lib/lib-context/build.gradle
@@ -5,6 +5,5 @@ dependencies {
 
     testImplementation project( ':tools:testing' )
 
-    testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
-
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitJupiterVersion}"
 }

--- a/modules/lib/lib-event/build.gradle
+++ b/modules/lib/lib-event/build.gradle
@@ -4,5 +4,5 @@ dependencies {
 
     testImplementation project( ':tools:testing' )
 
-    testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitJupiterVersion}"
 }

--- a/modules/lib/lib-i18n/build.gradle
+++ b/modules/lib/lib-i18n/build.gradle
@@ -4,5 +4,5 @@ dependencies {
 
     testImplementation project( ':tools:testing' )
 
-    testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitJupiterVersion}"
 }

--- a/modules/lib/lib-i18n/src/main/java/com/enonic/xp/lib/i18n/LocaleScriptBean.java
+++ b/modules/lib/lib-i18n/src/main/java/com/enonic/xp/lib/i18n/LocaleScriptBean.java
@@ -8,7 +8,6 @@ import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.i18n.LocaleService;
 import com.enonic.xp.i18n.MessageBundle;
 import com.enonic.xp.portal.PortalRequest;
-import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.script.ScriptValue;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
@@ -22,6 +21,8 @@ public final class LocaleScriptBean
     implements ScriptBean
 {
     private Supplier<LocaleService> localeService;
+
+    private Supplier<PortalRequest> portalRequest;
 
     private ApplicationKey application;
 
@@ -89,7 +90,7 @@ public final class LocaleScriptBean
         }
         else
         {
-            final PortalRequest req = getRequest();
+            final PortalRequest req = portalRequest.get();
             return req != null ? req.getApplicationKey() : ApplicationKey.from( LocaleScriptBean.class );
         }
     }
@@ -101,7 +102,7 @@ public final class LocaleScriptBean
 
     private Locale resolveLocaleFromSite()
     {
-        final PortalRequest request = getRequest();
+        final PortalRequest request = portalRequest.get();
         if ( request == null )
         {
             return null;
@@ -141,10 +142,6 @@ public final class LocaleScriptBean
     public void initialize( final BeanContext context )
     {
         this.localeService = context.getService( LocaleService.class );
-    }
-
-    private PortalRequest getRequest()
-    {
-        return PortalRequestAccessor.get();
+        this.portalRequest = context.getBinding( PortalRequest.class );
     }
 }

--- a/modules/lib/lib-i18n/src/test/java/com/enonic/xp/lib/i18n/GetSupportedLocalesScriptTest.java
+++ b/modules/lib/lib-i18n/src/test/java/com/enonic/xp/lib/i18n/GetSupportedLocalesScriptTest.java
@@ -4,7 +4,6 @@ import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Set;
 
-import org.junit.Ignore;
 import org.mockito.Mockito;
 
 import com.enonic.xp.app.ApplicationKey;
@@ -16,7 +15,6 @@ import com.enonic.xp.testing.ScriptRunnerSupport;
 
 import static org.mockito.ArgumentMatchers.any;
 
-@Ignore("Concourse issue")
 public class GetSupportedLocalesScriptTest
     extends ScriptRunnerSupport
 {
@@ -38,7 +36,7 @@ public class GetSupportedLocalesScriptTest
         locales.add( new Locale( "en" ) );
         locales.add( new Locale( "es" ) );
         locales.add( new Locale( "ca" ) );
-        Mockito.when( localeService.getLocales( any( ApplicationKey.class ), any( String[].class ) ) ).thenReturn( locales );
+        Mockito.when( localeService.getLocales( any( ApplicationKey.class ), any() ) ).thenReturn( locales );
 
         addService( LocaleService.class, localeService );
 

--- a/modules/lib/lib-i18n/src/test/java/com/enonic/xp/lib/i18n/I18NScriptTest.java
+++ b/modules/lib/lib-i18n/src/test/java/com/enonic/xp/lib/i18n/I18NScriptTest.java
@@ -41,11 +41,10 @@ public class I18NScriptTest
         locales.add( new Locale( "en" ) );
         locales.add( new Locale( "es" ) );
         locales.add( new Locale( "ca" ) );
-        Mockito.when( localeService.getLocales( any( ApplicationKey.class ), any( String[].class ) ) ).thenReturn( locales );
+        Mockito.when( localeService.getLocales( any( ApplicationKey.class ), any() ) ).thenReturn( locales );
 
         final MessageBundle bundle = Mockito.mock( MessageBundle.class, this::answer );
-        Mockito.when(
-            localeService.getBundle( Mockito.any( ApplicationKey.class ), Mockito.any( Locale.class ), any() ) ).
+        Mockito.when( localeService.getBundle( any( ApplicationKey.class ), any( Locale.class ), any() ) ).
             thenReturn( bundle );
 
         addService( LocaleService.class, localeService );

--- a/modules/lib/lib-i18n/src/test/java/com/enonic/xp/lib/i18n/LocalizeNoHttpTest.java
+++ b/modules/lib/lib-i18n/src/test/java/com/enonic/xp/lib/i18n/LocalizeNoHttpTest.java
@@ -6,8 +6,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.After;
-import org.junit.Ignore;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 
@@ -15,18 +13,14 @@ import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.i18n.LocaleService;
 import com.enonic.xp.i18n.MessageBundle;
 import com.enonic.xp.portal.PortalRequest;
-import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.testing.ScriptRunnerSupport;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
-@Ignore("Concourse issue")
 public class LocalizeNoHttpTest
     extends ScriptRunnerSupport
 {
-    private PortalRequest portalRequest;
-
     @Override
     public String getScriptTestFile()
     {
@@ -42,25 +36,13 @@ public class LocalizeNoHttpTest
 
         final Set<Locale> locales = new LinkedHashSet<>();
         locales.add( new Locale( "en" ) );
-        Mockito.when(
-            localeService.getLocales( eq( ApplicationKey.from( "com.enonic.myapplication" ) ), any( String[].class ) ) ).thenReturn(
-            locales );
+        Mockito.when( localeService.getLocales( eq( ApplicationKey.from( "com.enonic.myapplication" ) ), any() ) ).thenReturn( locales );
 
         final MessageBundle bundle = Mockito.mock( MessageBundle.class, this::answer );
-        Mockito.when( localeService.getBundle( eq( ApplicationKey.from( "com.enonic.myapplication" ) ), Mockito.any( Locale.class ),
-                                               any() ) ).
+        Mockito.when( localeService.getBundle( eq( ApplicationKey.from( "com.enonic.myapplication" ) ), any(), any() ) ).
             thenReturn( bundle );
 
         addService( LocaleService.class, localeService );
-    }
-
-    @After
-    public void tearDown()
-    {
-        if ( this.portalRequest != null )
-        {
-            PortalRequestAccessor.set( this.portalRequest );
-        }
     }
 
     private Object answer( final InvocationOnMock invocation )
@@ -77,10 +59,8 @@ public class LocalizeNoHttpTest
         return null;
     }
 
-    public void removeRequest()
+    protected PortalRequest createPortalRequest()
     {
-        this.portalRequest = PortalRequestAccessor.get();
-        PortalRequestAccessor.remove();
+        return null;
     }
-
 }

--- a/modules/lib/lib-i18n/src/test/resources/test/localize-nohttp-test.js
+++ b/modules/lib/lib-i18n/src/test/resources/test/localize-nohttp-test.js
@@ -2,7 +2,6 @@ var t = require('/lib/xp/testing');
 var i18n = require('/lib/xp/i18n');
 
 exports.testLocalize = function () {
-    testInstance.removeRequest();
 
     var result = i18n.localize({
         key: 'myKey',

--- a/modules/lib/lib-io/build.gradle
+++ b/modules/lib/lib-io/build.gradle
@@ -3,5 +3,5 @@ dependencies {
 
     testImplementation project( ':tools:testing' )
 
-    testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitJupiterVersion}"
 }

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/multipart/MultipartHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/multipart/MultipartHandler.java
@@ -6,7 +6,6 @@ import com.google.common.io.ByteSource;
 import com.google.common.net.MediaType;
 
 import com.enonic.xp.portal.PortalRequest;
-import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
 import com.enonic.xp.web.multipart.MultipartForm;
@@ -71,7 +70,7 @@ public final class MultipartHandler
     @Override
     public void initialize( final BeanContext context )
     {
-        final PortalRequest request = PortalRequestAccessor.get();
+        final PortalRequest request = context.getBinding( PortalRequest.class ).get();
         final MultipartService service = context.getService( MultipartService.class ).get();
         this.form = service.parse( request.getRawRequest() );
     }

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/url/AbstractUrlHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/url/AbstractUrlHandler.java
@@ -7,7 +7,6 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
 import com.enonic.xp.portal.PortalRequest;
-import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.portal.url.PortalUrlService;
 import com.enonic.xp.script.ScriptValue;
 import com.enonic.xp.script.bean.BeanContext;
@@ -99,7 +98,7 @@ public abstract class AbstractUrlHandler
     @Override
     public void initialize( final BeanContext context )
     {
-        this.request = PortalRequestAccessor.get();
+        this.request = context.getBinding( PortalRequest.class ).get();
         this.urlService = context.getService( PortalUrlService.class ).get();
     }
 }

--- a/modules/lib/lib-task/src/main/java/com/enonic/xp/lib/task/SubmitNamedTaskHandler.java
+++ b/modules/lib/lib-task/src/main/java/com/enonic/xp/lib/task/SubmitNamedTaskHandler.java
@@ -12,7 +12,6 @@ import com.enonic.xp.form.Form;
 import com.enonic.xp.lib.common.FormJsonToPropertyTreeTranslator;
 import com.enonic.xp.page.DescriptorKey;
 import com.enonic.xp.portal.PortalRequest;
-import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.schema.mixin.MixinService;
 import com.enonic.xp.script.ScriptValue;
 import com.enonic.xp.script.bean.BeanContext;
@@ -32,6 +31,8 @@ public final class SubmitNamedTaskHandler
     private Supplier<MixinService> mixinServiceSupplier;
 
     private Supplier<TaskDescriptorService> taskDescriptorServiceSupplier;
+
+    private Supplier<PortalRequest> requestSupplier;
 
     private String name;
 
@@ -79,7 +80,7 @@ public final class SubmitNamedTaskHandler
 
     private ApplicationKey getApplication()
     {
-        PortalRequest portalRequest = PortalRequestAccessor.get();
+        PortalRequest portalRequest = requestSupplier.get();
         if ( portalRequest != null )
         {
             return portalRequest.getApplicationKey();
@@ -112,6 +113,7 @@ public final class SubmitNamedTaskHandler
     @Override
     public void initialize( final BeanContext context )
     {
+        requestSupplier = context.getBinding( PortalRequest.class );
         taskServiceSupplier = context.getService( TaskService.class );
         mixinServiceSupplier = context.getService( MixinService.class );
         taskDescriptorServiceSupplier = context.getService( TaskDescriptorService.class );

--- a/modules/tools/testing/build.gradle
+++ b/modules/tools/testing/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     compile "org.mockito:mockito-core:${mockitoVersion}"
     compile 'org.hamcrest:hamcrest-library:1.3'
     compile "org.slf4j:slf4j-simple:${slf4jVersion}"
-    testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitJupiterVersion}"
 }

--- a/modules/tools/testing/src/main/java/com/enonic/xp/testing/ScriptTestSupport.java
+++ b/modules/tools/testing/src/main/java/com/enonic/xp/testing/ScriptTestSupport.java
@@ -140,7 +140,7 @@ public abstract class ScriptTestSupport
         return new MockBeanContext( key, this.serviceRegistry );
     }
 
-    private PortalRequest createPortalRequest()
+    protected PortalRequest createPortalRequest()
     {
         final PortalRequest request = new PortalRequest();
 


### PR DESCRIPTION
- access PortalRequest from script bindings where possible. This is the main part.
- update Mockito to latest. Initially I blamed Mockito for a bug.
- specified version for `org.junit.vintage:junit-vintage-engine` dependency. Without it Gradle didn't want to build.
- re-enabled a few tests. They were disabled due to this issue, I guess.