### PR TITLE
Switch from NPM_TOKEN to OIDC Trusted Publishing #11750

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,10 @@ jobs:
 
     needs: release_notes
 
+    permissions:
+      contents: write
+      id-token: write
+
     steps:
       - uses: actions/checkout@v5
 
@@ -60,9 +64,6 @@ jobs:
       - name: Verify release version
         if: steps.publish_vars.outputs.release != 'true'
         run: exit 1
-
-      - name: Set NPM token
-        run: npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
 
       - name: Publish
         run: ./gradlew publish -PrepoKey=${{ steps.publish_vars.outputs.repo }} -PrepoUser=ci -PrepoPassword=${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/modules/lib/build.gradle
+++ b/modules/lib/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 node {
     download = true
-    version = '18.16.0'
+    version = '24.13.1'
 }
 
 def coreDir = "$projectDir/core/"


### PR DESCRIPTION
Moved from classic token for npm publishing to Trusted publishing. 
Added permissions for "contents: write" (not "read" to guarantee artifacts will be saved, had issues with that in multiple repos) and "id-token: write" (for publishing). 
Upgraded Node (and bundled npm), since Trusted publishing requires npm >= 11.5.1

_All packages on npm were also configured to use Trusted publishing, so this should work now._

---

If 7.16.2 wasn't actually released, I'd suggest rolling back last 2 commit in 7.16, dropping 7.16.2 tag, merge these changes and repeat.
Also, `NPM_TOKEN` can be removed for this repo.