### PR TITLE
Fix #10176 Avoid having to set fragment: undefined everywhere

### DIFF
--- a/modules/lib/core/index.d.ts
+++ b/modules/lib/core/index.d.ts
@@ -178,7 +178,7 @@ export interface Content<
     _Component extends (
         Type extends 'portal:fragment'
             ? LayoutComponent | PartComponent
-            : PageComponent
+            : PageComponent | Record<string,never>
         ) = (
             Type extends 'portal:fragment'
                 ? Layout | Part
@@ -194,7 +194,7 @@ export interface Content<
     createdTime: string;
     modifiedTime?: string;
     owner: string;
-    data: Type extends 'portal:fragment' ? undefined : Data;
+    data: Type extends 'portal:fragment' ? Record<string,never> : Data;
     type: Type;
     displayName: string;
     hasChildren: boolean;
@@ -203,7 +203,7 @@ export interface Content<
     originProject?: string;
     childOrder?: string;
     _sort?: object[];
-    page: Type extends 'portal:fragment' ? undefined : _Component;
+    page?: Type extends 'portal:fragment' ? never : _Component;
     x: XpXData;
     attachments: Record<string, Attachment>;
     publish?: PublishInfo;
@@ -213,7 +213,7 @@ export interface Content<
     };
     inherit?: ('CONTENT' | 'PARENT' | 'NAME' | 'SORT')[];
     variantOf?: string;
-    fragment: Type extends 'portal:fragment' ? _Component : undefined;
+    fragment?: Type extends 'portal:fragment' ? _Component : never;
 }
 
 // Compliant with npm module ts-brand


### PR DESCRIPTION
Both fragment and page has to be optional, or we have to convert the interface to a type which has a conditional union or something similar:
https://github.com/sindresorhus/type-fest/blob/main/source/require-exactly-one.d.ts
https://stackoverflow.com/questions/49524414/typescript-interface-conditional-optional-parameters

This also support 'base:folder' by allowing page to be an empty object.

And fixes the fact that data is an empty object for portal:fragment, not undefined.