### PR TITLE
TypeScript: Library types #9888

### DIFF
--- a/modules/lib/lib-admin/src/main/resources/lib/xp/admin.ts
+++ b/modules/lib/lib-admin/src/main/resources/lib/xp/admin.ts
@@ -160,3 +160,19 @@ export function getInstallation(): string {
 export function getVersion(): string {
     return helper.getVersion();
 }
+
+const adminLibrary = {
+    getAssetsUri,
+    getBaseUri,
+    getHomeToolUrl,
+    getInstallation,
+    getLauncherPath,
+    getLauncherUrl,
+    getLocale,
+    getLocales,
+    getPhrases,
+    getToolUrl,
+    getVersion,
+};
+
+export type AdminLibrary = typeof adminLibrary;

--- a/modules/lib/lib-app/src/main/resources/lib/xp/app.ts
+++ b/modules/lib/lib-app/src/main/resources/lib/xp/app.ts
@@ -217,3 +217,15 @@ export function getApplicationMode(params: GetApplicationModeParams): string | n
     bean.setKey(params.key);
     return __.toNativeObject(bean.execute());
 }
+
+
+const appLibrary = {
+    createVirtualApplication,
+    deleteVirtualApplication,
+    get,
+    getApplicationMode,
+    getDescriptor,
+    list,
+};
+
+export type AppLibrary = typeof appLibrary;

--- a/modules/lib/lib-auditlog/src/main/resources/lib/xp/auditlog.ts
+++ b/modules/lib/lib-auditlog/src/main/resources/lib/xp/auditlog.ts
@@ -203,3 +203,11 @@ export function find(params: FindAuditLogParams): AuditLogs {
     bean.setObjectUris(__.toScriptValue(objects));
     return __.toNativeObject(bean.execute());
 }
+
+const auditLogLibrary = {
+    find,
+    get,
+    log,
+};
+
+export type AuditLogLibrary = typeof auditLogLibrary;

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
@@ -820,3 +820,31 @@ export function modifyRole(params: ModifyRoleParams): Role | null {
 
     return __.toNativeObject(bean.modifyRole());
 }
+
+const authLibrary = {
+    addMembers,
+    changePassword,
+    createGroup,
+    createRole,
+    createUser,
+    deletePrincipal,
+    findPrincipals,
+    findUsers,
+    generatePassword,
+    getIdProviderConfig,
+    getMembers,
+    getMemberships,
+    getPrincipal,
+    getProfile,
+    getUser,
+    hasRole,
+    login,
+    logout,
+    modifyGroup,
+    modifyProfile,
+    modifyRole,
+    modifyUser,
+    removeMembers,
+};
+
+export type AuthLibrary = typeof authLibrary;

--- a/modules/lib/lib-cluster/src/main/resources/lib/xp/cluster.ts
+++ b/modules/lib/lib-cluster/src/main/resources/lib/xp/cluster.ts
@@ -28,3 +28,9 @@ export function isMaster(): boolean {
     const bean = __.newBean<ClusterIsMasterHandler>('com.enonic.xp.lib.cluster.ClusterIsMasterHandler');
     return __.toNativeObject(bean.isMaster());
 }
+
+const clusterLibrary = {
+    isMaster,
+};
+
+export type ClusterLibrary = typeof clusterLibrary;

--- a/modules/lib/lib-common/src/main/resources/lib/xp/common.ts
+++ b/modules/lib/lib-common/src/main/resources/lib/xp/common.ts
@@ -43,3 +43,9 @@ export function sanitize(text: string): string {
     }
     return NamePrettyfier.create(text);
 }
+
+const commonLibrary = {
+    sanitize,
+};
+
+export type CommonLibrary = typeof commonLibrary;

--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -1588,3 +1588,33 @@ export function resetInheritance(params: ResetInheritanceParams): void {
 
     bean.execute();
 }
+
+const contentLibrary = {
+    addAttachment,
+    archive,
+    create,
+    createMedia,
+    delete: _delete,
+    exists,
+    get,
+    getAttachments,
+    getAttachmentStream,
+    getChildren,
+    getOutboundDependencies,
+    getPermissions,
+    getSite,
+    getSiteConfig,
+    getType,
+    getTypes,
+    modify,
+    move,
+    publish,
+    query,
+    removeAttachment,
+    resetInheritance,
+    restore,
+    setPermissions,
+    unpublish,
+};
+
+export type ContentLibrary = typeof contentLibrary;

--- a/modules/lib/lib-context/src/main/resources/lib/xp/context.ts
+++ b/modules/lib/lib-context/src/main/resources/lib/xp/context.ts
@@ -129,3 +129,9 @@ export function get(): Context {
     return __.toNativeObject(result);
 }
 
+const contextLibrary = {
+    get,
+    run,
+};
+
+export type ContextLibrary = typeof contextLibrary;

--- a/modules/lib/lib-event/src/main/resources/lib/xp/event.ts
+++ b/modules/lib/lib-event/src/main/resources/lib/xp/event.ts
@@ -124,3 +124,10 @@ export function send(event: SendParams): void {
 
     helper.send();
 }
+
+const eventLibrary = {
+    listener,
+    send,
+};
+
+export type EventLibrary = typeof eventLibrary;

--- a/modules/lib/lib-export/src/main/resources/lib/xp/export.ts
+++ b/modules/lib/lib-export/src/main/resources/lib/xp/export.ts
@@ -195,3 +195,10 @@ export function exportNodes(params: ExportNodesParams): ExportNodesResult {
 
     return __.toNativeObject(bean.execute());
 }
+
+const exportLibrary = {
+    exportNodes,
+    importNodes,
+};
+
+export type ExportLibrary = typeof exportLibrary;

--- a/modules/lib/lib-grid/src/main/resources/lib/xp/grid.ts
+++ b/modules/lib/lib-grid/src/main/resources/lib/xp/grid.ts
@@ -178,3 +178,8 @@ export function getMap<Map extends GridMap>(mapId: string): SharedMap<Map> {
     return new SharedMapImpl<Map>(requireNotNull(mapId, 'mapId'));
 }
 
+const gridLibrary = {
+    getMap,
+};
+
+export type GridLibrary = typeof gridLibrary;

--- a/modules/lib/lib-i18n/src/main/resources/lib/xp/i18n.ts
+++ b/modules/lib/lib-i18n/src/main/resources/lib/xp/i18n.ts
@@ -94,3 +94,11 @@ export function getSupportedLocales(bundles: string[]): string[] {
     const bean = __.newBean<LocaleScriptBean>('com.enonic.xp.lib.i18n.LocaleScriptBean');
     return __.toNativeObject(bean.getSupportedLocales(bundles));
 }
+
+const i18nLibrary = {
+    getPhrases,
+    getSupportedLocales,
+    localize,
+};
+
+export type I18NLibrary = typeof i18nLibrary;

--- a/modules/lib/lib-io/src/main/resources/lib/xp/io.ts
+++ b/modules/lib/lib-io/src/main/resources/lib/xp/io.ts
@@ -186,3 +186,15 @@ export function newStream(text: string): ByteSource {
 export function getResource(key: string): Resource {
     return new ResourceImpl(key);
 }
+
+const ioLibrary = {
+    getMimeType,
+    getResource,
+    getSize,
+    newStream,
+    processLines,
+    readLines,
+    readText,
+};
+
+export type IOLibrary = typeof ioLibrary;

--- a/modules/lib/lib-mail/src/main/resources/lib/xp/mail.ts
+++ b/modules/lib/lib-mail/src/main/resources/lib/xp/mail.ts
@@ -131,3 +131,9 @@ export function send(params: SendMessageParams): boolean {
 
     return bean.send();
 }
+
+const mailLibrary = {
+    send,
+};
+
+export type MailLibrary = typeof mailLibrary;

--- a/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
@@ -1445,3 +1445,10 @@ export function multiRepoConnect(params: MultiRepoConnectParams): MultiRepoConne
 
     return new MultiRepoConnectionImpl(multiRepoConnectFactory.create(multiRepoNodeHandleContext));
 }
+
+const nodeLibrary = {
+    connect,
+    multiRepoConnect,
+};
+
+export type NodeLibrary = typeof nodeLibrary;

--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -602,3 +602,30 @@ export function imagePlaceholder(params: ImagePlaceholderParams): string {
     bean.setHeight(params?.height ?? 0);
     return bean.createImagePlaceholder();
 }
+
+const portalLibrary = {
+    assetUrl,
+    attachmentUrl,
+    componentUrl,
+    getComponent,
+    getContent,
+    getIdProviderKey,
+    getMultipartForm,
+    getMultipartItem,
+    getMultipartStream,
+    getMultipartText,
+    getSite,
+    getSiteConfig,
+    idProviderUrl,
+    imagePlaceholder,
+    imageUrl,
+    loginUrl,
+    logoutUrl,
+    pageUrl,
+    processHtml,
+    sanitizeHtml,
+    serviceUrl,
+    url,
+};
+
+export type PortalLibrary = typeof portalLibrary;

--- a/modules/lib/lib-project/src/main/resources/lib/xp/project.ts
+++ b/modules/lib/lib-project/src/main/resources/lib/xp/project.ts
@@ -385,3 +385,17 @@ export function modifyReadAccess(params: ModifyProjectReadAccessParams): Project
     bean.setReadAccess(__.toScriptValue(params.readAccess));
     return __.toNativeObject(bean.execute());
 }
+
+const projectLibrary = {
+    addPermissions,
+    create,
+    delete: _delete,
+    get,
+    list,
+    modify,
+    modifyReadAccess,
+    removePermissions,
+    getAvailableApplications,
+};
+
+export type ProjectLibrary = typeof projectLibrary;

--- a/modules/lib/lib-repo/src/main/resources/lib/xp/repo.ts
+++ b/modules/lib/lib-repo/src/main/resources/lib/xp/repo.ts
@@ -378,3 +378,15 @@ export function getBinary(params: GetRepositoryBinaryParams): object {
 
     return bean.execute();
 }
+
+const repoLibrary = {
+    create,
+    createBranch,
+    delete: _delete,
+    deleteBranch,
+    get,
+    list,
+    refresh,
+};
+
+export type RepoLibrary = typeof repoLibrary;

--- a/modules/lib/lib-scheduler/src/main/resources/lib/xp/scheduler.ts
+++ b/modules/lib/lib-scheduler/src/main/resources/lib/xp/scheduler.ts
@@ -225,4 +225,12 @@ export function list<Config extends object = Record<string, unknown>>(): Schedul
     return __.toNativeObject(bean.execute());
 }
 
+const schedulerLibrary = {
+    get,
+    list,
+    create,
+    modify,
+    delete: _delete,
+};
 
+export type SchedulerLibrary = typeof schedulerLibrary;

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
@@ -772,3 +772,24 @@ export function listSchemas(params: ListDynamicSchemasParams): ContentSchemaType
     bean.setType(params.type);
     return __.toNativeObject(bean.execute());
 }
+
+const schemaLibrary = {
+    getSchema,
+    listSchemas,
+    createSchema,
+    updateSchema,
+    deleteSchema,
+    getComponent,
+    listComponents,
+    createComponent,
+    updateComponent,
+    deleteComponent,
+    getStyles,
+    createStyles,
+    updateStyles,
+    deleteStyles,
+    getSite,
+    updateSite,
+};
+
+export type SchemaLibrary = typeof schemaLibrary;

--- a/modules/lib/lib-task/src/main/resources/lib/xp/task.ts
+++ b/modules/lib/lib-task/src/main/resources/lib/xp/task.ts
@@ -338,3 +338,17 @@ export function isRunning(task: string): boolean {
 
     return __.toNativeObject(bean.isRunning(task));
 }
+
+const taskLibrary = {
+    get,
+    isRunning,
+    list,
+    progress,
+    sleep,
+    executeFunction,
+    submitTask,
+    submit,
+    submitNamed,
+};
+
+export type TaskLibrary = typeof taskLibrary;

--- a/modules/lib/lib-value/src/main/resources/lib/xp/value.ts
+++ b/modules/lib/lib-value/src/main/resources/lib/xp/value.ts
@@ -274,3 +274,16 @@ export function binary(name: string, stream: ByteSource): BinaryAttachment {
 
     return binaryAttachmentBean.newInstance(binaryReferenceBean.from(name), stream);
 }
+
+const valueLibrary = {
+    binary,
+    geoPoint,
+    geoPointString,
+    instant,
+    localDate,
+    localDateTime,
+    localTime,
+    reference,
+};
+
+export type ValueLibrary = typeof valueLibrary;

--- a/modules/lib/lib-vhost/src/main/resources/lib/xp/vhost.ts
+++ b/modules/lib/lib-vhost/src/main/resources/lib/xp/vhost.ts
@@ -61,3 +61,10 @@ export function list(): VirtualHosts {
     const bean = __.newBean<VirtualHostHandler>('com.enonic.xp.lib.vhost.VirtualHostHandler');
     return __.toNativeObject(bean.getVirtualHosts());
 }
+
+const virtualHostLibrary = {
+    isEnabled,
+    list,
+};
+
+export type VirtualHostLibrary = typeof virtualHostLibrary;

--- a/modules/lib/lib-websocket/src/main/resources/lib/xp/websocket.ts
+++ b/modules/lib/lib-websocket/src/main/resources/lib/xp/websocket.ts
@@ -88,3 +88,13 @@ export function getGroupSize(group: string): number {
     const bean = __.newBean<WebSocketManagerBean>('com.enonic.xp.lib.websocket.WebSocketManagerBean');
     return bean.getGroupSize(group);
 }
+
+const webSocketLibrary = {
+    addToGroup,
+    removeFromGroup,
+    send,
+    sendToGroup,
+    getGroupSize,
+};
+
+export type WebSocketLibrary = typeof webSocketLibrary;


### PR DESCRIPTION
These are useful when making mockups of our libs.

I'm working in a *.d.ts file and I tried

```
import {
	create,
	createBranch,
	delete as deleteRepo,
	deleteBranch,
	get,
	list,
	refresh,
} from '/lib/xp/repo'

const repoLibrary = {
	create,
	createBranch,
	delete: deleteRepo,
	deleteBranch,
	get,
	list,
	refresh,
}

type RepoLibrary = typeof repoLibrary;
```

But that only results in

```
'const' initializer in an ambient context must be a string or numeric literal
```

So I'd much rather simply do:

```
import type {RepoLibrary} from '/lib/xp/repo';
```