### PR TITLE
Management SSE for apps fails when Accept-Encoding is sent #8518

### DIFF
--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/SseEntryPoint.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/SseEntryPoint.java
@@ -76,7 +76,11 @@ public class SseEntryPoint
     @Context
     public void setSse( final Sse sse )
     {
-        this.contextHolder = new SseContextHolder( sse );
+        final SseContextHolder ctx = contextHolder;
+        if ( ctx == null )
+        {
+            this.contextHolder = new SseContextHolder( sse );
+        }
     }
 
     @GET
@@ -88,10 +92,8 @@ public class SseEntryPoint
 
         if ( ctx == null )
         {
-            return;
+            throw new IllegalStateException( "No SSE context" );
         }
-
-        ctx.broadcaster.register( sseEventSink );
 
         final OutboundSseEvent sseEvent = ctx.sse.newEventBuilder().
             name( "list" ).
@@ -102,6 +104,8 @@ public class SseEntryPoint
                 collect( Collectors.toList() ) ) ).build();
 
         sseEventSink.send( sseEvent );
+
+        ctx.broadcaster.register( sseEventSink );
     }
 
     @Override

--- a/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/SseEntryPointTest.java
+++ b/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/SseEntryPointTest.java
@@ -25,6 +25,7 @@ import com.enonic.xp.impl.server.rest.model.ListApplicationJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -199,7 +200,7 @@ public class SseEntryPointTest
     {
         final SseEventSink eventSink = mock( SseEventSink.class );
 
-        listener.subscribe( eventSink );
+        assertThrows( IllegalStateException.class, () -> listener.subscribe( eventSink ) );
     }
 
     @Test

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/configurator/GZipConfigurator.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/configurator/GZipConfigurator.java
@@ -18,6 +18,7 @@ public final class GZipConfigurator
         handler.setExcludedAgentPatterns();
         handler.setMinGzipSize( this.config.gzip_minSize() );
         handler.addExcludedMimeTypes( "application/octet-stream" );
+        handler.addExcludedMimeTypes( "text/event-stream" );
 
         this.object.setGzipHandler( handler );
     }


### PR DESCRIPTION
Main fix: disabled gzip for SSE. At least for now. see https://github.com/enonic/xp/issues/8518#issuecomment-736538234

A few other polishes:
- For some reason Resteasy injects Context twice. 
https://github.com/resteasy/Resteasy/blob/master/resteasy-core/src/main/java/org/jboss/resteasy/core/ResourceMethodRegistry.java#L228
https://github.com/resteasy/Resteasy/blob/master/resteasy-core/src/main/java/org/jboss/resteasy/core/ResourceMethodRegistry.java#L246
~~TODO: Create an issue for Resteasy?~~ https://issues.redhat.com/browse/RESTEASY-2779

That causes race conditions for us, so sse Context variable is set, I ignore others

- In case of not yet set contextHolder we should throw an error (well, it never happens, but still...), otherwise, if no error is thrown, client just hangs and never receives any messages

- Last fix is to send "list" message before any others can potentially arrive.