### PR TITLE
Issue mail generator: 'Show details' button is broken in Outlook #862…

### DIFF
--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/issue/IssueMailMessageGenerator.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/rest/resource/issue/IssueMailMessageGenerator.java
@@ -154,11 +154,6 @@ public abstract class IssueMailMessageGenerator<P extends IssueNotificationParam
     {
         final ProjectName projectName = ProjectName.from( ContextAccessor.current().getRepositoryId() );
 
-        if ( projectName.equals( DEFAULT_PROJECT_NAME ) )
-        {
-            return params.getUrl() + "#/issue/" + issueId;
-        }
-
         return params.getUrl() + "#/" + projectName + "/issue/" + issueId;
     }
 

--- a/modules/admin/admin-impl/src/main/resources/com/enonic/xp/admin/impl/rest/resource/issue/email.html
+++ b/modules/admin/admin-impl/src/main/resources/com/enonic/xp/admin/impl/rest/resource/issue/email.html
@@ -24,18 +24,17 @@
         </div>
     </div>
     <div style="margin-bottom: 25px;">
-        <a href="${url}">
-            <button title="${id}" style="background-color: ${statusBgColor}; padding: 4px 19px 4px 19px; border: none; cursor: pointer;">
-                <span style="
+        <a href="${url}" style="text-decoration: none">
+                <span title="${id}" style="
+                    background-color: ${statusBgColor};
+                    border: solid 15px ${statusBgColor};
                     color: white;
                     line-height: 24px;
                     font-size: 14px;
                     white-space: pre !important;
                     overflow: hidden;
                     text-overflow: ellipsis;
-                    max-width: 150px;
-                    display: inline-block;">${showDetailsCaption}</span>
-            </button>
+                    ">${showDetailsCaption}</span>
         </a>
     </div>
     <div style="margin-bottom: 40px; font-size: 16px; display: ${comments-block-visibility}">

--- a/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/issue/IssueNotificationsSenderImplTest.java
+++ b/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/rest/resource/issue/IssueNotificationsSenderImplTest.java
@@ -245,7 +245,7 @@ public class IssueNotificationsSenderImplTest
     private void verifyIssueLink( final MimeMessage msg )
         throws Exception
     {
-        assertTrue( msg.getContent().toString().contains( "url#/issue" ) );
+        assertTrue( msg.getContent().toString().contains( "url#/default/issue" ) );
     }
 
     private void verifyIssueLink( final MimeMessage msg, final String link )


### PR DESCRIPTION
…7 (#8628)

* Issue mail generator: 'Show details' button is broken in Outlook #8627

-Outlook ignores lots of HTML tags and attributes, using those that it supports
-Correctly resolving issue link for default layer

(cherry picked from commit ceacc6ec719b14ad5237f79a6b06680530078ea8)