### PR TITLE
Scheduled tasks may not run on clustered environments

### DIFF
--- a/modules/core/core-hazelcast/src/main/java/com/enonic/xp/core/impl/hazelcast/status/objects/HazelcastObjectsReport.java
+++ b/modules/core/core-hazelcast/src/main/java/com/enonic/xp/core/impl/hazelcast/status/objects/HazelcastObjectsReport.java
@@ -17,6 +17,8 @@ class HazelcastObjectsReport
 
     private final List<ExecutorServiceObjectReport> executorServiceObjectReports;
 
+    private final List<ScheduledExecutorServiceObjectReport> scheduledExecutorServiceObjectReports;
+
     private final List<FencedLockObjectReport> fencedLockObjectReports;
 
 
@@ -26,6 +28,7 @@ class HazelcastObjectsReport
         queueObjectReports = List.copyOf( builder.queueObjectReports );
         topicObjectReports = List.copyOf( builder.topicObjectReports );
         executorServiceObjectReports = List.copyOf( builder.executorServiceObjectReports );
+        scheduledExecutorServiceObjectReports = List.copyOf( builder.scheduledExecutorServiceObjectReports );
         fencedLockObjectReports = List.copyOf( builder.fencedLockObjectReports );
     }
 
@@ -40,6 +43,10 @@ class HazelcastObjectsReport
         topicObjectReports.stream().map( TopicObjectReport::toJson ).forEach( topicsJson::add );
         final ArrayNode executorServicesJson = json.putArray( "executorServices" );
         executorServiceObjectReports.stream().map( ExecutorServiceObjectReport::toJson ).forEach( executorServicesJson::add );
+        final ArrayNode scheduledExecutorServicesJson = json.putArray( "scheduledExecutorServices" );
+        scheduledExecutorServiceObjectReports.stream()
+            .map( ScheduledExecutorServiceObjectReport::toJson )
+            .forEach( scheduledExecutorServicesJson::add );
         final ArrayNode fencedLocks = json.putArray( "fencedLocks" );
         fencedLockObjectReports.stream().map( FencedLockObjectReport::toJson ).forEach( fencedLocks::add );
 
@@ -60,6 +67,8 @@ class HazelcastObjectsReport
         List<TopicObjectReport> topicObjectReports = new ArrayList<>();
 
         List<ExecutorServiceObjectReport> executorServiceObjectReports = new ArrayList<>();
+
+        List<ScheduledExecutorServiceObjectReport> scheduledExecutorServiceObjectReports = new ArrayList<>();
 
         List<FencedLockObjectReport> fencedLockObjectReports = new ArrayList<>();
 
@@ -90,6 +99,12 @@ class HazelcastObjectsReport
         Builder addFencedLockObject( FencedLockObjectReport fencedLockObjectReport )
         {
             fencedLockObjectReports.add( fencedLockObjectReport );
+            return this;
+        }
+
+        Builder addScheduledExecutorServiceObject( final ScheduledExecutorServiceObjectReport scheduledExecutorServiceObjectReport )
+        {
+            scheduledExecutorServiceObjectReports.add( scheduledExecutorServiceObjectReport );
             return this;
         }
 

--- a/modules/core/core-hazelcast/src/main/java/com/enonic/xp/core/impl/hazelcast/status/objects/HazelcastObjectsReporter.java
+++ b/modules/core/core-hazelcast/src/main/java/com/enonic/xp/core/impl/hazelcast/status/objects/HazelcastObjectsReporter.java
@@ -5,6 +5,8 @@ import java.util.Collection;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.hazelcast.core.DistributedObject;
@@ -15,6 +17,8 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.core.ITopic;
 import com.hazelcast.cp.lock.FencedLock;
+import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 
 import com.enonic.xp.status.JsonStatusReporter;
 import com.enonic.xp.status.StatusReporter;
@@ -23,6 +27,8 @@ import com.enonic.xp.status.StatusReporter;
 public class HazelcastObjectsReporter
     extends JsonStatusReporter
 {
+    private static final Logger LOG = LoggerFactory.getLogger( HazelcastObjectsReporter.class );
+
     private final HazelcastInstance hazelcastInstance;
 
     @Activate
@@ -52,31 +58,55 @@ public class HazelcastObjectsReporter
             else if ( object instanceof IQueue )
             {
                 IQueue<?> queue = hazelcastInstance.getQueue( object.getName() );
-                builder.addQueueObject( QueueObjectReport.create().
-                    name( DistributedObjectUtil.getName( object ) ).
-                    size( queue.size() ).
-                    build() );
+                builder.addQueueObject(
+                    QueueObjectReport.create().name( DistributedObjectUtil.getName( object ) ).size( queue.size() ).build() );
             }
             else if ( object instanceof ITopic )
             {
-                builder.addTopicObject( TopicObjectReport.create().
-                    name( DistributedObjectUtil.getName( object ) ).
-                    build() );
+                builder.addTopicObject( TopicObjectReport.create().name( DistributedObjectUtil.getName( object ) ).build() );
+            }
+            else if ( object instanceof IScheduledExecutorService )
+            {
+                final IScheduledExecutorService scheduledExecutorService = (IScheduledExecutorService) object;
+
+                final ScheduledExecutorServiceObjectReport.Builder sbuilder = ScheduledExecutorServiceObjectReport.create();
+                sbuilder.name( DistributedObjectUtil.getName( object ) );
+                scheduledExecutorService.getAllScheduledFutures().forEach( ( key, value ) -> {
+
+                    value.forEach( future -> {
+                        final ScheduledTaskHandler handler = future.getHandler();
+                        if ( handler != null ) // null handler means that task is already disposed
+                        {
+                            final String taskName = handler.getTaskName();
+                            final String memberUuid = key.getUuid();
+                            long totalRuns = -1;
+                            try
+                            {
+                                totalRuns = future.getStats().getTotalRuns();
+                            }
+                            catch ( Exception e )
+                            {
+                                LOG.debug( "Cannot get totalRuns for task {}", taskName );
+                            }
+                            sbuilder.task( new ScheduledTaskReport( memberUuid, taskName, totalRuns ) );
+                        }
+                    } );
+                } );
+                builder.addScheduledExecutorServiceObject( sbuilder.build() );
             }
             else if ( object instanceof IExecutorService )
             {
-                builder.addExecutorServiceObject( ExecutorServiceObjectReport.create().
-                    name( DistributedObjectUtil.getName( object ) ).
-                    build() );
+                builder.addExecutorServiceObject(
+                    ExecutorServiceObjectReport.create().name( DistributedObjectUtil.getName( object ) ).build() );
             }
             else if ( object instanceof FencedLock )
             {
                 FencedLock lock = hazelcastInstance.getCPSubsystem().getLock( object.getName() );
-                builder.addFencedLockObject( FencedLockObjectReport.create().
-                    name( DistributedObjectUtil.getName( object ) ).
-                    locked( lock.isLocked() ).
-                    lockCount( lock.getLockCount() ).
-                    build() );
+                builder.addFencedLockObject( FencedLockObjectReport.create()
+                                                 .name( DistributedObjectUtil.getName( object ) )
+                                                 .locked( lock.isLocked() )
+                                                 .lockCount( lock.getLockCount() )
+                                                 .build() );
             }
         }
 

--- a/modules/core/core-hazelcast/src/main/java/com/enonic/xp/core/impl/hazelcast/status/objects/ScheduledExecutorServiceObjectReport.java
+++ b/modules/core/core-hazelcast/src/main/java/com/enonic/xp/core/impl/hazelcast/status/objects/ScheduledExecutorServiceObjectReport.java
@@ -1,0 +1,67 @@
+package com.enonic.xp.core.impl.hazelcast.status.objects;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+class ScheduledExecutorServiceObjectReport
+{
+    private final String name;
+
+    private final List<ScheduledTaskReport> tasks;
+
+    private ScheduledExecutorServiceObjectReport( Builder builder )
+    {
+        name = builder.name;
+        tasks = List.copyOf( builder.tasks );
+    }
+
+    ObjectNode toJson()
+    {
+        final ObjectNode json = JsonNodeFactory.instance.objectNode();
+        json.put( "name", name );
+        final ArrayNode tasksArray = json.putArray( "tasks" );
+
+        tasks.forEach( task -> {
+            final ObjectNode taskJson = JsonNodeFactory.instance.objectNode();
+            taskJson.put( "member", task.getMember() );
+            taskJson.put( "taskName", task.getTaskName() );
+            taskJson.put( "totalRuns", task.getTotalRuns() );
+
+            tasksArray.add( taskJson );
+        } );
+        return json;
+    }
+
+    static Builder create()
+    {
+        return new Builder();
+    }
+
+    static class Builder
+    {
+        String name;
+
+        List<ScheduledTaskReport> tasks = new ArrayList<>();
+
+        public Builder name( final String name )
+        {
+            this.name = name;
+            return this;
+        }
+
+        public Builder task( final ScheduledTaskReport task )
+        {
+            this.tasks.add( task );
+            return this;
+        }
+
+        ScheduledExecutorServiceObjectReport build()
+        {
+            return new ScheduledExecutorServiceObjectReport( this );
+        }
+    }
+}

--- a/modules/core/core-hazelcast/src/main/java/com/enonic/xp/core/impl/hazelcast/status/objects/ScheduledTaskReport.java
+++ b/modules/core/core-hazelcast/src/main/java/com/enonic/xp/core/impl/hazelcast/status/objects/ScheduledTaskReport.java
@@ -1,0 +1,30 @@
+package com.enonic.xp.core.impl.hazelcast.status.objects;
+
+public class ScheduledTaskReport
+{
+    private final String member;
+    private final String taskName;
+    private final long totalRuns;
+
+    public ScheduledTaskReport( final String member, final String taskName, final long totalRuns )
+    {
+        this.member = member;
+        this.taskName = taskName;
+        this.totalRuns = totalRuns;
+    }
+
+    public String getMember()
+    {
+        return member;
+    }
+
+    public String getTaskName()
+    {
+        return taskName;
+    }
+
+    public long getTotalRuns()
+    {
+        return totalRuns;
+    }
+}

--- a/modules/core/core-hazelcast/src/test/resources/com/enonic/xp/core/impl/hazelcast/status/objects/hazelcast_objects.json
+++ b/modules/core/core-hazelcast/src/test/resources/com/enonic/xp/core/impl/hazelcast/status/objects/hazelcast_objects.json
@@ -21,6 +21,18 @@
       "name": "executorService"
     }
   ],
+  "scheduledExecutorServices": [
+    {
+      "name": "scheduledExecutorService",
+      "tasks": [
+        {
+          "member": "member-uuid",
+          "taskName": "some-task",
+          "totalRuns": -1
+        }
+      ]
+    }
+  ],
   "fencedLocks": [
     {
       "name": "lock",

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/SchedulerExecutorService.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/SchedulerExecutorService.java
@@ -17,6 +17,4 @@ public interface SchedulerExecutorService
     ScheduledFuture<?> schedule( SchedulableTask command, long delay, TimeUnit unit );
 
     ScheduledFuture<?> scheduleAtFixedRate( SchedulableTask command, long initialDelay, long period, TimeUnit unit );
-
-
 }

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/SchedulerServiceActivator.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/SchedulerServiceActivator.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.impl.scheduler;
 
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.osgi.framework.BundleContext;
@@ -73,9 +74,12 @@ public final class SchedulerServiceActivator
 
         try
         {
-            if ( !schedulerExecutorService.getAllFutures().contains( RescheduleTask.NAME ) )
+            final Set<String> allFutures = schedulerExecutorService.getAllFutures();
+            if ( !allFutures.contains( RescheduleTask.NAME ) )
             {
                 schedulerExecutorService.scheduleAtFixedRate( new RescheduleTask(), 0, 1, TimeUnit.SECONDS );
+            } else {
+                LOG.debug( "RescheduleTask already scheduled." );
             }
         }
         catch ( Exception e )

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/SystemScheduler.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/SystemScheduler.java
@@ -17,6 +17,4 @@ interface SystemScheduler
     ScheduledFuture<?> schedule( SchedulableTask command, long delay, TimeUnit unit );
 
     ScheduledFuture<?> scheduleAtFixedRate( SchedulableTask command, long initialDelay, long period, TimeUnit unit );
-
-
 }

--- a/modules/core/core-scheduler/src/test/java/com/enonic/xp/impl/scheduler/distributed/RescheduleTaskTest.java
+++ b/modules/core/core-scheduler/src/test/java/com/enonic/xp/impl/scheduler/distributed/RescheduleTaskTest.java
@@ -40,7 +40,6 @@ import com.enonic.xp.scheduler.SchedulerService;
 import com.enonic.xp.security.PrincipalKey;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
@@ -68,7 +67,7 @@ public class RescheduleTaskTest
     @Mock
     private SchedulerExecutorService schedulerExecutorService;
 
-    @Mock(stubOnly = true)
+    @Mock
     private BundleContext bundleContext;
 
     @BeforeEach
@@ -136,11 +135,11 @@ public class RescheduleTaskTest
         mockFutures();
         mockJobs();
 
-        for ( int i = 0; i < 9; i++ )
+        for ( int i = 0; i < 10; i++ )
         {
             createAndRunTask();
         }
-        assertThrows( IllegalStateException.class, this::createAndRunTask );
+        verify( bundleContext, times( 10 ) ).getServiceReferences( SchedulerService.class, null );
     }
 
     private RescheduleTask createAndRunTask()


### PR DESCRIPTION
catch all Throwables in RescheduleTask is the main fix.

Additional improvements:
- improved (currently undocumented) statistics endpoint, so it reports HZ ScheduledExecutorServices with some extra info needed for debug
- Added debug logging in a few important places
- Made RescheduleTask log counter thread safe