### PR TITLE
Focal point no longer works in image service #9244

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/image/Cropping.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/image/Cropping.java
@@ -138,8 +138,8 @@ public final class Cropping
         {
             this.top = 0;
             this.left = 0;
-            this.bottom = 0;
-            this.right = 0;
+            this.bottom = 1.0;
+            this.right = 1.0;
             this.zoom = 1.0;
         }
 

--- a/modules/core/core-api/src/test/java/com/enonic/xp/image/ReadImageParamsTest.java
+++ b/modules/core/core-api/src/test/java/com/enonic/xp/image/ReadImageParamsTest.java
@@ -20,7 +20,7 @@ public class ReadImageParamsTest
         final ReadImageParams readImageParams = ReadImageParams.newImageParams().
             contentId( ContentId.from( "contentId" ) ).
             binaryReference( BinaryReference.from( "binaryReference" ) ).
-            cropping( Cropping.create().bottom( 1 ).right( 1 ).build() ).
+            cropping( Cropping.create().build() ).
             scaleParams( new ScaleParams( "scaleParams", null ) ).
             focalPoint( FocalPoint.DEFAULT ).
             scaleSize( 1 ).
@@ -36,7 +36,7 @@ public class ReadImageParamsTest
         assertEquals( ContentId.from( "contentId" ), readImageParams.getContentId() );
         assertEquals( BinaryReference.from( "binaryReference" ), readImageParams.getBinaryReference() );
         assertEquals( BinaryReference.from( "binaryReference" ), readImageParams.getBinaryReference() );
-        assertEquals( Cropping.create().bottom( 1 ).right( 1 ).build(), readImageParams.getCropping() );
+        assertEquals( Cropping.create().build(), readImageParams.getCropping() );
         assertEquals( "scaleParams", readImageParams.getScaleParams().getName() );
         assertEquals( FocalPoint.DEFAULT, readImageParams.getFocalPoint() );
         assertEquals( 1, readImageParams.getScaleSize() );

--- a/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/NormalizedImageParams.java
+++ b/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/NormalizedImageParams.java
@@ -39,7 +39,7 @@ class NormalizedImageParams
     {
         this.contentId = readImageParams.getContentId();
         this.binaryReference = readImageParams.getBinaryReference();
-        this.cropping = readImageParams.getCropping();
+        this.cropping = normalizeCropping( readImageParams.getCropping() );
         this.scaleParams = normalizeScaleParams( readImageParams );
         this.focalPoint = readImageParams.getFocalPoint();
         this.filterParam = FilterSetExpr.parse( readImageParams.getFilterParam() );
@@ -97,6 +97,11 @@ class NormalizedImageParams
     public ImageOrientation getOrientation()
     {
         return orientation;
+    }
+
+    private static Cropping normalizeCropping( final Cropping cropping )
+    {
+        return cropping == null || cropping.isUnmodified() ? null : cropping;
     }
 
     private static String normalizeFormat( final ReadImageParams readImageParams )

--- a/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/effect/ScaleCalculator.java
+++ b/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/effect/ScaleCalculator.java
@@ -63,9 +63,8 @@ public interface ScaleCalculator
     {
         int diff = value1 - value2;
         final int centered = (int) ( value1 * offset ) - ( value2 / 2 );
-        return Math.max( Math.min( centered, 0 ), diff );
+        return Math.min( Math.max( centered, 0 ), diff );
     }
-
 
     private static Values scaledSub( final int newWidth, final int newHeight, final int widthOffset, final int heightOffset,
                                      final int viewWidth, final int viewHeight )

--- a/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/effect/ScaledFunction.java
+++ b/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/effect/ScaledFunction.java
@@ -35,6 +35,6 @@ public class ScaledFunction
     {
         final ScaleCalculator.Values values = scaleCalculator.calc( sourceWidth, sourceHeight );
 
-        return Math.multiplyExact( values.newWidth, values.newWidth );
+        return Math.multiplyExact( values.newWidth, values.newHeight );
     }
 }

--- a/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/NormalizedImageParamsTest.java
+++ b/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/NormalizedImageParamsTest.java
@@ -3,6 +3,7 @@ package com.enonic.xp.core.impl.image;
 import org.junit.jupiter.api.Test;
 
 import com.enonic.xp.content.ContentId;
+import com.enonic.xp.image.Cropping;
 import com.enonic.xp.image.ReadImageParams;
 import com.enonic.xp.image.ScaleParams;
 import com.enonic.xp.util.BinaryReference;
@@ -29,20 +30,27 @@ class NormalizedImageParamsTest
     @Test
     void normalizeNoScaleParams()
     {
-        final ScaleParams scaleParams = new NormalizedImageParams( someFormatTemplate().
-            build() ).getScaleParams();
+        final ScaleParams scaleParams = new NormalizedImageParams( someFormatTemplate().build() ).getScaleParams();
+        assertNull( scaleParams );
+    }
+
+    @Test
+    void normalizeInsignificantCropping()
+    {
+        final ScaleParams scaleParams = new NormalizedImageParams(
+            someFormatTemplate().cropping( Cropping.create().build() ).build() ).getScaleParams();
         assertNull( scaleParams );
     }
 
     @Test
     void normalizeScaleParams()
     {
-        final ScaleParams scaleParams = new NormalizedImageParams( someFormatTemplate().
-            scaleParams( new ScaleParams( "block", new Object[]{10, 15} ) ).
-            scaleSquare( true ).
-            scaleWidth( true ).
-            scaleSize( 10 ).
-            build() ).getScaleParams();
+        final ScaleParams scaleParams = new NormalizedImageParams(
+            someFormatTemplate().scaleParams( new ScaleParams( "block", new Object[]{10, 15} ) )
+                .scaleSquare( true )
+                .scaleWidth( true )
+                .scaleSize( 10 )
+                .build() ).getScaleParams();
         assertEquals( "block", scaleParams.getName() );
         assertArrayEquals( new Object[]{10, 15}, scaleParams.getArguments() );
     }
@@ -50,11 +58,8 @@ class NormalizedImageParamsTest
     @Test
     void normalizeScaleSquire()
     {
-        final ScaleParams scaleParams = new NormalizedImageParams( someFormatTemplate().
-            scaleSquare( true ).
-            scaleWidth( true ).
-            scaleSize( 10 ).
-            build() ).getScaleParams();
+        final ScaleParams scaleParams = new NormalizedImageParams(
+            someFormatTemplate().scaleSquare( true ).scaleWidth( true ).scaleSize( 10 ).build() ).getScaleParams();
         assertEquals( "square", scaleParams.getName() );
         assertArrayEquals( new Object[]{10}, scaleParams.getArguments() );
     }
@@ -62,11 +67,8 @@ class NormalizedImageParamsTest
     @Test
     void normalizeScaleWidth()
     {
-        final ScaleParams scaleParams = new NormalizedImageParams( someFormatTemplate().
-            scaleSquare( false ).
-            scaleWidth( true ).
-            scaleSize( 10 ).
-            build() ).getScaleParams();
+        final ScaleParams scaleParams = new NormalizedImageParams(
+            someFormatTemplate().scaleSquare( false ).scaleWidth( true ).scaleSize( 10 ).build() ).getScaleParams();
         assertEquals( "width", scaleParams.getName() );
         assertArrayEquals( new Object[]{10}, scaleParams.getArguments() );
     }
@@ -74,11 +76,8 @@ class NormalizedImageParamsTest
     @Test
     void normalizeScaleMax()
     {
-        final ScaleParams scaleParams = new NormalizedImageParams( someFormatTemplate().
-            scaleSquare( false ).
-            scaleWidth( false ).
-            scaleSize( 10 ).
-            build() ).getScaleParams();
+        final ScaleParams scaleParams = new NormalizedImageParams(
+            someFormatTemplate().scaleSquare( false ).scaleWidth( false ).scaleSize( 10 ).build() ).getScaleParams();
         assertEquals( "max", scaleParams.getName() );
         assertArrayEquals( new Object[]{10}, scaleParams.getArguments() );
     }
@@ -86,19 +85,13 @@ class NormalizedImageParamsTest
     @Test
     void normalizeBackgroundColor()
     {
-        assertEquals( 0xFFFFFF, new NormalizedImageParams( noFormatTemplate().
-            mimeType( "image/jpeg" ).
-            build() ).getBackgroundColor() );
+        assertEquals( 0xFFFFFF, new NormalizedImageParams( noFormatTemplate().mimeType( "image/jpeg" ).build() ).getBackgroundColor() );
 
-        assertEquals( 0x00FF00, new NormalizedImageParams( noFormatTemplate().
-            mimeType( "image/jpeg" ).
-            backgroundColor( 0x00FF00 ).
-            build() ).getBackgroundColor() );
+        assertEquals( 0x00FF00, new NormalizedImageParams(
+            noFormatTemplate().mimeType( "image/jpeg" ).backgroundColor( 0x00FF00 ).build() ).getBackgroundColor() );
 
-        assertEquals( 0xFFFFFF, new NormalizedImageParams( noFormatTemplate().
-            mimeType( "image/png" ).
-            backgroundColor( 0x00FF00 ).
-            build() ).getBackgroundColor() );
+        assertEquals( 0xFFFFFF, new NormalizedImageParams(
+            noFormatTemplate().mimeType( "image/png" ).backgroundColor( 0x00FF00 ).build() ).getBackgroundColor() );
     }
 
     private static ReadImageParams.Builder someFormatTemplate()
@@ -108,7 +101,6 @@ class NormalizedImageParamsTest
 
     private static ReadImageParams.Builder noFormatTemplate()
     {
-        return ReadImageParams.newImageParams().contentId( ContentId.from( "123" ) ).
-            binaryReference( BinaryReference.from( "456" ) );
+        return ReadImageParams.newImageParams().contentId( ContentId.from( "123" ) ).binaryReference( BinaryReference.from( "456" ) );
     }
 }

--- a/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/effect/ScaleCalculatorTest.java
+++ b/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/effect/ScaleCalculatorTest.java
@@ -1,0 +1,63 @@
+package com.enonic.xp.core.impl.image.effect;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScaleCalculatorTest
+{
+    @Test
+    void block_upscale_focal_upper_left()
+    {
+        final ScaleCalculator.Values values = ScaleCalculator.block( 1000, 1000, 0, 0 ).calc( 100, 200 );
+
+        assertThat( values ).extracting( v -> v.newWidth, v -> v.newHeight, v -> v.widthOffset, v -> v.heightOffset, v -> v.viewWidth,
+                                         v -> v.viewHeight ).containsExactly( 1000, 2000, 0, 0, 1000, 1000 );
+    }
+
+    @Test
+    void block_focal_upper_left()
+    {
+        final ScaleCalculator.Values values = ScaleCalculator.block( 10, 10, 0, 0 ).calc( 100, 200 );
+
+        assertThat( values ).extracting( v -> v.newWidth, v -> v.newHeight, v -> v.widthOffset, v -> v.heightOffset, v -> v.viewWidth,
+                                         v -> v.viewHeight ).containsExactly( 10, 20, 0, 0, 10, 10 );
+    }
+
+    @Test
+    void block_focal_lower_left()
+    {
+        final ScaleCalculator.Values values = ScaleCalculator.block( 10, 10, 0, 1 ).calc( 100, 200 );
+
+        assertThat( values ).extracting( v -> v.newWidth, v -> v.newHeight, v -> v.widthOffset, v -> v.heightOffset, v -> v.viewWidth,
+                                         v -> v.viewHeight ).containsExactly( 10, 20, 0, 10, 10, 10 );
+    }
+
+    @Test
+    void block_mixscale_focal_lower_left()
+    {
+        final ScaleCalculator.Values values = ScaleCalculator.block( 1000, 10, 0, 1 ).calc( 100, 200 );
+
+        assertThat( values ).extracting( v -> v.newWidth, v -> v.newHeight, v -> v.widthOffset, v -> v.heightOffset, v -> v.viewWidth,
+                                         v -> v.viewHeight ).containsExactly( 1000, 2000, 0, 1990, 1000, 10 );
+    }
+
+    @Test
+    void block_focal_upper_right()
+    {
+        final ScaleCalculator.Values values = ScaleCalculator.block( 10, 10, 1, 0 ).calc( 200, 100 );
+
+        assertThat( values ).extracting( v -> v.newWidth, v -> v.newHeight, v -> v.widthOffset, v -> v.heightOffset, v -> v.viewWidth,
+                                         v -> v.viewHeight ).containsExactly( 20, 10, 10, 0, 10, 10 );
+    }
+
+    @Test
+    void block_focal_lower_right()
+    {
+        final ScaleCalculator.Values values = ScaleCalculator.block( 10, 10, 1, 1 ).calc( 200, 100 );
+
+        assertThat( values ).extracting( v -> v.newWidth, v -> v.newHeight, v -> v.widthOffset, v -> v.heightOffset, v -> v.viewWidth,
+                                         v -> v.viewHeight ).containsExactly( 20, 10, 10, 0, 10, 10 );
+    }
+
+}

--- a/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/effect/ScaledFunctionTest.java
+++ b/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/effect/ScaledFunctionTest.java
@@ -1,0 +1,16 @@
+package com.enonic.xp.core.impl.image.effect;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ScaledFunctionTest
+{
+    @Test
+    void estimateResolution()
+    {
+        final ScaledFunction scaledFunction = new ScaledFunction( ScaleCalculator.block( 10, 15, 0.5, 0.5 ) );
+        assertEquals( 150, scaledFunction.estimateResolution( 1000, 1500 ) );
+
+    }
+}


### PR DESCRIPTION
`Math.max( Math.min( centered, 0 ), diff );` changed to `Math.min( Math.max( centered, 0 ), diff );`

Additional fixes:
- if cropping is specified but not essential, it won't affect file cache key
- estimated resolution for memory constraints did not take into account image height (it was WxW instead of WxH)