### PR TITLE
Grid Library types improvements #9730

### DIFF
--- a/modules/lib/lib-grid/src/main/resources/lib/xp/grid.ts
+++ b/modules/lib/lib-grid/src/main/resources/lib/xp/grid.ts
@@ -15,47 +15,75 @@ declare global {
 
 export type SharedMapValueType = string | number | boolean | object | null;
 
-export type SharedMapModifierFn = (oldValue: SharedMapValueType) => SharedMapValueType;
+export type GridMap = Record<string, SharedMapValueType>;
 
-interface ISharedMap {
-    get(key: string): SharedMapValueType;
+export type SharedMapModifierFn<Map extends GridMap, Key extends keyof Map> = (value: Map[Key] | null) => Map[Key] | null;
 
-    delete(key: string): SharedMapValueType;
+interface JavaSharedMap<Map extends GridMap> {
+    get<Key extends keyof Map>(key: keyof Map): Map[Key] | null;
 
-    set(key: string, value: SharedMapValueType): void;
+    delete(key: keyof Map): void;
 
-    set(key: string, value: SharedMapValueType, ttlSeconds?: number | null): void;
+    set<Key extends keyof Map>(key: Key, value: Map[Key] | null, ttlSeconds?: number | null): void;
 
-    modify(key: string, modifier: SharedMapModifierFn): SharedMapValueType;
-
-    modify(key: string, modifier: SharedMapModifierFn, ttlSeconds?: number | null): SharedMapValueType;
+    modify<Key extends keyof Map>(key: Key, modifier: SharedMapModifierFn<Map, Key>, ttlSeconds?: number | null): Map[Key];
 }
 
-export interface SetParams {
-    key: string;
-    value: SharedMapValueType
+interface SharedMapHandler<Map extends GridMap> {
+    getMap(mapId: string): JavaSharedMap<Map>;
+}
+
+export interface SetParams<Map extends GridMap, Key extends keyof Map> {
+    key: Key;
+    value: Map[Key] | null;
     ttlSeconds?: number;
 }
 
-export interface ModifyParams {
-    key: string;
-    func: SharedMapModifierFn;
+export interface ModifyParams<Map extends GridMap, Key extends keyof Map> {
+    key: Key;
+    func: SharedMapModifierFn<Map, Key>;
     ttlSeconds?: number;
 }
 
 /**
  * Shared Map is similar to other Map, but its instances are shared across all applications and even cluster nodes.
-
- WARNING: Due to distributed nature of the Shared Map not all types of keys and values can be used. Strings, numbers, and pure JSON objects are supported. There is no runtime check for type compatibility due to performance reasons. The developer is also responsible for not modifying shared objects (keys and values) in place.
- * @param mapId - map identifier
+ *
+ *  WARNING: Due to distributed nature of the Shared Map not all types of keys and values can be used.
+ *  Strings, numbers, and pure JSON objects are supported. There is no runtime check for type compatibility due to performance reasons.
+ *  The developer is also responsible for not modifying shared objects (keys and values) in place.
+ *
  * @constructor
+ * @hideconstructor
+ * @alias SharedMap
  */
-export class SharedMap {
+export interface SharedMap<Map extends GridMap> {
+    get<Key extends keyof Map>(key: Key): Map[Key];
 
-    private map: ISharedMap;
+    set<Key extends keyof Map>(params: SetParams<Map, Key>): void;
+
+    modify<Key extends keyof Map>(params: ModifyParams<Map, Key>): Map[Key];
+
+    delete(key: keyof Map): void;
+}
+
+/**
+ * Shared Map is similar to other Map, but its instances are shared across all applications and even cluster nodes.
+ *
+ *  WARNING: Due to distributed nature of the Shared Map not all types of keys and values can be used.
+ *  Strings, numbers, and pure JSON objects are supported. There is no runtime check for type compatibility due to performance reasons.
+ *  The developer is also responsible for not modifying shared objects (keys and values) in place.
+ *
+ * @constructor
+ * @hideconstructor
+ * @alias SharedMap
+ */
+class SharedMapImpl<Map extends GridMap>
+    implements SharedMap<Map> {
+
+    private map: JavaSharedMap<Map>;
 
     constructor(mapId: string) {
-        const bean = __.newBean<SharedMapHandler>('com.enonic.xp.lib.grid.SharedMapHandler');
+        const bean = __.newBean<SharedMapHandler<Map>>('com.enonic.xp.lib.grid.SharedMapHandler');
         this.map = bean.getMap(mapId);
     }
 
@@ -65,7 +93,7 @@ export class SharedMap {
      * @param {string} key - key the key whose associated value is to be returned
      * @returns {string|number|boolean|JSON|null} the value to which the specified key is mapped, or null if this map contains no mapping for the key
      */
-    get(key: string): SharedMapValueType {
+    get<Key extends keyof Map>(key: Key): Map[Key] {
         return __.toNativeObject(this.map.get(key));
     }
 
@@ -78,7 +106,7 @@ export class SharedMap {
      * @param {string|number|boolean|JSON|null} params.value value of the entry
      * @param {number} [params.ttlSeconds] maximum time to live in seconds for this entry to stay in the map. (0 means infinite, negative means map config default or infinite if map config is not available)
      */
-    set(params: SetParams): void {
+    set(params: SetParams<Map, keyof Map>): void {
         const key = requireNotNull(params.key, 'key');
         const ttlSeconds = __.nullOrValue(params.ttlSeconds);
         const value = convertValue(params.value);
@@ -100,7 +128,7 @@ export class SharedMap {
      * @param {number} [params.ttlSeconds] maximum time to live in seconds for this entry to stay in the map. (0 means infinite, negative means map config default or infinite if map config is not available)
      * @returns the new value to which the specified key is mapped, or null if this map no longer contains mapping for the key
      */
-    modify(params: ModifyParams): SharedMapValueType {
+    modify<Key extends keyof Map>(params: ModifyParams<Map, Key>): Map[Key] {
         const key = requireNotNull(params.key, 'key');
         const func = requireNotNull(params.func, 'func');
         if (typeof func !== 'function') {
@@ -109,9 +137,9 @@ export class SharedMap {
 
         const ttlSeconds = __.nullOrValue(params.ttlSeconds);
 
-        const modifierFn = (oldValue: SharedMapValueType): SharedMapValueType => {
-            return convertValue(func.call(this, __.toNativeObject(oldValue)));
-        };
+        function modifierFn<Key extends keyof Map>(oldValue: Map[Key] | null): Map[Key] | null {
+            return convertValue<Map, Key>(func.call(this, __.toNativeObject(oldValue)));
+        }
 
         if (ttlSeconds === null) {
             return __.toNativeObject(this.map.modify(key, modifierFn));
@@ -125,29 +153,25 @@ export class SharedMap {
      *
      * @param {string} key the key whose associated value is to be removed
      */
-    delete(key: string): void {
+    delete(key: keyof Map): void {
         this.map.delete(key);
     }
 }
 
-interface SharedMapHandler {
-    getMap(mapId: string): ISharedMap;
-}
-
-function requireNotNull<T extends string | SharedMapModifierFn>(value: T, parameterName: string): T {
+function requireNotNull<T>(value: T, parameterName: string): T {
     if (value == null) {
         throw `Parameter "${parameterName}" is required`;
     }
     return value;
 }
 
-function convertValue(value: SharedMapValueType): SharedMapValueType {
+function convertValue<Map extends GridMap, Key extends keyof Map>(value: Map[Key] | null): Map[Key] | null {
     if (typeof value === 'undefined' || value === null) {
         return null;
     } else if (Array.isArray(value)) {
-        return __.toScriptValue(value).getList();
+        return __.toScriptValue(value).getList() as Map[Key];
     } else if (typeof value === 'object') {
-        return __.toScriptValue(value).getMap();
+        return __.toScriptValue(value).getMap() as Map[Key];
     } else {
         return value;
     }
@@ -159,7 +183,7 @@ function convertValue(value: SharedMapValueType): SharedMapValueType {
  * @param {string} mapId map identifier
  * @returns {SharedMap} an instance of SharedMap
  */
-export function getMap(mapId: string): SharedMap {
-    return new SharedMap(requireNotNull(mapId, 'mapId'));
+export function getMap<Map extends GridMap>(mapId: string): SharedMap<Map> {
+    return new SharedMapImpl<Map>(requireNotNull(mapId, 'mapId'));
 }
 

--- a/modules/lib/lib-scheduler/src/main/resources/lib/xp/scheduler.ts
+++ b/modules/lib/lib-scheduler/src/main/resources/lib/xp/scheduler.ts
@@ -58,7 +58,7 @@ export interface ScheduledJob<Config extends object = Record<string, unknown>> {
     schedule: OneTimeSchedule | CronSchedule;
 }
 
-interface CreateScheduledJobHandler<Config extends object = Record<string, unknown>> {
+interface CreateScheduledJobHandler<Config extends object> {
     setName(value: string): void;
 
     setSchedule(value: OneTimeSchedule | CronSchedule): void;
@@ -117,7 +117,7 @@ export interface ModifyScheduledJobParams<Config extends object = Record<string,
     editor: EditorFn<ScheduledJob<Config>>;
 }
 
-interface ModifyScheduledJobHandler<Config extends object = Record<string, unknown>> {
+interface ModifyScheduledJobHandler<Config extends object> {
     setName(value: string): void;
 
     setEditor(value: ScriptValue): void;
@@ -181,7 +181,7 @@ export interface GetScheduledJobParams {
     name: string;
 }
 
-interface GetScheduledJobHandler<Config extends object = Record<string, unknown>> {
+interface GetScheduledJobHandler<Config extends object> {
     setName(value: string): void;
 
     execute(): ScheduledJob<Config> | null;
@@ -205,7 +205,7 @@ export function get<Config extends object = Record<string, unknown>>(params: Get
     return __.toNativeObject(bean.execute());
 }
 
-interface ListScheduledJobsHandler<Config extends object = Record<string, unknown>> {
+interface ListScheduledJobsHandler<Config extends object> {
     execute(): ScheduledJob<Config>[];
 }
 


### PR DESCRIPTION
Added generics for better and typesafe mappings.
Renamed `ISharedMap` to `JavaSharedMap`.
Renamed `SharedMap` to `SharedMapImpl`.
Added `SharedMap` interface and made it exportable instead of `SharedMapImpl` class. Removed default value in internal generics.