### PR TITLE
Add type parameters to Content

### DIFF
--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -12,7 +12,6 @@ declare global {
         '/lib/xp/content': typeof import('./content');
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
     interface XpXData {
         [key: string]: Record<string, Record<string, unknown>>
     }

--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -11,6 +11,10 @@ declare global {
     interface XpLibraries {
         '/lib/xp/portal': typeof import('./portal');
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface XpXData {
+    }
 }
 
 export interface Attachment {
@@ -43,7 +47,7 @@ export interface PublishInfo {
     first?: string;
 }
 
-export interface Content {
+export interface Content<Data = Record<string, unknown>, Type extends string = string> {
     _id: string;
     _name: string;
     _path: string;
@@ -53,7 +57,8 @@ export interface Content {
     createdTime: string;
     modifiedTime: string;
     owner: string;
-    type: string;
+    data: Data;
+    type: Type;
     displayName: string;
     hasChildren: boolean;
     language: string;
@@ -61,17 +66,21 @@ export interface Content {
     originProject: string;
     childOrder?: string;
     _sort?: object[];
-    data: Record<string, unknown>;
-    x: XData;
+    x: XpXData;
     attachments: Attachments;
     publish?: PublishInfo;
     workflow?: Workflow;
     inherit?: ContentInheritType[];
 }
 
-export interface Site
-    extends Content {
-    description: string;
+export type Site<Config> = Content<{
+    description?: string;
+    siteConfig: SiteConfig<Config> | SiteConfig<Config>[];
+}, 'portal:site'>;
+
+export interface SiteConfig<Config> {
+    applicationKey: string;
+    config: Config;
 }
 
 export interface AssetUrlParams {
@@ -433,7 +442,7 @@ export function sanitizeHtml(html: string): string {
 }
 
 interface GetCurrentSiteHandler {
-    execute(): Site | null;
+    execute<Config>(): Site<Config> | null;
 }
 
 /**
@@ -444,15 +453,13 @@ interface GetCurrentSiteHandler {
  *
  * @returns {object|null} The current site as JSON.
  */
-export function getSite(): Site | null {
+export function getSite<Config = Record<string, unknown>>(): Site<Config> | null {
     const bean = __.newBean<GetCurrentSiteHandler>('com.enonic.xp.lib.portal.current.GetCurrentSiteHandler');
-    return __.toNativeObject(bean.execute());
+    return __.toNativeObject(bean.execute<Config>());
 }
 
-export type SiteConfig = Record<string, unknown>;
-
 interface GetCurrentSiteConfigHandler {
-    execute(): SiteConfig | null;
+    execute<Config>(): Config | null;
 }
 
 /**
@@ -463,13 +470,13 @@ interface GetCurrentSiteConfigHandler {
  *
  * @returns {object|null} The site configuration for current application as JSON.
  */
-export function getSiteConfig(): SiteConfig | null {
+export function getSiteConfig<Config = Record<string, unknown>>(): Config | null {
     const bean = __.newBean<GetCurrentSiteConfigHandler>('com.enonic.xp.lib.portal.current.GetCurrentSiteConfigHandler');
-    return __.toNativeObject(bean.execute());
+    return __.toNativeObject(bean.execute<Config>());
 }
 
 interface GetCurrentContentHandler {
-    execute(): Content | null;
+    execute<Data, Type extends string>(): Content<Data, Type> | null;
 }
 
 /**
@@ -480,9 +487,9 @@ interface GetCurrentContentHandler {
  *
  * @returns {object|null} The current content as JSON.
  */
-export function getContent(): Content | null {
+export function getContent<Data = Record<string, unknown>, Type extends string = string>(): Content<Data, Type> | null {
     const bean = __.newBean<GetCurrentContentHandler>('com.enonic.xp.lib.portal.current.GetCurrentContentHandler');
-    return __.toNativeObject(bean.execute());
+    return __.toNativeObject(bean.execute<Data, Type>());
 }
 
 export interface Component<Config extends object = object, Regions extends Record<string, Region> = Record<string, Region>> {


### PR DESCRIPTION
This commit adds two type parameters to the `Content` interface to make it possible to configure the shape of `Content.data` and `Content.type`.

By having the `Content.data` field specified by the `<Data>` type parameter a JavaScript-/TypeScript-developer can now easily specify the correct shape of `Content` (without using hacks like `as`). The `Content.type` field can be narrowed by setting the `<Type>` type parameter to a string literal (e.g. `"com.mycompany:article"`). This makes a union of `Content` into a discriminated union, where we can use normal `if`-statements to split the union.

The fallback value for `Content.data` is `Record<string, unknown>` and `Content.type` is `string` so the default shape of `Content` is by default the exact same as it was before this commit.

The `x` field has been set to a new global interface `XpXData`. This interface has the same shape as the old `XData` interface, but it allows developers extend the shape, so that it can be configured once for every content type. This will allow e.g. *lib-menu* to have code that automatically adds the correct shape to `XpXData`.

The shape of `Site` was wrong, and has been corrected. And `getSite()` and `getSiteConfig()` can now take the shape of `config` as a type parameter `<Config>`. The default value of `<Config>` is `Record<string, unknown>`. So it will by default have the exact same shape as before this commit.

*portal-lib* has been updated with the same changes to `Content` as *content-lib*.

I moved the `data` field before the `type` field in `Content`. The reason is that type inference in TypeScript might be better if the type parameter order is the same as the order they are found in the code.