### PR TITLE
TypeScript type for Union of Content #9808

### DIFF
--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -55,7 +55,7 @@ interface GetContentHandler {
 
     setVersionId(value?: string | null): void;
 
-    execute<Data, Type extends string>(): Content<Data, Type> | null;
+    execute<Hit extends Content<unknown>>(): Hit | null;
 }
 
 interface GetAttachmentsHandler {
@@ -542,7 +542,7 @@ export type SortDsl = FieldSortDsl | GeoDistanceSortDsl;
  *
  * @returns {object} The content (as JSON) fetched from the repository.
  */
-export function get<Data = Record<string, unknown>, Type extends string = string>(params: GetContentParams): Content<Data, Type> | null {
+export function get<Hit extends Content<unknown> = Content>(params: GetContentParams): Hit | null {
     checkRequired(params, 'key');
 
     const bean = __.newBean<GetContentHandler>('com.enonic.xp.lib.content.GetContentHandler');
@@ -550,7 +550,7 @@ export function get<Data = Record<string, unknown>, Type extends string = string
     bean.setKey(params.key);
     bean.setVersionId(__.nullOrValue(params.versionId));
 
-    return __.toNativeObject(bean.execute<Data, Type>());
+    return __.toNativeObject(bean.execute<Hit>());
 }
 
 /**
@@ -795,10 +795,10 @@ export {
     _delete as delete,
 };
 
-export interface ContentsResult<Data, Type extends string> {
+export interface ContentsResult<Hit extends Content<unknown>> {
     total: number;
     count: number;
-    hits: Content<Data, Type>[];
+    hits: Hit[];
     aggregations?: Record<string, AggregationsResult>;
     highlight?: Record<string, HighlightResult>;
 }
@@ -819,7 +819,7 @@ interface GetChildContentHandler {
 
     setSort(value?: string | null): void;
 
-    execute<Data, Type extends string>(): ContentsResult<Data, Type>;
+    execute<Hit extends Content<unknown>>(): ContentsResult<Hit>;
 }
 
 /**
@@ -835,7 +835,7 @@ interface GetChildContentHandler {
  *
  * @returns {Object} Result (of content) fetched from the repository.
  */
-export function getChildren<Data = Record<string, unknown>, Type extends string = string>(params: GetChildContentParams): ContentsResult<Data, Type> {
+export function getChildren<Hit extends Content<unknown> = Content>(params: GetChildContentParams): ContentsResult<Hit> {
     checkRequired(params, 'key');
 
     const {
@@ -850,7 +850,7 @@ export function getChildren<Data = Record<string, unknown>, Type extends string 
     bean.setStart(start);
     bean.setCount(count);
     bean.setSort(__.nullOrValue(sort));
-    return __.toNativeObject(bean.execute<Data, Type>());
+    return __.toNativeObject(bean.execute<Hit>());
 }
 
 export type IdGeneratorSupplier = (value: string) => string;
@@ -989,7 +989,7 @@ interface QueryContentHandler {
 
     setHighlight(value: ScriptValue): void;
 
-    execute<Data, Type extends string>(): ContentsResult<Data, Type>;
+    execute<Hit extends Content<unknown>>(): ContentsResult<Hit>;
 }
 
 /**
@@ -1008,7 +1008,7 @@ interface QueryContentHandler {
  *
  * @returns {object} Result of query.
  */
-export function query<Data = Record<string, unknown>, Type extends string = string>(params: QueryContentParams): ContentsResult<Data, Type> {
+export function query<Hit extends Content<unknown> = Content>(params: QueryContentParams): ContentsResult<Hit> {
     const bean = __.newBean<QueryContentHandler>('com.enonic.xp.lib.content.QueryContentHandler');
 
     bean.setStart(params.start);
@@ -1020,7 +1020,7 @@ export function query<Data = Record<string, unknown>, Type extends string = stri
     bean.setFilters(__.toScriptValue(params.filters));
     bean.setHighlight(__.toScriptValue(params.highlight));
 
-    return __.toNativeObject(bean.execute<Data, Type>());
+    return __.toNativeObject(bean.execute<Hit>());
 }
 
 export interface ModifyContentParams<Data, Type extends string> {

--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -427,7 +427,7 @@ export function getSiteConfig<Config = Record<string, unknown>>(): Config | null
 }
 
 interface GetCurrentContentHandler {
-    execute<Data, Type extends string, Page extends Component>(): Content<Data, Type, Page> | null;
+    execute<Hit extends Content<unknown>>(): Hit | null;
 }
 
 /**
@@ -438,14 +438,9 @@ interface GetCurrentContentHandler {
  *
  * @returns {object|null} The current content as JSON.
  */
-export function getContent<
-    Data = Record<string, unknown>,
-    Type extends string = string,
-    Config extends object = object,
-    Regions extends Record<string, Region> = Record<string, Region>
->(): Content<Data, Type, Component<Config, Regions>> | null {
+export function getContent<Hit extends Content<unknown> = Content>(): Hit | null {
     const bean = __.newBean<GetCurrentContentHandler>('com.enonic.xp.lib.portal.current.GetCurrentContentHandler');
-    return __.toNativeObject(bean.execute<Data, Type, Component<Config, Regions>>());
+    return __.toNativeObject(bean.execute<Hit>());
 }
 
 interface GetCurrentComponentHandler<Config extends object = object,


### PR DESCRIPTION
The return type of `contentLib.query()` (and similar functions) should have the shape `Content<A, 'a'> | Content<B, 'b'>` instead of the current implementation which is `Content<A | B, 'a' | 'b'>`.

This change allows TypeScript to infer the correct type of content by using a simple if-statement against `Content.type`, which is the natural way for an application programmer to do this.