### PR TITLE
Fix #10555 Make global types importable (#10557)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ generated-java
 classes/
 out/
 .xp/
+.vscode/
 
 # Visual Studio Code
 bin/

--- a/modules/lib/build.gradle
+++ b/modules/lib/build.gradle
@@ -28,7 +28,9 @@ check.dependsOn lint
 
 /* Configure & Build */
 
-task typescript( type: NpmTask, dependsOn: npmInstall ) {
+task typescript( type: NpmTask ) {
+    dependsOn 'npmInstall', 'prepareToPublish'
+
     description = 'Create JS and DTS files from TS'
     args = ['run', 'build']
 
@@ -84,6 +86,12 @@ task prepareGlobalToPublish( type: Copy ) {
     from 'README.md'
     from 'global.d.ts'
 
+    def dependencyLines = [
+        '    "dependencies": {',
+        '        "@enonic-types/core": "' + version + '"',
+        '    }'
+    ]
+
     from( 'package.template.json' ) {
         filter { line ->
             line
@@ -91,6 +99,7 @@ task prepareGlobalToPublish( type: Copy ) {
                 .replaceAll( '%FULL_NAME%|%FILE_NAME%', 'global' )
                 .replaceAll( '%SHORT_NAME%', 'common' )
                 .replaceAll( '%DESCRIPTION%', 'Global variables and functions type definition.' )
+                .replaceAll( /    "dependencies": \{\}/, dependencyLines.join( '\n' ) )
         }
         rename '.+', 'package.json'
     }

--- a/modules/lib/core/index.d.ts
+++ b/modules/lib/core/index.d.ts
@@ -5,9 +5,11 @@ export interface NestedRecord {
 }
 
 declare global {
+    interface XpBeans {}
     interface XpLayoutMap {
         [layoutDescriptor: ComponentDescriptor]: NestedRecord;
     }
+    interface XpLibraries {}
     interface XpPageMap {
         [pageDescriptor: ComponentDescriptor]: NestedRecord;
     }
@@ -18,6 +20,127 @@ declare global {
         [key: string]: Record<string, Record<string, unknown>>;
     }
 }
+
+export interface App {
+    /**
+     * The name of the application.
+     *
+     * @type string
+     */
+    name: string;
+    /**
+     * Version of the application.
+     *
+     * @type string
+     */
+    version: string;
+    /**
+     * Values from the application’s configuration file.
+     * This can be set using $XP_HOME/config/<app.name>.cfg.
+     * Every time the configuration is changed the app is restarted.
+     *
+     * @type Object
+     */
+    config: Record<string, string | undefined>;
+}
+
+export interface DoubleUnderscore {
+    /**
+     * Creates a new JavaScript bean that wraps the given Java class and makes its methods available to be called from JavaScript.
+     */
+    newBean: NewBean;
+    /**
+     * Converts arrays or complex Java objects to JSON.
+     * @param value Value to convert
+     */
+    toNativeObject: <T = unknown>(value: T) => T;
+    /**
+     * Converts JSON to a Java Map structure that can be used as parameters to a Java method on a bean created with newBean.
+     * @param value Value to convert
+     */
+    toScriptValue: <T = object>(value: T) => ScriptValue;
+    /**
+     * Add a disposer that is called when the app is stopped.
+     * @param callback Function to call
+     */
+    disposer: (callback: (...args: unknown[]) => unknown) => void;
+    /**
+     * Converts a JavaScript variable that is undefined to a Java <code>null</code> object.
+     * If the JavaScript variable is defined, it is returned as is.
+     * @param value Value to convert
+     */
+    nullOrValue: <T = object>(value: T) => T | null | undefined;
+
+    /**
+     * Doc registerMock.
+     *
+     * @param name Name of mock.
+     * @param value Value to register.
+     */
+    registerMock: (name: string, value: object) => void
+}
+
+export interface Log {
+    /**
+     * Log debug message.
+     *
+     * @param {Array} args... logging arguments.
+     */
+    debug: (...args: unknown[]) => void;
+
+    /**
+     * Log info message.
+     *
+     * @param {Array} args... logging arguments.
+     */
+    info: (...args: unknown[]) => void;
+
+    /**
+     * Log warning message.
+     *
+     * @param {Array} args... logging arguments.
+     */
+    warning: (...args: unknown[]) => void;
+
+    /**
+     * Log error message.
+     *
+     * @param {Array} args... logging arguments.
+     */
+    error: (...args: unknown[]) => void;
+}
+
+export type NewBean = <T = unknown, Bean extends keyof XpBeans | string = string>(bean: Bean) =>
+    Bean extends keyof XpBeans ? XpBeans[Bean] : T;
+
+export type Resolve = (path: string) => ResourceKey;
+
+export interface ScriptValue {
+    isArray(): boolean;
+
+    isObject(): boolean;
+
+    isValue(): boolean;
+
+    isFunction(): boolean;
+
+    getValue(): unknown;
+
+    getKeys(): string[];
+
+    hasMember(key: string): boolean;
+
+    getMember(key: string): ScriptValueDefinition;
+
+    getArray(): ScriptValueDefinition[];
+
+    getMap(): Record<string, unknown>;
+
+    getList(): object[];
+}
+
+export type XpRequire = <Key extends keyof XpLibraries | string = string>(path: Key) =>
+    Key extends keyof XpLibraries ? XpLibraries[Key] : unknown;
 
 export type UserKey = `user:${string}:${string}`;
 export type GroupKey = `group:${string}:${string}`;
@@ -356,9 +479,9 @@ export type QueryDsl = {
     exists: ExistsDslExpression;
 };
 
-type SortDirection = 'ASC' | 'DESC';
+export type SortDirection = 'ASC' | 'DESC';
 
-type DistanceUnit =
+export type DistanceUnit =
     | 'm'
     | 'meters'
     | 'in'

--- a/modules/lib/global.d.ts
+++ b/modules/lib/global.d.ts
@@ -1,210 +1,100 @@
-interface XpLibraries {}
+import type {
+    App,
+    DoubleUnderscore,
+    Log,
+    Resolve,
+    XpRequire,
+} from '@enonic-types/core';
 
-interface XpBeans {}
 
-/**
- * The globally available app object holds information about the contextual application.
- * @example
- * var nameVersion = app.name + ' v' + app.version;
- *
- * @global
- * @namespace
- */
-declare const app: {
+declare global {
     /**
-     * The name of the application.
+     * The globally available app object holds information about the contextual application.
+     * @example
+     * var nameVersion = app.name + ' v' + app.version;
      *
-     * @type string
+     * @global
+     * @namespace
      */
-    name: string;
-    /**
-     * Version of the application.
-     *
-     * @type string
-     */
-    version: string;
-    /**
-     * Values from the application’s configuration file.
-     * This can be set using $XP_HOME/config/<app.name>.cfg.
-     * Every time the configuration is changed the app is restarted.
-     *
-     * @type Object
-     */
-    config: Record<string, string | undefined>;
-};
-
-/**
- * Logging functions.
- *
- * @example
- * // Log with simple message
- * log.debug('My log message');
- *
- * @example
- * // Log with placeholders
- * log.info('My %s message with %s', 'log', 'placeholders');
- *
- * @example
- * // Log a JSON object
- * log.warning('My JSON: %s', {a: 1});
- *
- * @example
- * // Log JSON object using string
- * log.error('My JSON: %s', JSON.stringify({a: 1}, null, 2));
- *
- * @global
- * @namespace
- */
-declare const log: {
-    /**
-     * Log debug message.
-     *
-     * @param {Array} args... logging arguments.
-     */
-    debug: (...args: unknown[]) => void;
+    declare const app: App;
 
     /**
-     * Log info message.
+     * Logging functions.
      *
-     * @param {Array} args... logging arguments.
+     * @example
+     * // Log with simple message
+     * log.debug('My log message');
+     *
+     * @example
+     * // Log with placeholders
+     * log.info('My %s message with %s', 'log', 'placeholders');
+     *
+     * @example
+     * // Log a JSON object
+     * log.warning('My JSON: %s', {a: 1});
+     *
+     * @example
+     * // Log JSON object using string
+     * log.error('My JSON: %s', JSON.stringify({a: 1}, null, 2));
+     *
+     * @global
+     * @namespace
      */
-    info: (...args: unknown[]) => void;
+    declare const log: Log;
 
     /**
-     * Log warning message.
+     * Javascript to Java bridge functions.
      *
-     * @param {Array} args... logging arguments.
+     * @example
+     * var bean = __.newBean('com.enonic.xp.MyJavaUtils');
+     *
+     * @example
+     * return __.toNativeObject(bean.findArray(arrayName));
+     *
+     * @global
+     * @namespace
      */
-    warning: (...args: unknown[]) => void;
+    declare const __: DoubleUnderscore;
 
     /**
-     * Log error message.
+     * This globally available function will load a JavaScript file and return the exports as objects.
+     * The function implements parts of the `CommonJS Modules Specification`.
      *
-     * @param {Array} args... logging arguments.
+     * @example
+     * // Require relative to this
+     * var other = require('./other.js');
+     *
+     * @example
+     * // Require absolute
+     * var other = require('/path/to/other.js');
+     *
+     * @example
+     * // Require without .js extension
+     * var other = require('./other');
+     *
+     * @param {string} path Path for javascript file (relative or absolute and .js ending is optional).
+     * @returns {object} Exports from loaded javascript.
+     * @global
      */
-    error: (...args: unknown[]) => void;
-};
+    declare const require: XpRequire;
 
-declare interface ScriptValue {
-    isArray(): boolean;
-
-    isObject(): boolean;
-
-    isValue(): boolean;
-
-    isFunction(): boolean;
-
-    getValue(): unknown;
-
-    getKeys(): string[];
-
-    hasMember(key: string): boolean;
-
-    getMember(key: string): ScriptValue;
-
-    getArray(): ScriptValue[];
-
-    getMap(): Record<string, unknown>;
-
-    getList(): object[];
+    /**
+     * Resolves a path to another file. Can use relative or absolute path.
+     *
+     * @example
+     * // Resolve relative to this
+     * var path = resolve('./other.html');
+     *
+     * @example
+     * // Resolve absolute
+     * var path = resolve('/path/to/other.html');
+     *
+     * @param {string} path Path to resolve.
+     * @returns {*} Reference to an object.
+     * @global
+     */
+    declare const resolve: Resolve;
 }
 
-type NewBean = <T = unknown, Bean extends keyof XpBeans | string = string>(bean: Bean) =>
-    Bean extends keyof XpBeans ? XpBeans[Bean] : T;
-
-/**
- * Javascript to Java bridge functions.
- *
- * @example
- * var bean = __.newBean('com.enonic.xp.MyJavaUtils');
- *
- * @example
- * return __.toNativeObject(bean.findArray(arrayName));
- *
- * @global
- * @namespace
- */
-declare const __: {
-    /**
-     * Creates a new JavaScript bean that wraps the given Java class and makes its methods available to be called from JavaScript.
-     */
-    newBean: NewBean;
-    /**
-     * Converts arrays or complex Java objects to JSON.
-     * @param value Value to convert
-     */
-    toNativeObject: <T = unknown>(value: T) => T;
-    /**
-     * Converts JSON to a Java Map structure that can be used as parameters to a Java method on a bean created with newBean.
-     * @param value Value to convert
-     */
-    toScriptValue: <T = object>(value: T) => ScriptValue;
-    /**
-     * Add a disposer that is called when the app is stopped.
-     * @param callback Function to call
-     */
-    disposer: (callback: (...args: unknown[]) => unknown) => void;
-    /**
-     * Converts a JavaScript variable that is undefined to a Java <code>null</code> object.
-     * If the JavaScript variable is defined, it is returned as is.
-     * @param value Value to convert
-     */
-    nullOrValue: <T = object>(value: T) => T | null | undefined;
-
-    /**
-     * Doc registerMock.
-     *
-     * @param name Name of mock.
-     * @param value Value to register.
-     */
-    registerMock: (name: string, value: object) => void
-};
-
-declare type XpRequire = <Key extends keyof XpLibraries | string = string>(path: Key) =>
-    Key extends keyof XpLibraries ? XpLibraries[Key] : unknown;
-
-/**
- * This globally available function will load a JavaScript file and return the exports as objects.
- * The function implements parts of the `CommonJS Modules Specification`.
- *
- * @example
- * // Require relative to this
- * var other = require('./other.js');
- *
- * @example
- * // Require absolute
- * var other = require('/path/to/other.js');
- *
- * @example
- * // Require without .js extension
- * var other = require('./other');
- *
- * @param {string} path Path for javascript file (relative or absolute and .js ending is optional).
- * @returns {object} Exports from loaded javascript.
- * @global
- */
-declare const require: XpRequire;
-
-/**
- * Resolves a path to another file. Can use relative or absolute path.
- *
- * @example
- * // Resolve relative to this
- * var path = resolve('./other.html');
- *
- * @example
- * // Resolve absolute
- * var path = resolve('/path/to/other.html');
- *
- * @param {string} path Path to resolve.
- * @returns {*} Reference to an object.
- * @global
- */
-declare const resolve: (path: string) => {
-    getApplicationKey(): string;
-    getPath(): string;
-    getUri(): string;
-    isRoot(): boolean;
-    getName(): string;
-    getExtension(): string;
-};
+// Making sure the file is a module
+export {};

--- a/modules/lib/lib-auditlog/src/main/resources/lib/xp/auditlog.ts
+++ b/modules/lib/lib-auditlog/src/main/resources/lib/xp/auditlog.ts
@@ -13,9 +13,9 @@ declare global {
     }
 }
 
-import type {UserKey} from '@enonic-types/core';
+import type {ScriptValue, UserKey} from '@enonic-types/core';
 
-export type {UserKey} from '@enonic-types/core';
+export type {ScriptValue, UserKey} from '@enonic-types/core';
 
 function checkRequired<T extends object>(obj: T, name: keyof T): void {
     if (obj == null || obj[name] == null) {

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
@@ -13,9 +13,9 @@ declare global {
     }
 }
 
-import type {Group, GroupKey, Principal, PrincipalKey, Role, RoleKey, User, UserKey} from '@enonic-types/core';
+import type {Group, GroupKey, Principal, PrincipalKey, Role, RoleKey, ScriptValue, User, UserKey} from '@enonic-types/core';
 
-export type {PrincipalKey, UserKey, GroupKey, RoleKey, Principal, User, Group, Role} from '@enonic-types/core';
+export type {PrincipalKey, UserKey, GroupKey, RoleKey, Principal, ScriptValue, User, Group, Role} from '@enonic-types/core';
 
 function checkRequired<T extends object>(obj: T, name: keyof T): void {
     if (obj == null || obj[name] == null) {
@@ -498,7 +498,7 @@ export function addMembers(principalKey: GroupKey | RoleKey, members: (UserKey |
     const bean = __.newBean<AddMembersHandler>('com.enonic.xp.lib.auth.AddMembersHandler');
 
     bean.setPrincipalKey(principalKey);
-    bean.setMembers([].concat(members));
+    bean.setMembers(([] as (UserKey | GroupKey)[]).concat(members));
 
     bean.addMembers();
 }
@@ -525,7 +525,7 @@ export function removeMembers(principalKey: GroupKey | RoleKey, members: (UserKe
     const bean = __.newBean<RemoveMembersHandler>('com.enonic.xp.lib.auth.RemoveMembersHandler');
 
     bean.setPrincipalKey(principalKey);
-    bean.setMembers([].concat(members));
+    bean.setMembers(([] as (UserKey | GroupKey)[]).concat(members));
 
     bean.removeMembers();
 }

--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -28,6 +28,7 @@ import type {
     HighlightResult,
     PublishInfo,
     QueryDsl,
+    ScriptValue,
     SortDsl,
 } from '@enonic-types/core';
 
@@ -110,6 +111,7 @@ export type {
     RangeDslExpression,
     Region,
     RoleKey,
+    ScriptValue,
     SingleValueMetricAggregationResult,
     SingleValueMetricAggregationsUnion,
     SortDirection,
@@ -1335,10 +1337,10 @@ export function modifyMedia<Data = Record<string, unknown>, Type extends string 
     bean.setArtist(([] as string[]).concat(artist));
     bean.setTags(([] as string[]).concat(tags));
 
-    if (params.focalX != null) {
+    if (focalX != null) {
         bean.setFocalX(focalX);
     }
-    if (params.focalY != null) {
+    if (focalY != null) {
         bean.setFocalY(focalY);
     }
 
@@ -1365,13 +1367,13 @@ interface DuplicateContentHandler {
 
     setWorkflow(value: ScriptValue): void;
 
-    setIncludeChildren(value: boolean);
+    setIncludeChildren(value: boolean): void;
 
-    setVariant(value: boolean);
+    setVariant(value: boolean): void;
 
-    setName(value?: string);
+    setName(value?: string): void;
 
-    setParentPath(value?: string);
+    setParentPath(value?: string): void;
 
     execute(): DuplicateContentsResult;
 }
@@ -1406,8 +1408,12 @@ export function duplicate(params: DuplicateContentParams): DuplicateContentsResu
 
     bean.setContentId(contentId);
     bean.setWorkflow(__.toScriptValue(workflow));
-    bean.setName(__.nullOrValue(name));
-    bean.setParentPath(__.nullOrValue(parent));
+    if (name != null) {
+        bean.setName((name));
+    }
+    if (parent != null) {
+        bean.setParentPath(parent);
+    }
     bean.setIncludeChildren(includeChildren);
     bean.setVariant(variant);
 

--- a/modules/lib/lib-context/src/main/resources/lib/xp/context.ts
+++ b/modules/lib/lib-context/src/main/resources/lib/xp/context.ts
@@ -13,9 +13,9 @@ declare global {
     }
 }
 
-import type {PrincipalKey, User} from '@enonic-types/core';
+import type {PrincipalKey, ScriptValue, User} from '@enonic-types/core';
 
-export type {PrincipalKey, UserKey, Principal, User} from '@enonic-types/core';
+export type {PrincipalKey, UserKey, Principal, ScriptValue, User} from '@enonic-types/core';
 
 export interface AuthInfo {
     user?: User | null;

--- a/modules/lib/lib-i18n/src/main/resources/lib/xp/i18n.ts
+++ b/modules/lib/lib-i18n/src/main/resources/lib/xp/i18n.ts
@@ -4,6 +4,10 @@ declare global {
     }
 }
 
+import type {ScriptValue} from '@enonic-types/core';
+
+export type {ScriptValue} from '@enonic-types/core';
+
 export interface LocalizeParams {
     key: string;
     locale?: string | string[];

--- a/modules/lib/lib-project/src/main/resources/lib/xp/project.ts
+++ b/modules/lib/lib-project/src/main/resources/lib/xp/project.ts
@@ -13,6 +13,10 @@ declare global {
     }
 }
 
+import type {ScriptValue} from '@enonic-types/core';
+
+export type {ScriptValue} from '@enonic-types/core';
+
 function checkRequired<T extends object>(obj: T, name: keyof T): void {
     if (obj == null || obj[name] === undefined) {
         throw `Parameter '${String(name)}' is required`;
@@ -114,8 +118,8 @@ export function create<Config extends Record<string, unknown> = Record<string, u
     bean.setLanguage(__.nullOrValue(params.language));
     bean.setPermissions(__.toScriptValue(params.permissions));
     bean.setReadAccess(__.toScriptValue(params.readAccess));
-    if (params.parent) {
-        bean.setParents([__.nullOrValue(params.parent)]);
+    if (params.parent != null) {
+        bean.setParents([params.parent]);
     }
     if (params.parents) {
         bean.setParents(__.nullOrValue(params.parents));

--- a/modules/lib/lib-repo/src/main/resources/lib/xp/repo.ts
+++ b/modules/lib/lib-repo/src/main/resources/lib/xp/repo.ts
@@ -13,6 +13,10 @@ declare global {
     }
 }
 
+import type {ScriptValue} from '@enonic-types/core';
+
+export type {ScriptValue} from '@enonic-types/core';
+
 function checkRequiredValue(value: unknown, name: string): void {
     if (value == null) {
         throw `Parameter '${String(name)}' is required`;

--- a/modules/lib/lib-scheduler/src/main/resources/lib/xp/scheduler.ts
+++ b/modules/lib/lib-scheduler/src/main/resources/lib/xp/scheduler.ts
@@ -13,9 +13,9 @@ declare global {
     }
 }
 
-import type {UserKey} from '@enonic-types/core';
+import type {ScriptValue, UserKey} from '@enonic-types/core';
 
-export type {PrincipalKey, UserKey, GroupKey, RoleKey} from '@enonic-types/core';
+export type {PrincipalKey, UserKey, GroupKey, RoleKey, ScriptValue} from '@enonic-types/core';
 
 function checkRequired<T extends object>(obj: T, name: keyof T): void {
     if (obj == null || obj[name] === undefined) {

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
@@ -116,7 +116,9 @@ export function createSchema(params: CreateDynamicContentSchemaParams): ContentT
     const bean = __.newBean<CreateDynamicContentSchemaHandler>('com.enonic.xp.lib.schema.CreateDynamicContentSchemaHandler');
     bean.setName(params.name);
     bean.setType(params.type);
-    bean.setResource(params.resource);
+    if (params.resource != null) {
+        bean.setResource(params.resource);
+    }
     return __.toNativeObject(bean.execute());
 }
 
@@ -373,9 +375,9 @@ export interface DeleteDynamicContentSchemaParams {
 }
 
 interface DeleteDynamicContentSchemaHandler {
-    setName(value: string);
+    setName(value: string): void;
 
-    setType(value: ContentSchemaType);
+    setType(value: ContentSchemaType): void;
 
     execute(): boolean;
 }

--- a/modules/lib/lib-task/src/main/resources/lib/xp/task.ts
+++ b/modules/lib/lib-task/src/main/resources/lib/xp/task.ts
@@ -13,9 +13,9 @@ declare global {
     }
 }
 
-import type {UserKey} from '@enonic-types/core';
+import type {ScriptValue, UserKey} from '@enonic-types/core';
 
-export type {UserKey} from '@enonic-types/core';
+export type {ScriptValue, UserKey} from '@enonic-types/core';
 
 function checkRequired<T extends object>(obj: T, name: keyof T): void {
     if (obj == null || obj[name] == null) {

--- a/modules/lib/package-lock.json
+++ b/modules/lib/package-lock.json
@@ -9,7 +9,6 @@
             "version": "1.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@enonic-types/core": "./core",
                 "@enonic/eslint-config": "^0.1.0",
                 "@typescript-eslint/eslint-plugin": "^5.23.0",
                 "@typescript-eslint/parser": "^5.23.0",
@@ -21,7 +20,7 @@
         "core": {
             "name": "@enonic-types/core",
             "version": "0.0.1",
-            "dev": true
+            "extraneous": true
         },
         "node_modules/@babel/parser": {
             "version": "7.18.11",
@@ -33,10 +32,6 @@
             "engines": {
                 "node": ">=6.0.0"
             }
-        },
-        "node_modules/@enonic-types/core": {
-            "resolved": "core",
-            "link": true
         },
         "node_modules/@enonic/eslint-config": {
             "version": "0.1.0",
@@ -1677,9 +1672,6 @@
             "version": "7.18.11",
             "integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
             "dev": true
-        },
-        "@enonic-types/core": {
-            "version": "file:core"
         },
         "@enonic/eslint-config": {
             "version": "0.1.0",

--- a/modules/lib/package.json
+++ b/modules/lib/package.json
@@ -23,7 +23,6 @@
     "homepage": "https://github.com/enonic/xp/tree/master#readme",
     "devDependencies": {
         "@enonic/eslint-config": "^0.1.0",
-        "@enonic-types/core": "./core",
         "@typescript-eslint/eslint-plugin": "^5.23.0",
         "@typescript-eslint/parser": "^5.23.0",
         "eslint": "^8.15.0",

--- a/modules/lib/tsconfig.build.json
+++ b/modules/lib/tsconfig.build.json
@@ -1,10 +1,16 @@
-{
+{ // This file is used to build typescript declaration files
     "extends": "./tsconfig",
     "include": [
       "./lib-*/build/typescript/",
       "./global.d.ts"
     ],
+    // Since this file extends tsconfig.json which excludes "./**/build", this
+    // file needs it's own exclude.
     "exclude": [
       "./lib-*/*.ts"
-    ]
+    ],
+    "compilerOptions": {
+      "removeComments": false,
+      "sourceMap": false
+    }
 }

--- a/modules/lib/tsconfig.json
+++ b/modules/lib/tsconfig.json
@@ -1,18 +1,35 @@
 {
+    // This file is mainly be used by the IDE,
+    // but also extended in the tsconfig.build.json file.
     "compilerOptions": {
+        // NOTE: This is probably correct since we're still building for Nashorn.
         "lib": ["es5"],
-        "removeComments": false,
+
+        // The target setting changes which JS features are downleveled and
+        // which are left intact. Changing target also changes the default value
+        // of lib. You may “mix and match” target and lib settings as desired,
+        // but you could just set target for convenience.
+        // NOTE: This is probably correct since we're still building for Nashorn.
         "target": "es5",
+
+        // NOTE: This is probably correct since we're still building for Nashorn.
         "module": "commonjs",
+
+        // NOTE: Even though we are not using Node 9 or older to build, we
+        // cannot change this setting to Node16, since that would require module
+        // to be changed to Node16 aswell, which would break the build.
         "moduleResolution": "node",
-        "typeRoots": [
-            "node_modules/@enonic-types"
-        ],
-        "sourceMap": false,
+
+        "paths": {
+            // So they can be imported from without installing old ones into
+            // node_modules:
+            "@enonic-types/global": ["./global.d.ts"],
+            "@enonic-types/core": ["./core/index.d.ts"]
+        },
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "skipLibCheck": true,
-        "noImplicitUseStrict": true
+        "strict": true
     },
     "exclude": [
         "./**/build",


### PR DESCRIPTION
* Fix #10555 Make global types importable

* Define and reuse definitions both as global and export

* XpBeans and XpLibraries belongs in globals

* Make global depend on core (not the other way around)

* Remove noImplicitUseStrict which is deprecated in TypeScript 5.5

* Remove NewBean and ScriptValue from global scope. Can be imported from core instead.

* Enable strict and fix most type errors

* Fix TypeScript errors in grid.ts

---------

Co-authored-by: Mikita Taukachou <edloidas@gmail.com>

(cherry picked from commit 1a48ac121aef8d94f6e2e71d3d1b462158fb73d3)