### PR TITLE
Duplicate headers in controller creates a crash. #8404

### DIFF
--- a/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/app/MainWebHandlerTest.java
+++ b/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/app/MainWebHandlerTest.java
@@ -1,10 +1,7 @@
 package com.enonic.xp.admin.impl.app;
 
-import java.nio.file.Path;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
@@ -15,9 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MainWebHandlerTest
 {
-    @TempDir
-    public Path temporaryFolder;
-
     private MainWebHandler handler;
 
     @BeforeEach

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/PortalResponse.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/PortalResponse.java
@@ -3,6 +3,7 @@ package com.enonic.xp.portal;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
 
 import com.enonic.xp.annotation.PublicApi;
 import com.enonic.xp.portal.postprocess.HtmlTag;
@@ -33,7 +34,7 @@ public final class PortalResponse
 
     public ImmutableList<String> getContributions( final HtmlTag tag )
     {
-        return this.contributions.containsKey( tag ) ? this.contributions.get( tag ) : ImmutableList.of();
+        return this.contributions.get( tag );
     }
 
     public boolean hasContributions()
@@ -45,7 +46,6 @@ public final class PortalResponse
     {
         return new Builder();
     }
-
 
     public boolean applyFilters()
     {
@@ -67,26 +67,24 @@ public final class PortalResponse
     {
         private boolean postProcess = true;
 
-        private ImmutableListMultimap.Builder<HtmlTag, String> contributions;
+        private ImmutableListMultimap.Builder<HtmlTag, String> contributions = ImmutableListMultimap.builder();
 
         private boolean applyFilters = true;
 
         private Builder()
         {
-            clearContributions();
         }
 
         private Builder( final WebResponse source )
         {
             super( source );
-            clearContributions();
         }
 
         private Builder( final PortalResponse source )
         {
             super( source );
             this.postProcess = source.postProcess;
-            contributions( source.contributions );
+            putAllContributions( source.contributions );
             this.applyFilters = source.applyFilters;
         }
 
@@ -98,31 +96,19 @@ public final class PortalResponse
 
         public Builder contributions( final ListMultimap<HtmlTag, String> contributions )
         {
-            if ( this.contributions == null )
-            {
-                clearContributions();
-            }
-            this.contributions.putAll( contributions );
+            putAllContributions( contributions );
             return this;
         }
 
         public Builder contribution( final HtmlTag tag, final String value )
         {
-            if ( this.contributions == null )
-            {
-                clearContributions();
-            }
             this.contributions.put( tag, value );
             return this;
         }
 
         public Builder contributionsFrom( final PortalResponse portalResponse )
         {
-            if ( this.contributions == null )
-            {
-                clearContributions();
-            }
-            this.contributions.putAll( portalResponse.contributions );
+            putAllContributions( portalResponse.contributions );
             return this;
         }
 
@@ -142,6 +128,11 @@ public final class PortalResponse
         public PortalResponse build()
         {
             return new PortalResponse( this );
+        }
+
+        private void putAllContributions( final Multimap<HtmlTag, String> contributions )
+        {
+            this.contributions.putAll( contributions );
         }
     }
 }

--- a/modules/web/web-api/src/test/java/com/enonic/xp/web/WebResponseTest.java
+++ b/modules/web/web-api/src/test/java/com/enonic/xp/web/WebResponseTest.java
@@ -1,0 +1,40 @@
+package com.enonic.xp.web;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WebResponseTest
+{
+    @Test
+    void header_same_name_overrides_previous_value()
+    {
+        final WebResponse webResponse = WebResponse.create().header( "a", "b" ).header( "a", "c" ).build();
+        assertEquals( Map.of( "a", "c" ), webResponse.getHeaders() );
+    }
+
+    @Test
+    void headers_same_name_overrides_previous_values()
+    {
+        final WebResponse.Builder<?> builder = WebResponse.create();
+        builder.headers( Map.of( "a", "av", "b", "bv" ) );
+
+        final WebResponse webResponse = builder.headers( Map.of( "a", "av-new", "b", "bv-new" ) ).build();
+        assertEquals( Map.of( "a", "av-new", "b", "bv-new" ), webResponse.getHeaders() );
+    }
+
+    @Test
+    void headers_case_insensitive()
+    {
+        final WebResponse webResponse = WebResponse.create().headers( Map.of( "A", "av", "B", "bv" ) ).build();
+
+        final ImmutableMap<String, String> headers = webResponse.getHeaders();
+        assertAll( () -> assertEquals( Map.of( "a", "av", "B", "bv" ), headers ), () -> assertEquals( "av", headers.get( "A" ) ),
+                   () -> assertEquals( "bv", headers.get( "b" ) ) );
+    }
+}


### PR DESCRIPTION
There were a few iterations of HTTP header specs and how they should handled

Firstly they are case-insensitive preferably lowercased
https://tools.ietf.org/html/rfc7540#section-8.1.2

Secondly the order is not significant
https://tools.ietf.org/html/rfc7230#section-3.2.2

So, it is safe to lowercase them and when response is built, headers get populated into case-insensitive sorted map (for backwards compatibility, so `location = headers['Location']` works equally to `location = headers['location']`)


Instead of throwing an Exception, it is possible to replace previous header values with new ones.
This is the easiest fix for now. More info in https://github.com/enonic/xp/issues/8404#issuecomment-737301463