### PR TITLE
CreateRoleParams displayName is optional but throws NPE #10486

### DIFF
--- a/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/CreateRoleHandler.java
+++ b/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/CreateRoleHandler.java
@@ -40,7 +40,7 @@ public final class CreateRoleHandler
     {
         final Role role = this.securityService.get().createRole( CreateRoleParams.create().
             roleKey( PrincipalKey.ofRole( name ) ).
-            displayName( this.displayName ).
+            displayName( this.displayName != null ? this.displayName : this.name ).
             description( this.description ).
             build() );
         return new PrincipalMapper( role );

--- a/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/CreateUserHandler.java
+++ b/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/CreateUserHandler.java
@@ -46,9 +46,12 @@ public final class CreateUserHandler
 
     public PrincipalMapper createUser()
     {
-        final User user = this.securityService.get().createUser(
-            CreateUserParams.create().displayName( this.displayName ).email( this.email ).login( this.name ).userKey(
-                PrincipalKey.ofUser( this.idProviderKey, this.name ) ).build() );
+        final User user = this.securityService.get().createUser( CreateUserParams.create().
+            displayName( this.displayName != null ? this.displayName : this.name ).
+            email( this.email ).
+            login( this.name ).
+            userKey( PrincipalKey.ofUser( this.idProviderKey, this.name ) ).
+            build() );
         return new PrincipalMapper( user );
     }
 


### PR DESCRIPTION
Made behaviour in `createUser` and `createRole` consistent with `createGroup`: use `name` when `displayName` is omitted