### PR TITLE
Node and Content libs: wrong query results #9850

### DIFF
--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -63,7 +63,7 @@ interface GetAttachmentsHandler {
 }
 
 export interface Bucket {
-    [subAggregationName: string]: BucketsAggregation | StatsAggregation | SingleValueMetricAggregation | string | number | undefined;
+    [subAggregationName: string]: AggregationsResult | string | number | undefined;
 
     key: string;
     docCount: number;
@@ -81,11 +81,11 @@ export interface DateBucket
     to?: string;
 }
 
-export interface BucketsAggregation {
+export interface BucketsAggregationResult {
     buckets: (DateBucket | NumericBucket)[];
 }
 
-export interface StatsAggregation {
+export interface StatsAggregationResult {
     count: number;
     min: number;
     max: number;
@@ -93,11 +93,11 @@ export interface StatsAggregation {
     sum: number;
 }
 
-export interface SingleValueMetricAggregation {
+export interface SingleValueMetricAggregationResult {
     value: number;
 }
 
-export type AggregationsResult = BucketsAggregation | StatsAggregation | SingleValueMetricAggregation;
+export type AggregationsResult = BucketsAggregationResult | StatsAggregationResult | SingleValueMetricAggregationResult;
 
 export type Aggregation =
     | TermsAggregation
@@ -118,9 +118,7 @@ export interface TermsAggregation {
         size?: number;
         minDocCount?: number;
     };
-    aggregations?: {
-        [subAggregations: string]: Aggregation;
-    };
+    aggregations?: Record<string, Aggregation>;
 }
 
 export interface HistogramAggregation {
@@ -132,9 +130,7 @@ export interface HistogramAggregation {
         extendedBoundMax?: number;
         minDocCount?: number;
     };
-    aggregations?: {
-        [subAggregations: string]: Aggregation;
-    };
+    aggregations?: Record<string, Aggregation>;
 }
 
 export interface DateHistogramAggregation {
@@ -144,9 +140,7 @@ export interface DateHistogramAggregation {
         minDocCount?: number;
         format: string;
     };
-    aggregations?: {
-        [subAggregations: string]: Aggregation;
-    };
+    aggregations?: Record<string, Aggregation>;
 }
 
 export interface NumericRange {
@@ -160,9 +154,7 @@ export interface NumericRangeAggregation {
         field: string;
         ranges?: NumericRange[];
     };
-    aggregations?: {
-        [subAggregations: string]: Aggregation;
-    };
+    aggregations?: Record<string, Aggregation>;
 }
 
 export interface NumericRangeAggregation {
@@ -170,9 +162,7 @@ export interface NumericRangeAggregation {
         field: string;
         ranges?: NumericRange[];
     };
-    aggregations?: {
-        [subAggregations: string]: Aggregation;
-    };
+    aggregations?: Record<string, Aggregation>;
 }
 
 export interface DateRange {
@@ -187,9 +177,7 @@ export interface DateRangeAggregation {
         format: string;
         ranges: DateRange[];
     };
-    aggregations?: {
-        [subAggregations: string]: Aggregation;
-    };
+    aggregations?: Record<string, Aggregation>;
 }
 
 export interface StatsAggregation {

--- a/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
@@ -28,7 +28,7 @@ function checkRequired<T extends object>(obj: T, name: keyof T): void {
 // START AGGREGATIONS, FILTERS, QUERIES, SUGGESTIONS
 
 export interface Bucket {
-    [subAggregationName: string]: BucketsAggregation | StatsAggregation | SingleValueMetricAggregation | string | number | undefined;
+    [subAggregationName: string]: AggregationsResult | string | number | undefined;
 
     key: string;
     docCount: number;
@@ -46,11 +46,11 @@ export interface DateBucket
     to?: string;
 }
 
-export interface BucketsAggregation {
+export interface BucketsAggregationResult {
     buckets: (DateBucket | NumericBucket)[];
 }
 
-export interface StatsAggregation {
+export interface StatsAggregationResult {
     count: number;
     min: number;
     max: number;
@@ -58,11 +58,11 @@ export interface StatsAggregation {
     sum: number;
 }
 
-export interface SingleValueMetricAggregation {
+export interface SingleValueMetricAggregationResult {
     value: number;
 }
 
-export type AggregationsResult = BucketsAggregation | StatsAggregation | SingleValueMetricAggregation;
+export type AggregationsResult = BucketsAggregationResult | StatsAggregationResult | SingleValueMetricAggregationResult;
 
 export type Aggregation =
     | TermsAggregation
@@ -234,8 +234,6 @@ export interface BooleanFilter {
 
 export type Filter = ExistsFilter | NotExistsFilter | HasValueFilter | IdsFilter | BooleanFilter;
 
-export type Suggestion = TermSuggestion;
-
 export interface TermSuggestion {
     text: string;
     term: TermSuggestionOptions;
@@ -406,16 +404,14 @@ export interface NodeQueryResultHit {
     highlight?: HighlightResult;
 }
 
-export interface NodeQueryResultSuggestion {
-    [suggestionName: string]: {
+export interface SuggestionResult {
+    text: string;
+    length: number;
+    offset: number;
+    options: {
         text: string;
-        length: number;
-        offset: number;
-        options: {
-            text: string;
-            score: number;
-            freq?: number; // only for term
-        }[];
+        score: number;
+        freq?: number; // only for term
     }[];
 }
 
@@ -423,8 +419,8 @@ export interface NodeQueryResult {
     total: number;
     count: number;
     hits: NodeQueryResultHit[];
-    aggregations?: AggregationsResult;
-    suggestions?: NodeQueryResultSuggestion[];
+    aggregations?: Record<string, AggregationsResult>;
+    suggestions?: Record<string, SuggestionResult[]>;
 }
 
 export interface NodeMultiRepoQueryResult {
@@ -434,8 +430,8 @@ export interface NodeMultiRepoQueryResult {
         repoId: string;
         branch: string;
     })[];
-    aggregations?: AggregationsResult;
-    suggestions?: NodeQueryResultSuggestion[];
+    aggregations?: Record<string, AggregationsResult>;
+    suggestions?: Record<string, SuggestionResult[]>;
 }
 
 // END AGGREGATIONS, FILTERS, QUERIES, SUGGESTIONS
@@ -641,7 +637,7 @@ export interface QueryNodeParams {
     sort?: string | SortDsl | SortDsl[];
     filters?: Filter | Filter[];
     aggregations?: Record<string, Aggregation>;
-    suggestions?: Record<string, Suggestion>;
+    suggestions?: Record<string, TermSuggestion>;
     highlight?: Highlight;
     explain?: boolean;
 }


### PR DESCRIPTION
Types for aggregations and suggestions in result and in params were incorrect. I tried to make them match the Java implementation and work with JS examples, but I'm not 100% everything is correct, so it's better to test them on some real data before actually releasing.

What were changed:
* `StatsAggregation` interface was declared twice and used both in result and in params types. The stats aggregation in result is now called `StatsAggregationResult`.
* `suggestions` in result type was invalid, according to the [examples](https://github.com/enonic/xp/blob/master/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/query.js#L175).
* Same for the `aggregations`. See [examples](https://github.com/enonic/xp/blob/master/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/query.js#L129).