### PR TITLE
Text component should not be wrapped inside a div in edit mode #9453

### DIFF
--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/rendering/TextRendererTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/rendering/TextRendererTest.java
@@ -73,7 +73,7 @@ public class TextRendererTest
         // exercise
         portalResponse = renderer.render( textComponent, portalRequest );
         // verify
-        assertEquals( "<div data-portal-component-type=\"text\"><section></section></div>", portalResponse.getAsString() );
+        assertEquals( "<section data-portal-component-type=\"text\"></section>", portalResponse.getAsString() );
     }
 
     @Test
@@ -89,7 +89,7 @@ public class TextRendererTest
         portalResponse = renderer.render( textComponent, portalRequest );
 
         // verify
-        assertEquals( "<section data-portal-component-type=\"text\"></section>", portalResponse.getAsString() );
+        assertEquals( "", portalResponse.getAsString() );
     }
 
     @Test
@@ -105,7 +105,7 @@ public class TextRendererTest
         portalResponse = renderer.render( textComponent, portalRequest );
 
         // verify
-        assertEquals( "<section data-portal-component-type=\"text\"></section>", portalResponse.getAsString() );
+        assertEquals( "", portalResponse.getAsString() );
     }
 
 
@@ -155,7 +155,7 @@ public class TextRendererTest
         portalResponse = renderer.render( textComponent, portalRequest );
 
         // verify
-        assertEquals( "<div data-portal-component-type=\"text\"><section>" + text + "</section></div>", portalResponse.getAsString() );
+        assertEquals( "<section data-portal-component-type=\"text\">" + text + "</section>", portalResponse.getAsString() );
     }
 
     private static class MockMacroService


### PR DESCRIPTION
- removed extra `div` in EDIT mode
In addition empty text component renders the same (empty string) in PREVIEW and INLINE