### PR TITLE
Add default parameters for AggregationInput and Output #10101

### DIFF
--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -432,7 +432,7 @@ export {
 
 export interface ContentsResult<
     Hit extends Content<unknown>,
-    AggregationOutput extends Record<string, AggregationsResult>
+    AggregationOutput extends Record<string, AggregationsResult> | undefined = undefined
 > {
     total: number;
     count: number;
@@ -608,7 +608,7 @@ export function create<
     return __.toNativeObject(bean.execute<Data, Type>());
 }
 
-export interface QueryContentParams<AggregationInput extends Aggregations> {
+export interface QueryContentParams<AggregationInput extends Aggregations = never> {
     start?: number;
     count?: number;
     query?: QueryDsl | string;

--- a/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
@@ -138,7 +138,7 @@ export interface SuggestionResult {
     }[];
 }
 
-export interface NodeQueryResult<AggregationOutput extends Record<string, AggregationsResult>> {
+export interface NodeQueryResult<AggregationOutput extends Record<string, AggregationsResult> | undefined = undefined> {
     total: number;
     count: number;
     hits: NodeQueryResultHit[];
@@ -146,7 +146,7 @@ export interface NodeQueryResult<AggregationOutput extends Record<string, Aggreg
     suggestions?: Record<string, SuggestionResult[]>;
 }
 
-export interface NodeMultiRepoQueryResult<AggregationOutput extends Record<string, AggregationsResult>> {
+export interface NodeMultiRepoQueryResult<AggregationOutput extends Record<string, AggregationsResult> | undefined = undefined> {
     total: number;
     count: number;
     hits: (NodeQueryResultHit & {
@@ -346,7 +346,7 @@ export interface SetChildOrderParams {
     childOrder: string;
 }
 
-export interface QueryNodeParams<AggregationInput extends Aggregations> {
+export interface QueryNodeParams<AggregationInput extends Aggregations = never> {
     start?: number;
     count?: number;
     query?: QueryDsl | string;


### PR DESCRIPTION
`never` is used as the default type parameter for the `aggregation` properties in the different QueryParams.

`undefined` is used as the default type parameter for `aggregations` in different query results. The reason `never` is not used is that since the property is not optional, we are not able to construct this object independently of the library functions.