### PR TITLE
Node library: CreateNodeParams accepts invalid index config #9844

### DIFF
--- a/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
@@ -545,7 +545,7 @@ interface NodeHandler {
 export type CreateNodeParams<NodeData = unknown> = {
     _name?: string;
     _parentPath?: string;
-    _indexConfig?: NodeConfigEntry;
+    _indexConfig?: Partial<NodeIndexConfig>;
     _permissions?: AccessControlEntry[];
     _inheritsPermissions?: boolean;
     _manualOrderValue?: number;
@@ -1109,7 +1109,7 @@ class RepoConnectionImpl
      *
      * @param {string} [key] node path or id.
      *
-     * @returns {boolean} True if exist, false otherwise.
+     * @returns {boolean} True if exists, false otherwise.
      */
     exists(key: string): boolean {
         return __.toNativeObject(this.nodeHandler.exist(key));


### PR DESCRIPTION
Example [here](https://github.com/enonic/xp/blob/master/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/create-2.js#L38).