### PR TITLE
Content library type definitions contain invalid core reference #9766

### DIFF
--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -11,9 +11,12 @@ declare global {
     interface XpLibraries {
         '/lib/xp/content': typeof import('./content');
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface XpXData {}
 }
 
-import type {Attachment, Component, Content, PublishInfo, Region} from '@enonic-types/core';
+import type {Content, PublishInfo} from '@enonic-types/core';
 
 export type {Attachment, PublishInfo, Content, Component, Region} from '@enonic-types/core';
 


### PR DESCRIPTION
Added global `XpXData` interface to prevent reference injection into the DTS file on compile.
Removed unused imports.