### PR TITLE
portal.getComponent is missing path in fragment preview #10116

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/region/Component.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/region/Component.java
@@ -25,7 +25,7 @@ public abstract class Component
 
     public ComponentPath getPath()
     {
-        return region == null ? null : ComponentPath.from( region.getRegionPath(), region.getIndex( this ) );
+        return region == null ? ComponentPath.from( "/" ) : ComponentPath.from( region.getRegionPath(), region.getIndex( this ) );
     }
 
     void setRegion( final Region region )

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/ComponentDataSerializer.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/ComponentDataSerializer.java
@@ -19,7 +19,7 @@ abstract class ComponentDataSerializer<DATA extends Component>
         final PropertySet asData = parent.addSet( COMPONENTS );
 
         asData.setString( TYPE, component.getType().toString() );
-        asData.setString( PATH, component.getPath() != null ? component.getPath().toString() : "/" );
+        asData.setString( PATH, component.getPath().toString() );
 
         applyComponentToData( component, asData );
     }

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/serializer/PageDataSerializerTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/serializer/PageDataSerializerTest.java
@@ -10,6 +10,7 @@ import com.enonic.xp.page.DescriptorKey;
 import com.enonic.xp.page.Page;
 import com.enonic.xp.page.PageRegions;
 import com.enonic.xp.page.PageTemplateKey;
+import com.enonic.xp.region.ComponentPath;
 import com.enonic.xp.region.ImageComponent;
 import com.enonic.xp.region.LayoutComponent;
 import com.enonic.xp.region.LayoutRegions;
@@ -127,6 +128,7 @@ public class PageDataSerializerTest
 
         // verify
         assertEquals( page, parsedPage );
+        assertEquals( parsedPage.getFragment().getPath(), ComponentPath.from( "/" ) );
     }
 
     private Page createPage()

--- a/modules/lib/lib-content/src/test/resources/test/GetContentHandlerTest.js
+++ b/modules/lib/lib-content/src/test/resources/test/GetContentHandlerTest.js
@@ -189,6 +189,7 @@ var expectedJson = {
 
 var pageAsFragmentJson = {
     'fragment': {
+        "path": "/",
         'type': 'layout',
         'descriptor': 'layoutDescriptor:name',
         'config': {},


### PR DESCRIPTION
- A component is supposed to always have some path, but in case of a fragment content it's root fragment component was having null returned as path. Fixing it by setting component's path to "/" in case it doesn't have a region (which means it is a fragment)