### PR TITLE
Login property in User type must not be optional #9840

### DIFF
--- a/modules/lib/core/index.d.ts
+++ b/modules/lib/core/index.d.ts
@@ -17,7 +17,7 @@ export interface User {
     modifiedTime: string;
     disabled?: boolean;
     email?: string;
-    login?: string;
+    login: string;
     idProvider: string;
 }
 


### PR DESCRIPTION
See explanation in [task](https://github.com/enonic/xp/issues/9840) description.