### PR TITLE
Migrate Javascript API to Typescript for lib-admin #9537

### DIFF
--- a/modules/lib/lib-admin/README.md
+++ b/modules/lib/lib-admin/README.md
@@ -1,0 +1,81 @@
+# Enonic XP lib-admin TS types
+
+> TypeScript definitions for `lib-admin` library of Enonic XP
+
+## Install
+
+```bash
+npm i --save-dev @enonic/lib-admin
+```
+
+## Use
+
+Add the corresponding types to your `tsconfig.json` file that is used for application's server-side TypeScript code.
+
+`tsconfig.json`
+
+```json
+{
+  "compilerOptions": {
+    "types": [
+      "@enonic-types/lib-admin"
+    ]
+  }
+}
+```
+
+### Require and custom imports
+
+To make `require` work out of box, you must install and add the `@enonic-types/global` types. Aside from providing definitions for XP global
+objects, e.g. `log`, `app`, `__`, etc, requiring library by the default path will return typed object.
+
+`tsconfig.json`
+
+```diff
+{
+  "compilerOptions": {
+    "types": [
++     "@enonic-types/global"
+      "@enonic-types/lib-admin"
+    ]
+  }
+}
+```
+
+`example.ts`
+
+```ts
+const {assetUrl} = require('/lib/xp/admin');
+```
+
+More detailed explanation on how it works and how to type custom import function can be
+found [here](https://github.com/enonic/xp/tree/master/modules/lib/typescript/README.md).
+
+### ES6-style import
+
+If you are planning to use `import` in your code and transpile it with the default `tsc` TypeScript compiler, you'll need to add proper
+types mapping to your configuration.
+
+`tsconfig.json`
+
+```diff
+{
+  "compilerOptions": {
+    "types": [
+      "@enonic-types/lib-admin"
+    ]
++   "baseUrl": "./",
++   "paths": {
++     "/lib/xp/admin": ["node_modules/@enonic-types/lib-admin"],
++   }
+  }
+}
+```
+
+`example.ts`
+
+```ts
+import {getBaseUri, getAssetsUri, getHomeToolUrl, HomeToolUrlType} from '/lib/xp/admin';
+```
+
+Setting `baseUrl` and `paths` will allow the `tsc` to keep the valid paths in the resulting JavaScript files.

--- a/modules/lib/lib-admin/build.gradle
+++ b/modules/lib/lib-admin/build.gradle
@@ -1,3 +1,5 @@
+apply from: "$rootDir/gradle/npm.gradle"
+
 dependencies {
     compileOnly project( ':core:core-api' )
     compileOnly project( ':admin:admin-api' )

--- a/modules/lib/lib-admin/src/main/resources/lib/xp/admin.ts
+++ b/modules/lib/lib-admin/src/main/resources/lib/xp/admin.ts
@@ -1,3 +1,9 @@
+declare global {
+    interface XpLibraries {
+        '/lib/xp/admin': typeof import('./admin');
+    }
+}
+
 /**
  * Admin related functions.
  *
@@ -6,80 +12,101 @@
  *
  * @module admin
  */
-/* global __*/
 
-var i18n = require('/lib/xp/i18n');
-var portal = require('/lib/xp/portal');
-var helper = __.newBean('com.enonic.xp.lib.admin.AdminLibHelper');
+const i18n = require('/lib/xp/i18n');
+const portal = require('/lib/xp/portal');
 
+const helper = __.newBean<AdminLibHelper>('com.enonic.xp.lib.admin.AdminLibHelper');
 
-var adminToolsUriPrefix = '/admin/tool';
+interface AdminLibHelper {
+    getHomeAppName(): string;
+
+    generateAdminToolUri(application: string, adminTool: string): string;
+
+    getAssetsUri(): string;
+
+    getBaseUri(): string;
+
+    getHomeToolUri(): string;
+
+    getInstallation(): string;
+
+    getLauncherToolUrl(): string;
+
+    getLocale(): string;
+
+    getLocales(): string[];
+
+    getPhrases(): string;
+
+    getVersion(): string;
+}
 
 /**
  * Returns the admin base uri.
  *
  * @returns {string} Admin base uri.
  */
-exports.getBaseUri = function () {
+export function getBaseUri(): string {
     return helper.getBaseUri();
-};
+}
 
 /**
  * Returns the admin assets uri.
  *
  * @returns {string} Assets uri.
  */
-exports.getAssetsUri = function () {
+export function getAssetsUri(): string {
     return helper.getAssetsUri();
-};
+}
 
 /**
  * Returns the preferred locale based on the current HTTP request, or the server default locale if none is specified.
  *
  * @returns {string} Current locale.
  */
-exports.getLocale = function () {
+export function getLocale(): string {
     return helper.getLocale();
-};
+}
 
 /**
  * Returns the list of preferred locales based on the current HTTP request, or the server default locale if none is specified.
  *
  * @returns {string[]} Current locales in order of preference.
  */
-exports.getLocales = function () {
+export function getLocales(): string[] {
     return __.toNativeObject(helper.getLocales());
-};
+}
 
 /**
  * Returns all i18n phrases.
  *
  * @returns {object} JSON object with phrases.
  */
-exports.getPhrases = function () {
-    return JSON.stringify(i18n.getPhrases(exports.getLocales(), ['i18n/common', 'i18n/phrases']));
-};
+export function getPhrases(): string {
+    return JSON.stringify(i18n.getPhrases(getLocales(), ['i18n/common', 'i18n/phrases']));
+}
 
 /**
  * Returns the URL for launcher panel.
  *
  * @returns {string} URL.
  */
-exports.getLauncherUrl = function () {
+export function getLauncherUrl(): string {
     return helper.getLauncherToolUrl();
-};
+}
 
 /**
  * Returns the URL for launcher javascript.
  *
  * @returns {string} Path.
  */
-exports.getLauncherPath = function () {
+export function getLauncherPath(): string {
     return portal.assetUrl({
         application: helper.getHomeAppName(),
         path: '/js/launcher/bundle.js'
     });
-};
+}
 
 /**
  * Returns the URL for an admin tool of specific application.
@@ -88,13 +115,13 @@ exports.getLauncherPath = function () {
  *
  * @returns {string} URL.
  */
-exports.getToolUrl = function (application, tool) {
+export function getToolUrl(application: string, tool: string) {
     if (application) {
         return helper.generateAdminToolUri(application, tool);
     }
 
-    return helper.generateHomeToolUri();
-};
+    return helper.getHomeToolUri();
+}
 
 /**
  * Returns the URL for the Home admin tool.
@@ -103,27 +130,33 @@ exports.getToolUrl = function (application, tool) {
  *
  * @returns {string} URL.
  */
-exports.getHomeToolUrl = function (params) {
+export function getHomeToolUrl(params: GetHomeToolUrlParams) {
     return portal.url({
-        path: adminToolsUriPrefix,
-        type: params && params.type
+        path: '/admin/tool',
+        type: params?.type,
     });
-};
+}
+
+export interface GetHomeToolUrlParams {
+    type: HomeToolUrlType;
+}
+
+export type HomeToolUrlType = 'server' | 'absolute';
 
 /**
  * Returns installation name.
  *
  * @returns {string} Installation name.
  */
-exports.getInstallation = function () {
+export function getInstallation(): string {
     return helper.getInstallation();
-};
+}
 
 /**
  * Returns version of XP installation.
  *
  * @returns {string} Version.
  */
-exports.getVersion = function () {
+export function getVersion(): string {
     return helper.getVersion();
-};
+}

--- a/modules/lib/lib-i18n/src/main/resources/lib/xp/i18n.ts
+++ b/modules/lib/lib-i18n/src/main/resources/lib/xp/i18n.ts
@@ -15,7 +15,7 @@ export interface LocalizeParams {
 interface LocaleScriptBean {
     localize(key: string, locales: string[], values: string[], bundles?: string[] | null): string;
 
-    getPhrases(locale: string[], bundles: string[]): object;
+    getPhrases(locale: string[], bundles: string[]): Record<string, string>;
 
     getSupportedLocales(bundles: string[]): string[];
 
@@ -72,7 +72,7 @@ export function localize(params: LocalizeParams): string {
  * @example
  * i18nLib.getPhrases('en', ['i18n/phrases'])
  */
-export function getPhrases(locale: string | string[], bundles: string[]): object {
+export function getPhrases(locale: string | string[], bundles: string[]): Record<string, string> {
     const bean = __.newBean<LocaleScriptBean>('com.enonic.xp.lib.i18n.LocaleScriptBean');
     const locales: string[] = ([] as string[]).concat(locale);
     return __.toNativeObject(bean.getPhrases(locales, bundles));


### PR DESCRIPTION
Added lib-admin types.
Updated `getPhrases` return type to more specific object.
Fixed `generateHomeToolUri` helper's call, since it was renamed to `getHomeToolUri`.