### PR TITLE
Page resolving: add flag to resolve empty regions in Content API

### DIFF
--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/AbstractCreatingOrUpdatingContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/AbstractCreatingOrUpdatingContentCommand.java
@@ -13,6 +13,9 @@ import com.enonic.xp.content.ContentValidator;
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.core.internal.FileNames;
+import com.enonic.xp.page.PageDescriptorService;
+import com.enonic.xp.region.LayoutDescriptorService;
+import com.enonic.xp.region.PartDescriptorService;
 import com.enonic.xp.schema.xdata.XDataService;
 import com.enonic.xp.security.User;
 import com.enonic.xp.site.SiteService;
@@ -35,6 +38,12 @@ class AbstractCreatingOrUpdatingContentCommand
 
     final List<ContentValidator> contentValidators;
 
+    protected final PageDescriptorService pageDescriptorService;
+
+    protected final PartDescriptorService partDescriptorService;
+
+    protected final LayoutDescriptorService layoutDescriptorService;
+
     final boolean allowUnsafeAttachmentNames;
 
     AbstractCreatingOrUpdatingContentCommand( final Builder<?> builder )
@@ -45,6 +54,9 @@ class AbstractCreatingOrUpdatingContentCommand
         this.contentProcessors = List.copyOf( builder.contentProcessors );
         this.contentValidators = List.copyOf( builder.contentValidators );
         this.allowUnsafeAttachmentNames = builder.allowUnsafeAttachmentNames;
+        this.pageDescriptorService = builder.pageDescriptorService;
+        this.partDescriptorService = builder.partDescriptorService;
+        this.layoutDescriptorService = builder.layoutDescriptorService;
     }
 
     public static class Builder<B extends Builder<B>>
@@ -60,6 +72,12 @@ class AbstractCreatingOrUpdatingContentCommand
 
         private boolean allowUnsafeAttachmentNames;
 
+        private PageDescriptorService pageDescriptorService;
+
+        private PartDescriptorService partDescriptorService;
+
+        private LayoutDescriptorService layoutDescriptorService;
+
         Builder()
         {
         }
@@ -71,6 +89,9 @@ class AbstractCreatingOrUpdatingContentCommand
             this.siteService = source.siteService;
             this.contentProcessors = source.contentProcessors;
             this.contentValidators = source.contentValidators;
+            this.pageDescriptorService = source.pageDescriptorService;
+            this.partDescriptorService = source.partDescriptorService;
+            this.layoutDescriptorService = source.layoutDescriptorService;
         }
 
         @SuppressWarnings("unchecked")
@@ -105,6 +126,24 @@ class AbstractCreatingOrUpdatingContentCommand
         B allowUnsafeAttachmentNames( final boolean allowUnsafeAttachmentNames )
         {
             this.allowUnsafeAttachmentNames = allowUnsafeAttachmentNames;
+            return (B) this;
+        }
+
+        B pageDescriptorService( final PageDescriptorService pageDescriptorService )
+        {
+            this.pageDescriptorService = pageDescriptorService;
+            return (B) this;
+        }
+
+        B partDescriptorService( final PartDescriptorService partDescriptorService )
+        {
+            this.partDescriptorService = partDescriptorService;
+            return (B) this;
+        }
+
+        B layoutDescriptorService( final LayoutDescriptorService layoutDescriptorService )
+        {
+            this.layoutDescriptorService = layoutDescriptorService;
             return (B) this;
         }
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentConfig.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentConfig.java
@@ -8,5 +8,7 @@ public @interface ContentConfig
 
     boolean attachments_allowUnsafeNames() default false;
 
+    boolean resolveEmptyRegions() default false;
+
     String auditlog_filter() default "!system.content.update,*";
 }

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentNodeTranslator.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentNodeTranslator.java
@@ -27,8 +27,18 @@ public class ContentNodeTranslator
 
     public ContentNodeTranslator( final NodeService nodeService )
     {
+        this(nodeService, new ContentDataSerializer());
+    }
+
+    public ContentNodeTranslator( final NodeService nodeService, final ContentDataSerializer contentDataSerializer )
+    {
         this.nodeService = nodeService;
-        this.contentDataSerializer = new ContentDataSerializer();
+        this.contentDataSerializer = contentDataSerializer;
+    }
+
+    public ContentDataSerializer getContentDataSerializer()
+    {
+        return contentDataSerializer;
     }
 
     public Contents fromNodes( final Nodes nodes, final boolean resolveHasChildren )

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentOutboundDependenciesIdsResolver.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentOutboundDependenciesIdsResolver.java
@@ -18,12 +18,9 @@ class ContentOutboundDependenciesIdsResolver
 {
     private final ContentService contentService;
 
-    private final ContentDataSerializer contentDataSerializer;
-
     ContentOutboundDependenciesIdsResolver( final ContentService contentService )
     {
         this.contentService = contentService;
-        this.contentDataSerializer = new ContentDataSerializer();
     }
 
     public ContentIds resolve( final ContentId contentId )
@@ -40,7 +37,7 @@ class ContentOutboundDependenciesIdsResolver
         final PropertySet contentPageData = new PropertyTree().getRoot();
         if ( content.getPage() != null )
         {
-            contentDataSerializer.toPageData( content.getPage(), contentPageData );
+            new ContentDataSerializer().toPageData( content.getPage(), contentPageData );
         }
 
         final Stream<Property> extraDataDependencies = content.hasExtraData() ? content.getAllExtraData().

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateContentCommand.java
@@ -35,9 +35,6 @@ import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeAccessException;
 import com.enonic.xp.node.NodeAlreadyExistAtPathException;
 import com.enonic.xp.node.RefreshMode;
-import com.enonic.xp.page.PageDescriptorService;
-import com.enonic.xp.region.LayoutDescriptorService;
-import com.enonic.xp.region.PartDescriptorService;
 import com.enonic.xp.schema.content.ContentType;
 import com.enonic.xp.schema.content.GetContentTypeParams;
 import com.enonic.xp.security.PrincipalKey;
@@ -56,21 +53,12 @@ final class CreateContentCommand
 
     private final FormDefaultValuesProcessor formDefaultValuesProcessor;
 
-    private final PageDescriptorService pageDescriptorService;
-
-    private final PartDescriptorService partDescriptorService;
-
-    private final LayoutDescriptorService layoutDescriptorService;
-
     private CreateContentCommand( final Builder builder )
     {
         super( builder );
         this.params = builder.params;
         this.mediaInfo = builder.mediaInfo;
         this.formDefaultValuesProcessor = builder.formDefaultValuesProcessor;
-        this.pageDescriptorService = builder.pageDescriptorService;
-        this.partDescriptorService = builder.partDescriptorService;
-        this.layoutDescriptorService = builder.layoutDescriptorService;
     }
 
     static Builder create()
@@ -108,6 +96,7 @@ final class CreateContentCommand
             .xDataService( this.xDataService )
             .partDescriptorService( this.partDescriptorService )
             .layoutDescriptorService( this.layoutDescriptorService )
+            .contentDataSerializer( this.translator.getContentDataSerializer() )
             .siteService( this.siteService )
             .build()
             .produce().refresh( params.isRefresh() ? RefreshMode.ALL : RefreshMode.STORAGE ).build();
@@ -322,12 +311,6 @@ final class CreateContentCommand
 
         private FormDefaultValuesProcessor formDefaultValuesProcessor;
 
-        private PageDescriptorService pageDescriptorService;
-
-        private PartDescriptorService partDescriptorService;
-
-        private LayoutDescriptorService layoutDescriptorService;
-
         private Builder()
         {
         }
@@ -352,24 +335,6 @@ final class CreateContentCommand
         Builder formDefaultValuesProcessor( final FormDefaultValuesProcessor formDefaultValuesProcessor )
         {
             this.formDefaultValuesProcessor = formDefaultValuesProcessor;
-            return this;
-        }
-
-        Builder pageDescriptorService( final PageDescriptorService value )
-        {
-            this.pageDescriptorService = value;
-            return this;
-        }
-
-        Builder partDescriptorService( final PartDescriptorService value )
-        {
-            this.partDescriptorService = value;
-            return this;
-        }
-
-        Builder layoutDescriptorService( final LayoutDescriptorService value )
-        {
-            this.layoutDescriptorService = value;
             return this;
         }
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateMediaCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateMediaCommand.java
@@ -13,9 +13,6 @@ import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.form.FormDefaultValuesProcessor;
 import com.enonic.xp.media.MediaInfo;
 import com.enonic.xp.media.MediaInfoService;
-import com.enonic.xp.page.PageDescriptorService;
-import com.enonic.xp.region.LayoutDescriptorService;
-import com.enonic.xp.region.PartDescriptorService;
 import com.enonic.xp.schema.content.ContentTypeFromMimeTypeResolver;
 import com.enonic.xp.schema.content.ContentTypeName;
 
@@ -28,21 +25,12 @@ final class CreateMediaCommand
 
     private final FormDefaultValuesProcessor formDefaultValuesProcessor;
 
-    private final PageDescriptorService pageDescriptorService;
-
-    private final PartDescriptorService partDescriptorService;
-
-    private final LayoutDescriptorService layoutDescriptorService;
-
     private CreateMediaCommand( final Builder builder )
     {
         super( builder );
         this.params = builder.params;
         this.mediaInfoService = builder.mediaInfoService;
         this.formDefaultValuesProcessor = builder.formDefaultValuesProcessor;
-        this.pageDescriptorService = builder.pageDescriptorService;
-        this.partDescriptorService = builder.partDescriptorService;
-        this.layoutDescriptorService = builder.layoutDescriptorService;
     }
 
     Content execute()
@@ -103,6 +91,7 @@ final class CreateMediaCommand
 
         final CreateContentCommand createCommand = CreateContentCommand.create( this ).
             mediaInfo( mediaInfo ).
+            translator( this.translator ).
             params( createContentParams ).
             siteService( this.siteService ).
             xDataService( this.xDataService ).
@@ -140,12 +129,6 @@ final class CreateMediaCommand
 
         private FormDefaultValuesProcessor formDefaultValuesProcessor;
 
-        private PageDescriptorService pageDescriptorService;
-
-        private PartDescriptorService partDescriptorService;
-
-        private LayoutDescriptorService layoutDescriptorService;
-
         public Builder params( final CreateMediaParams params )
         {
             this.params = params;
@@ -161,24 +144,6 @@ final class CreateMediaCommand
         public Builder formDefaultValuesProcessor( final FormDefaultValuesProcessor formDefaultValuesProcessor )
         {
             this.formDefaultValuesProcessor = formDefaultValuesProcessor;
-            return this;
-        }
-
-        Builder pageDescriptorService( final PageDescriptorService value )
-        {
-            this.pageDescriptorService = value;
-            return this;
-        }
-
-        Builder partDescriptorService( final PartDescriptorService value )
-        {
-            this.partDescriptorService = value;
-            return this;
-        }
-
-        Builder layoutDescriptorService( final LayoutDescriptorService value )
-        {
-            this.layoutDescriptorService = value;
             return this;
         }
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateNodeParamsFactory.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateNodeParamsFactory.java
@@ -45,6 +45,8 @@ public class CreateNodeParamsFactory
 
     private final SiteService siteService;
 
+    private final ContentDataSerializer contentDataSerializer;
+
     public CreateNodeParamsFactory( final Builder builder )
     {
         this.params = builder.params;
@@ -54,11 +56,11 @@ public class CreateNodeParamsFactory
         this.pageDescriptorService = builder.pageDescriptorService;
         this.partDescriptorService = builder.partDescriptorService;
         this.layoutDescriptorService = builder.layoutDescriptorService;
+        this.contentDataSerializer = builder.contentDataSerializer;
     }
 
     public CreateNodeParams.Builder produce()
     {
-        final ContentDataSerializer contentDataSerializer = new ContentDataSerializer();
         final PropertyTree contentAsData = contentDataSerializer.toCreateNodeData( params );
 
         final PropertySet extraDataSet = contentAsData.getPropertySet( PropertyPath.from( ContentPropertyNames.EXTRA_DATA ) );
@@ -147,6 +149,8 @@ public class CreateNodeParamsFactory
 
         private LayoutDescriptorService layoutDescriptorService;
 
+        private ContentDataSerializer contentDataSerializer;
+
         private SiteService siteService;
 
         Builder( final CreateContentTranslatorParams params )
@@ -190,6 +194,12 @@ public class CreateNodeParamsFactory
             return this;
         }
 
+        Builder contentDataSerializer( final ContentDataSerializer value )
+        {
+            this.contentDataSerializer = value;
+            return this;
+        }
+
         void validate()
         {
             Preconditions.checkNotNull( params );
@@ -197,6 +207,7 @@ public class CreateNodeParamsFactory
             Preconditions.checkNotNull( pageDescriptorService );
             Preconditions.checkNotNull( siteService );
             Preconditions.checkNotNull( xDataService );
+            Preconditions.checkNotNull( contentDataSerializer );
         }
 
         public CreateNodeParamsFactory build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ImportContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ImportContentCommand.java
@@ -34,6 +34,7 @@ final class ImportContentCommand
     {
         final Node importNode = ImportContentFactory.create().
             params( params ).
+            contentDataSerializer( this.translator.getContentDataSerializer() ).
             build().execute();
 
         final ImportNodeParams importNodeParams = ImportNodeParams.create().importNode( importNode )

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ImportContentFactory.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ImportContentFactory.java
@@ -20,9 +20,12 @@ public class ImportContentFactory
 {
     private final ImportContentParams params;
 
+    private final ContentDataSerializer contentDataSerializer;
+
     private ImportContentFactory( Builder builder )
     {
         this.params = builder.params;
+        this.contentDataSerializer = builder.contentDataSerializer;
     }
 
     public static Builder create()
@@ -32,7 +35,6 @@ public class ImportContentFactory
 
     public Node execute()
     {
-        final ContentDataSerializer contentDataSerializer = new ContentDataSerializer();
         final PropertyTree nodeData = contentDataSerializer.toNodeData( params.getContent() );
 
         if ( params.getInherit() != null )
@@ -72,6 +74,8 @@ public class ImportContentFactory
     {
         private ImportContentParams params;
 
+        private ContentDataSerializer contentDataSerializer;
+
         private Builder()
         {
         }
@@ -79,6 +83,12 @@ public class ImportContentFactory
         public Builder params( final ImportContentParams params )
         {
             this.params = params;
+            return this;
+        }
+
+        public Builder contentDataSerializer( final ContentDataSerializer contentDataSerializer )
+        {
+            this.contentDataSerializer = contentDataSerializer;
             return this;
         }
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/RenameContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/RenameContentCommand.java
@@ -13,9 +13,6 @@ import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeName;
 import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.node.RenameNodeParams;
-import com.enonic.xp.page.PageDescriptorService;
-import com.enonic.xp.region.LayoutDescriptorService;
-import com.enonic.xp.region.PartDescriptorService;
 
 import static com.enonic.xp.core.impl.content.ContentNodeHelper.translateNodePathToContentPath;
 
@@ -25,19 +22,10 @@ final class RenameContentCommand
 {
     private final RenameContentParams params;
 
-    private final PageDescriptorService pageDescriptorService;
-
-    private final PartDescriptorService partDescriptorService;
-
-    private final LayoutDescriptorService layoutDescriptorService;
-
     private RenameContentCommand( final Builder builder )
     {
         super( builder );
         this.params = builder.params;
-        this.pageDescriptorService = builder.pageDescriptorService;
-        this.partDescriptorService = builder.partDescriptorService;
-        this.layoutDescriptorService = builder.layoutDescriptorService;
     }
 
     public static Builder create( final RenameContentParams params )
@@ -126,33 +114,9 @@ final class RenameContentCommand
     {
         private final RenameContentParams params;
 
-        private PageDescriptorService pageDescriptorService;
-
-        private PartDescriptorService partDescriptorService;
-
-        private LayoutDescriptorService layoutDescriptorService;
-
         Builder( final RenameContentParams params )
         {
             this.params = params;
-        }
-
-        Builder pageDescriptorService( final PageDescriptorService value )
-        {
-            this.pageDescriptorService = value;
-            return this;
-        }
-
-        Builder partDescriptorService( final PartDescriptorService value )
-        {
-            this.partDescriptorService = value;
-            return this;
-        }
-
-        Builder layoutDescriptorService( final LayoutDescriptorService value )
-        {
-            this.layoutDescriptorService = value;
-            return this;
         }
 
         @Override

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ReprocessContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ReprocessContentCommand.java
@@ -15,9 +15,6 @@ import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.node.UpdateNodeParams;
-import com.enonic.xp.page.PageDescriptorService;
-import com.enonic.xp.region.LayoutDescriptorService;
-import com.enonic.xp.region.PartDescriptorService;
 
 import static com.enonic.xp.content.ContentPropertyNames.MODIFIED_TIME;
 
@@ -29,20 +26,11 @@ final class ReprocessContentCommand
 
     private final MediaInfoService mediaInfoService;
 
-    private final PageDescriptorService pageDescriptorService;
-
-    private final PartDescriptorService partDescriptorService;
-
-    private final LayoutDescriptorService layoutDescriptorService;
-
     private ReprocessContentCommand( final Builder builder )
     {
         super( builder );
         this.params = builder.params;
         this.mediaInfoService = builder.mediaInfoService;
-        this.pageDescriptorService = builder.pageDescriptorService;
-        this.partDescriptorService = builder.partDescriptorService;
-        this.layoutDescriptorService = builder.layoutDescriptorService;
     }
 
     Content execute()
@@ -107,12 +95,6 @@ final class ReprocessContentCommand
 
         private MediaInfoService mediaInfoService;
 
-        private PageDescriptorService pageDescriptorService;
-
-        private PartDescriptorService partDescriptorService;
-
-        private LayoutDescriptorService layoutDescriptorService;
-
         private Builder( final ReprocessContentParams params )
         {
             this.params = params;
@@ -122,30 +104,6 @@ final class ReprocessContentCommand
         {
             this.mediaInfoService = value;
             return this;
-        }
-
-        public Builder pageDescriptorService( final PageDescriptorService value )
-        {
-            this.pageDescriptorService = value;
-            return this;
-        }
-
-        public Builder partDescriptorService( final PartDescriptorService value )
-        {
-            this.partDescriptorService = value;
-            return this;
-        }
-
-        public Builder layoutDescriptorService( final LayoutDescriptorService value )
-        {
-            this.layoutDescriptorService = value;
-            return this;
-        }
-
-        @Override
-        void validate()
-        {
-            super.validate();
         }
 
         public ReprocessContentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateContentCommand.java
@@ -45,9 +45,6 @@ import com.enonic.xp.node.NodeCommitEntry;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeIds;
 import com.enonic.xp.node.UpdateNodeParams;
-import com.enonic.xp.page.PageDescriptorService;
-import com.enonic.xp.region.LayoutDescriptorService;
-import com.enonic.xp.region.PartDescriptorService;
 import com.enonic.xp.schema.content.ContentType;
 import com.enonic.xp.schema.content.ContentTypeName;
 import com.enonic.xp.schema.content.GetContentTypeParams;
@@ -63,20 +60,11 @@ final class UpdateContentCommand
 
     private final MediaInfo mediaInfo;
 
-    private final PageDescriptorService pageDescriptorService;
-
-    private final PartDescriptorService partDescriptorService;
-
-    private final LayoutDescriptorService layoutDescriptorService;
-
     private UpdateContentCommand( final Builder builder )
     {
         super( builder );
         this.params = builder.params;
         this.mediaInfo = builder.mediaInfo;
-        this.pageDescriptorService = builder.pageDescriptorService;
-        this.partDescriptorService = builder.partDescriptorService;
-        this.layoutDescriptorService = builder.layoutDescriptorService;
     }
 
     public static Builder create( final UpdateContentParams params )
@@ -197,6 +185,7 @@ final class UpdateContentCommand
                 .pageDescriptorService( this.pageDescriptorService )
                 .partDescriptorService( this.partDescriptorService )
                 .layoutDescriptorService( this.layoutDescriptorService )
+                .contentDataSerializer( this.translator.getContentDataSerializer() )
                 .siteService( this.siteService )
                 .build()
                 .produce();
@@ -355,12 +344,6 @@ final class UpdateContentCommand
 
         private MediaInfo mediaInfo;
 
-        private PageDescriptorService pageDescriptorService;
-
-        private PartDescriptorService partDescriptorService;
-
-        private LayoutDescriptorService layoutDescriptorService;
-
         Builder( final UpdateContentParams params )
         {
             this.params = params;
@@ -380,24 +363,6 @@ final class UpdateContentCommand
         Builder mediaInfo( final MediaInfo value )
         {
             this.mediaInfo = value;
-            return this;
-        }
-
-        Builder pageDescriptorService( final PageDescriptorService value )
-        {
-            this.pageDescriptorService = value;
-            return this;
-        }
-
-        Builder partDescriptorService( final PartDescriptorService value )
-        {
-            this.partDescriptorService = value;
-            return this;
-        }
-
-        Builder layoutDescriptorService( final LayoutDescriptorService value )
-        {
-            this.layoutDescriptorService = value;
             return this;
         }
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
@@ -11,9 +11,6 @@ import com.enonic.xp.content.UpdateContentParams;
 import com.enonic.xp.content.UpdateMediaParams;
 import com.enonic.xp.media.MediaInfo;
 import com.enonic.xp.media.MediaInfoService;
-import com.enonic.xp.page.PageDescriptorService;
-import com.enonic.xp.region.LayoutDescriptorService;
-import com.enonic.xp.region.PartDescriptorService;
 import com.enonic.xp.schema.content.ContentTypeFromMimeTypeResolver;
 import com.enonic.xp.schema.content.ContentTypeName;
 
@@ -24,20 +21,11 @@ final class UpdateMediaCommand
 
     private final MediaInfoService mediaInfoService;
 
-    private final PageDescriptorService pageDescriptorService;
-
-    private final PartDescriptorService partDescriptorService;
-
-    private final LayoutDescriptorService layoutDescriptorService;
-
     private UpdateMediaCommand( final Builder builder )
     {
         super( builder );
         this.params = builder.params;
         this.mediaInfoService = builder.mediaInfoService;
-        this.pageDescriptorService = builder.pageDescriptorService;
-        this.partDescriptorService = builder.partDescriptorService;
-        this.layoutDescriptorService = builder.layoutDescriptorService;
     }
 
     public static Builder create( final UpdateMediaParams params )
@@ -123,13 +111,6 @@ final class UpdateMediaCommand
 
         private MediaInfoService mediaInfoService;
 
-        private PageDescriptorService pageDescriptorService;
-
-        private PartDescriptorService partDescriptorService;
-
-        private LayoutDescriptorService layoutDescriptorService;
-
-
         Builder( final UpdateMediaParams params )
         {
             this.params = params;
@@ -144,24 +125,6 @@ final class UpdateMediaCommand
         public Builder mediaInfoService( final MediaInfoService value )
         {
             this.mediaInfoService = value;
-            return this;
-        }
-
-        public Builder pageDescriptorService( final PageDescriptorService value )
-        {
-            this.pageDescriptorService = value;
-            return this;
-        }
-
-        public Builder partDescriptorService( final PartDescriptorService value )
-        {
-            this.partDescriptorService = value;
-            return this;
-        }
-
-        public Builder layoutDescriptorService( final LayoutDescriptorService value )
-        {
-            this.layoutDescriptorService = value;
             return this;
         }
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateNodeParamsFactory.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateNodeParamsFactory.java
@@ -44,6 +44,8 @@ public class UpdateNodeParamsFactory
 
     private final SiteService siteService;
 
+    private final ContentDataSerializer contentDataSerializer;
+
     public UpdateNodeParamsFactory( final Builder builder )
     {
         this.editedContent = builder.editedContent;
@@ -55,6 +57,7 @@ public class UpdateNodeParamsFactory
         this.pageDescriptorService = builder.pageDescriptorService;
         this.partDescriptorService = builder.partDescriptorService;
         this.layoutDescriptorService = builder.layoutDescriptorService;
+        this.contentDataSerializer = builder.contentDataSerializer;
         this.siteService = builder.siteService;
     }
 
@@ -81,7 +84,6 @@ public class UpdateNodeParamsFactory
 
     private NodeEditor toNodeEditor()
     {
-        final ContentDataSerializer contentDataSerializer = new ContentDataSerializer();
         final PropertyTree nodeData = contentDataSerializer.toUpdateNodeData( editedContent, modifier, attachments );
 
         final ContentIndexConfigFactory indexConfigFactory = ContentIndexConfigFactory.create().
@@ -126,6 +128,8 @@ public class UpdateNodeParamsFactory
         private PartDescriptorService partDescriptorService;
 
         private LayoutDescriptorService layoutDescriptorService;
+
+        private ContentDataSerializer contentDataSerializer;
 
         private SiteService siteService;
 
@@ -189,6 +193,12 @@ public class UpdateNodeParamsFactory
             return this;
         }
 
+        Builder contentDataSerializer( final ContentDataSerializer contentDataSerializer )
+        {
+            this.contentDataSerializer = contentDataSerializer;
+            return this;
+        }
+
         void validate()
         {
             Preconditions.checkNotNull( modifier, "modifier cannot be null" );
@@ -201,6 +211,7 @@ public class UpdateNodeParamsFactory
             Preconditions.checkNotNull( pageDescriptorService );
             Preconditions.checkNotNull( partDescriptorService );
             Preconditions.checkNotNull( layoutDescriptorService );
+            Preconditions.checkNotNull( contentDataSerializer );
         }
 
         public UpdateNodeParamsFactory build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/ComponentDataSerializerProvider.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/ComponentDataSerializerProvider.java
@@ -4,6 +4,7 @@ import com.enonic.xp.region.ComponentType;
 import com.enonic.xp.region.FragmentComponentType;
 import com.enonic.xp.region.ImageComponentType;
 import com.enonic.xp.region.LayoutComponentType;
+import com.enonic.xp.region.LayoutDescriptorService;
 import com.enonic.xp.region.PartComponentType;
 import com.enonic.xp.region.TextComponentType;
 
@@ -21,14 +22,22 @@ public final class ComponentDataSerializerProvider
 
     private final RegionDataSerializer regionDataSerializer;
 
-    public ComponentDataSerializerProvider( )
+    public ComponentDataSerializerProvider()
+    {
+        this( null );
+    }
+
+    public ComponentDataSerializerProvider( final LayoutDescriptorService layoutDescriptorService )
     {
         this.regionDataSerializer = new RegionDataSerializer( this );
         this.partDataSerializer = new PartComponentDataSerializer();
         this.textDataSerializer = new TextComponentDataSerializer();
-        this.layoutDataSerializer = new LayoutComponentDataSerializer( this.regionDataSerializer );
         this.imageDataSerializer = new ImageComponentDataSerializer();
         this.fragmentDataSerializer = new FragmentComponentDataSerializer();
+
+        this.layoutDataSerializer = layoutDescriptorService == null
+            ? new LayoutComponentDataSerializer( this.regionDataSerializer )
+            : new FullLayoutComponentDataSerializer( layoutDescriptorService, regionDataSerializer );
     }
 
     public ComponentDataSerializer getDataSerializer( final ComponentType componentType )

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/ContentDataSerializer.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/ContentDataSerializer.java
@@ -89,7 +89,12 @@ public class ContentDataSerializer
 
     public ContentDataSerializer( )
     {
-        this.pageDataSerializer = new PageDataSerializer();
+        this( new PageDataSerializer() );
+    }
+
+    protected ContentDataSerializer( final PageDataSerializer pageDataSerializer )
+    {
+        this.pageDataSerializer = pageDataSerializer;
         this.extraDataSerializer = new ExtraDataSerializer();
         this.workflowInfoSerializer = new WorkflowInfoSerializer();
         this.publishInfoSerializer = new PublishInfoSerializer();

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/FullContentDataSerializer.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/FullContentDataSerializer.java
@@ -1,0 +1,54 @@
+package com.enonic.xp.core.impl.content.serializer;
+
+import com.google.common.base.Preconditions;
+
+import com.enonic.xp.page.PageDescriptorService;
+import com.enonic.xp.region.LayoutDescriptorService;
+
+public class FullContentDataSerializer extends ContentDataSerializer
+{
+    private FullContentDataSerializer( final Builder builder )
+    {
+        super( FullPageDataSerializer.create()
+                   .pageDescriptorService( builder.pageDescriptorService )
+                   .layoutDescriptorService( builder.layoutDescriptorService )
+                   .build() );
+    }
+
+    public static Builder create()
+    {
+        return new Builder();
+    }
+
+    public static class Builder
+    {
+        private PageDescriptorService pageDescriptorService;
+
+        private LayoutDescriptorService layoutDescriptorService;
+
+        public Builder pageDescriptorService( final PageDescriptorService value )
+        {
+            this.pageDescriptorService = value;
+            return this;
+        }
+
+        public Builder layoutDescriptorService( final LayoutDescriptorService value )
+        {
+            this.layoutDescriptorService = value;
+            return this;
+        }
+
+        void validate()
+        {
+            Preconditions.checkNotNull( pageDescriptorService );
+            Preconditions.checkNotNull( layoutDescriptorService );
+        }
+
+        public FullContentDataSerializer build()
+        {
+            validate();
+            return new FullContentDataSerializer( this );
+        }
+    }
+
+}

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/FullLayoutComponentDataSerializer.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/FullLayoutComponentDataSerializer.java
@@ -1,0 +1,56 @@
+package com.enonic.xp.core.impl.content.serializer;
+
+
+import java.util.List;
+
+import com.enonic.xp.data.PropertySet;
+import com.enonic.xp.page.DescriptorKey;
+import com.enonic.xp.region.LayoutComponent;
+import com.enonic.xp.region.LayoutComponentType;
+import com.enonic.xp.region.LayoutDescriptor;
+import com.enonic.xp.region.LayoutDescriptorService;
+import com.enonic.xp.region.LayoutRegions;
+
+class FullLayoutComponentDataSerializer
+    extends LayoutComponentDataSerializer
+{
+    private final LayoutDescriptorService layoutDescriptorService;
+
+    FullLayoutComponentDataSerializer( final LayoutDescriptorService layoutDescriptorService, final RegionDataSerializer regionDataSerializer )
+    {
+        super( regionDataSerializer );
+        this.layoutDescriptorService = layoutDescriptorService;
+    }
+
+    public LayoutComponent fromData( final PropertySet layoutData, final List<PropertySet> componentsAsData )
+    {
+        final LayoutComponent.Builder layoutComponent = LayoutComponent.create();
+
+        final LayoutRegions.Builder layoutRegionsBuilder = LayoutRegions.create();
+
+        final PropertySet specialBlockSet = layoutData.getSet( LayoutComponentType.INSTANCE.toString() );
+
+        if ( specialBlockSet != null && specialBlockSet.isNotNull( DESCRIPTOR ) )
+        {
+            final DescriptorKey descriptorKey = DescriptorKey.from( specialBlockSet.getString( DESCRIPTOR ) );
+
+            layoutComponent.descriptor( descriptorKey );
+            layoutComponent.config( getConfigFromData( specialBlockSet, descriptorKey ) );
+
+            final LayoutDescriptor layoutDescriptor = layoutDescriptorService.getByKey( descriptorKey );
+
+            final String layoutPath = layoutData.getString( PATH );
+
+            if ( layoutDescriptor.getRegions() != null && layoutDescriptor.getRegions().numberOfRegions() > 0 )
+            {
+                layoutDescriptor.getRegions().forEach( regionDescriptor -> {
+                    layoutRegionsBuilder.add( regionDataSerializer.fromData( regionDescriptor, layoutPath, componentsAsData ) );
+                } );
+            }
+        }
+
+        layoutComponent.regions( layoutRegionsBuilder.build() );
+
+        return layoutComponent.build();
+    }
+}

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/FullPageDataSerializer.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/FullPageDataSerializer.java
@@ -1,0 +1,78 @@
+package com.enonic.xp.core.impl.content.serializer;
+
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+
+import com.enonic.xp.data.PropertySet;
+import com.enonic.xp.page.DescriptorKey;
+import com.enonic.xp.page.PageDescriptor;
+import com.enonic.xp.page.PageDescriptorService;
+import com.enonic.xp.page.PageRegions;
+import com.enonic.xp.region.ComponentPath;
+import com.enonic.xp.region.LayoutDescriptorService;
+import com.enonic.xp.region.RegionDescriptors;
+
+final class FullPageDataSerializer
+    extends PageDataSerializer
+{
+    private final PageDescriptorService pageDescriptorService;
+
+    private FullPageDataSerializer( final Builder builder )
+    {
+        this.pageDescriptorService = builder.pageDescriptorService;
+        this.componentDataSerializerProvider = new ComponentDataSerializerProvider( builder.layoutDescriptorService );
+    }
+
+    protected PageRegions getPageRegions( final DescriptorKey descriptorKey, final List<PropertySet> componentsAsData )
+    {
+        final PageDescriptor pageDescriptor = pageDescriptorService.getByKey( descriptorKey );
+
+        final RegionDescriptors regionDescriptors = pageDescriptor.getRegions();
+
+        final PageRegions.Builder pageRegionsBuilder = PageRegions.create();
+
+        regionDescriptors.forEach( regionDescriptor -> {
+            pageRegionsBuilder.add( componentDataSerializerProvider.getRegionDataSerializer()
+                                        .fromData( regionDescriptor, ComponentPath.DIVIDER, componentsAsData ) );
+        } );
+
+        return pageRegionsBuilder.build();
+    }
+
+    public static Builder create()
+    {
+        return new Builder();
+    }
+
+    public static class Builder
+    {
+        private PageDescriptorService pageDescriptorService;
+
+        private LayoutDescriptorService layoutDescriptorService;
+
+        public Builder pageDescriptorService( final PageDescriptorService value )
+        {
+            this.pageDescriptorService = value;
+            return this;
+        }
+
+        public Builder layoutDescriptorService( final LayoutDescriptorService value )
+        {
+            this.layoutDescriptorService = value;
+            return this;
+        }
+
+        void validate()
+        {
+            Preconditions.checkNotNull( pageDescriptorService );
+            Preconditions.checkNotNull( layoutDescriptorService );
+        }
+
+        public FullPageDataSerializer build()
+        {
+            validate();
+            return new FullPageDataSerializer( this );
+        }
+    }
+}

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/LayoutComponentDataSerializer.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/LayoutComponentDataSerializer.java
@@ -15,10 +15,10 @@ import com.enonic.xp.region.LayoutRegions;
 import com.enonic.xp.region.Region;
 import com.enonic.xp.region.RegionDescriptors;
 
-final class LayoutComponentDataSerializer
+class LayoutComponentDataSerializer
     extends DescriptorBasedComponentDataSerializer<LayoutComponent>
 {
-    private final RegionDataSerializer regionDataSerializer;
+    protected final RegionDataSerializer regionDataSerializer;
 
     LayoutComponentDataSerializer( final RegionDataSerializer regionDataSerializer )
     {

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/ImportContentFactoryTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/ImportContentFactoryTest.java
@@ -17,6 +17,7 @@ import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.content.ContentPublishInfo;
 import com.enonic.xp.content.ImportContentParams;
+import com.enonic.xp.core.impl.content.serializer.ContentDataSerializer;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.project.ProjectName;
@@ -107,6 +108,6 @@ public class ImportContentFactoryTest
 
     private ImportContentFactory createFactory()
     {
-        return ImportContentFactory.create().params( this.params ).build();
+        return ImportContentFactory.create().params( this.params ).contentDataSerializer( new ContentDataSerializer() ).build();
     }
 }

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/RenameContentCommandTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/RenameContentCommandTest.java
@@ -97,6 +97,7 @@ class RenameContentCommandTest
 
         when( nodeService.rename( isA( RenameNodeParams.class ) ) ).thenReturn( mockNode );
         when( nodeService.getById( mockNode.id() ) ).thenReturn( mockNode );
+        when( translator.getContentDataSerializer() ).thenReturn( new ContentDataSerializer() );
     }
 
     @Test

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/serializer/FullLayoutComponentDataSerializerTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/serializer/FullLayoutComponentDataSerializerTest.java
@@ -1,0 +1,58 @@
+package com.enonic.xp.core.impl.content.serializer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.enonic.xp.data.PropertySet;
+import com.enonic.xp.data.PropertyTree;
+import com.enonic.xp.form.Form;
+import com.enonic.xp.page.DescriptorKey;
+import com.enonic.xp.region.LayoutComponent;
+import com.enonic.xp.region.LayoutComponentType;
+import com.enonic.xp.region.LayoutDescriptor;
+import com.enonic.xp.region.LayoutDescriptorService;
+import com.enonic.xp.region.RegionDescriptor;
+import com.enonic.xp.region.RegionDescriptors;
+
+import static com.enonic.xp.core.impl.content.serializer.DescriptorBasedComponentDataSerializer.DESCRIPTOR;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class FullLayoutComponentDataSerializerTest
+{
+    private LayoutDescriptorService layoutDescriptorService;
+
+    private FullLayoutComponentDataSerializer componentDataSerializer;
+
+    @BeforeEach
+    public void setUp()
+    {
+        this.layoutDescriptorService = Mockito.mock( LayoutDescriptorService.class );
+        this.componentDataSerializer = new FullLayoutComponentDataSerializer( layoutDescriptorService, new RegionDataSerializer(
+            new ComponentDataSerializerProvider() ) );
+    }
+
+    @Test
+    public void testRegionsFetched()
+    {
+        final DescriptorKey pageDescriptorKey = DescriptorKey.from( "myapplication:my-page" );
+        final RegionDescriptors regions = RegionDescriptors.create().add( RegionDescriptor.create().name( "main" ).build() ).build();
+        final LayoutDescriptor layoutDescriptor = LayoutDescriptor.create().key( pageDescriptorKey )
+            .config( Form.create().build() )
+            .regions( regions )
+            .build();
+
+        final PropertyTree newPropertyTree = new PropertyTree();
+        final PropertySet layoutRootData = newPropertyTree.getRoot();
+        final PropertySet layoutData = layoutRootData.addSet( LayoutComponentType.INSTANCE.toString() );
+
+        Mockito.when( layoutDescriptorService.getByKey( pageDescriptorKey ) ).thenReturn( layoutDescriptor );
+
+        layoutData.addString( DESCRIPTOR, "myapplication:my-page" );
+
+        final LayoutComponent layoutComponent = componentDataSerializer.fromData( layoutRootData );
+
+        assertNotNull( layoutComponent );
+        assertNotNull( layoutComponent.getRegion( "main" ) );
+    }
+}

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/serializer/FullPageDataSerializerTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/serializer/FullPageDataSerializerTest.java
@@ -1,0 +1,74 @@
+package com.enonic.xp.core.impl.content.serializer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.enonic.xp.core.impl.content.page.AbstractDataSerializerTest;
+import com.enonic.xp.data.PropertySet;
+import com.enonic.xp.data.PropertyTree;
+import com.enonic.xp.form.Form;
+import com.enonic.xp.page.DescriptorKey;
+import com.enonic.xp.page.Page;
+import com.enonic.xp.page.PageDescriptor;
+import com.enonic.xp.page.PageDescriptorService;
+import com.enonic.xp.region.ComponentPath;
+import com.enonic.xp.region.LayoutDescriptorService;
+import com.enonic.xp.region.RegionDescriptor;
+import com.enonic.xp.region.RegionDescriptors;
+
+import static com.enonic.xp.content.ContentPropertyNames.PAGE;
+import static com.enonic.xp.core.impl.content.serializer.ComponentDataSerializer.COMPONENTS;
+import static com.enonic.xp.core.impl.content.serializer.ComponentDataSerializer.PATH;
+import static com.enonic.xp.core.impl.content.serializer.ComponentDataSerializer.TYPE;
+import static com.enonic.xp.core.impl.content.serializer.DescriptorBasedComponentDataSerializer.DESCRIPTOR;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FullPageDataSerializerTest
+    extends AbstractDataSerializerTest
+{
+
+    private FullContentDataSerializer contentDataSerializer;
+
+    private PageDescriptorService pageDescriptorService;
+
+    @BeforeEach
+    public void setUp()
+    {
+        this.pageDescriptorService = Mockito.mock( PageDescriptorService.class );
+        this.contentDataSerializer = FullContentDataSerializer.create()
+            .layoutDescriptorService( Mockito.mock( LayoutDescriptorService.class ) )
+            .pageDescriptorService( pageDescriptorService )
+            .build();
+    }
+
+    @Test
+    public void testRegionsFetched()
+    {
+        final DescriptorKey pageDescriptorKey = DescriptorKey.from( "myapplication:my-page" );
+        final RegionDescriptors regions = RegionDescriptors.create().add( RegionDescriptor.create().name( "main" ).build() ).build();
+        final PageDescriptor pageDescriptor = PageDescriptor.create()
+            .key( pageDescriptorKey )
+            .regions( regions )
+            .config( Form.create().build() )
+            .build();
+
+        Mockito.when( pageDescriptorService.getByKey( pageDescriptorKey ) ).thenReturn( pageDescriptor );
+
+        final PropertyTree newPropertyTree = new PropertyTree();
+        final PropertySet contentAsData = newPropertyTree.getRoot();
+        final PropertySet asSet = contentAsData.addSet( COMPONENTS );
+
+        asSet.setString( TYPE, PAGE );
+        asSet.setString( PATH, ComponentPath.DIVIDER );
+
+        final PropertySet specialBlockSet = asSet.addSet( PAGE );
+        specialBlockSet.addString( DESCRIPTOR, pageDescriptorKey.toString() );
+
+        final Page parsedPage = contentDataSerializer.fromPageData( contentAsData );
+
+        assertTrue( parsedPage.hasRegions() );
+        assertNotNull( parsedPage.getRegions().getRegion( "main" ) );
+    }
+}

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/AbstractContentServiceTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/AbstractContentServiceTest.java
@@ -144,6 +144,8 @@ public abstract class AbstractContentServiceTest
 
     protected ContentServiceImpl contentService;
 
+    protected ContentConfig config;
+
     protected NodeServiceImpl nodeService;
 
     protected MixinService mixinService;
@@ -320,7 +322,8 @@ public abstract class AbstractContentServiceTest
 
         projectService.create( CreateProjectParams.create().name( testprojectName ).displayName( "test" ).build() );
 
-        contentService = new ContentServiceImpl( nodeService, pageDescriptorService, partDescriptorService, layoutDescriptorService );
+        this.config = mock( ContentConfig.class, invocation -> invocation.getMethod().getDefaultValue() );
+        contentService = new ContentServiceImpl( nodeService, pageDescriptorService, partDescriptorService, layoutDescriptorService, config );
         contentService.setEventPublisher( eventPublisher );
         contentService.setMediaInfoService( mediaInfoService );
         contentService.setSiteService( siteService );
@@ -334,8 +337,6 @@ public abstract class AbstractContentServiceTest
         contentService.addContentValidator( new SiteConfigsValidator( siteService ) );
         contentService.addContentValidator( new OccurrenceValidator() );
         contentService.addContentValidator( new ExtraDataValidator( xDataService ) );
-
-        contentService.initialize( mock( ContentConfig.class, invocation -> invocation.getMethod().getDefaultValue() ) );
     }
 
     @AfterEach

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/AbstractContentSynchronizerTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/AbstractContentSynchronizerTest.java
@@ -254,7 +254,8 @@ public abstract class AbstractContentSynchronizerTest
         final ContentAuditLogSupportImpl contentAuditLogSupport =
             new ContentAuditLogSupportImpl( contentConfig, Runnable::run, auditLogService, contentAuditLogFilterService );
 
-        contentService = new ContentServiceImpl( nodeService, pageDescriptorService, partDescriptorService, layoutDescriptorService );
+        final ContentConfig config = mock( ContentConfig.class, invocation -> invocation.getMethod().getDefaultValue() );
+        contentService = new ContentServiceImpl( nodeService, pageDescriptorService, partDescriptorService, layoutDescriptorService, config );
         contentService.setEventPublisher( eventPublisher );
         contentService.setMediaInfoService( mediaInfoService );
         contentService.setSiteService( siteService );
@@ -263,7 +264,6 @@ public abstract class AbstractContentSynchronizerTest
         contentService.setFormDefaultValuesProcessor( ( form, data ) -> {
         } );
         contentService.setContentAuditLogSupport( contentAuditLogSupport );
-        contentService.initialize( mock( ContentConfig.class, invocation -> invocation.getMethod().getDefaultValue() ) );
     }
 
     private void setupTaskService()

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/ContentServiceImplTest_media.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/ContentServiceImplTest_media.java
@@ -84,10 +84,8 @@ public class ContentServiceImplTest_media
 
         Mockito.when( this.xDataService.getFromContentType( Mockito.any( ContentType.class ) ) ).thenReturn( XDatas.empty() );
 
-        final ContentConfig contentConfig = mock( ContentConfig.class );
-        when( contentConfig.attachments_allowUnsafeNames() ).thenReturn( true );
+        when( config.attachments_allowUnsafeNames() ).thenReturn( true );
 
-        contentService.initialize( contentConfig );
         final Content content = this.contentService.create( createMediaParams );
 
         final Content storedContent = this.contentService.getById( content.getId() );

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/postprocess/instruction/ComponentInstruction.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/postprocess/instruction/ComponentInstruction.java
@@ -87,7 +87,7 @@ public final class ComponentInstruction
     {
         if ( FRAGMENT_COMPONENT.equalsIgnoreCase( componentSelector ) )
         {
-            return resolveFragmentComponent( portalRequest );
+            return getPageFragment( portalRequest );
         }
 
         if ( componentSelector.startsWith( APPLICATION_COMPONENT_PREFIX ) )
@@ -138,31 +138,7 @@ public final class ComponentInstruction
             throw new RenderException( MessageFormat.format( "Component not found: [{0}]", path ) );
         }
 
-        if ( component instanceof LayoutComponent )
-        {
-            return resolveLayoutWithRegions( (LayoutComponent) component, content.getPage() );
-        }
-
         return component;
-    }
-
-    private LayoutComponent resolveLayoutWithRegions( final LayoutComponent existingLayout, final Page page )
-    {
-        if ( !existingLayout.hasDescriptor() )
-        {
-            return existingLayout;
-        }
-
-        final LayoutComponent layoutFromDescriptor = (LayoutComponent) componentService.getByKey( existingLayout.getDescriptor() );
-
-        if ( layoutFromDescriptor == null )
-        {
-            return existingLayout;
-        }
-
-        final LayoutComponent layoutComponent = buildLayoutWithRegions( existingLayout, layoutFromDescriptor );
-        setParentRegionOnLayout( page, existingLayout, layoutComponent );
-        return layoutComponent;
     }
 
     private LayoutComponent buildLayoutWithRegions( final LayoutComponent existingLayout, final LayoutComponent layoutFromDescriptor )
@@ -215,22 +191,6 @@ public final class ComponentInstruction
         }
 
         return component;
-    }
-
-    private Component resolveFragmentComponent( final PortalRequest portalRequest )
-    {
-        final Component fragmentComponent = getPageFragment( portalRequest );
-        return processFragment( fragmentComponent );
-    }
-
-    private Component processFragment( final Component fragmentComponent )
-    {
-        if ( fragmentComponent instanceof LayoutComponent )
-        {
-            return resolveLayoutWithRegions( (LayoutComponent) fragmentComponent, null  );
-        }
-
-        return fragmentComponent;
     }
 
     private Component getPageFragment( final PortalRequest portalRequest )

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/rendering/RendererDelegateImpl.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/rendering/RendererDelegateImpl.java
@@ -12,6 +12,7 @@ import com.enonic.xp.content.ContentService;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalResponse;
 import com.enonic.xp.region.FragmentComponent;
+import com.enonic.xp.region.LayoutDescriptorService;
 
 @Component
 public final class RendererDelegateImpl
@@ -21,10 +22,14 @@ public final class RendererDelegateImpl
 
     private final ContentService contentService;
 
+    private final LayoutDescriptorService layoutDescriptorService;
+
     @Activate
-    public RendererDelegateImpl( @Reference final ContentService contentService )
+    public RendererDelegateImpl( @Reference final ContentService contentService,
+                                 @Reference final LayoutDescriptorService layoutDescriptorService )
     {
         this.contentService = contentService;
+        this.layoutDescriptorService = layoutDescriptorService;
     }
 
     @Override
@@ -32,7 +37,7 @@ public final class RendererDelegateImpl
     {
         if ( renderable instanceof FragmentComponent )
         {
-            return new FragmentRenderer( contentService, this ).render( (FragmentComponent) renderable, portalRequest );
+            return new FragmentRenderer( contentService, layoutDescriptorService, this ).render( (FragmentComponent) renderable, portalRequest );
         }
         return renderers.stream().
             filter( r -> r.getType().isInstance( renderable ) ).

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/postprocess/instruction/ComponentInstructionTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/postprocess/instruction/ComponentInstructionTest.java
@@ -104,32 +104,6 @@ public class ComponentInstructionTest
     }
 
     @Test
-    public void testLayoutIsReturnedWithRegions()
-        throws Exception
-    {
-        final ArgumentCaptor<Component> captor = ArgumentCaptor.forClass( Component.class );
-        returnOnRender( "render result", captor.capture() );
-
-        final DescriptorKey layoutDescriptorKey = DescriptorKey.from( "myapplication:layout" );
-        final LayoutRegions regions =
-            LayoutRegions.create().add( Region.create().name( "r1" ).build() ).add( Region.create().name( "r2" ).build() ).build();
-        final LayoutComponent layoutFromService = LayoutComponent.create().descriptor( layoutDescriptorKey ).regions( regions ).build();
-
-        when( componentService.getByKey( Mockito.any( DescriptorKey.class) ) ).thenReturn( layoutFromService );
-
-        final PortalRequest portalRequest = new PortalRequest();
-        final LayoutComponent emptyLayoutComponent =
-            LayoutComponent.create().descriptor( DescriptorKey.from( "myapplication:layout" ) ).build();
-
-        final Content content = createPage( "content-id", "content-name", "myapplication:content-type", emptyLayoutComponent );
-        portalRequest.setContent( content );
-
-        instruction.evaluate( portalRequest, "COMPONENT myRegion/0" );
-
-        assertEquals( captor.getValue(), layoutFromService );
-    }
-
-    @Test
     public void testFragmentContentNotLayoutThrowsException()
     {
         final PortalRequest portalRequest = new PortalRequest();

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/rendering/RendererDelegateImplTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/rendering/RendererDelegateImplTest.java
@@ -1,24 +1,45 @@
 package com.enonic.xp.portal.impl.rendering;
 
+import java.time.Instant;
+
 import org.junit.jupiter.api.Test;
 
+import com.google.common.net.MediaType;
+
 import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ContentId;
+import com.enonic.xp.content.ContentNotFoundException;
 import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.content.ContentService;
+import com.enonic.xp.form.Form;
+import com.enonic.xp.page.DescriptorKey;
+import com.enonic.xp.page.Page;
 import com.enonic.xp.page.PageTemplate;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalResponse;
+import com.enonic.xp.portal.RenderMode;
+import com.enonic.xp.region.FragmentComponent;
+import com.enonic.xp.region.LayoutComponent;
+import com.enonic.xp.region.LayoutDescriptor;
+import com.enonic.xp.region.LayoutDescriptorService;
+import com.enonic.xp.region.Region;
+import com.enonic.xp.region.RegionDescriptor;
+import com.enonic.xp.region.RegionDescriptors;
+import com.enonic.xp.region.TextComponent;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RendererDelegateImplTest
 {
     @Test
     public void given_Renderable_matching_only_on_superType_when_getRenderer_then_Renderer_for_superType_is_returned()
     {
-        RendererDelegateImpl factory = new RendererDelegateImpl( mock( ContentService.class ) );
+        RendererDelegateImpl factory = new RendererDelegateImpl( mock( ContentService.class ), mock( LayoutDescriptorService.class ) );
         final PortalResponse response = PortalResponse.create().build();
         factory.addRenderer( createRenderer( Content.class, response ) );
 
@@ -32,7 +53,7 @@ public class RendererDelegateImplTest
     @Test
     public void given_Renderable_having_not_matching_Renderer_when_getRenderer_then_Renderer_for_that_type_is_returned()
     {
-        RendererDelegateImpl factory = new RendererDelegateImpl( mock( ContentService.class ) );
+        RendererDelegateImpl factory = new RendererDelegateImpl( mock( ContentService.class ), mock( LayoutDescriptorService.class ) );
         final PortalResponse response = PortalResponse.create().build();
         factory.addRenderer( createRenderer( Content.class, response ) );
 
@@ -46,11 +67,209 @@ public class RendererDelegateImplTest
     @Test
     public void given_Renderable_matching_no_given_type_when_getRenderer_then_Renderer_for_that_type_is_returned()
     {
-        RendererDelegateImpl factory = new RendererDelegateImpl( mock( ContentService.class ) );
+        RendererDelegateImpl factory = new RendererDelegateImpl( mock( ContentService.class ), mock( LayoutDescriptorService.class ) );
         factory.addRenderer( createRenderer( RendererDelegateImplTest.class, null ) );
 
         // exercise
         assertThrows( RendererNotFoundException.class, () -> factory.render( createContent(), null ) );
+    }
+
+    @Test
+    public void renderEmptyFragment()
+    {
+        RendererDelegateImpl factory = new RendererDelegateImpl( mock( ContentService.class ), mock( LayoutDescriptorService.class ) );
+        final PortalRequest portalRequest = new PortalRequest();
+        portalRequest.setMode( RenderMode.EDIT );
+
+        // exercise
+        final PortalResponse renderResponse = factory.render( createEmptyFragmentComponent(), portalRequest );
+
+        // verify
+        assertEquals( renderResponse.getAsString(), "<div data-portal-component-type=\"fragment\"></div>" );
+    }
+
+    @Test
+    public void fragmentNotFoundInEditMode()
+    {
+        final ContentService contentService = mock( ContentService.class );
+        final ContentId contentId = ContentId.from( "contentId" );
+        when( contentService.getById( contentId ) ).thenThrow( ContentNotFoundException.class );
+        RendererDelegateImpl factory = new RendererDelegateImpl( contentService, mock( LayoutDescriptorService.class ) );
+        final PortalRequest portalRequest = new PortalRequest();
+        portalRequest.setMode( RenderMode.EDIT );
+
+        // exercise
+        final PortalResponse renderResponse = factory.render( createFragmentComponent( contentId ), portalRequest );
+
+        // verify
+        assertTrue( renderResponse.getAsString().contains( "Fragment content could not be found" ) );
+    }
+
+    @Test
+    public void fragmentContentHasNoPage()
+    {
+        final ContentService contentService = mock( ContentService.class );
+        final ContentId contentId = ContentId.from( "contentId" );
+        when( contentService.getById( contentId ) ).thenReturn( createContent() );
+        RendererDelegateImpl factory = new RendererDelegateImpl( contentService, mock( LayoutDescriptorService.class ) );
+        final PortalRequest portalRequest = new PortalRequest();
+        portalRequest.setMode( RenderMode.EDIT );
+
+        final PortalResponse renderResponse = factory.render( createFragmentComponent( contentId ), portalRequest );
+
+        assertTrue( renderResponse.getAsString().contains( "Fragment content could not be found" ) );
+    }
+
+    @Test
+    public void fragmentNotFoundInNonEditMode()
+    {
+        final ContentService contentService = mock( ContentService.class );
+        final ContentId contentId = ContentId.from( "contentId" );
+        when( contentService.getById( contentId ) ).thenThrow( ContentNotFoundException.class );
+        RendererDelegateImpl factory = new RendererDelegateImpl( contentService, mock( LayoutDescriptorService.class ) );
+        final PortalRequest portalRequest = new PortalRequest();
+        portalRequest.setMode( RenderMode.PREVIEW );
+
+        final PortalResponse renderResponse = factory.render( createFragmentComponent( contentId ), portalRequest );
+
+        assertTrue( renderResponse.getAsString().isEmpty() );
+    }
+
+    @Test
+    public void fragmentRenderLayoutNoDescriptor()
+    {
+        final ContentService contentService = mock( ContentService.class );
+        final ContentId contentId = ContentId.from( "contentId" );
+        when( contentService.getById( contentId ) ).thenReturn( createFragmentContentWithLayoutComponent( DescriptorKey.from( "des" ) ) );
+        RendererDelegateImpl factory = new RendererDelegateImpl( contentService, mock( LayoutDescriptorService.class ) );
+        factory.addRenderer( createRenderer( LayoutComponent.class, PortalResponse.create().body( "LayoutRendered" ).build() ) );
+        final PortalRequest portalRequest = new PortalRequest();
+        portalRequest.setContent( createContentWithPage() );
+        portalRequest.setMode( RenderMode.EDIT );
+
+        final PortalResponse response = factory.render( createFragmentComponent( contentId ), portalRequest );
+
+        assertEquals( "LayoutRendered", response.getAsString() );
+    }
+
+    @Test
+    public void fragmentRenderLayoutWithoDescriptor()
+    {
+        final ContentService contentService = mock( ContentService.class );
+        final LayoutDescriptorService layoutDescriptorService = mock( LayoutDescriptorService.class );
+        final ContentId contentId = ContentId.from( "contentId" );
+        final DescriptorKey descriptorKey = DescriptorKey.from( "descriptorKey" );
+        when( contentService.getById( contentId ) ).thenReturn( createFragmentContentWithLayoutComponent( descriptorKey ) );
+        when( layoutDescriptorService.getByKey( descriptorKey ) ).thenReturn( createLayoutDescriptor(descriptorKey) );
+        RendererDelegateImpl factory = new RendererDelegateImpl( contentService, layoutDescriptorService );
+        factory.addRenderer( createRenderer( LayoutComponent.class, PortalResponse.create().body( "LayoutRendered" ).build() ) );
+        final PortalRequest portalRequest = new PortalRequest();
+        portalRequest.setContent( createContentWithPage() );
+        portalRequest.setMode( RenderMode.EDIT );
+
+        final PortalResponse response = factory.render( createFragmentComponent( contentId ), portalRequest );
+
+        assertEquals( "LayoutRendered", response.getAsString() );
+    }
+
+    private LayoutDescriptor createLayoutDescriptor( final DescriptorKey descriptorKey )
+    {
+        return LayoutDescriptor.create()
+            .key( descriptorKey )
+            .regions( RegionDescriptors.create().add( RegionDescriptor.create().name( "r1" ).build() ).build() )
+            .config( Form.create().build() )
+            .modifiedTime( Instant.now() )
+            .build();
+    }
+
+    @Test
+    public void fragmentRenderComponentNonUTF8()
+    {
+        final String textComponentValue = "textrendered";
+        final PortalResponse fragmentResponse = PortalResponse.create().body( textComponentValue ).build();
+        final PortalResponse renderResponse = renderFragmentComponent( fragmentResponse, RenderMode.EDIT );
+
+        assertEquals( textComponentValue, renderResponse.getAsString() );
+    }
+
+    @Test
+    public void fragmentRenderComponentUTF8()
+    {
+        final String textComponentValue = "textrendered";
+        final PortalResponse fragmentResponse =
+            PortalResponse.create().contentType( MediaType.HTML_UTF_8 ).body( textComponentValue ).build();
+        final PortalResponse renderResponse = renderFragmentComponent( fragmentResponse, RenderMode.EDIT );
+
+        assertEquals( "<div data-portal-component-type=\"fragment\">" + textComponentValue + "</div>", renderResponse.getAsString() );
+    }
+
+    @Test
+    public void fragmentRenderNonEditMode()
+    {
+        final String textComponentValue = "textrendered";
+        final PortalResponse fragmentResponse =
+            PortalResponse.create().contentType( MediaType.HTML_UTF_8 ).body( textComponentValue ).build();
+        final PortalResponse renderResponse = renderFragmentComponent( fragmentResponse, RenderMode.PREVIEW );
+
+        assertEquals( textComponentValue, renderResponse.getAsString() );
+    }
+
+    @Test
+    public void fragmentRenderWithNoSuchMethodError()
+    {
+        final String errorText = "No method provided to handle request";
+        final PortalResponse fragmentResponse = PortalResponse.create().contentType( MediaType.HTML_UTF_8 ).body( errorText ).build();
+        final PortalResponse renderResponse = renderFragmentComponent( fragmentResponse, RenderMode.EDIT );
+
+        assertTrue( renderResponse.getAsString().contains( "<span class=\"data-portal-placeholder-error\">" + errorText + "</span>" ) );
+    }
+
+    private PortalResponse renderFragmentComponent( final PortalResponse fragmentRenderResult, final RenderMode renderMode )
+    {
+        final ContentService contentService = mock( ContentService.class );
+        final ContentId contentId = ContentId.from( "contentId" );
+        when( contentService.getById( contentId ) ).thenReturn( createFragmentContentWithTextComponent() );
+        RendererDelegateImpl factory = new RendererDelegateImpl( contentService, mock( LayoutDescriptorService.class ) );
+        factory.addRenderer( createRenderer( TextComponent.class, fragmentRenderResult ) );
+        final PortalRequest portalRequest = new PortalRequest();
+        portalRequest.setContent( createContentWithPage() );
+        portalRequest.setMode( renderMode );
+
+        return factory.render( createFragmentComponent( contentId ), portalRequest );
+    }
+
+    private FragmentComponent createEmptyFragmentComponent()
+    {
+        return FragmentComponent.create().build();
+    }
+
+    private FragmentComponent createFragmentComponent( final ContentId contentId )
+    {
+        final FragmentComponent fragmentComponent = FragmentComponent.create().fragment( contentId ).build();
+        Region.create().add( fragmentComponent ).name( "main" ).build();
+        return fragmentComponent;
+    }
+
+    private Content createFragmentContentWithTextComponent()
+    {
+        final TextComponent textComponent = TextComponent.create().text( "my-text" ).build();
+
+        return Content.create()
+            .name( "my-content" )
+            .parentPath( ContentPath.ROOT )
+            .page( Page.create().fragment( textComponent ).build() )
+            .build();
+    }
+
+    private Content createFragmentContentWithLayoutComponent( final DescriptorKey descriptorKey )
+    {
+        final LayoutComponent layoutComponent = LayoutComponent.create().descriptor( descriptorKey ).build();
+
+        return Content.create()
+            .name( "my-content" )
+            .parentPath( ContentPath.ROOT )
+            .page( Page.create().fragment( layoutComponent ).build() )
+            .build();
     }
 
     private PageTemplate createPageTemplate()
@@ -61,6 +280,11 @@ public class RendererDelegateImplTest
     private Content createContent()
     {
         return Content.create().name( "my-content" ).parentPath( ContentPath.ROOT ).build();
+    }
+
+    private Content createContentWithPage()
+    {
+        return Content.create().name( "my-content" ).page( Page.create().build() ).parentPath( ContentPath.ROOT ).build();
     }
 
     private Renderer createRenderer( final Class type, final PortalResponse response )


### PR DESCRIPTION
- Introduced xp.content config variable resolveEmptyRegions (set to 'false' by default) that allows to switch between previous content page resolving behavior that forces injection of all descriptor's regions into page/layout and new one where content's page object is returned as it is 
- Updated core-content classes to read config variable and build page object according to it 
- Updated portal-impl classes to read descriptor and inject empty regions into page if it is not being made by content api, and not to read and inject regions if it is done by content api