### PR TITLE
User.modifiedTime should be optional #10221

### DIFF
--- a/modules/lib/core/index.d.ts
+++ b/modules/lib/core/index.d.ts
@@ -29,7 +29,7 @@ export interface User {
     type: 'user';
     key: UserKey;
     displayName: string;
-    modifiedTime: string;
+    modifiedTime?: string;
     disabled?: boolean;
     email?: string;
     login: string;


### PR DESCRIPTION
Made the `modifiedTime` property optional so that the type matches some predefined users, such as ANONYMOUS.