### PR TITLE
DslQueryType has illegal type #9848

### DIFF
--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -28,8 +28,6 @@ type Workflow = Content['workflow'];
 
 export type Schedule = Omit<PublishInfo, 'first'>;
 
-type LiteralUnion<T extends U, U = string> = T | (U & Record<never, never>);
-
 /* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any*/
 declare const Java: any;
 
@@ -396,7 +394,7 @@ export interface FormItemOptionSet {
 
 export type FormItem = FormItemSet | FormItemLayout | FormItemOptionSet | FormItemInput;
 
-export type DslQueryType = LiteralUnion<'dateTime' | 'time'> | number | boolean;
+export type DslQueryType = 'dateTime' | 'time';
 
 export type DslOperator = 'OR' | 'AND';
 

--- a/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
@@ -256,9 +256,7 @@ export interface TermSuggestionOptions {
     maxTermFreq?: number | null;
 }
 
-type LiteralUnion<T extends U, U = string> = T | (U & Record<never, never>);
-
-export type DslQueryType = LiteralUnion<'dateTime' | 'time'> | number | boolean;
+export type DslQueryType = 'dateTime' | 'time';
 
 export type DslOperator = 'OR' | 'AND';
 


### PR DESCRIPTION
`DslQueryType` must not be `LiteralUnion`, `boolean` or `number`. `'dateTime' | 'time'` is the only valid options.
See how the `type` property of type `DslQueryType` is [parsed](https://github.com/enonic/xp/blob/master/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/factory/dsl/ExpressionQueryBuilder.java#L37) in Java.