### PR TITLE
Don't merge permissions for children nodes

### DIFF
--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ApplyNodePermissionsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ApplyNodePermissionsCommand.java
@@ -175,6 +175,12 @@ public class ApplyNodePermissionsCommand
 
         final AccessControlList permissions = mergingStrategy.mergePermissions( node.getPermissions(), params.getPermissions() );
 
+        if ( permissions.equals( node.getPermissions() ) )
+        {
+            results.addResult( node.id(), branch, node );
+            return;
+        }
+
         final NodeVersionData updatedSourceNode =
             updatePermissionsInBranch( node.id(), appliedVersions.get( node.getNodeVersionId() ), branch, permissions );
 

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/ContentServiceImplTest_applyPermissions.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/ContentServiceImplTest_applyPermissions.java
@@ -74,7 +74,7 @@ public class ContentServiceImplTest_applyPermissions
 
         final ApplyContentPermissionsResult result = this.contentService.applyPermissions( applyParams );
 
-        verify( listener, times( 2 ) ).permissionsApplied( 1 );
+        verify( listener, times( 1 ) ).permissionsApplied( 1 );
 
         assertEquals( 2, result.getResults().size() );
 

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/ApplyNodePermissionsCommandTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/ApplyNodePermissionsCommandTest.java
@@ -132,11 +132,8 @@ public class ApplyNodePermissionsCommandTest
                                                                                                       .add( AccessControlEntry.create()
                                                                                                                 .allowAll()
                                                                                                                 .principal(
-
-                                                                                                                    ContextAccessor.current()
-                                                                                                                        .getAuthInfo()
-                                                                                                                        .getUser()
-                                                                                                                        .getKey() )
+                                                                                                                    PrincipalKey.from(
+                                                                                                                        "user:my-provider:my-wwuser" ) )
                                                                                                                 .build() )
                                                                                                       .build() )
                                                                                     .build() );


### PR DESCRIPTION
`inheritPermissions` field is deprecated and removed from node, so there is no need to go through a tree and merge on SINGLE `applyPermissions` mode 