### PR TITLE
TS Add return type of resolve function #9761

### DIFF
--- a/modules/lib/core/index.d.ts
+++ b/modules/lib/core/index.d.ts
@@ -109,6 +109,9 @@ type Brand<
 
 export type ByteSource = Brand<object, 'ByteSource'>;
 
+//
+// RESOURCES
+//
 export interface Resource {
     getSize(): number;
 
@@ -117,6 +120,15 @@ export interface Resource {
     getStream(): ByteSource;
 
     exists(): boolean;
+}
+
+export interface ResourceKey {
+    getApplicationKey(): string;
+    getPath(): string;
+    getUri(): string;
+    isRoot(): boolean;
+    getName(): string;
+    getExtension(): string;
 }
 
 //

--- a/modules/lib/global.d.ts
+++ b/modules/lib/global.d.ts
@@ -193,11 +193,18 @@ declare const require: XpRequire;
  * var path = resolve('./other.html');
  *
  * @example
- * // Reslove absolute
+ * // Resolve absolute
  * var path = resolve('/path/to/other.html');
  *
  * @param {string} path Path to resolve.
  * @returns {*} Reference to an object.
  * @global
  */
-declare const resolve: (path: string) => object;
+declare const resolve: (path: string) => {
+    getApplicationKey(): string;
+    getPath(): string;
+    getUri(): string;
+    isRoot(): boolean;
+    getName(): string;
+    getExtension(): string;
+};

--- a/modules/lib/lib-export/src/main/resources/lib/xp/export.ts
+++ b/modules/lib/lib-export/src/main/resources/lib/xp/export.ts
@@ -13,19 +13,14 @@ declare global {
     }
 }
 
+import type {ResourceKey} from '@enonic-types/core';
+
+export type {ResourceKey} from '@enonic-types/core';
+
 function checkRequired<T extends object>(obj: T, name: keyof T): void {
     if (obj == null || obj[name] == null) {
         throw `Parameter '${String(name)}' is required`;
     }
-}
-
-export interface ResourceKey {
-    applicationKey: string;
-    path: string;
-    uri: string;
-    root: boolean;
-    name: string;
-    extension: string;
 }
 
 export interface ImportNodesParams {

--- a/modules/lib/lib-io/src/main/resources/lib/xp/io.ts
+++ b/modules/lib/lib-io/src/main/resources/lib/xp/io.ts
@@ -16,11 +16,13 @@ declare global {
 import type {
     ByteSource,
     Resource,
+    ResourceKey,
 } from '@enonic-types/core';
 
 export type {
     ByteSource,
     Resource,
+    ResourceKey,
 } from '@enonic-types/core';
 
 interface JavaResource {
@@ -46,7 +48,7 @@ interface IOHandlerBean {
 
     newStream(text: string): ByteSource;
 
-    getResource(key: string): JavaResource;
+    getResource(key: string | ResourceKey): JavaResource;
 }
 
 const bean = __.newBean<IOHandlerBean>('com.enonic.xp.lib.io.IOHandlerBean');
@@ -62,7 +64,7 @@ class ResourceImpl
     implements Resource {
     private res: JavaResource;
 
-    constructor(key: string) {
+    constructor(key: string | ResourceKey) {
         this.res = bean.getResource(key);
     }
 
@@ -183,6 +185,6 @@ export function newStream(text: string): ByteSource {
  * @param {string} key Resource key to look up.
  * @returns {Resource} Resource reference.
  */
-export function getResource(key: string): Resource {
+export function getResource(key: string | ResourceKey): Resource {
     return new ResourceImpl(key);
 }


### PR DESCRIPTION
Moved the `ResourceKey` to core package.
Made `resolve` function definition in `global.d.ts` to return the same object as `ResourceKey`. I don't want to make `global.d.ts` depend on `core` and be importable, neither define `ResourceKey` in global scope. I guess `ResourceKey` is not something that will change and we can keep compromise here using the identical "types" in different contexts.