### PR TITLE
Static-import Objects.requireNonNull and its variants

### DIFF
--- a/modules/admin/admin-api/src/main/java/com/enonic/xp/admin/tool/AdminToolDescriptor.java
+++ b/modules/admin/admin-api/src/main/java/com/enonic/xp/admin/tool/AdminToolDescriptor.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.admin.tool;
 
-import java.util.Objects;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
@@ -14,6 +13,8 @@ import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.PrincipalKeys;
 import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.util.GenericValue;
+
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class AdminToolDescriptor
@@ -45,7 +46,7 @@ public final class AdminToolDescriptor
         description = builder.description;
         descriptionI18nKey = builder.descriptionI18nKey;
         allowedPrincipals = PrincipalKeys.from( builder.allowedPrincipals.build() );
-        apiMounts = Objects.requireNonNullElse( builder.apiMounts, DescriptorKeys.empty() );
+        apiMounts = requireNonNullElse( builder.apiMounts, DescriptorKeys.empty() );
         interfaces = builder.interfaces;
         icon = builder.icon;
         schemaConfig = builder.schemaConfig.build();

--- a/modules/admin/admin-event/src/test/java/com/enonic/xp/admin/event/impl/json/EventJsonSerializerTest.java
+++ b/modules/admin/admin-event/src/test/java/com/enonic/xp/admin/event/impl/json/EventJsonSerializerTest.java
@@ -3,8 +3,6 @@ package com.enonic.xp.admin.event.impl.json;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Objects;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -18,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.enonic.xp.core.internal.json.ObjectMapperHelper;
 import com.enonic.xp.event.Event;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -82,7 +81,7 @@ class EventJsonSerializerTest
         throws Exception
     {
         final InputStream stream =
-            Objects.requireNonNull( getClass().getResourceAsStream( fileName ), "Resource file [" + fileName + "] not found" );
+            requireNonNull( getClass().getResourceAsStream( fileName ), "Resource file [" + fileName + "] not found" );
         try (stream)
         {
             return new String( stream.readAllBytes(), StandardCharsets.UTF_8 );

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionApiHandler.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionApiHandler.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.admin.impl.portal.extension;
 
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,6 +22,8 @@ import com.enonic.xp.security.PrincipalKeys;
 import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
+
+import static java.util.Objects.requireNonNull;
 
 @Component(immediate = true, service = AdminExtensionApiHandler.class)
 public class AdminExtensionApiHandler
@@ -49,7 +50,7 @@ public class AdminExtensionApiHandler
 
     public WebResponse handle( final WebRequest webRequest )
     {
-        final String path = Objects.requireNonNull( webRequest.getEndpointPath(), "Endpoint path cannot be null" );
+        final String path = requireNonNull( webRequest.getEndpointPath(), "Endpoint path cannot be null" );
 
         final Matcher matcher = EXTENSION_API_PATTERN.matcher( path );
 

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionDispatcherApiHandler.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionDispatcherApiHandler.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.admin.impl.portal.extension;
 
-import java.util.Objects;
-
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -14,6 +12,8 @@ import com.enonic.xp.web.HttpMethod;
 import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
+
+import static java.util.Objects.requireNonNull;
 
 @Component(immediate = true, property = {"key=" + AdminExtensionDispatcherApiHandler.EXTENSIONS_API,
     "allowedPrincipals=role:system.admin.login", "title=Admin Extensions API"})
@@ -41,7 +41,7 @@ public class AdminExtensionDispatcherApiHandler
     @Override
     public WebResponse handle( final WebRequest webRequest )
     {
-        Objects.requireNonNull( webRequest.getEndpointPath(), "Endpoint path cannot be null" );
+        requireNonNull( webRequest.getEndpointPath(), "Endpoint path cannot be null" );
 
         if ( HttpMethod.GET.equals( webRequest.getMethod() ) && WebHandlerHelper.findApiPath( webRequest, EXTENSIONS_API ).isEmpty() )
         {

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/extension/GetListAllowedAdminExtensionsHandler.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/extension/GetListAllowedAdminExtensionsHandler.java
@@ -3,8 +3,6 @@ package com.enonic.xp.admin.impl.portal.extension;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
-
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -30,6 +28,7 @@ import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNullElse;
 
 @Component(immediate = true, service = GetListAllowedAdminExtensionsHandler.class)
 public class GetListAllowedAdminExtensionsHandler
@@ -158,7 +157,7 @@ public class GetListAllowedAdminExtensionsHandler
 
         try
         {
-            return Objects.requireNonNullElse( bundle.localize( key ), defaultValue );
+            return requireNonNullElse( bundle.localize( key ), defaultValue );
         }
         catch ( IllegalArgumentException e )
         {

--- a/modules/blobstore/blobstore-file/src/main/java/com/enonic/xp/internal/blobstore/file/FileBlobRecord.java
+++ b/modules/blobstore/blobstore-file/src/main/java/com/enonic/xp/internal/blobstore/file/FileBlobRecord.java
@@ -4,21 +4,21 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
 import com.google.common.io.MoreFiles;
 
 import com.enonic.xp.blob.BlobKey;
 import com.enonic.xp.blob.BlobRecord;
 
+import static java.util.Objects.requireNonNull;
+
 record FileBlobRecord(BlobKey key, Path file)
     implements BlobRecord
 {
     FileBlobRecord( final BlobKey key, final Path file )
     {
-        this.key = Objects.requireNonNull( key );
-        this.file = Objects.requireNonNull( file );
+        this.key = requireNonNull( key );
+        this.file = requireNonNull( file );
     }
 
     public BlobKey getKey()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/api/ApiDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/api/ApiDescriptor.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.api;
 
-import java.util.Objects;
 import java.util.Set;
 
 import com.google.common.base.Preconditions;
@@ -11,6 +10,8 @@ import com.enonic.xp.schema.LocalizedText;
 import com.enonic.xp.security.PrincipalKeys;
 import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.util.GenericValue;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ApiDescriptor
@@ -35,8 +36,8 @@ public final class ApiDescriptor
 
     private ApiDescriptor( final Builder builder )
     {
-        Objects.requireNonNull( builder.key, "key cannot be null" );
-        Objects.requireNonNull( builder.allowedPrincipals, "allowedPrincipals cannot be null" );
+        requireNonNull( builder.key, "key cannot be null" );
+        requireNonNull( builder.allowedPrincipals, "allowedPrincipals cannot be null" );
         Preconditions.checkArgument( !builder.allowedPrincipals.isEmpty(), "allowedPrincipals cannot be empty" );
 
         this.key = builder.key;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/app/ApplicationDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/app/ApplicationDescriptor.java
@@ -6,6 +6,8 @@ import com.enonic.xp.icon.Icon;
 import com.enonic.xp.schema.LocalizedText;
 import com.enonic.xp.util.GenericValue;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class ApplicationDescriptor
 {
@@ -31,7 +33,7 @@ public final class ApplicationDescriptor
 
     private ApplicationDescriptor( final Builder builder )
     {
-        this.key = Objects.requireNonNull( builder.key, "key cannot be null" );
+        this.key = requireNonNull( builder.key, "key cannot be null" );
         this.description = builder.description != null ? builder.description : "";
         this.descriptionI18nKey = builder.descriptionI18nKey;
         this.icon = builder.icon;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/app/ApplicationKey.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/app/ApplicationKey.java
@@ -2,12 +2,13 @@ package com.enonic.xp.app;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.jspecify.annotations.NullMarked;
 
 import com.enonic.xp.core.internal.NameValidator;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -41,7 +42,7 @@ public final class ApplicationKey
 
     private ApplicationKey( final String name )
     {
-        this.name = Objects.requireNonNull( name );
+        this.name = requireNonNull( name );
     }
 
     public String getName()
@@ -69,7 +70,7 @@ public final class ApplicationKey
 
     public static ApplicationKey from( final String name )
     {
-        return switch ( Objects.requireNonNull( name, "ApplicationKey cannot be null" ) )
+        return switch ( requireNonNull( name, "ApplicationKey cannot be null" ) )
         {
             case "system" -> SYSTEM;
             case "media" -> MEDIA_MOD;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/app/CreateVirtualApplicationParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/app/CreateVirtualApplicationParams.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.app;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class CreateVirtualApplicationParams
@@ -38,7 +38,7 @@ public final class CreateVirtualApplicationParams
 
         private void validate()
         {
-            Objects.requireNonNull( key, "key is required" );
+            requireNonNull( key, "key is required" );
         }
 
         public CreateVirtualApplicationParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/archive/ArchiveContentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/archive/ArchiveContentParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.archive;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentId;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ArchiveContentParams
@@ -72,7 +72,7 @@ public final class ArchiveContentParams
 
         private void validate()
         {
-            Objects.requireNonNull( contentId, "contentId is required" );
+            requireNonNull( contentId, "contentId is required" );
         }
 
         public ArchiveContentParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/archive/RestoreContentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/archive/RestoreContentParams.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.archive;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentPath;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class RestoreContentParams
@@ -73,7 +73,7 @@ public final class RestoreContentParams
 
         private void validate()
         {
-            Objects.requireNonNull( contentId, "contentId is required" );
+            requireNonNull( contentId, "contentId is required" );
         }
 
         public RestoreContentParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/archive/RestoreContentsResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/archive/RestoreContentsResult.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.archive;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentIds;
 import com.enonic.xp.content.ContentPath;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class RestoreContentsResult
@@ -58,7 +58,7 @@ public final class RestoreContentsResult
 
         private void validate()
         {
-            Objects.requireNonNull( parentPath );
+            requireNonNull( parentPath );
         }
 
         public RestoreContentsResult build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/attachment/Attachment.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/attachment/Attachment.java
@@ -7,6 +7,8 @@ import com.google.common.io.Files;
 
 import com.enonic.xp.util.BinaryReference;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class Attachment
 {
@@ -24,8 +26,8 @@ public final class Attachment
 
     public Attachment( final Builder builder )
     {
-        this.mimeType = Objects.requireNonNull( builder.mimeType, "mimeType is mandatory for an Attachment" );
-        this.name = Objects.requireNonNull( builder.name, "name is mandatory for an Attachment" );
+        this.mimeType = requireNonNull( builder.mimeType, "mimeType is mandatory for an Attachment" );
+        this.name = requireNonNull( builder.name, "name is mandatory for an Attachment" );
         this.sha512 = builder.sha512;
         this.size = builder.size;
         this.label = builder.label;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/attachment/CreateAttachment.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/attachment/CreateAttachment.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.attachment;
 
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
 import com.google.common.io.Files;
 
 import com.enonic.xp.util.BinaryReference;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class CreateAttachment
@@ -136,8 +136,8 @@ public final class CreateAttachment
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
-            Objects.requireNonNull( byteSource, "byteSource is required" );
+            requireNonNull( name, "name is required" );
+            requireNonNull( byteSource, "byteSource is required" );
         }
 
         public CreateAttachment build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/audit/FindAuditLogParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/audit/FindAuditLogParams.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.audit;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.security.PrincipalKeys;
+
+import static java.util.Objects.requireNonNullElse;
 
 public class FindAuditLogParams
 {
@@ -29,8 +29,8 @@ public class FindAuditLogParams
 
     private FindAuditLogParams( final Builder builder )
     {
-        start = Objects.requireNonNullElse( builder.start, 0 );
-        count = Objects.requireNonNullElse( builder.count, DEFAULT_FETCH_SIZE );
+        start = requireNonNullElse( builder.start, 0 );
+        count = requireNonNullElse( builder.count, DEFAULT_FETCH_SIZE );
         ids = builder.ids;
         from = builder.from;
         to = builder.to;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/audit/FindAuditLogResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/audit/FindAuditLogResult.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.audit;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 public final class FindAuditLogResult
 {
@@ -10,8 +10,8 @@ public final class FindAuditLogResult
 
     private FindAuditLogResult( final Builder builder )
     {
-        hits = Objects.requireNonNull( builder.hits, "FindAuditLogResult hits cannot be null" );
-        total = Objects.requireNonNull( builder.total, "FindAuditLogResult total cannot be null" );
+        hits = requireNonNull( builder.hits, "FindAuditLogResult hits cannot be null" );
+        total = requireNonNull( builder.total, "FindAuditLogResult total cannot be null" );
     }
 
     public AuditLogs getHits()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/audit/LogAuditLogParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/audit/LogAuditLogParams.java
@@ -7,6 +7,9 @@ import com.enonic.xp.core.internal.Millis;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.security.PrincipalKey;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
 public final class LogAuditLogParams
 {
     private final String type;
@@ -23,12 +26,12 @@ public final class LogAuditLogParams
 
     private LogAuditLogParams( final Builder builder )
     {
-        type = Objects.requireNonNull( builder.type, "LogAuditLogParams type cannot be null" );
+        type = requireNonNull( builder.type, "LogAuditLogParams type cannot be null" );
         time = Millis.fromOrElseNow( builder.time );
-        source = Objects.requireNonNullElse( builder.source, "" );
+        source = requireNonNullElse( builder.source, "" );
         user = builder.user;
-        objectUris = Objects.requireNonNullElse( builder.objectUris, AuditLogUris.empty() );
-        data = Objects.requireNonNullElse( builder.data, new PropertyTree() );
+        objectUris = requireNonNullElse( builder.objectUris, AuditLogUris.empty() );
+        data = requireNonNullElse( builder.data, new PropertyTree() );
     }
 
     public String getType()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/blob/BlobKey.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/blob/BlobKey.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.blob;
 
 import java.io.IOException;
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
 
 import com.enonic.xp.core.internal.security.MessageDigests;
+
+import static java.util.Objects.requireNonNull;
 
 public final class BlobKey
 {
@@ -13,7 +13,7 @@ public final class BlobKey
 
     private BlobKey( final String key )
     {
-        this.key = Objects.requireNonNull( key );
+        this.key = requireNonNull( key );
     }
 
     @Override

--- a/modules/core/core-api/src/main/java/com/enonic/xp/blob/SegmentLevel.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/blob/SegmentLevel.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.blob;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 public final class SegmentLevel
 {
@@ -8,7 +8,7 @@ public final class SegmentLevel
 
     SegmentLevel( final String value )
     {
-        this.value = Objects.requireNonNull( value );
+        this.value = requireNonNull( value );
     }
 
     public static SegmentLevel from( final String value )

--- a/modules/core/core-api/src/main/java/com/enonic/xp/branch/Branch.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/branch/Branch.java
@@ -2,10 +2,11 @@ package com.enonic.xp.branch;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 import com.enonic.xp.core.internal.NameValidator;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class Branch
@@ -27,12 +28,12 @@ public final class Branch
 
     private Branch( final String value )
     {
-        this.value = Objects.requireNonNull( value );
+        this.value = requireNonNull( value );
     }
 
     public static Branch from( final String name )
     {
-        return switch ( Objects.requireNonNull( name, "Branch cannot be null" ) )
+        return switch ( requireNonNull( name, "Branch cannot be null" ) )
         {
             case "master" -> MASTER;
             case "draft" -> DRAFT;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/cluster/ClusterNodeId.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/cluster/ClusterNodeId.java
@@ -1,7 +1,7 @@
 package com.enonic.xp.cluster;
 
 import java.io.Serializable;
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class ClusterNodeId
@@ -13,7 +13,7 @@ public final class ClusterNodeId
 
     private ClusterNodeId( final String value )
     {
-        this.value = Objects.requireNonNull( value );
+        this.value = requireNonNull( value );
     }
 
     @Override

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/AttachmentValidationError.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/AttachmentValidationError.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 import com.enonic.xp.util.BinaryReference;
 
+import static java.util.Objects.requireNonNull;
+
 public final class AttachmentValidationError
     extends ValidationError
 {
@@ -14,7 +16,7 @@ public final class AttachmentValidationError
                                       final List<Object> args )
     {
         super( errorCode, message, i18n, args );
-        this.attachment = Objects.requireNonNull( attachment );
+        this.attachment = requireNonNull( attachment );
     }
 
     public BinaryReference getAttachment()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/CompareContentsParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/CompareContentsParams.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class CompareContentsParams
@@ -38,7 +38,7 @@ public final class CompareContentsParams
 
         public CompareContentsParams build()
         {
-            Objects.requireNonNull( this.contentIds, "contentIds is required" );
+            requireNonNull( this.contentIds, "contentIds is required" );
             return new CompareContentsParams( this );
         }
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ComponentConfigValidationError.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ComponentConfigValidationError.java
@@ -7,6 +7,8 @@ import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.data.PropertyPath;
 import com.enonic.xp.region.ComponentPath;
 
+import static java.util.Objects.requireNonNull;
+
 public final class ComponentConfigValidationError
     extends DataValidationError
 {
@@ -19,8 +21,8 @@ public final class ComponentConfigValidationError
                                     final List<Object> args )
     {
         super( propertyPath, errorCode, message, i18n, args );
-        this.applicationKey = Objects.requireNonNull( applicationKey );
-        this.componentPath = Objects.requireNonNull( componentPath );
+        this.applicationKey = requireNonNull( applicationKey );
+        this.componentPath = requireNonNull( componentPath );
     }
 
     public ApplicationKey getApplicationKey()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/Content.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/Content.java
@@ -23,6 +23,7 @@ import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.site.Site;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 
@@ -96,7 +97,7 @@ public class Content
         this.id = builder.id;
         this.data = builder.data;
         this.attachments = requireNonNullElse( builder.attachments, Attachments.empty() );
-        this.mixins = Objects.requireNonNull( builder.mixins );
+        this.mixins = requireNonNull( builder.mixins );
         this.createdTime = Millis.from( builder.createdTime );
         this.modifiedTime = Millis.from( builder.modifiedTime );
         this.publishInfo = builder.publishInfo;
@@ -537,7 +538,7 @@ public class Content
 
         public BUILDER data( final PropertyTree data )
         {
-            this.data = Objects.requireNonNull( data );
+            this.data = requireNonNull( data );
             return (BUILDER) this;
         }
 
@@ -699,18 +700,18 @@ public class Content
         {
             if ( !root )
             {
-                Objects.requireNonNull( parentPath, "parentPath is required for a Content" );
-                Objects.requireNonNull( name, "name is required for a Content" );
+                requireNonNull( parentPath, "parentPath is required for a Content" );
+                requireNonNull( name, "name is required for a Content" );
             }
 
-            Objects.requireNonNull( data, "data is required for a Content" );
+            requireNonNull( data, "data is required for a Content" );
 
             if ( page != null )
             {
                 Preconditions.checkArgument( !( page.getDescriptor() != null && page.getTemplate() != null ),
                                              "A Page cannot have both have a descriptor and a template set" );
             }
-            Objects.requireNonNull( type, "type is required for a Content" );
+            requireNonNull( type, "type is required for a Content" );
         }
 
         public Content build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ContentValidatorParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ContentValidatorParams.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.attachment.CreateAttachments;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.page.Page;
 import com.enonic.xp.schema.content.ContentType;
+
+import static java.util.Objects.requireNonNullElse;
 
 public final class ContentValidatorParams
 {
@@ -31,11 +31,11 @@ public final class ContentValidatorParams
     {
         contentId = builder.contentId;
         data = builder.data;
-        mixins = Objects.requireNonNullElse( builder.mixins, Mixins.empty() );
+        mixins = requireNonNullElse( builder.mixins, Mixins.empty() );
         contentType = builder.contentType;
         name = builder.name;
         displayName = builder.displayName;
-        createAttachments = Objects.requireNonNullElse( builder.createAttachments, CreateAttachments.empty() );
+        createAttachments = requireNonNullElse( builder.createAttachments, CreateAttachments.empty() );
         page = builder.page;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ContentValidityParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ContentValidityParams.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 public final class ContentValidityParams
 {
@@ -37,7 +37,7 @@ public final class ContentValidityParams
 
         public ContentValidityParams build()
         {
-            Objects.requireNonNull( this.contentIds, "contentIds is required" );
+            requireNonNull( this.contentIds, "contentIds is required" );
             return new ContentValidityParams( this.contentIds );
         }
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ContentVersionId.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ContentVersionId.java
@@ -2,6 +2,8 @@ package com.enonic.xp.content;
 
 import java.util.Objects;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class ContentVersionId
 {
@@ -9,7 +11,7 @@ public final class ContentVersionId
 
     private ContentVersionId( final String value )
     {
-        Objects.requireNonNull( value, "ContentVersionId cannot be null" );
+        requireNonNull( value, "ContentVersionId cannot be null" );
         this.value = value;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/CreateContentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/CreateContentParams.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.content;
 
 import java.util.Locale;
-import java.util.Objects;
-
 import com.enonic.xp.attachment.CreateAttachments;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.index.ChildOrder;
@@ -10,6 +8,9 @@ import com.enonic.xp.page.Page;
 import com.enonic.xp.schema.content.ContentTypeName;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.acl.AccessControlList;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class CreateContentParams
@@ -48,17 +49,17 @@ public final class CreateContentParams
 
     private CreateContentParams( Builder builder )
     {
-        this.data = Objects.requireNonNull( builder.data, "data is required" );
-        this.mixins = Objects.requireNonNullElse( builder.mixins, Mixins.empty() );
-        this.type = Objects.requireNonNull( builder.type, "type is required" );
+        this.data = requireNonNull( builder.data, "data is required" );
+        this.mixins = requireNonNullElse( builder.mixins, Mixins.empty() );
+        this.type = requireNonNull( builder.type, "type is required" );
         this.owner = builder.owner;
         this.displayName = builder.displayName;
         this.name = builder.name;
-        this.parentContentPath = Objects.requireNonNull( builder.parentPath, "parentPath is required" );
+        this.parentContentPath = requireNonNull( builder.parentPath, "parentPath is required" );
         this.requireValid = builder.requireValid;
         this.permissions = builder.permissions;
         this.inheritPermissions = builder.inheritPermissions;
-        this.createAttachments = Objects.requireNonNullElse( builder.createAttachments, CreateAttachments.empty() );
+        this.createAttachments = requireNonNullElse( builder.createAttachments, CreateAttachments.empty() );
         this.childOrder = builder.childOrder;
         this.language = builder.language;
         this.refresh = builder.refresh;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/CreateMediaParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/CreateMediaParams.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 import com.google.common.io.ByteSource;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class CreateMediaParams
 {
@@ -104,9 +106,9 @@ public final class CreateMediaParams
 
     public void validate()
     {
-        Objects.requireNonNull( this.parent, "parent is required" );
-        Objects.requireNonNull( this.name, "name is required" );
-        Objects.requireNonNull( this.byteSource, "byteSource is required" );
+        requireNonNull( this.parent, "parent is required" );
+        requireNonNull( this.name, "name is required" );
+        requireNonNull( this.byteSource, "byteSource is required" );
     }
 
     public ContentPath getParent()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/DataValidationError.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/DataValidationError.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 import com.enonic.xp.data.PropertyPath;
 
+import static java.util.Objects.requireNonNull;
+
 public sealed class DataValidationError
     extends ValidationError
     permits SiteConfigValidationError, MixinConfigValidationError, ComponentConfigValidationError
@@ -15,7 +17,7 @@ public sealed class DataValidationError
                          final List<Object> args )
     {
         super( errorCode, message, i18n, args );
-        this.propertyPath = Objects.requireNonNull( propertyPath );
+        this.propertyPath = requireNonNull( propertyPath );
     }
 
     public PropertyPath getPropertyPath()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/DeleteContentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/DeleteContentParams.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class DeleteContentParams
@@ -54,7 +54,7 @@ public final class DeleteContentParams
 
         public DeleteContentParams build()
         {
-            Objects.requireNonNull( this.contentPath, "contentPath is required" );
+            requireNonNull( this.contentPath, "contentPath is required" );
             return new DeleteContentParams( this );
         }
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/DuplicateContentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/DuplicateContentParams.java
@@ -1,6 +1,7 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class DuplicateContentParams
@@ -111,7 +112,7 @@ public final class DuplicateContentParams
 
         public Builder includeChildren( final Boolean includeChildren )
         {
-            this.includeChildren = Objects.requireNonNullElse( includeChildren, true );
+            this.includeChildren = requireNonNullElse( includeChildren, true );
             return this;
         }
 
@@ -135,7 +136,7 @@ public final class DuplicateContentParams
 
         public DuplicateContentParams build()
         {
-            Objects.requireNonNull( this.contentId, "contentId is required" );
+            requireNonNull( this.contentId, "contentId is required" );
             return new DuplicateContentParams( this );
         }
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/EditableContent.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/EditableContent.java
@@ -1,14 +1,14 @@
 package com.enonic.xp.content;
 
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullUnmarked;
 
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.page.EditablePage;
 import com.enonic.xp.page.Page;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class EditableContent
@@ -60,7 +60,7 @@ public final class EditableContent
 
     public EditableContent( @NonNull final Content source )
     {
-        this.source = Objects.requireNonNull( source );
+        this.source = requireNonNull( source );
         this.displayName = source.getDisplayName();
         this.data = source.getData().copy();
         this.mixins = source.getMixins().copy();

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/FindContentIdsByQueryResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/FindContentIdsByQueryResult.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.content;
 
 import java.util.Map;
-import java.util.Objects;
-
 import com.google.common.collect.ImmutableMap;
 
 import com.enonic.xp.aggregation.Aggregations;
 import com.enonic.xp.highlight.HighlightedProperties;
 import com.enonic.xp.sortvalues.SortValuesProperty;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class FindContentIdsByQueryResult
@@ -26,7 +26,7 @@ public final class FindContentIdsByQueryResult
 
     private FindContentIdsByQueryResult( final Builder builder )
     {
-        this.contentIds = Objects.requireNonNull( builder.contentIds );
+        this.contentIds = requireNonNull( builder.contentIds );
         this.totalHits = builder.totalHits;
         this.aggregations = builder.aggregations;
         this.highlight = builder.highlight != null ? ImmutableMap.copyOf( builder.highlight ) : null;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/GetActiveContentVersionsParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/GetActiveContentVersionsParams.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import com.enonic.xp.branch.Branches;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -17,8 +17,8 @@ public final class GetActiveContentVersionsParams
 
     private GetActiveContentVersionsParams( final Builder builder )
     {
-        contentId = Objects.requireNonNull( builder.contentId, "contentId is required" );
-        branches = Objects.requireNonNull( builder.branches, "branches is required" );
+        contentId = requireNonNull( builder.contentId, "contentId is required" );
+        branches = requireNonNull( builder.branches, "branches is required" );
     }
 
     public ContentId getContentId()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/GetContentByIdsParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/GetContentByIdsParams.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class GetContentByIdsParams
@@ -10,7 +10,7 @@ public final class GetContentByIdsParams
     @Deprecated
     public GetContentByIdsParams( final ContentIds ids )
     {
-        this.ids = Objects.requireNonNull( ids, "ids must be specified" );
+        this.ids = requireNonNull( ids, "ids must be specified" );
     }
 
     public GetContentByIdsParams( final Builder builder )
@@ -44,7 +44,7 @@ public final class GetContentByIdsParams
 
         public GetContentByIdsParams build()
         {
-            Objects.requireNonNull( this.contentIds, "contentIds is required" );
+            requireNonNull( this.contentIds, "contentIds is required" );
             return new GetContentByIdsParams( this );
         }
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/GetContentVersionsParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/GetContentVersionsParams.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -18,7 +18,7 @@ public final class GetContentVersionsParams
 
     private GetContentVersionsParams( final Builder builder )
     {
-        contentId = Objects.requireNonNull( builder.contentId, "contentId cannot be null" );
+        contentId = requireNonNull( builder.contentId, "contentId cannot be null" );
         cursor = builder.cursor;
         size = builder.size;
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/GetContentVersionsResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/GetContentVersionsResult.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -17,7 +17,7 @@ public final class GetContentVersionsResult
 
     private GetContentVersionsResult( Builder builder )
     {
-        contentVersions = Objects.requireNonNull( builder.contentVersions );
+        contentVersions = requireNonNull( builder.contentVersions );
         totalHits = builder.totalHits;
         cursor = builder.cursor;
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/GetPublishStatusesParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/GetPublishStatusesParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.branch.Branch;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class GetPublishStatusesParams
@@ -48,7 +48,7 @@ public final class GetPublishStatusesParams
 
         public GetPublishStatusesParams build()
         {
-            Objects.requireNonNull( this.contentIds, "contentIds is required" );
+            requireNonNull( this.contentIds, "contentIds is required" );
             return new GetPublishStatusesParams( this );
         }
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/HasUnpublishedChildrenParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/HasUnpublishedChildrenParams.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class HasUnpublishedChildrenParams
@@ -38,7 +38,7 @@ public final class HasUnpublishedChildrenParams
 
         public HasUnpublishedChildrenParams build()
         {
-            Objects.requireNonNull( this.contentId, "contentId is required" );
+            requireNonNull( this.contentId, "contentId is required" );
             return new HasUnpublishedChildrenParams( this );
         }
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ImportContentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ImportContentParams.java
@@ -2,10 +2,10 @@ package com.enonic.xp.content;
 
 import java.util.Collection;
 import java.util.EnumSet;
-import java.util.Objects;
-
 import com.enonic.xp.attachment.CreateAttachments;
 import com.enonic.xp.project.ProjectName;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ImportContentParams
 {
@@ -139,8 +139,8 @@ public final class ImportContentParams
 
         private void validate()
         {
-            Objects.requireNonNull( this.content, "content is required" );
-            Objects.requireNonNull( this.targetPath, "targetPath is required" );
+            requireNonNull( this.content, "content is required" );
+            requireNonNull( this.targetPath, "targetPath is required" );
         }
 
         public ImportContentParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ImportContentResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ImportContentResult.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 public final class ImportContentResult
 {
@@ -37,7 +37,7 @@ public final class ImportContentResult
 
         private void validate()
         {
-            Objects.requireNonNull( content );
+            requireNonNull( content );
         }
 
         public ImportContentResult build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/Mixin.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/Mixin.java
@@ -6,6 +6,8 @@ import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.schema.mixin.MixinName;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class Mixin
 {
@@ -15,8 +17,8 @@ public final class Mixin
 
     public Mixin( final MixinName name, final PropertyTree data )
     {
-        this.name = Objects.requireNonNull( name, "name cannot be null" );
-        this.data = Objects.requireNonNull( data, "data cannot be null" );
+        this.name = requireNonNull( name, "name cannot be null" );
+        this.data = requireNonNull( data, "data cannot be null" );
     }
 
     public PropertyTree getData()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/MixinConfigValidationError.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/MixinConfigValidationError.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import com.enonic.xp.data.PropertyPath;
 import com.enonic.xp.schema.mixin.MixinName;
 
+import static java.util.Objects.requireNonNull;
+
 public final class MixinConfigValidationError
     extends DataValidationError
 {
@@ -15,7 +17,7 @@ public final class MixinConfigValidationError
                                 final String i18n, final MixinName mixinName, final List<Object> args )
     {
         super( propertyPath, errorCode, message, i18n, args );
-        this.mixinName = Objects.requireNonNull( mixinName );
+        this.mixinName = requireNonNull( mixinName );
     }
 
     public MixinName getMixinName()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/MoveContentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/MoveContentParams.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class MoveContentParams
@@ -86,7 +86,7 @@ public final class MoveContentParams
 
         public MoveContentParams build()
         {
-            Objects.requireNonNull( this.contentId, "contentId is required" );
+            requireNonNull( this.contentId, "contentId is required" );
             return new MoveContentParams( this );
         }
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/PatchContentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/PatchContentParams.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
-
 import com.google.common.collect.ImmutableSet;
 
 import com.enonic.xp.attachment.CreateAttachments;
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.branch.Branches;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 
 public final class PatchContentParams
@@ -90,7 +90,7 @@ public final class PatchContentParams
 
         public Builder createAttachments( final CreateAttachments value )
         {
-            this.createAttachments = Objects.requireNonNullElseGet( value, CreateAttachments::empty );
+            this.createAttachments = requireNonNullElseGet( value, CreateAttachments::empty );
             return this;
         }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/PatchableContent.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/PatchableContent.java
@@ -3,7 +3,6 @@ package com.enonic.xp.content;
 import java.time.Instant;
 import java.util.EnumSet;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -18,6 +17,8 @@ import com.enonic.xp.page.Page;
 import com.enonic.xp.project.ProjectName;
 import com.enonic.xp.schema.content.ContentTypeName;
 import com.enonic.xp.security.PrincipalKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -159,7 +160,7 @@ public class PatchableContent
 
         public PatchableField<T> setPatcher( Function<PatchableContent, @Nullable T> patcher )
         {
-            this.patcher = Objects.requireNonNull( patcher );
+            this.patcher = requireNonNull( patcher );
             return this;
         }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ProjectSyncParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ProjectSyncParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.project.ProjectName;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ProjectSyncParams
 {
@@ -39,7 +39,7 @@ public final class ProjectSyncParams
 
         private void validate()
         {
-            Objects.requireNonNull( targetProject, "targetProject is required" );
+            requireNonNull( targetProject, "targetProject is required" );
         }
 
         public ProjectSyncParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/PublishContentResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/PublishContentResult.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.content;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.google.common.collect.ImmutableList;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class PublishContentResult
@@ -86,7 +86,7 @@ public final class PublishContentResult
 
         public static Result failure( final ContentId contentId, Reason failureReason )
         {
-            return new Result( contentId, Objects.requireNonNull( failureReason ) );
+            return new Result( contentId, requireNonNull( failureReason ) );
         }
     }
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/PushContentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/PushContentParams.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.content;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
+
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class PushContentParams
@@ -30,10 +30,10 @@ public final class PushContentParams
         this.publishFrom = builder.publishFrom;
         this.publishTo = builder.publishTo;
         this.includeDependencies = builder.includeDependencies;
-        this.excludeDescendantsOf = Objects.requireNonNullElse( builder.excludeDescendantsOf, ContentIds.empty() );
+        this.excludeDescendantsOf = requireNonNullElse( builder.excludeDescendantsOf, ContentIds.empty() );
         this.publishContentListener = builder.publishContentListener;
         this.message = builder.message;
-        this.excludedContentIds = Objects.requireNonNullElse( builder.excludedContentIds, ContentIds.empty() );
+        this.excludedContentIds = requireNonNullElse( builder.excludedContentIds, ContentIds.empty() );
     }
 
     public static Builder create()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ReorderChildContentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ReorderChildContentParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ReorderChildContentParams
@@ -56,7 +56,7 @@ public final class ReorderChildContentParams
 
         public ReorderChildContentParams build()
         {
-            Objects.requireNonNull( contentToMove, "contentToMove is required" );
+            requireNonNull( contentToMove, "contentToMove is required" );
             Preconditions.checkArgument( !contentToMove.equals( contentToMoveBefore ),
                                          "contentToMove and contentToMoveBefore must be different" );
             return new ReorderChildContentParams( this );

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ResolvePublishDependenciesParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ResolvePublishDependenciesParams.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class ResolvePublishDependenciesParams
@@ -13,9 +13,9 @@ public final class ResolvePublishDependenciesParams
 
     private ResolvePublishDependenciesParams( Builder builder )
     {
-        contentIds = Objects.requireNonNullElse( builder.contentIds, ContentIds.empty() );
-        excludeDescendantsOf = Objects.requireNonNullElse( builder.excludeDescendantsOf, ContentIds.empty() );
-        excludedContentIds = Objects.requireNonNullElse( builder.excludedContentIds, ContentIds.empty() );
+        contentIds = requireNonNullElse( builder.contentIds, ContentIds.empty() );
+        excludeDescendantsOf = requireNonNullElse( builder.excludeDescendantsOf, ContentIds.empty() );
+        excludedContentIds = requireNonNullElse( builder.excludedContentIds, ContentIds.empty() );
     }
 
     public static Builder create()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ResolveRequiredDependenciesParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ResolveRequiredDependenciesParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.branch.Branch;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ResolveRequiredDependenciesParams
@@ -45,7 +45,7 @@ public final class ResolveRequiredDependenciesParams
 
         public ResolveRequiredDependenciesParams build()
         {
-            Objects.requireNonNull( this.contentIds, "contentIds is required" );
+            requireNonNull( this.contentIds, "contentIds is required" );
             return new ResolveRequiredDependenciesParams( this );
         }
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/SiteConfigValidationError.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/SiteConfigValidationError.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.data.PropertyPath;
 
+import static java.util.Objects.requireNonNull;
+
 public final class SiteConfigValidationError
     extends DataValidationError
 {
@@ -15,7 +17,7 @@ public final class SiteConfigValidationError
                                final String i18n, final ApplicationKey applicationKey, final List<Object> args )
     {
         super( propertyPath, errorCode, message, i18n, args );
-        this.applicationKey = Objects.requireNonNull( applicationKey );
+        this.applicationKey = requireNonNull( applicationKey );
     }
 
     public ApplicationKey getApplicationKey()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/UpdateContentMetadataParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/UpdateContentMetadataParams.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -15,8 +15,8 @@ public final class UpdateContentMetadataParams
 
     private UpdateContentMetadataParams( final Builder builder )
     {
-        this.contentId = Objects.requireNonNull( builder.contentId, "contentId is required" );
-        this.editor = Objects.requireNonNull( builder.editor, "editor is required" );
+        this.contentId = requireNonNull( builder.contentId, "contentId is required" );
+        this.editor = requireNonNull( builder.editor, "editor is required" );
     }
 
     public static Builder create()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/UpdateContentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/UpdateContentParams.java
@@ -1,9 +1,10 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.attachment.CreateAttachments;
 import com.enonic.xp.util.BinaryReferences;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElseGet;
 
 
 public final class UpdateContentParams
@@ -34,7 +35,7 @@ public final class UpdateContentParams
 
     public UpdateContentParams createAttachments( final CreateAttachments value )
     {
-        this.createAttachments = Objects.requireNonNullElseGet( value, CreateAttachments::empty );
+        this.createAttachments = requireNonNullElseGet( value, CreateAttachments::empty );
         return this;
     }
 
@@ -46,7 +47,7 @@ public final class UpdateContentParams
 
     public UpdateContentParams removeAttachments( final BinaryReferences removeAttachments )
     {
-        this.removeAttachments = Objects.requireNonNullElseGet( removeAttachments, BinaryReferences::empty );
+        this.removeAttachments = requireNonNullElseGet( removeAttachments, BinaryReferences::empty );
         return this;
     }
 
@@ -58,7 +59,7 @@ public final class UpdateContentParams
 
     public void validate()
     {
-        Objects.requireNonNull( contentId, "contentId is required" );
+        requireNonNull( contentId, "contentId is required" );
     }
 
     public ContentEditor getEditor()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/UpdateMediaParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/UpdateMediaParams.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.content;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class UpdateMediaParams
@@ -98,9 +98,9 @@ public final class UpdateMediaParams
 
     public void validate()
     {
-        Objects.requireNonNull( this.content, "content to update is required" );
-        Objects.requireNonNull( this.name, "name is required" );
-        Objects.requireNonNull( this.byteSource, "byteSource is required" );
+        requireNonNull( this.content, "content to update is required" );
+        requireNonNull( this.name, "name is required" );
+        requireNonNull( this.byteSource, "byteSource is required" );
     }
 
     public ContentId getContent()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/UpdateWorkflowParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/UpdateWorkflowParams.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.content;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -15,8 +15,8 @@ public final class UpdateWorkflowParams
 
     private UpdateWorkflowParams( final Builder builder )
     {
-        this.contentId = Objects.requireNonNull( builder.contentId, "contentId is required" );
-        this.editor = Objects.requireNonNull( builder.editor, "editor is required" );
+        this.contentId = requireNonNull( builder.contentId, "contentId is required" );
+        this.editor = requireNonNull( builder.editor, "editor is required" );
     }
 
     public static Builder create()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ValidationError.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ValidationError.java
@@ -14,6 +14,8 @@ import com.enonic.xp.region.ComponentPath;
 import com.enonic.xp.schema.mixin.MixinName;
 import com.enonic.xp.util.BinaryReference;
 
+import static java.util.Objects.requireNonNull;
+
 public sealed class ValidationError
     permits DataValidationError, AttachmentValidationError
 {
@@ -178,7 +180,7 @@ public sealed class ValidationError
 
         public ValidationError build()
         {
-            Objects.requireNonNull( errorCode );
+            requireNonNull( errorCode );
 
             final List<Object> args = this.argsBuilder.build();
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ValidationErrorCode.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ValidationErrorCode.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 
 import com.enonic.xp.app.ApplicationKey;
 
+import static java.util.Objects.requireNonNull;
+
 public final class ValidationErrorCode
 {
     private static final String SEPARATOR = ":";
@@ -15,7 +17,7 @@ public final class ValidationErrorCode
     private ValidationErrorCode( final ApplicationKey applicationKey, final String code )
     {
         this.applicationKey = applicationKey;
-        this.code = Objects.requireNonNull( code );
+        this.code = requireNonNull( code );
     }
 
     public ApplicationKey getApplicationKey()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/WorkflowInfo.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/WorkflowInfo.java
@@ -2,6 +2,8 @@ package com.enonic.xp.content;
 
 import java.util.Objects;
 
+import static java.util.Objects.requireNonNull;
+
 public final class WorkflowInfo
 {
     private static final WorkflowInfo IN_PROGRESS = WorkflowInfo.create().state( WorkflowState.IN_PROGRESS ).build();
@@ -68,7 +70,7 @@ public final class WorkflowInfo
 
         private void validate()
         {
-            Objects.requireNonNull( this.state, "state is required" );
+            requireNonNull( this.state, "state is required" );
         }
 
         public WorkflowInfo build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/data/Property.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/data/Property.java
@@ -11,6 +11,8 @@ import com.enonic.xp.util.GeoPoint;
 import com.enonic.xp.util.Link;
 import com.enonic.xp.util.Reference;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class Property
 {
@@ -170,7 +172,7 @@ public final class Property
 
     public static void checkName( final String name )
     {
-        Objects.requireNonNull( name, "Property name cannot be null" );
+        requireNonNull( name, "Property name cannot be null" );
         if ( name.isBlank() )
         {
             throw new IllegalArgumentException( "Property name cannot be blank" );

--- a/modules/core/core-api/src/main/java/com/enonic/xp/data/PropertyArray.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/data/PropertyArray.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 
 import com.google.common.collect.ImmutableList;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class PropertyArray
 {
@@ -19,9 +21,9 @@ public final class PropertyArray
 
     PropertyArray( final PropertySet parent, final String name, final ValueType valueType, final int initialCapacity )
     {
-        Objects.requireNonNull( parent, "parent cannot be null" );
-        Objects.requireNonNull( name, "name cannot be null" );
-        Objects.requireNonNull( valueType, "valueType cannot be null" );
+        requireNonNull( parent, "parent cannot be null" );
+        requireNonNull( name, "name cannot be null" );
+        requireNonNull( valueType, "valueType cannot be null" );
         Property.checkName( name );
 
         this.parent = parent;
@@ -35,8 +37,8 @@ public final class PropertyArray
      */
     private PropertyArray( final PropertyArray source, final PropertySet parent )
     {
-        Objects.requireNonNull( source, "source cannot be null" );
-        Objects.requireNonNull( parent, "parent cannot be null" );
+        requireNonNull( source, "source cannot be null" );
+        requireNonNull( parent, "parent cannot be null" );
 
         this.parent = parent;
         this.name = source.name;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/data/PropertyPath.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/data/PropertyPath.java
@@ -3,7 +3,6 @@ package com.enonic.xp.data;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 
@@ -11,6 +10,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
 
 
 /**
@@ -28,35 +28,35 @@ public final class PropertyPath
 
     public static PropertyPath from( final PropertyPath parentPath, final String element )
     {
-        Objects.requireNonNull( parentPath, "parentPath cannot be null" );
-        Objects.requireNonNull( element, "element cannot be null" );
+        requireNonNull( parentPath, "parentPath cannot be null" );
+        requireNonNull( element, "element cannot be null" );
         return new PropertyPath( parentPath, new Element( element ) );
     }
 
     public static PropertyPath from( final PropertyPath parentPath, final Element element )
     {
-        Objects.requireNonNull( parentPath, "parentPath cannot be null" );
-        Objects.requireNonNull( element, "element cannot be null" );
+        requireNonNull( parentPath, "parentPath cannot be null" );
+        requireNonNull( element, "element cannot be null" );
 
         return new PropertyPath( parentPath, element );
     }
 
     public static PropertyPath from( final Iterable<Element> pathElements )
     {
-        Objects.requireNonNull( pathElements, "pathElements cannot be null" );
+        requireNonNull( pathElements, "pathElements cannot be null" );
         return new PropertyPath( ImmutableList.copyOf( pathElements ) );
     }
 
     public static PropertyPath from( final String path )
     {
-        Objects.requireNonNull( path, "path cannot be null" );
+        requireNonNull( path, "path cannot be null" );
         return new PropertyPath( splitPathIntoElements( path ) );
     }
 
     public static PropertyPath from( final String parentPath, final String... children )
     {
-        Objects.requireNonNull( parentPath, "parentPath cannot be null" );
-        Objects.requireNonNull( children, "children cannot be null" );
+        requireNonNull( parentPath, "parentPath cannot be null" );
+        requireNonNull( children, "children cannot be null" );
 
         final List<Element> elements = new ArrayList<>( splitPathIntoElements( parentPath ) );
 
@@ -70,7 +70,7 @@ public final class PropertyPath
 
     public static PropertyPath from( final Element... pathElements )
     {
-        Objects.requireNonNull( pathElements, "pathElements cannot be null" );
+        requireNonNull( pathElements, "pathElements cannot be null" );
         return new PropertyPath( ImmutableList.copyOf( pathElements ) );
     }
 
@@ -81,8 +81,8 @@ public final class PropertyPath
 
     private PropertyPath( final PropertyPath parentPath, final Element element )
     {
-        Objects.requireNonNull( parentPath, "parentPath cannot be null" );
-        Objects.requireNonNull( element, "element cannot be null" );
+        requireNonNull( parentPath, "parentPath cannot be null" );
+        requireNonNull( element, "element cannot be null" );
 
         final ImmutableList.Builder<Element> elementBuilder = ImmutableList.builder();
         elementBuilder.addAll( parentPath.pathElements() ).add( element );
@@ -239,7 +239,7 @@ public final class PropertyPath
 
         public Element( final String element )
         {
-            Objects.requireNonNull( element, "Element cannot be null" );
+            requireNonNull( element, "Element cannot be null" );
             Preconditions.checkArgument( !element.isEmpty(), "Element cannot be empty" );
 
             int indexStart = element.indexOf( INDEX_START_MARKER );
@@ -276,7 +276,7 @@ public final class PropertyPath
 
         public Element( final String name, final int index )
         {
-            Objects.requireNonNull( name, "Element name cannot be null" );
+            requireNonNull( name, "Element name cannot be null" );
             Preconditions.checkArgument( !isNullOrEmpty( name ), "Element name cannot be empty" );
             Preconditions.checkArgument( index >= 0, "an index cannot be less than zero" );
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/data/Value.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/data/Value.java
@@ -13,6 +13,8 @@ import com.enonic.xp.util.GeoPoint;
 import com.enonic.xp.util.Link;
 import com.enonic.xp.util.Reference;
 
+import static java.util.Objects.requireNonNull;
+
 
 public abstract class Value
 {
@@ -22,7 +24,7 @@ public abstract class Value
 
     protected Value( final ValueType type, final Object value )
     {
-        Objects.requireNonNull( type, "type cannot be null" );
+        requireNonNull( type, "type cannot be null" );
         if ( value != null )
         {
             Preconditions.checkArgument( !( value instanceof Value ), "The value of a Value cannot be: %s", value.getClass() );

--- a/modules/core/core-api/src/main/java/com/enonic/xp/descriptor/Descriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/descriptor/Descriptor.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.descriptor;
 
-import java.util.Objects;
-
 import com.enonic.xp.app.ApplicationKey;
+
+import static java.util.Objects.requireNonNull;
 
 public abstract class Descriptor
 {
@@ -10,7 +10,7 @@ public abstract class Descriptor
 
     public Descriptor( final DescriptorKey key )
     {
-        Objects.requireNonNull( key, "key cannot be null" );
+        requireNonNull( key, "key cannot be null" );
         this.key = key;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/descriptor/DescriptorKey.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/descriptor/DescriptorKey.java
@@ -9,6 +9,8 @@ import org.jspecify.annotations.NullMarked;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.core.internal.NameValidator;
 
+import static java.util.Objects.requireNonNull;
+
 
 @NullMarked
 public final class DescriptorKey
@@ -36,8 +38,8 @@ public final class DescriptorKey
 
     private DescriptorKey( final ApplicationKey applicationKey, final String name )
     {
-        this.applicationKey = Objects.requireNonNull( applicationKey );
-        this.name = Objects.requireNonNull( name );
+        this.applicationKey = requireNonNull( applicationKey );
+        this.name = requireNonNull( name );
     }
 
     public ApplicationKey getApplicationKey()
@@ -79,7 +81,7 @@ public final class DescriptorKey
 
     public static DescriptorKey from( final String key )
     {
-        Objects.requireNonNull( key, "DescriptorKey cannot be null" );
+        requireNonNull( key, "DescriptorKey cannot be null" );
         final int index = key.indexOf( SEPARATOR );
         if ( index == -1 )
         {

--- a/modules/core/core-api/src/main/java/com/enonic/xp/dump/DumpUpgradeStepResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/dump/DumpUpgradeStepResult.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.dump;
 
-import java.util.Objects;
-
 import com.enonic.xp.util.Version;
+
+import static java.util.Objects.requireNonNull;
 
 public final class DumpUpgradeStepResult
 {
@@ -20,9 +20,9 @@ public final class DumpUpgradeStepResult
 
     private DumpUpgradeStepResult( final Builder builder )
     {
-        initialVersion = Objects.requireNonNull( builder.initialVersion, "initialVersion cannot be null" );
-        upgradedVersion = Objects.requireNonNull( builder.upgradedVersion, "upgradedVersion cannot be null" );
-        stepName = Objects.requireNonNull( builder.stepName, "stepName cannot be null" );
+        initialVersion = requireNonNull( builder.initialVersion, "initialVersion cannot be null" );
+        upgradedVersion = requireNonNull( builder.upgradedVersion, "upgradedVersion cannot be null" );
+        stepName = requireNonNull( builder.stepName, "stepName cannot be null" );
         processed = builder.processed;
         errors = builder.errors;
         warnings = builder.warnings;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/event/Event.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/event/Event.java
@@ -3,13 +3,14 @@ package com.enonic.xp.event;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 
 import com.enonic.xp.convert.Converters;
+
+import static java.util.Objects.requireNonNull;
 
 public final class Event
     implements Serializable
@@ -216,7 +217,7 @@ public final class Event
 
         private void validate()
         {
-            Objects.requireNonNull( type, "type is required" );
+            requireNonNull( type, "type is required" );
         }
 
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/export/ExportNodesParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/export/ExportNodesParams.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.export;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.core.internal.FileNames;
 import com.enonic.xp.node.NodePath;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ExportNodesParams
@@ -91,7 +91,7 @@ public final class ExportNodesParams
 
         private void validate()
         {
-            Objects.requireNonNull( sourceNodePath, "sourceNodePath is required" );
+            requireNonNull( sourceNodePath, "sourceNodePath is required" );
             Preconditions.checkArgument( exportName != null, "exportName is required" );
             Preconditions.checkArgument( FileNames.isSafeFileName( exportName ), "Invalid export name" );
         }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/form/FieldSet.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/form/FieldSet.java
@@ -7,6 +7,8 @@ import java.util.Objects;
 
 import com.enonic.xp.schema.LocalizedText;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class FieldSet
     extends FormItem
@@ -20,7 +22,7 @@ public final class FieldSet
 
     private FieldSet( final Builder builder )
     {
-        this.label = Objects.requireNonNull( builder.label, "label is required" );
+        this.label = requireNonNull( builder.label, "label is required" );
         this.labelI18nKey = builder.labelI18nKey;
         this.formItems = new FormItems( this, builder.formItems );
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/form/Form.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/form/Form.java
@@ -8,6 +8,8 @@ import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class Form
     implements Iterable<FormItem>
@@ -114,7 +116,7 @@ public final class Form
 
         private Builder( final Form source )
         {
-            Objects.requireNonNull( source, "Given form cannot be null" );
+            requireNonNull( source, "Given form cannot be null" );
 
             this.formItemsList = new ArrayList<>();
             for ( FormItem formItem : source.formItems )

--- a/modules/core/core-api/src/main/java/com/enonic/xp/form/FormFragment.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/form/FormFragment.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import com.enonic.xp.schema.formfragment.FormFragmentDescriptor;
 import com.enonic.xp.schema.formfragment.FormFragmentName;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class FormFragment
     extends FormItem
@@ -16,7 +18,7 @@ public final class FormFragment
     {
         super();
 
-        Objects.requireNonNull( builder.formFragmentName, "formFragmentName is required" );
+        requireNonNull( builder.formFragmentName, "formFragmentName is required" );
         this.formFragmentName = builder.formFragmentName;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/form/FormItemPath.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/form/FormItemPath.java
@@ -2,12 +2,13 @@ package com.enonic.xp.form;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableList;
 
 import com.enonic.xp.data.PropertyPath;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class FormItemPath
@@ -26,29 +27,29 @@ public final class FormItemPath
 
     public static FormItemPath from( final FormItemPath parentPath, final String name )
     {
-        Objects.requireNonNull( parentPath, "parentPath cannot be null" );
-        Objects.requireNonNull( name, "name cannot be null" );
+        requireNonNull( parentPath, "parentPath cannot be null" );
+        requireNonNull( name, "name cannot be null" );
 
         return fromInternal( ImmutableList.<String>builder().addAll( parentPath.elements ).add( name ).build() );
     }
 
     public static FormItemPath from( final Iterable<String> pathElements )
     {
-        Objects.requireNonNull( pathElements, "pathElements cannot be null" );
+        requireNonNull( pathElements, "pathElements cannot be null" );
 
         return fromInternal( ImmutableList.copyOf( pathElements ) );
     }
 
     public static FormItemPath from( final String path )
     {
-        Objects.requireNonNull( path, "path cannot be null" );
+        requireNonNull( path, "path cannot be null" );
 
         return fromInternal( ImmutableList.copyOf( path.split( Pattern.quote( ELEMENT_DIVIDER ), -1 ) ) );
     }
 
     public static FormItemPath from( final PropertyPath path )
     {
-        Objects.requireNonNull( path, "path cannot be null" );
+        requireNonNull( path, "path cannot be null" );
         return fromInternal( path.pathElements().stream().map( PropertyPath.Element::getName ).collect( ImmutableList.toImmutableList() ) );
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/form/FormItems.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/form/FormItems.java
@@ -10,6 +10,8 @@ import java.util.function.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
+import static java.util.Objects.requireNonNull;
+
 final class FormItems
     implements Iterable<FormItem>
 {
@@ -51,7 +53,7 @@ final class FormItems
 
     FormItem getFormItem( final FormItemPath path )
     {
-        Objects.requireNonNull( path, "path cannot be null" );
+        requireNonNull( path, "path cannot be null" );
         Preconditions.checkArgument( path.elementCount() >= 1, "path must have at least one element" );
 
         if ( path.elementCount() > 1 )

--- a/modules/core/core-api/src/main/java/com/enonic/xp/form/Input.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/form/Input.java
@@ -10,6 +10,7 @@ import com.enonic.xp.schema.LocalizedText;
 import com.enonic.xp.util.GenericValue;
 
 import static com.google.common.base.Strings.nullToEmpty;
+import static java.util.Objects.requireNonNull;
 
 
 public final class Input
@@ -37,7 +38,7 @@ public final class Input
 
         Preconditions.checkArgument( !nullToEmpty( builder.name ).isBlank(), "name is required for a Input" );
         Preconditions.checkArgument( !builder.name.contains( "." ), "name cannot contain punctuations: %s", builder.name );
-        Objects.requireNonNull( builder.inputType, "inputType is required for a Input" );
+        requireNonNull( builder.inputType, "inputType is required for a Input" );
         Preconditions.checkArgument( !nullToEmpty( builder.label ).isBlank(), "label is required for a Input" );
 
         this.name = builder.name;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/highlight/HighlightedProperty.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/highlight/HighlightedProperty.java
@@ -6,6 +6,8 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class HighlightedProperty
 {
@@ -79,7 +81,7 @@ public final class HighlightedProperty
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
+            requireNonNull( name, "name is required" );
         }
 
         public HighlightedProperty build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/icon/Icon.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/icon/Icon.java
@@ -11,6 +11,8 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteStreams;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class Icon
 {
@@ -22,8 +24,8 @@ public final class Icon
 
     private Icon( final byte[] iconData, final String mimeType, final Instant modifiedTime )
     {
-        Objects.requireNonNull( mimeType, "mimeType is required" );
-        Objects.requireNonNull( iconData, "iconData is required" );
+        requireNonNull( mimeType, "mimeType is required" );
+        requireNonNull( iconData, "iconData is required" );
         Preconditions.checkArgument( iconData.length > 0, "iconData cannot be empty" );
         this.iconData = iconData;
         this.mimeType = mimeType;
@@ -97,7 +99,7 @@ public final class Icon
 
     public static Icon from( final InputStream dataStream, final String mimeType, final Instant modifiedTime )
     {
-        Objects.requireNonNull( dataStream, "dataStream is required" );
+        requireNonNull( dataStream, "dataStream is required" );
         try
         {
             return new Icon( ByteStreams.toByteArray( dataStream ), mimeType, modifiedTime );

--- a/modules/core/core-api/src/main/java/com/enonic/xp/idprovider/IdProviderDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/idprovider/IdProviderDescriptor.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.idprovider;
 
-import java.util.Objects;
-
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.form.Form;
 import com.enonic.xp.util.GenericValue;
+
+import static java.util.Objects.requireNonNullElse;
 
 public final class IdProviderDescriptor
 {
@@ -20,7 +20,7 @@ public final class IdProviderDescriptor
     {
         this.key = builder.key;
         this.mode = builder.mode;
-        this.config = Objects.requireNonNullElse( builder.config, Form.empty() );
+        this.config = requireNonNullElse( builder.config, Form.empty() );
         this.schemaConfig = builder.schemaConfig.build();
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/image/ReadImageParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/image/ReadImageParams.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.image;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.media.ImageOrientation;
 import com.enonic.xp.util.BinaryReference;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ReadImageParams
 {
@@ -253,9 +253,9 @@ public final class ReadImageParams
 
         public ReadImageParams build()
         {
-            Objects.requireNonNull( contentId, "contentId is required" );
-            Objects.requireNonNull( binaryReference, "binaryReference is required" );
-            Objects.requireNonNull( mimeType, "mimeType is required" );
+            requireNonNull( contentId, "contentId is required" );
+            requireNonNull( binaryReference, "binaryReference is required" );
+            requireNonNull( mimeType, "mimeType is required" );
             Preconditions.checkArgument( quality >= 0 && quality <= 100, "Quality out of bounds 0-100" );
             Preconditions.checkArgument( backgroundColor >= 0 && backgroundColor <= 0xFFFFFF, "Background color out of bounds 0-0xFFFFFF" );
             return new ReadImageParams( this );

--- a/modules/core/core-api/src/main/java/com/enonic/xp/init/ExternalInitializer.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/init/ExternalInitializer.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.init;
 
-import java.util.Objects;
-
 import com.enonic.xp.index.IndexService;
+
+import static java.util.Objects.requireNonNull;
 
 public abstract class ExternalInitializer
     extends Initializer
@@ -41,7 +41,7 @@ public abstract class ExternalInitializer
 
         protected void validate()
         {
-            Objects.requireNonNull( indexService );
+            requireNonNull( indexService );
         }
     }
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/init/Initializer.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/init/Initializer.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.init;
 
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.enonic.xp.exception.InitializationException;
+
+import static java.util.Objects.requireNonNullElse;
 
 public abstract class Initializer
 {
@@ -23,7 +23,7 @@ public abstract class Initializer
 
     protected Initializer( final Builder builder )
     {
-        this.initializationCheckPeriod = Objects.requireNonNullElse( builder.initializationCheckPeriod, INITIALIZATION_CHECK_PERIOD );
+        this.initializationCheckPeriod = requireNonNullElse( builder.initializationCheckPeriod, INITIALIZATION_CHECK_PERIOD );
         this.initializationCheckMaxCount = builder.initializationCheckMaxCount != null
             ? builder.initializationCheckMaxCount
             : Long.getLong( "xp.init.maxTries", INITIALIZATION_CHECK_MAX_COUNT );

--- a/modules/core/core-api/src/main/java/com/enonic/xp/inputtype/InputTypeName.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/inputtype/InputTypeName.java
@@ -1,7 +1,7 @@
 package com.enonic.xp.inputtype;
 
 import java.util.Locale;
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class InputTypeName
@@ -58,7 +58,7 @@ public final class InputTypeName
 
     private InputTypeName( final String name )
     {
-        Objects.requireNonNull( name, "InputTypeName can't be null" );
+        requireNonNull( name, "InputTypeName can't be null" );
         this.name = name;
         this.lowercaseName = name.toLowerCase( Locale.ROOT );
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/inputtype/InputTypeValidationException.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/inputtype/InputTypeValidationException.java
@@ -8,6 +8,8 @@ import com.enonic.xp.data.Property;
 import com.enonic.xp.data.PropertyPath;
 import com.enonic.xp.data.ValueType;
 
+import static java.util.Objects.requireNonNull;
+
 public final class InputTypeValidationException
     extends RuntimeException
 {
@@ -16,7 +18,7 @@ public final class InputTypeValidationException
     private InputTypeValidationException( final String message, final PropertyPath propertyPath )
     {
         super( message );
-        this.propertyPath = Objects.requireNonNull( propertyPath );
+        this.propertyPath = requireNonNull( propertyPath );
     }
 
     public PropertyPath getPropertyPath()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/issue/PublishRequestItem.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/issue/PublishRequestItem.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 
 import com.enonic.xp.content.ContentId;
 
+import static java.util.Objects.requireNonNull;
+
 public final class PublishRequestItem
 {
     private final ContentId id;
@@ -81,7 +83,7 @@ public final class PublishRequestItem
 
         private void validate()
         {
-            Objects.requireNonNull( id, "content id is required" );
+            requireNonNull( id, "content id is required" );
         }
 
         public PublishRequestItem build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/macro/MacroDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/macro/MacroDescriptor.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.macro;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.form.Form;
 import com.enonic.xp.icon.Icon;
 import com.enonic.xp.schema.LocalizedText;
 import com.enonic.xp.util.GenericValue;
+
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class MacroDescriptor
@@ -36,7 +36,7 @@ public final class MacroDescriptor
         this.titleI18nKey = builder.titleI18nKey;
         this.description = builder.description;
         this.descriptionI18nKey = builder.descriptionI18nKey;
-        this.form = Objects.requireNonNullElse( builder.form, Form.empty() );
+        this.form = requireNonNullElse( builder.form, Form.empty() );
         this.icon = builder.icon;
         this.modifiedTime = builder.modifiedTime;
         this.schemaConfig = builder.schemaConfig.build();

--- a/modules/core/core-api/src/main/java/com/enonic/xp/mail/MailAttachment.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/mail/MailAttachment.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.mail;
 
 import java.util.Map;
-import java.util.Objects;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class MailAttachment
@@ -19,8 +19,8 @@ public final class MailAttachment
 
     private MailAttachment( final Builder builder )
     {
-        this.fileName = Objects.requireNonNull( builder.fileName );
-        this.data = Objects.requireNonNull( builder.data );
+        this.fileName = requireNonNull( builder.fileName );
+        this.data = requireNonNull( builder.data );
         this.mimeType = builder.mimeType;
         this.headers = builder.headers != null ? ImmutableMap.copyOf( builder.headers ) : ImmutableMap.of();
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/media/MediaInfo.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/media/MediaInfo.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.media;
 
-import java.util.Objects;
-
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.form.FormItemName;
 import com.enonic.xp.schema.mixin.MixinName;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class MediaInfo
@@ -43,7 +43,7 @@ public final class MediaInfo
     private MediaInfo( final Builder builder )
     {
         this.mediaType = builder.mediaType;
-        this.metadata = Objects.requireNonNull( builder.metadata.build(), "metadata cannot be null" );
+        this.metadata = requireNonNull( builder.metadata.build(), "metadata cannot be null" );
         this.textContent = builder.textContent;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/name/Name.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/name/Name.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.name;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 
 import com.enonic.xp.core.internal.NameValidator;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -19,7 +19,7 @@ public abstract class Name
 
     protected Name( final String name, final boolean validate )
     {
-        this.value = Objects.requireNonNull( validate ? NameValidator.NAME.cachedExtend( getClass() ).validate( name ) : name );
+        this.value = requireNonNull( validate ? NameValidator.NAME.cachedExtend( getClass() ).validate( name ) : name );
     }
 
     @Override

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/ApplyNodePermissionsParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/ApplyNodePermissionsParams.java
@@ -1,11 +1,12 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.branch.Branches;
 import com.enonic.xp.security.acl.AccessControlList;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class ApplyNodePermissionsParams
@@ -28,14 +29,14 @@ public final class ApplyNodePermissionsParams
 
     private ApplyNodePermissionsParams( Builder builder )
     {
-        nodeId = Objects.requireNonNull( builder.nodeId );
-        scope = Objects.requireNonNullElse( builder.scope, ApplyPermissionsScope.SINGLE );
+        nodeId = requireNonNull( builder.nodeId );
+        scope = requireNonNullElse( builder.scope, ApplyPermissionsScope.SINGLE );
         permissions = builder.permissions.build();
         addPermissions = builder.addPermissions.build();
         removePermissions = builder.removePermissions.build();
         versionAttributesResolver = builder.versionAttributesResolver;
         listener = builder.listener;
-        branches = Objects.requireNonNullElse( builder.branches, Branches.empty() );
+        branches = requireNonNullElse( builder.branches, Branches.empty() );
 
         Preconditions.checkArgument( permissions.isEmpty() || ( addPermissions.isEmpty() && removePermissions.isEmpty() ),
                                      "Permissions cannot be set together with addPermissions or removePermissions" );

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/ApplyVersionAttributesParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/ApplyVersionAttributesParams.java
@@ -1,12 +1,13 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
 import java.util.Set;
 
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import com.google.common.collect.ImmutableSet;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Represents the parameters used to apply attributes to a specific node version.
@@ -25,7 +26,7 @@ public final class ApplyVersionAttributesParams
 
     private ApplyVersionAttributesParams( final Builder builder )
     {
-        this.nodeVersionId = Objects.requireNonNull( builder.nodeVersionId );
+        this.nodeVersionId = requireNonNull( builder.nodeVersionId );
         this.addAttributes = builder.addAttributes.build();
         this.removeAttributes = builder.removeAttributes.build();
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/CreateNodeParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/CreateNodeParams.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
 
 import com.enonic.xp.data.PropertyTree;
@@ -9,6 +7,9 @@ import com.enonic.xp.index.ChildOrder;
 import com.enonic.xp.index.IndexConfigDocument;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.util.BinaryReference;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class CreateNodeParams
@@ -49,9 +50,9 @@ public final class CreateNodeParams
         this.indexConfigDocument = builder.indexConfigDocument;
         this.childOrder = builder.childOrder;
         this.nodeId = builder.nodeId;
-        this.permissions = Objects.requireNonNullElse( builder.permissions, AccessControlList.empty() );
+        this.permissions = requireNonNullElse( builder.permissions, AccessControlList.empty() );
         this.inheritPermissions = builder.inheritPermissions;
-        this.insertManualStrategy = Objects.requireNonNullElse( builder.insertManualStrategy, InsertManualStrategy.FIRST );
+        this.insertManualStrategy = requireNonNullElse( builder.insertManualStrategy, InsertManualStrategy.FIRST );
         this.manualOrderValue = builder.manualOrderValue;
         this.nodeType = builder.nodeType;
         this.binaryAttachments = builder.binaryAttachments.build();
@@ -304,7 +305,7 @@ public final class CreateNodeParams
 
         public CreateNodeParams build()
         {
-            Objects.requireNonNull( parent, "parent is required" );
+            requireNonNull( parent, "parent is required" );
 
             return new CreateNodeParams( this );
         }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/CreateRootNodeParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/CreateRootNodeParams.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.index.ChildOrder;
@@ -12,6 +10,8 @@ import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.acl.AccessControlEntry;
 import com.enonic.xp.security.acl.AccessControlList;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class CreateRootNodeParams
 {
@@ -21,7 +21,7 @@ public final class CreateRootNodeParams
 
     private CreateRootNodeParams( Builder builder )
     {
-        Objects.requireNonNull( builder.permissions, "Missing permissions for root node" );
+        requireNonNull( builder.permissions, "Missing permissions for root node" );
         Preconditions.checkArgument( !builder.permissions.isEmpty(), "Missing permissions for root node" );
         childOrder = builder.childOrder;
         permissions = builder.permissions;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/DuplicateNodeParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/DuplicateNodeParams.java
@@ -1,6 +1,7 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class DuplicateNodeParams
@@ -120,7 +121,7 @@ public final class DuplicateNodeParams
 
         public Builder includeChildren( final Boolean includeChildren )
         {
-            this.includeChildren = Objects.requireNonNullElse( includeChildren, true );
+            this.includeChildren = requireNonNullElse( includeChildren, true );
             return this;
         }
 
@@ -150,7 +151,7 @@ public final class DuplicateNodeParams
 
         private void validate()
         {
-            Objects.requireNonNull( this.nodeId, "nodeId is required" );
+            requireNonNull( this.nodeId, "nodeId is required" );
         }
 
         public DuplicateNodeParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/DuplicateNodeResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/DuplicateNodeResult.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 public class DuplicateNodeResult
 {
@@ -53,7 +53,7 @@ public class DuplicateNodeResult
 
         private void validate()
         {
-            Objects.requireNonNull( node, "node is required" );
+            requireNonNull( node, "node is required" );
         }
 
         public DuplicateNodeResult build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/FindNodesByParentResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/FindNodesByParentResult.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class FindNodesByParentResult
@@ -12,7 +12,7 @@ public final class FindNodesByParentResult
     private FindNodesByParentResult( final long totalHits, final NodeIds nodeIds )
     {
         this.totalHits = totalHits;
-        this.nodeIds = Objects.requireNonNull( nodeIds );
+        this.nodeIds = requireNonNull( nodeIds );
     }
 
     public static Builder create()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/GetActiveNodeVersionsParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/GetActiveNodeVersionsParams.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import com.enonic.xp.branch.Branches;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -17,8 +17,8 @@ public final class GetActiveNodeVersionsParams
 
     private GetActiveNodeVersionsParams( Builder builder )
     {
-        nodeId = Objects.requireNonNull( builder.nodeId, "nodeId is required" );
-        branches = Objects.requireNonNull( builder.branches, "branches is required" );
+        nodeId = requireNonNull( builder.nodeId, "nodeId is required" );
+        branches = requireNonNull( builder.branches, "branches is required" );
     }
 
     public static Builder create()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/GetNodeVersionsParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/GetNodeVersionsParams.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -18,7 +18,7 @@ public final class GetNodeVersionsParams
 
     private GetNodeVersionsParams( Builder builder )
     {
-        nodeId = Objects.requireNonNull( builder.nodeId, "nodeId cannot be null" );
+        nodeId = requireNonNull( builder.nodeId, "nodeId cannot be null" );
         cursor = builder.cursor;
         size = builder.size;
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/GetNodeVersionsResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/GetNodeVersionsResult.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -18,7 +18,7 @@ public final class GetNodeVersionsResult
 
     private GetNodeVersionsResult( Builder builder )
     {
-        nodeVersions = Objects.requireNonNull( builder.nodeVersions );
+        nodeVersions = requireNonNull( builder.nodeVersions );
         totalHits = builder.totalHits;
         cursor = builder.cursor;
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/ImportNodeResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/ImportNodeResult.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 public final class ImportNodeResult
 {
@@ -54,7 +54,7 @@ public final class ImportNodeResult
 
         private void validate()
         {
-            Objects.requireNonNull( node );
+            requireNonNull( node );
         }
 
         public ImportNodeResult build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/MoveNodeParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/MoveNodeParams.java
@@ -1,8 +1,9 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class MoveNodeParams
@@ -23,12 +24,12 @@ public final class MoveNodeParams
 
     private MoveNodeParams( final Builder builder )
     {
-        this.nodeId = Objects.requireNonNull( builder.nodeId, "nodeId is required" );
+        this.nodeId = requireNonNull( builder.nodeId, "nodeId is required" );
         this.newName = builder.newName;
         this.newParentPath = builder.newParentPath;
         this.versionAttributesResolver = builder.versionAttributesResolver;
         this.moveListener = builder.moveListener;
-        this.processor = Objects.requireNonNullElse( builder.processor, ( n, p ) -> n );
+        this.processor = requireNonNullElse( builder.processor, ( n, p ) -> n );
         this.refresh = builder.refresh;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/MoveNodeResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/MoveNodeResult.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.node;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.google.common.collect.ImmutableList;
+
+import static java.util.Objects.requireNonNull;
 
 public final class MoveNodeResult
 {
@@ -75,8 +75,8 @@ public final class MoveNodeResult
 
             private void validate()
             {
-                Objects.requireNonNull( previousPath );
-                Objects.requireNonNull( node );
+                requireNonNull( previousPath );
+                requireNonNull( node );
             }
 
             public MovedNode build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/MultiRepoNodeQuery.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/MultiRepoNodeQuery.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 public final class MultiRepoNodeQuery
 {
@@ -10,8 +10,8 @@ public final class MultiRepoNodeQuery
 
     public MultiRepoNodeQuery( final SearchTargets searchTargets, final NodeQuery nodeQuery )
     {
-        this.searchTargets = Objects.requireNonNull( searchTargets );
-        this.nodeQuery = Objects.requireNonNull( nodeQuery );
+        this.searchTargets = requireNonNull( searchTargets );
+        this.nodeQuery = requireNonNull( nodeQuery );
     }
 
     public SearchTargets getSearchTargets()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/Node.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/Node.java
@@ -11,6 +11,9 @@ import com.enonic.xp.index.IndexConfigDocument;
 import com.enonic.xp.index.PatternIndexConfigDocument;
 import com.enonic.xp.security.acl.AccessControlList;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
 
 public final class Node
 {
@@ -78,7 +81,7 @@ public final class Node
             this.path = null;
         }
 
-        this.indexConfigDocument = Objects.requireNonNullElse( builder.indexConfigDocument, DEFAULT_INDEX_CONFIG );
+        this.indexConfigDocument = requireNonNullElse( builder.indexConfigDocument, DEFAULT_INDEX_CONFIG );
     }
 
     public boolean isRoot()
@@ -315,11 +318,11 @@ public final class Node
 
         private void validate()
         {
-            Objects.requireNonNull( this.permissions, "permissions is required" );
-            Objects.requireNonNull( this.data, "data is required" );
+            requireNonNull( this.permissions, "permissions is required" );
+            requireNonNull( this.data, "data is required" );
             if ( NodeId.ROOT.equals( this.id ) )
             {
-                Objects.requireNonNull( this.childOrder, "childOrder is required" );
+                requireNonNull( this.childOrder, "childOrder is required" );
             }
         }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/NodePath.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/NodePath.java
@@ -5,13 +5,13 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Splitter;
 
 import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
 
 
 public final class NodePath
@@ -33,7 +33,7 @@ public final class NodePath
 
     public NodePath( final String path )
     {
-        Objects.requireNonNull( emptyToNull( path ), "path not given" );
+        requireNonNull( emptyToNull( path ), "path not given" );
         if ( path.equals( ELEMENT_DIVIDER ) )
         {
             this.path = ELEMENT_DIVIDER;
@@ -157,7 +157,7 @@ public final class NodePath
 
         private Builder( final NodePath source )
         {
-            Objects.requireNonNull( source, "source to build copy from not given" );
+            requireNonNull( source, "source to build copy from not given" );
             this.elementListBuilder = source.isRoot() ? new ArrayList<>() : toElements( source.path );
         }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/NodeType.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/NodeType.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class NodeType
@@ -11,7 +11,7 @@ public final class NodeType
 
     private NodeType( final String name )
     {
-        this.name = Objects.requireNonNull( name );
+        this.name = requireNonNull( name );
     }
 
     public static NodeType from( final String name )

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/NodeVersion.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/NodeVersion.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import com.enonic.xp.blob.BlobKeys;
 import com.enonic.xp.core.internal.Millis;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class NodeVersion
 {
@@ -27,13 +29,13 @@ public final class NodeVersion
 
     private NodeVersion( Builder builder )
     {
-        nodeVersionId = Objects.requireNonNull( builder.nodeVersionId );
-        nodeVersionKey = Objects.requireNonNull( builder.nodeVersionKey );
-        binaryBlobKeys = Objects.requireNonNull( builder.binaryBlobKeys );
-        nodeId = Objects.requireNonNull( builder.nodeId );
-        nodePath = Objects.requireNonNull( builder.nodePath );
+        nodeVersionId = requireNonNull( builder.nodeVersionId );
+        nodeVersionKey = requireNonNull( builder.nodeVersionKey );
+        binaryBlobKeys = requireNonNull( builder.binaryBlobKeys );
+        nodeId = requireNonNull( builder.nodeId );
+        nodePath = requireNonNull( builder.nodePath );
         nodeCommitId = builder.nodeCommitId;
-        timestamp = Objects.requireNonNull( Millis.from( builder.timestamp ) );
+        timestamp = requireNonNull( Millis.from( builder.timestamp ) );
         attributes = builder.attributes;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/NodeVersionKey.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/NodeVersionKey.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 
 import com.enonic.xp.blob.BlobKey;
 
+import static java.util.Objects.requireNonNull;
+
 public final class NodeVersionKey
 {
     private final BlobKey nodeBlobKey;
@@ -14,9 +16,9 @@ public final class NodeVersionKey
 
     private NodeVersionKey( final Builder builder )
     {
-        nodeBlobKey = Objects.requireNonNull( builder.nodeBlobKey );
-        indexConfigBlobKey = Objects.requireNonNull( builder.indexConfigBlobKey );
-        accessControlBlobKey = Objects.requireNonNull( builder.accessControlBlobKey );
+        nodeBlobKey = requireNonNull( builder.nodeBlobKey );
+        indexConfigBlobKey = requireNonNull( builder.indexConfigBlobKey );
+        accessControlBlobKey = requireNonNull( builder.accessControlBlobKey );
     }
 
     public BlobKey getNodeBlobKey()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/NodeVersionQueryResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/NodeVersionQueryResult.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -15,7 +15,7 @@ public final class NodeVersionQueryResult
 
     private NodeVersionQueryResult( Builder builder )
     {
-        nodeVersions = Objects.requireNonNull( builder.nodeVersions );
+        nodeVersions = requireNonNull( builder.nodeVersions );
         totalHits = builder.totalHits;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/PatchNodeParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/PatchNodeParams.java
@@ -1,11 +1,12 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
 
 import com.enonic.xp.branch.Branches;
 import com.enonic.xp.util.BinaryReference;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class PatchNodeParams
@@ -32,7 +33,7 @@ public final class PatchNodeParams
         this.binaryAttachments = builder.binaryAttachments.build();
         this.versionAttributesResolver = builder.versionAttributesResolver;
         this.refresh = builder.refresh;
-        this.branches = Objects.requireNonNullElse( builder.branches, Branches.empty() );
+        this.branches = requireNonNullElse( builder.branches, Branches.empty() );
     }
 
     public static Builder create()
@@ -159,7 +160,7 @@ public final class PatchNodeParams
             {
                 throw new IllegalArgumentException( "Either id or path is required" );
             }
-            Objects.requireNonNull( this.editor, "editor is required" );
+            requireNonNull( this.editor, "editor is required" );
         }
     }
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/PushNodeParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/PushNodeParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.branch.Branch;
+
+import static java.util.Objects.requireNonNull;
 
 public final class PushNodeParams
 {
@@ -16,8 +16,8 @@ public final class PushNodeParams
 
     private PushNodeParams( final Builder builder )
     {
-        this.ids = Objects.requireNonNull( builder.ids, "ids is required" );
-        this.target = Objects.requireNonNull( builder.target, "target is required" );
+        this.ids = requireNonNull( builder.ids, "ids is required" );
+        this.target = requireNonNull( builder.target, "target is required" );
         this.pushListener = builder.pushListener;
         this.processor = builder.processor;
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/PushNodeResult.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/PushNodeResult.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class PushNodeResult
@@ -58,7 +58,7 @@ public final class PushNodeResult
 
     public static PushNodeResult failure( final NodeId nodeId, final NodePath nodePath, final Reason failureReason )
     {
-        return new PushNodeResult( nodeId, nodePath, null, null, Objects.requireNonNull( failureReason ) );
+        return new PushNodeResult( nodeId, nodePath, null, null, requireNonNull( failureReason ) );
     }
 
     public enum Reason

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/ReorderChildNodeParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/ReorderChildNodeParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ReorderChildNodeParams
@@ -56,7 +56,7 @@ public final class ReorderChildNodeParams
 
         public ReorderChildNodeParams build()
         {
-            Objects.requireNonNull( nodeId, "nodeId is required" );
+            requireNonNull( nodeId, "nodeId is required" );
             Preconditions.checkArgument( !nodeId.equals( moveBefore ), "nodeId and moveBefore must be different" );
             return new ReorderChildNodeParams( this );
         }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/SearchTarget.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/SearchTarget.java
@@ -1,13 +1,14 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.security.PrincipalKeys;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 @NullMarked
 public final class SearchTarget
@@ -20,9 +21,9 @@ public final class SearchTarget
 
     private SearchTarget( final Builder builder )
     {
-        this.principalKeys = Objects.requireNonNullElse( builder.principalKeys, PrincipalKeys.empty() );
-        this.branch = Objects.requireNonNull( builder.branch, "branch is required" );
-        this.repositoryId = Objects.requireNonNull( builder.repositoryId, "repositoryId is required" );
+        this.principalKeys = requireNonNullElse( builder.principalKeys, PrincipalKeys.empty() );
+        this.branch = requireNonNull( builder.branch, "branch is required" );
+        this.repositoryId = requireNonNull( builder.repositoryId, "repositoryId is required" );
     }
 
     public static Builder create()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/SortNodeParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/SortNodeParams.java
@@ -1,11 +1,12 @@
 package com.enonic.xp.node;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.google.common.collect.ImmutableList;
 
 import com.enonic.xp.index.ChildOrder;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class SortNodeParams
@@ -33,8 +34,8 @@ public final class SortNodeParams
         this.manualOrderSeed = builder.manualOrderSeed;
         this.reorderChildNodes = builder.reorderChildNodes.build();
         this.versionAttributesResolver = builder.versionAttributesResolver;
-        this.processor = Objects.requireNonNullElse( builder.processor, ( n, p ) -> n );
-        this.childProcessor = Objects.requireNonNullElse( builder.childProcessor, ( n, p ) -> n );
+        this.processor = requireNonNullElse( builder.processor, ( n, p ) -> n );
+        this.childProcessor = requireNonNullElse( builder.childProcessor, ( n, p ) -> n );
         this.refresh = builder.refresh;
     }
 
@@ -155,8 +156,8 @@ public final class SortNodeParams
 
         public SortNodeParams build()
         {
-            Objects.requireNonNull( nodeId, "nodeId is required" );
-            Objects.requireNonNull( childOrder, "childOrder is required" );
+            requireNonNull( nodeId, "nodeId is required" );
+            requireNonNull( childOrder, "childOrder is required" );
             return new SortNodeParams( this );
         }
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/UUID.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/UUID.java
@@ -1,10 +1,11 @@
 package com.enonic.xp.node;
 
 
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 import com.google.common.base.Preconditions;
+
+import static java.util.Objects.requireNonNull;
 
 
 public class UUID
@@ -31,14 +32,14 @@ public class UUID
         }
         else
         {
-            Objects.requireNonNull( object, "UUID cannot be null" );
+            requireNonNull( object, "UUID cannot be null" );
             this.value = check( object.toString() );
         }
     }
 
     private static String check( String value )
     {
-        Objects.requireNonNull( value, "UUID cannot be null" );
+        requireNonNull( value, "UUID cannot be null" );
         Preconditions.checkArgument( !value.isBlank(), "UUID cannot be blank" );
         Preconditions.checkArgument( value.length() <= 256, "UUID cannot exceed 256 characters: %s", value );
         Preconditions.checkArgument( VALID_NODE_ID_PATTERN.matcher( value ).matches(), "UUID format incorrect: %s", value );

--- a/modules/core/core-api/src/main/java/com/enonic/xp/node/UpdateNodeParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/node/UpdateNodeParams.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.node;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteSource;
 
 import com.enonic.xp.util.BinaryReference;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class UpdateNodeParams
@@ -140,7 +140,7 @@ public final class UpdateNodeParams
         private void validate()
         {
             Preconditions.checkArgument( this.id != null || this.path != null, "Either id or path is required" );
-            Objects.requireNonNull( this.editor, "editor is required" );
+            requireNonNull( this.editor, "editor is required" );
         }
     }
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/page/CreatePageParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/page/CreatePageParams.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.page;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.descriptor.DescriptorKey;
 import com.enonic.xp.region.Component;
 import com.enonic.xp.region.Regions;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class CreatePageParams
@@ -104,6 +104,6 @@ public final class CreatePageParams
 
     public void validate()
     {
-        Objects.requireNonNull( this.content, "content is required" );
+        requireNonNull( this.content, "content is required" );
     }
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/page/PageDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/page/PageDescriptor.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.page;
 
-import java.util.Objects;
-
 import com.enonic.xp.descriptor.DescriptorKey;
 import com.enonic.xp.region.ComponentDescriptor;
 import com.enonic.xp.region.RegionDescriptors;
 import com.enonic.xp.resource.ResourceKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class PageDescriptor
@@ -17,7 +17,7 @@ public final class PageDescriptor
     private PageDescriptor( final Builder builder )
     {
         super( builder );
-        this.regions = Objects.requireNonNull( builder.regions, "regions cannot be null" );
+        this.regions = requireNonNull( builder.regions, "regions cannot be null" );
     }
 
     @Override

--- a/modules/core/core-api/src/main/java/com/enonic/xp/project/CreateProjectParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/project/CreateProjectParams.java
@@ -2,13 +2,13 @@ package com.enonic.xp.project;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
-
 import com.google.common.collect.ImmutableList;
 
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.site.SiteConfig;
 import com.enonic.xp.site.SiteConfigs;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class CreateProjectParams
@@ -157,7 +157,7 @@ public final class CreateProjectParams
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
+            requireNonNull( name, "name is required" );
         }
 
         public CreateProjectParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/project/ModifyProjectIconParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/project/ModifyProjectIconParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.project;
 
-import java.util.Objects;
-
 import com.enonic.xp.attachment.CreateAttachment;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ModifyProjectIconParams
@@ -72,7 +72,7 @@ public final class ModifyProjectIconParams
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
+            requireNonNull( name, "name is required" );
         }
 
         public ModifyProjectIconParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/project/ModifyProjectParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/project/ModifyProjectParams.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.project;
 
-import java.util.Objects;
-
 import com.enonic.xp.site.SiteConfig;
 import com.enonic.xp.site.SiteConfigs;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ModifyProjectParams
@@ -89,7 +89,7 @@ public final class ModifyProjectParams
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
+            requireNonNull( name, "name is required" );
         }
 
         public ModifyProjectParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/project/Project.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/project/Project.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.project;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.google.common.collect.ImmutableList;
 
 import com.enonic.xp.attachment.Attachment;
 import com.enonic.xp.site.SiteConfig;
 import com.enonic.xp.site.SiteConfigs;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class Project
@@ -136,7 +136,7 @@ public final class Project
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
+            requireNonNull( name, "name is required" );
         }
 
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/project/ProjectGraphEntry.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/project/ProjectGraphEntry.java
@@ -2,10 +2,11 @@ package com.enonic.xp.project;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ProjectGraphEntry
@@ -77,7 +78,7 @@ public final class ProjectGraphEntry
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
+            requireNonNull( name, "name is required" );
         }
 
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/project/ProjectName.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/project/ProjectName.java
@@ -2,11 +2,12 @@ package com.enonic.xp.project;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 import com.enonic.xp.core.internal.NameValidator;
 import com.enonic.xp.repository.RepositoryId;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ProjectName
@@ -29,7 +30,7 @@ public final class ProjectName
 
     private ProjectName( final String value )
     {
-        this.value = Objects.requireNonNull( value );
+        this.value = requireNonNull( value );
     }
 
     public static ProjectName from( final String projectName )

--- a/modules/core/core-api/src/main/java/com/enonic/xp/query/expr/DslOrderExpr.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/query/expr/DslOrderExpr.java
@@ -10,6 +10,7 @@ import com.enonic.xp.data.PropertySet;
 import com.enonic.xp.data.PropertyTree;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
 
 
 public final class DslOrderExpr
@@ -37,8 +38,8 @@ public final class DslOrderExpr
         this.language = isNullOrEmpty( langString ) ? null : Locale.forLanguageTag( langString );
 
         final PropertySet location = expression.getSet( "location" );
-        this.lat = location != null ? Objects.requireNonNull( location.getDouble( "lat" ) ) : null;
-        this.lon = location != null ? Objects.requireNonNull( location.getDouble( "lon" ) ) : null;
+        this.lat = location != null ? requireNonNull( location.getDouble( "lat" ) ) : null;
+        this.lon = location != null ? requireNonNull( location.getDouble( "lon" ) ) : null;
     }
 
     public static DslOrderExpr from( final PropertyTree expression )

--- a/modules/core/core-api/src/main/java/com/enonic/xp/query/expr/FieldExpr.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/query/expr/FieldExpr.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.query.expr;
 
-import java.util.Objects;
-
 import com.enonic.xp.index.IndexPath;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class FieldExpr
@@ -12,7 +12,7 @@ public final class FieldExpr
 
     private FieldExpr( final IndexPath indexPath )
     {
-        this.indexPath = Objects.requireNonNull( indexPath );
+        this.indexPath = requireNonNull( indexPath );
     }
 
     @Deprecated

--- a/modules/core/core-api/src/main/java/com/enonic/xp/query/expr/FieldOrderExpr.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/query/expr/FieldOrderExpr.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 import com.enonic.xp.index.IndexPath;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class FieldOrderExpr
     extends OrderExpr
@@ -21,7 +23,7 @@ public final class FieldOrderExpr
     public FieldOrderExpr( final FieldExpr field, final Locale language, final Direction direction )
     {
         super( direction );
-        this.field = Objects.requireNonNull( field );
+        this.field = requireNonNull( field );
         this.language = language;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/query/filter/FieldFilter.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/query/filter/FieldFilter.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.query.filter;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public abstract class FieldFilter
@@ -11,7 +11,7 @@ public abstract class FieldFilter
     protected FieldFilter( final Builder builder )
     {
         super( builder );
-        this.fieldName = Objects.requireNonNull( builder.fieldName );
+        this.fieldName = requireNonNull( builder.fieldName );
     }
 
     public String getFieldName()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/query/highlight/HighlightQueryProperty.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/query/highlight/HighlightQueryProperty.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.query.highlight;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.enonic.xp.query.highlight.constants.Fragmenter;
 import com.enonic.xp.query.highlight.constants.Order;
+
+import static java.util.Objects.requireNonNull;
 
 public final class HighlightQueryProperty
 {
@@ -91,7 +91,7 @@ public final class HighlightQueryProperty
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
+            requireNonNull( name, "name is required" );
         }
 
         public HighlightQueryProperty build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/query/suggester/SuggestionQuery.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/query/suggester/SuggestionQuery.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.query.suggester;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 public abstract class SuggestionQuery
 {
@@ -16,9 +16,9 @@ public abstract class SuggestionQuery
 
     protected SuggestionQuery( final SuggestionQuery.Builder builder )
     {
-        this.name = Objects.requireNonNull( builder.name, "name is required" );
-        this.field = Objects.requireNonNull( builder.field, "field is required" );
-        this.text = Objects.requireNonNull( builder.text, "text is required" );
+        this.name = requireNonNull( builder.name, "name is required" );
+        this.field = requireNonNull( builder.field, "field is required" );
+        this.text = requireNonNull( builder.text, "text is required" );
         this.size = builder.size;
         this.analyzer = builder.analyzer;
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/region/ComponentDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/region/ComponentDescriptor.java
@@ -1,14 +1,14 @@
 package com.enonic.xp.region;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.descriptor.Descriptor;
 import com.enonic.xp.descriptor.DescriptorKey;
 import com.enonic.xp.form.Form;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.schema.LocalizedText;
 import com.enonic.xp.util.GenericValue;
+
+import static java.util.Objects.requireNonNullElse;
 
 
 public abstract class ComponentDescriptor
@@ -37,7 +37,7 @@ public abstract class ComponentDescriptor
         this.description = builder.description;
         this.descriptionI18nKey = builder.descriptionI18nKey;
         this.modifiedTime = builder.modifiedTime;
-        this.config = Objects.requireNonNullElse( builder.config, Form.empty() );
+        this.config = requireNonNullElse( builder.config, Form.empty() );
         this.schemaConfig = builder.schemaConfig.build();
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/region/CreateFragmentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/region/CreateFragmentParams.java
@@ -6,6 +6,8 @@ import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.content.WorkflowInfo;
 import com.enonic.xp.data.PropertyTree;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class CreateFragmentParams
 {
@@ -125,9 +127,9 @@ public final class CreateFragmentParams
 
         private void validate()
         {
-            Objects.requireNonNull( parentPath, "parentPath is required" );
-            Objects.requireNonNull( component, "component is required" );
-            Objects.requireNonNull( workflowInfo, "workflowInfo is required" );
+            requireNonNull( parentPath, "parentPath is required" );
+            requireNonNull( component, "component is required" );
+            requireNonNull( workflowInfo, "workflowInfo is required" );
         }
 
         public CreateFragmentParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/region/LayoutDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/region/LayoutDescriptor.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.region;
 
-import java.util.Objects;
-
 import com.enonic.xp.descriptor.DescriptorKey;
 import com.enonic.xp.resource.ResourceKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class LayoutDescriptor
@@ -14,7 +14,7 @@ public final class LayoutDescriptor
     private LayoutDescriptor( final Builder builder )
     {
         super( builder );
-        this.regions = Objects.requireNonNull( builder.regions, "regions cannot be null" );
+        this.regions = requireNonNull( builder.regions, "regions cannot be null" );
     }
 
     public RegionDescriptors getRegions()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/region/Region.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/region/Region.java
@@ -8,6 +8,8 @@ import java.util.Objects;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class Region
 {
@@ -19,7 +21,7 @@ public final class Region
 
     public Region( final Builder builder )
     {
-        this.name = Objects.requireNonNull( builder.name, "name cannot be null" );
+        this.name = requireNonNull( builder.name, "name cannot be null" );
         this.parent = builder.parent;
         this.components = ImmutableList.copyOf( builder.components );
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/region/RegionDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/region/RegionDescriptor.java
@@ -3,6 +3,8 @@ package com.enonic.xp.region;
 
 import java.util.Objects;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class RegionDescriptor
 {
@@ -10,7 +12,7 @@ public final class RegionDescriptor
 
     private RegionDescriptor( final Builder builder )
     {
-        this.name = Objects.requireNonNull( builder.name, "name cannot be null" );
+        this.name = requireNonNull( builder.name, "name cannot be null" );
     }
 
     public String getName()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/region/RegionPath.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/region/RegionPath.java
@@ -2,6 +2,8 @@ package com.enonic.xp.region;
 
 import java.util.Objects;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class RegionPath
 {
@@ -14,7 +16,7 @@ public final class RegionPath
     private RegionPath( final ComponentPath parentComponentPath, final String regionName )
     {
         this.parentComponentPath = parentComponentPath;
-        this.regionName = Objects.requireNonNull( regionName, "regionName cannot be null" );
+        this.regionName = requireNonNull( regionName, "regionName cannot be null" );
 
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/region/Regions.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/region/Regions.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.region;
 
 import java.util.Iterator;
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class Regions
@@ -36,7 +36,7 @@ public final class Regions
 
     public Component getComponent( final ComponentPath path )
     {
-        Objects.requireNonNull( path, "no path for Component given" );
+        requireNonNull( path, "no path for Component given" );
         Preconditions.checkArgument( path.numberOfLevels() > 0, "empty path for Component given" );
 
         final ComponentPath.RegionAndComponent first = path.getFirstLevel();

--- a/modules/core/core-api/src/main/java/com/enonic/xp/repository/CreateRepositoryParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/repository/CreateRepositoryParams.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.repository;
 
-import java.util.Objects;
-
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.index.ChildOrder;
 import com.enonic.xp.security.acl.AccessControlList;
+
+import static java.util.Objects.requireNonNull;
 
 public final class CreateRepositoryParams
 {
@@ -111,7 +111,7 @@ public final class CreateRepositoryParams
 
         private void validate()
         {
-            Objects.requireNonNull( repositoryId, "repositoryId is required" );
+            requireNonNull( repositoryId, "repositoryId is required" );
         }
 
         public CreateRepositoryParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/repository/Repository.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/repository/Repository.java
@@ -1,13 +1,14 @@
 package com.enonic.xp.repository;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.branch.Branches;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.node.AttachedBinaries;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElseGet;
 
 
 public final class Repository
@@ -26,8 +27,8 @@ public final class Repository
     {
         this.id = builder.id;
         this.branches = builder.branches;
-        this.data = Objects.requireNonNullElseGet( builder.data, PropertyTree::new );
-        this.attachments = Objects.requireNonNullElseGet( builder.attachments, AttachedBinaries::empty );
+        this.data = requireNonNullElseGet( builder.data, PropertyTree::new );
+        this.attachments = requireNonNullElseGet( builder.attachments, AttachedBinaries::empty );
         this.transientFlag = builder.transientFlag;
     }
 
@@ -116,7 +117,7 @@ public final class Repository
 
         private void validate()
         {
-            Objects.requireNonNull( branches, "branches is required" );
+            requireNonNull( branches, "branches is required" );
             Preconditions.checkArgument( branches.contains( RepositoryConstants.MASTER_BRANCH ), "branches must contain master branch" );
         }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/repository/RepositoryId.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/repository/RepositoryId.java
@@ -9,6 +9,8 @@ import org.jspecify.annotations.NullMarked;
 
 import com.enonic.xp.core.internal.NameValidator;
 
+import static java.util.Objects.requireNonNull;
+
 
 @NullMarked
 public final class RepositoryId
@@ -31,7 +33,7 @@ public final class RepositoryId
 
     private RepositoryId( final String value )
     {
-        this.value = Objects.requireNonNull( value );
+        this.value = requireNonNull( value );
     }
 
     @Override

--- a/modules/core/core-api/src/main/java/com/enonic/xp/repository/UpdateRepositoryParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/repository/UpdateRepositoryParams.java
@@ -1,7 +1,8 @@
 package com.enonic.xp.repository;
 
-import java.util.Objects;
 import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class UpdateRepositoryParams
@@ -55,7 +56,7 @@ public final class UpdateRepositoryParams
 
         private void validate()
         {
-            Objects.requireNonNull( repositoryId, "repositoryId is required" );
+            requireNonNull( repositoryId, "repositoryId is required" );
         }
 
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/CreateDynamicComponentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/CreateDynamicComponentParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.descriptor.DescriptorKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class CreateDynamicComponentParams
@@ -72,8 +72,8 @@ public final class CreateDynamicComponentParams
 
         private void validate()
         {
-            Objects.requireNonNull( key, "key is required" );
-            Objects.requireNonNull( type, "type is required" );
+            requireNonNull( key, "key is required" );
+            requireNonNull( type, "type is required" );
         }
 
         public CreateDynamicComponentParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/CreateDynamicContentSchemaParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/CreateDynamicContentSchemaParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.schema.BaseSchemaName;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class CreateDynamicContentSchemaParams
@@ -72,8 +72,8 @@ public final class CreateDynamicContentSchemaParams
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
-            Objects.requireNonNull( type, "type is required" );
+            requireNonNull( name, "name is required" );
+            requireNonNull( type, "type is required" );
         }
 
         public CreateDynamicContentSchemaParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/CreateDynamicStylesParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/CreateDynamicStylesParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.app.ApplicationKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class CreateDynamicStylesParams
@@ -56,8 +56,8 @@ public final class CreateDynamicStylesParams
 
         private void validate()
         {
-            Objects.requireNonNull( key, "key is required" );
-            Objects.requireNonNull( resource, "resource is required" );
+            requireNonNull( key, "key is required" );
+            requireNonNull( resource, "resource is required" );
         }
 
         public CreateDynamicStylesParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/DeleteDynamicComponentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/DeleteDynamicComponentParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.descriptor.DescriptorKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class DeleteDynamicComponentParams
@@ -56,8 +56,8 @@ public final class DeleteDynamicComponentParams
 
         private void validate()
         {
-            Objects.requireNonNull( key, "key is required" );
-            Objects.requireNonNull( type, "type is required" );
+            requireNonNull( key, "key is required" );
+            requireNonNull( type, "type is required" );
         }
 
         public DeleteDynamicComponentParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/DeleteDynamicContentSchemaParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/DeleteDynamicContentSchemaParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.schema.BaseSchemaName;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class DeleteDynamicContentSchemaParams
@@ -56,8 +56,8 @@ public final class DeleteDynamicContentSchemaParams
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
-            Objects.requireNonNull( type, "type is required" );
+            requireNonNull( name, "name is required" );
+            requireNonNull( type, "type is required" );
         }
 
         public DeleteDynamicContentSchemaParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/GetDynamicComponentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/GetDynamicComponentParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.descriptor.DescriptorKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class GetDynamicComponentParams
@@ -56,8 +56,8 @@ public final class GetDynamicComponentParams
 
         private void validate()
         {
-            Objects.requireNonNull( key, "key is required" );
-            Objects.requireNonNull( type, "type is required" );
+            requireNonNull( key, "key is required" );
+            requireNonNull( type, "type is required" );
         }
 
         public GetDynamicComponentParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/GetDynamicContentSchemaParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/GetDynamicContentSchemaParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.schema.BaseSchemaName;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class GetDynamicContentSchemaParams
@@ -56,8 +56,8 @@ public final class GetDynamicContentSchemaParams
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
-            Objects.requireNonNull( type, "type is required" );
+            requireNonNull( name, "name is required" );
+            requireNonNull( type, "type is required" );
         }
 
         public GetDynamicContentSchemaParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/ListDynamicComponentsParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/ListDynamicComponentsParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.app.ApplicationKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ListDynamicComponentsParams
@@ -56,8 +56,8 @@ public final class ListDynamicComponentsParams
 
         private void validate()
         {
-            Objects.requireNonNull( key, "key is required" );
-            Objects.requireNonNull( type, "type is required" );
+            requireNonNull( key, "key is required" );
+            requireNonNull( type, "type is required" );
         }
 
         public ListDynamicComponentsParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/ListDynamicContentSchemasParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/ListDynamicContentSchemasParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.app.ApplicationKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ListDynamicContentSchemasParams
@@ -56,8 +56,8 @@ public final class ListDynamicContentSchemasParams
 
         private void validate()
         {
-            Objects.requireNonNull( key, "key is required" );
-            Objects.requireNonNull( type, "type is required" );
+            requireNonNull( key, "key is required" );
+            requireNonNull( type, "type is required" );
         }
 
         public ListDynamicContentSchemasParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/ResourceKey.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/ResourceKey.java
@@ -7,6 +7,8 @@ import com.google.common.io.Files;
 
 import com.enonic.xp.app.ApplicationKey;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class ResourceKey
 {
@@ -106,7 +108,7 @@ public final class ResourceKey
 
     public static ResourceKey from( final String uri )
     {
-        Objects.requireNonNull( uri );
+        requireNonNull( uri );
 
         final int pos = uri.indexOf( ':' );
         Preconditions.checkArgument( pos > 0, "Invalid applicationKey file key uri specification" );
@@ -116,15 +118,15 @@ public final class ResourceKey
 
     public static ResourceKey from( final ApplicationKey application, final String path )
     {
-        Objects.requireNonNull( application );
-        Objects.requireNonNull( path );
+        requireNonNull( application );
+        requireNonNull( path );
 
         return new ResourceKey( application, normalizePath( path ) );
     }
 
     public static ResourceKey assets( final ApplicationKey application )
     {
-        Objects.requireNonNull( application );
+        requireNonNull( application );
 
         return new ResourceKey( application, "/assets/" );
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/ResourceProcessor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/ResourceProcessor.java
@@ -1,7 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
 import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ResourceProcessor<K, V>
 {
@@ -83,10 +84,10 @@ public final class ResourceProcessor<K, V>
 
         public ResourceProcessor<K, V> build()
         {
-            Objects.requireNonNull( this.key, "key is required" );
-            Objects.requireNonNull( this.segment, "segment is required" );
-            Objects.requireNonNull( this.keyTranslator, "keyTranslator is required" );
-            Objects.requireNonNull( this.processor, "processor is required" );
+            requireNonNull( this.key, "key is required" );
+            requireNonNull( this.segment, "segment is required" );
+            requireNonNull( this.keyTranslator, "keyTranslator is required" );
+            requireNonNull( this.processor, "processor is required" );
 
             return new ResourceProcessor<>( this );
         }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/UpdateDynamicCmsParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/UpdateDynamicCmsParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.app.ApplicationKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class UpdateDynamicCmsParams
@@ -56,8 +56,8 @@ public final class UpdateDynamicCmsParams
 
         private void validate()
         {
-            Objects.requireNonNull( key, "key is required" );
-            Objects.requireNonNull( resource, "resource is required" );
+            requireNonNull( key, "key is required" );
+            requireNonNull( resource, "resource is required" );
         }
 
         public UpdateDynamicCmsParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/UpdateDynamicComponentParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/UpdateDynamicComponentParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.descriptor.DescriptorKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class UpdateDynamicComponentParams
@@ -72,8 +72,8 @@ public final class UpdateDynamicComponentParams
 
         private void validate()
         {
-            Objects.requireNonNull( key, "key is required" );
-            Objects.requireNonNull( type, "type is required" );
+            requireNonNull( key, "key is required" );
+            requireNonNull( type, "type is required" );
         }
 
         public UpdateDynamicComponentParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/UpdateDynamicContentSchemaParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/UpdateDynamicContentSchemaParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.schema.BaseSchemaName;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class UpdateDynamicContentSchemaParams
@@ -72,8 +72,8 @@ public final class UpdateDynamicContentSchemaParams
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
-            Objects.requireNonNull( type, "type is required" );
+            requireNonNull( name, "name is required" );
+            requireNonNull( type, "type is required" );
         }
 
         public UpdateDynamicContentSchemaParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/UpdateDynamicStylesParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/UpdateDynamicStylesParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.resource;
 
-import java.util.Objects;
-
 import com.enonic.xp.app.ApplicationKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class UpdateDynamicStylesParams
@@ -56,8 +56,8 @@ public final class UpdateDynamicStylesParams
 
         private void validate()
         {
-            Objects.requireNonNull( key, "key is required" );
-            Objects.requireNonNull( resource, "resource is required" );
+            requireNonNull( key, "key is required" );
+            requireNonNull( resource, "resource is required" );
         }
 
         public UpdateDynamicStylesParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/scheduler/CreateScheduledJobParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/scheduler/CreateScheduledJobParams.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.scheduler;
 
-import java.util.Objects;
-
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.descriptor.DescriptorKey;
 import com.enonic.xp.security.PrincipalKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class CreateScheduledJobParams
@@ -138,10 +138,10 @@ public final class CreateScheduledJobParams
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
-            Objects.requireNonNull( calendar, "calendar is required" );
-            Objects.requireNonNull( descriptor, "descriptor is required" );
-            Objects.requireNonNull( config, "config is required" );
+            requireNonNull( name, "name is required" );
+            requireNonNull( calendar, "calendar is required" );
+            requireNonNull( descriptor, "descriptor is required" );
+            requireNonNull( config, "config is required" );
         }
 
         public CreateScheduledJobParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/scheduler/ModifyScheduledJobParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/scheduler/ModifyScheduledJobParams.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.scheduler;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class ModifyScheduledJobParams
@@ -54,8 +54,8 @@ public final class ModifyScheduledJobParams
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
-            Objects.requireNonNull( editor, "editor is required" );
+            requireNonNull( name, "name is required" );
+            requireNonNull( editor, "editor is required" );
         }
 
         public ModifyScheduledJobParams build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/scheduler/ScheduledJob.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/scheduler/ScheduledJob.java
@@ -2,13 +2,13 @@ package com.enonic.xp.scheduler;
 
 import java.io.Serializable;
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.core.internal.Millis;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.descriptor.DescriptorKey;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.task.TaskId;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class ScheduledJob
@@ -241,10 +241,10 @@ public final class ScheduledJob
 
         private void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
-            Objects.requireNonNull( calendar, "calendar is required" );
-            Objects.requireNonNull( descriptor, "descriptor is required" );
-            Objects.requireNonNull( config, "config is required" );
+            requireNonNull( name, "name is required" );
+            requireNonNull( calendar, "calendar is required" );
+            requireNonNull( descriptor, "descriptor is required" );
+            requireNonNull( config, "config is required" );
         }
 
         public ScheduledJob build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/schema/BaseSchema.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/schema/BaseSchema.java
@@ -7,6 +7,8 @@ import java.util.Objects;
 import com.enonic.xp.icon.Icon;
 import com.enonic.xp.security.PrincipalKey;
 
+import static java.util.Objects.requireNonNull;
+
 
 public abstract class BaseSchema<T extends BaseSchemaName>
 {
@@ -148,7 +150,7 @@ public abstract class BaseSchema<T extends BaseSchemaName>
 
         public Builder( final BaseSchema schema )
         {
-            Objects.requireNonNull( schema, "BaseSchema cannot be null" );
+            requireNonNull( schema, "BaseSchema cannot be null" );
             this.name = (SCHEMA_NAME) schema.name;
             this.title = schema.title;
             this.titleI18nKey = schema.titleI18nKey;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/schema/BaseSchemaName.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/schema/BaseSchemaName.java
@@ -7,6 +7,8 @@ import org.jspecify.annotations.NullMarked;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.descriptor.DescriptorKey;
 
+import static java.util.Objects.requireNonNull;
+
 
 @NullMarked
 public abstract class BaseSchemaName
@@ -15,7 +17,7 @@ public abstract class BaseSchemaName
 
     protected BaseSchemaName( final String name )
     {
-        Objects.requireNonNull( name, "BaseSchemaName cannot be null" );
+        requireNonNull( name, "BaseSchemaName cannot be null" );
         this.descriptorKey = DescriptorKey.from( name );
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/schema/content/GetChildContentTypesParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/schema/content/GetChildContentTypesParams.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.schema.content;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class GetChildContentTypesParams
@@ -20,6 +20,6 @@ public final class GetChildContentTypesParams
 
     public void validate()
     {
-        Objects.requireNonNull( this.parentName, "parentName is required" );
+        requireNonNull( this.parentName, "parentName is required" );
     }
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/schema/content/GetContentTypeParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/schema/content/GetContentTypeParams.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.schema.content;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class GetContentTypeParams
@@ -31,6 +31,6 @@ public final class GetContentTypeParams
 
     public void validate()
     {
-        Objects.requireNonNull( this.contentTypeName, "contentTypeName is required" );
+        requireNonNull( this.contentTypeName, "contentTypeName is required" );
     }
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/CreateGroupParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/CreateGroupParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.security;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class CreateGroupParams
@@ -15,8 +15,8 @@ public final class CreateGroupParams
 
     private CreateGroupParams( final Builder builder )
     {
-        this.key = Objects.requireNonNull( builder.principalKey, "groupKey is required for a group" );
-        this.displayName = Objects.requireNonNull( builder.displayName, "displayName is required for a group" );
+        this.key = requireNonNull( builder.principalKey, "groupKey is required for a group" );
+        this.displayName = requireNonNull( builder.displayName, "displayName is required for a group" );
         this.description = builder.description;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/CreateIdProviderParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/CreateIdProviderParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.security;
 
-import java.util.Objects;
-
 import com.enonic.xp.security.acl.IdProviderAccessControlList;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class CreateIdProviderParams
@@ -20,8 +20,8 @@ public final class CreateIdProviderParams
 
     private CreateIdProviderParams( final Builder builder )
     {
-        this.idProviderKey = Objects.requireNonNull( builder.idProviderKey, "idProviderKey is required" );
-        this.displayName = Objects.requireNonNull( builder.displayName, "displayName is required" );
+        this.idProviderKey = requireNonNull( builder.idProviderKey, "idProviderKey is required" );
+        this.displayName = requireNonNull( builder.displayName, "displayName is required" );
         this.description = builder.description;
         this.idProviderConfig = builder.idProviderConfig;
         this.idProviderPermissions =

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/CreateRoleParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/CreateRoleParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.security;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class CreateRoleParams
@@ -15,8 +15,8 @@ public final class CreateRoleParams
 
     private CreateRoleParams( final Builder builder )
     {
-        this.key = Objects.requireNonNull( builder.principalKey, "roleKey is required for a role" );
-        this.displayName = Objects.requireNonNull( builder.displayName, "displayName is required for a role" );
+        this.key = requireNonNull( builder.principalKey, "roleKey is required for a role" );
+        this.displayName = requireNonNull( builder.displayName, "displayName is required for a role" );
         this.description = builder.description;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/CreateUserParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/CreateUserParams.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.security;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.mail.EmailValidator;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class CreateUserParams
@@ -21,14 +21,14 @@ public final class CreateUserParams
 
     private CreateUserParams( final Builder builder )
     {
-        this.key = Objects.requireNonNull( builder.principalKey, "userKey is required for a user" );
-        this.displayName = Objects.requireNonNull( builder.displayName, "displayName is required for a user" );
+        this.key = requireNonNull( builder.principalKey, "userKey is required for a user" );
+        this.displayName = requireNonNull( builder.displayName, "displayName is required for a user" );
         if ( builder.email != null )
         {
             Preconditions.checkArgument( EmailValidator.isValid( builder.email ), "Email [%s] is not valid", builder.email );
         }
         this.email = builder.email;
-        this.login = Objects.requireNonNull( builder.login, "login is required for a user" );
+        this.login = requireNonNull( builder.login, "login is required for a user" );
         this.password = builder.password;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/IdProviderConfig.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/IdProviderConfig.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.data.PropertyTree;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class IdProviderConfig
 {
@@ -15,7 +17,7 @@ public final class IdProviderConfig
 
     private IdProviderConfig( final Builder builder )
     {
-        this.applicationKey = Objects.requireNonNull( builder.applicationKey, "applicationKey cannot be null" );
+        this.applicationKey = requireNonNull( builder.applicationKey, "applicationKey cannot be null" );
         this.config = builder.config == null ? new PropertyTree() : builder.config;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/IdProviderKey.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/IdProviderKey.java
@@ -2,11 +2,11 @@ package com.enonic.xp.security;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 
 import com.enonic.xp.core.internal.NameValidator;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -28,7 +28,7 @@ public final class IdProviderKey
 
     private IdProviderKey( final String id )
     {
-        this.id = Objects.requireNonNull( id );
+        this.id = requireNonNull( id );
     }
 
     @Override
@@ -51,7 +51,7 @@ public final class IdProviderKey
 
     public static IdProviderKey from( final String id )
     {
-        return switch ( Objects.requireNonNull( id, "IdProviderKey cannot be null" ) )
+        return switch ( requireNonNull( id, "IdProviderKey cannot be null" ) )
         {
             case "system" -> SYSTEM;
             default ->

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/Principal.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/Principal.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 import com.enonic.xp.core.internal.Millis;
 
+import static java.util.Objects.requireNonNull;
+
 
 public abstract class Principal
     implements java.security.Principal
@@ -133,8 +135,8 @@ public abstract class Principal
 
         void validate()
         {
-            Objects.requireNonNull( key, "Principal key cannot be null" );
-            Objects.requireNonNull( displayName, "Principal display name cannot be null" );
+            requireNonNull( key, "Principal key cannot be null" );
+            requireNonNull( displayName, "Principal display name cannot be null" );
         }
     }
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/PrincipalKey.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/PrincipalKey.java
@@ -9,6 +9,8 @@ import java.util.regex.Pattern;
 import com.enonic.xp.core.internal.NameValidator;
 import com.enonic.xp.node.NodePath;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class PrincipalKey
     implements Serializable
@@ -51,13 +53,13 @@ public final class PrincipalKey
     private PrincipalKey( final IdProviderKey idProviderKey, final PrincipalType type, final String id )
     {
         this.idProviderKey = idProviderKey;
-        this.type = Objects.requireNonNull( type );
-        this.id = Objects.requireNonNull( id );
+        this.type = requireNonNull( type );
+        this.id = requireNonNull( id );
     }
 
     public static PrincipalKey from( final String principalKey )
     {
-        switch ( Objects.requireNonNull( principalKey, "PrincipalKey cannot be null" ) )
+        switch ( requireNonNull( principalKey, "PrincipalKey cannot be null" ) )
         {
             case "user:system:anonymous":
                 return ANONYMOUS_PRINCIPAL;
@@ -171,13 +173,13 @@ public final class PrincipalKey
 
     public static PrincipalKey ofUser( final IdProviderKey idProvider, final String userId )
     {
-        return new PrincipalKey( Objects.requireNonNull( idProvider, "User idProvider cannot be null" ), PrincipalType.USER,
+        return new PrincipalKey( requireNonNull( idProvider, "User idProvider cannot be null" ), PrincipalType.USER,
                                  ID_VALIDATOR.withSubject( "User id" ).validate( userId ) );
     }
 
     public static PrincipalKey ofGroup( final IdProviderKey idProvider, final String groupId )
     {
-        return new PrincipalKey( Objects.requireNonNull( idProvider, "Group idProvider cannot be null" ), PrincipalType.GROUP,
+        return new PrincipalKey( requireNonNull( idProvider, "Group idProvider cannot be null" ), PrincipalType.GROUP,
                                  ID_VALIDATOR.withSubject( "Group id" ).validate( groupId ) );
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/PrincipalRelationship.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/PrincipalRelationship.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 
 import com.google.common.base.Preconditions;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class PrincipalRelationship
 {
@@ -13,8 +15,8 @@ public final class PrincipalRelationship
 
     private PrincipalRelationship( final Builder builder )
     {
-        Objects.requireNonNull( builder.from, "Principal relationship 'from' cannot be null" );
-        Objects.requireNonNull( builder.to, "Principal relationship 'to' cannot be null" );
+        requireNonNull( builder.from, "Principal relationship 'from' cannot be null" );
+        requireNonNull( builder.to, "Principal relationship 'to' cannot be null" );
         Preconditions.checkArgument( !builder.from.equals( builder.to ),
                                      "Principal relationship 'from' and 'to' cannot refer to the same principal" );
         Preconditions.checkArgument( !( builder.from.isRole() && builder.to.isRole() ),

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/UpdateGroupParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/UpdateGroupParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.security;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class UpdateGroupParams
@@ -17,7 +17,7 @@ public final class UpdateGroupParams
 
     private UpdateGroupParams( final Builder builder )
     {
-        this.key = Objects.requireNonNull( builder.principalKey, "groupKey is required for a group" );
+        this.key = requireNonNull( builder.principalKey, "groupKey is required for a group" );
         this.displayName = builder.displayName;
         this.editor = builder.editor;
         this.description = builder.description;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/UpdateIdProviderParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/UpdateIdProviderParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.security;
 
-import java.util.Objects;
-
 import com.enonic.xp.security.acl.IdProviderAccessControlList;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class UpdateIdProviderParams
@@ -22,7 +22,7 @@ public final class UpdateIdProviderParams
 
     private UpdateIdProviderParams( final Builder builder )
     {
-        this.idProviderKey = Objects.requireNonNull( builder.idProviderKey, "idProviderKey is required" );
+        this.idProviderKey = requireNonNull( builder.idProviderKey, "idProviderKey is required" );
         this.displayName = builder.displayName;
         this.description = builder.description;
         this.idProviderConfig = builder.idProviderConfig;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/UpdateRoleParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/UpdateRoleParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.security;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class UpdateRoleParams
@@ -17,7 +17,7 @@ public final class UpdateRoleParams
 
     private UpdateRoleParams( final Builder builder )
     {
-        this.key = Objects.requireNonNull( builder.principalKey, "roleKey is required for a role" );
+        this.key = requireNonNull( builder.principalKey, "roleKey is required for a role" );
         this.displayName = builder.displayName;
         this.editor = builder.editor;
         this.description = builder.description;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/UpdateUserParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/UpdateUserParams.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.security;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.mail.EmailValidator;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class UpdateUserParams
@@ -21,7 +21,7 @@ public final class UpdateUserParams
 
     private UpdateUserParams( final Builder builder )
     {
-        this.key = Objects.requireNonNull( builder.principalKey, "userKey is required for a user" );
+        this.key = requireNonNull( builder.principalKey, "userKey is required for a user" );
         this.displayName = builder.displayName;
         if ( builder.email != null )
         {

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/User.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/User.java
@@ -9,6 +9,7 @@ import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.mail.EmailValidator;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
 
 
 public final class User
@@ -168,7 +169,7 @@ public final class User
         protected void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.login, "login is required for a User" );
+            requireNonNull( this.login, "login is required for a User" );
             Preconditions.checkArgument( this.key.isUser(), "Invalid Principal Type for User: %s", this.key.getType() );
             if ( !isNullOrEmpty( this.email ) )
             {

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/acl/AccessControlEntry.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/acl/AccessControlEntry.java
@@ -10,6 +10,8 @@ import com.google.common.collect.Sets;
 
 import com.enonic.xp.security.PrincipalKey;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class AccessControlEntry
 {
@@ -21,7 +23,7 @@ public final class AccessControlEntry
 
     private AccessControlEntry( final Builder builder )
     {
-        this.principal = Objects.requireNonNull( builder.principal, "ACE principal cannot be null" );
+        this.principal = requireNonNull( builder.principal, "ACE principal cannot be null" );
         this.allowedPermissions = Sets.immutableEnumSet( builder.allowedPermissions );
         this.deniedPermissions = Sets.immutableEnumSet( builder.deniedPermissions );
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/acl/IdProviderAccessControlEntry.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/acl/IdProviderAccessControlEntry.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 
 import com.enonic.xp.security.PrincipalKey;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class IdProviderAccessControlEntry
 {
@@ -13,8 +15,8 @@ public final class IdProviderAccessControlEntry
 
     private IdProviderAccessControlEntry( final Builder builder )
     {
-        this.principal = Objects.requireNonNull( builder.principal, "principal cannot be null" );
-        this.access = Objects.requireNonNull( builder.access, "access cannot be null" );
+        this.principal = requireNonNull( builder.principal, "principal cannot be null" );
+        this.access = requireNonNull( builder.access, "access cannot be null" );
     }
 
     public PrincipalKey getPrincipal()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/auth/AuthenticationInfo.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/auth/AuthenticationInfo.java
@@ -17,6 +17,8 @@ import com.enonic.xp.security.PrincipalKeys;
 import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.User;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class AuthenticationInfo
     implements Serializable
@@ -35,7 +37,7 @@ public final class AuthenticationInfo
         this.authenticated = builder.authenticated;
         if ( builder.authenticated )
         {
-            this.user = Objects.requireNonNull( builder.user, "user is required" );
+            this.user = requireNonNull( builder.user, "user is required" );
             builder.principals.add( user.getKey() );
         }
         else

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/auth/AuthenticationToken.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/auth/AuthenticationToken.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.security.auth;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 
 import com.enonic.xp.security.IdProviderKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -15,7 +15,7 @@ public abstract sealed class AuthenticationToken
 
     protected AuthenticationToken( final IdProviderKey idProvider )
     {
-        this.idProvider = Objects.requireNonNull( idProvider );
+        this.idProvider = requireNonNull( idProvider );
     }
 
     public final IdProviderKey getIdProvider()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/auth/EmailPasswordAuthToken.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/auth/EmailPasswordAuthToken.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.security.auth;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.mail.EmailValidator;
 import com.enonic.xp.security.IdProviderKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -29,7 +29,7 @@ public final class EmailPasswordAuthToken
 
     private static String checkValidEmail( final String email )
     {
-        Objects.requireNonNull( email, "email is required" );
+        requireNonNull( email, "email is required" );
         Preconditions.checkArgument( EmailValidator.isValid( email ), "Email [%s] is not valid", email );
         return email;
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/auth/PasswordAuthToken.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/auth/PasswordAuthToken.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.security.auth;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 
 import com.enonic.xp.security.IdProviderKey;
+
+import static java.util.Objects.requireNonNull;
 
 @NullMarked
 public abstract sealed class PasswordAuthToken
@@ -16,7 +16,7 @@ public abstract sealed class PasswordAuthToken
     protected PasswordAuthToken( final IdProviderKey idProvider, final String password )
     {
         super( idProvider );
-        this.password = Objects.requireNonNull( password, "password cannot be null" );
+        this.password = requireNonNull( password, "password cannot be null" );
     }
 
     public final String getPassword()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/security/auth/VerifiedEmailAuthToken.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/security/auth/VerifiedEmailAuthToken.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.security.auth;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.mail.EmailValidator;
 import com.enonic.xp.security.IdProviderKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 @NullMarked
@@ -29,7 +29,7 @@ public final class VerifiedEmailAuthToken
 
     private static String checkValidEmail( final String email )
     {
-        Objects.requireNonNull( email, "email is required" );
+        requireNonNull( email, "email is required" );
         Preconditions.checkArgument( EmailValidator.isValid( email ), "Email [%s] is not valid", email );
         return email;
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/session/SessionKey.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/session/SessionKey.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.session;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class SessionKey
@@ -9,7 +9,7 @@ public final class SessionKey
 
     private SessionKey( final String value )
     {
-        this.value = Objects.requireNonNull( value );
+        this.value = requireNonNull( value );
     }
 
     @Override

--- a/modules/core/core-api/src/main/java/com/enonic/xp/site/CmsDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/site/CmsDescriptor.java
@@ -1,12 +1,11 @@
 package com.enonic.xp.site;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.form.Form;
 import com.enonic.xp.util.GenericValue;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public final class CmsDescriptor
@@ -23,7 +22,7 @@ public final class CmsDescriptor
 
     private CmsDescriptor( final Builder builder )
     {
-        this.applicationKey = Objects.requireNonNull( builder.applicationKey );
+        this.applicationKey = requireNonNull( builder.applicationKey );
         this.form = requireNonNullElse( builder.form, Form.empty() );
         this.mixinMappings = requireNonNullElse( builder.mixinMappings, MixinMappings.empty() );
         this.modifiedTime = builder.modifiedTime;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/site/MixinMapping.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/site/MixinMapping.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 import com.enonic.xp.schema.mixin.MixinName;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class MixinMapping
 {
@@ -96,7 +98,7 @@ public final class MixinMapping
 
         private void validate()
         {
-            Objects.requireNonNull( mixinName, "mixinName is required" );
+            requireNonNull( mixinName, "mixinName is required" );
         }
 
         public MixinMapping build()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/site/SiteConfig.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/site/SiteConfig.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.data.PropertyTree;
 
+import static java.util.Objects.requireNonNull;
+
 
 public final class SiteConfig
 {
@@ -15,8 +17,8 @@ public final class SiteConfig
 
     public SiteConfig( final Builder builder )
     {
-        this.applicationKey = Objects.requireNonNull( builder.applicationKey, "applicationKey cannot be null" );
-        this.config = Objects.requireNonNull( builder.config, "config cannot be null" );
+        this.applicationKey = requireNonNull( builder.applicationKey, "applicationKey cannot be null" );
+        this.config = requireNonNull( builder.config, "config cannot be null" );
     }
 
     public ApplicationKey getApplicationKey()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/site/SiteDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/site/SiteDescriptor.java
@@ -2,14 +2,13 @@ package com.enonic.xp.site;
 
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.descriptor.DescriptorKeys;
 import com.enonic.xp.site.mapping.ControllerMappingDescriptors;
 import com.enonic.xp.site.processor.ResponseProcessorDescriptors;
 import com.enonic.xp.util.GenericValue;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 
@@ -29,7 +28,7 @@ public final class SiteDescriptor
 
     private SiteDescriptor( final Builder builder )
     {
-        this.applicationKey = Objects.requireNonNull( builder.applicationKey );
+        this.applicationKey = requireNonNull( builder.applicationKey );
         this.modifiedTime = builder.modifiedTime;
         this.responseProcessors = requireNonNullElse( builder.responseProcessors, ResponseProcessorDescriptors.empty() );
         this.mappingDescriptors = requireNonNullElse( builder.mappingDescriptors, ControllerMappingDescriptors.empty() );

--- a/modules/core/core-api/src/main/java/com/enonic/xp/site/processor/ResponseProcessorDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/site/processor/ResponseProcessorDescriptor.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 
 import com.enonic.xp.app.ApplicationKey;
 
+import static java.util.Objects.requireNonNull;
+
 public final class ResponseProcessorDescriptor
 {
     private final String name;
@@ -14,8 +16,8 @@ public final class ResponseProcessorDescriptor
 
     private ResponseProcessorDescriptor( final Builder builder )
     {
-        this.name = Objects.requireNonNull( builder.name, "name cannot be null" );
-        this.application = Objects.requireNonNull( builder.application, "application cannot be null" );
+        this.name = requireNonNull( builder.name, "name cannot be null" );
+        this.application = requireNonNull( builder.application, "application cannot be null" );
         this.order = builder.order;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/style/StyleDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/style/StyleDescriptor.java
@@ -11,6 +11,8 @@ import com.google.common.collect.ImmutableList;
 
 import com.enonic.xp.app.ApplicationKey;
 
+import static java.util.Objects.requireNonNull;
+
 public final class StyleDescriptor
 {
     private final ApplicationKey applicationKey;
@@ -23,7 +25,7 @@ public final class StyleDescriptor
 
     private StyleDescriptor( final Builder builder )
     {
-        this.applicationKey = Objects.requireNonNull( builder.application, "applicationKey is required" );
+        this.applicationKey = requireNonNull( builder.application, "applicationKey is required" );
         this.cssPath = builder.cssPath;
         this.elements = builder.elements.build();
         this.modifiedTime = builder.modifiedTime;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/task/SubmitLocalTaskParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/task/SubmitLocalTaskParams.java
@@ -1,6 +1,6 @@
 package com.enonic.xp.task;
 
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 
 public final class SubmitLocalTaskParams
@@ -13,7 +13,7 @@ public final class SubmitLocalTaskParams
 
     private SubmitLocalTaskParams( final Builder builder )
     {
-        this.runnableTask = Objects.requireNonNull( builder.runnableTask, "runnableTask is required" );
+        this.runnableTask = requireNonNull( builder.runnableTask, "runnableTask is required" );
         this.name = builder.name;
         this.description = builder.description;
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/task/SubmitTaskParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/task/SubmitTaskParams.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.task;
 
-import java.util.Objects;
-
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.descriptor.DescriptorKey;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class SubmitTaskParams
@@ -16,7 +16,7 @@ public final class SubmitTaskParams
 
     private SubmitTaskParams( final Builder builder )
     {
-        this.descriptorKey = Objects.requireNonNull( builder.descriptorKey, "descriptor key is required" );
+        this.descriptorKey = requireNonNull( builder.descriptorKey, "descriptor key is required" );
         this.name = builder.name;
         this.data = builder.data;
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/task/TaskDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/task/TaskDescriptor.java
@@ -8,6 +8,9 @@ import com.enonic.xp.form.Form;
 import com.enonic.xp.schema.LocalizedText;
 import com.enonic.xp.util.GenericValue;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
 
 public final class TaskDescriptor
     extends Descriptor
@@ -25,7 +28,7 @@ public final class TaskDescriptor
         super( builder.key );
         this.description = builder.description;
         this.descriptionI18nKey = builder.descriptionI18nKey;
-        this.config = Objects.requireNonNullElse( builder.config, Form.empty() );
+        this.config = requireNonNullElse( builder.config, Form.empty() );
         this.schemaConfig = builder.schemaConfig.build();
     }
 
@@ -131,7 +134,7 @@ public final class TaskDescriptor
 
         public TaskDescriptor build()
         {
-            Objects.requireNonNull( this.key, "key is required" );
+            requireNonNull( this.key, "key is required" );
             return new TaskDescriptor( this );
         }
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/task/TaskId.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/task/TaskId.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.task;
 
 import java.io.Serializable;
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class TaskId
@@ -15,7 +15,7 @@ public final class TaskId
 
     private TaskId( final String value )
     {
-        Objects.requireNonNull( value, "TaskId cannot be null" );
+        requireNonNull( value, "TaskId cannot be null" );
         Preconditions.checkArgument( !value.isBlank(), "TaskId cannot be blank" );
         this.value = value;
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/task/TaskInfo.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/task/TaskInfo.java
@@ -10,6 +10,9 @@ import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.cluster.ClusterNodeId;
 import com.enonic.xp.security.PrincipalKey;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
 
 public final class TaskInfo
     implements Serializable
@@ -36,14 +39,14 @@ public final class TaskInfo
 
     private TaskInfo( final Builder builder )
     {
-        id = Objects.requireNonNull( builder.id, "Task id is required" );
-        application = Objects.requireNonNull( builder.application, "Task application is required" );
-        name = Objects.requireNonNull( builder.name, "Task name is required" );
-        state = Objects.requireNonNullElse( builder.state, TaskState.WAITING );
-        description = Objects.requireNonNullElse( builder.description, "" );
-        progress = Objects.requireNonNullElse( builder.progress, TaskProgress.EMPTY );
-        user = Objects.requireNonNullElse( builder.user, PrincipalKey.ofAnonymous() );
-        startTime = Objects.requireNonNull( builder.startTime, "Task startTime is required" );
+        id = requireNonNull( builder.id, "Task id is required" );
+        application = requireNonNull( builder.application, "Task application is required" );
+        name = requireNonNull( builder.name, "Task name is required" );
+        state = requireNonNullElse( builder.state, TaskState.WAITING );
+        description = requireNonNullElse( builder.description, "" );
+        progress = requireNonNullElse( builder.progress, TaskProgress.EMPTY );
+        user = requireNonNullElse( builder.user, PrincipalKey.ofAnonymous() );
+        startTime = requireNonNull( builder.startTime, "Task startTime is required" );
         node = builder.node;
     }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/task/TaskProgress.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/task/TaskProgress.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
 
+import static java.util.Objects.requireNonNullElse;
+
 
 public final class TaskProgress
     implements Serializable
@@ -23,7 +25,7 @@ public final class TaskProgress
     {
         current = builder.current;
         total = builder.total;
-        info = Objects.requireNonNullElse( builder.info, "" );
+        info = requireNonNullElse( builder.info, "" );
     }
 
     public int getCurrent()

--- a/modules/core/core-api/src/main/java/com/enonic/xp/util/GenericValue.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/util/GenericValue.java
@@ -22,6 +22,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.math.DoubleMath;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A generic value wrapper that can hold different types of values such as String, Number, Boolean, List, and Map, similar to JSON values.
  * It provides methods to access and convert the underlying value in a type-safe manner.
@@ -47,7 +49,7 @@ public final class GenericValue
 
     private GenericValue( final Serializable value )
     {
-        this.value = Objects.requireNonNull( value );
+        this.value = requireNonNull( value );
     }
 
     /**
@@ -462,7 +464,7 @@ public final class GenericValue
          */
         public ObjectBuilder put( final String key, final String value )
         {
-            builder.put( Objects.requireNonNull( key ), GenericValue.stringValue( value ) );
+            builder.put( requireNonNull( key ), GenericValue.stringValue( value ) );
             return this;
         }
 
@@ -475,7 +477,7 @@ public final class GenericValue
          */
         public ObjectBuilder put( final String key, final long value )
         {
-            builder.put( Objects.requireNonNull( key ), GenericValue.numberValue( value ) );
+            builder.put( requireNonNull( key ), GenericValue.numberValue( value ) );
             return this;
         }
 
@@ -488,7 +490,7 @@ public final class GenericValue
          */
         public ObjectBuilder put( final String key, final double value )
         {
-            builder.put( Objects.requireNonNull( key ), GenericValue.numberValue( value ) );
+            builder.put( requireNonNull( key ), GenericValue.numberValue( value ) );
             return this;
         }
 
@@ -501,7 +503,7 @@ public final class GenericValue
          */
         public ObjectBuilder put( final String key, final boolean value )
         {
-            builder.put( Objects.requireNonNull( key ), GenericValue.booleanValue( value ) );
+            builder.put( requireNonNull( key ), GenericValue.booleanValue( value ) );
             return this;
         }
 
@@ -514,7 +516,7 @@ public final class GenericValue
          */
         public ObjectBuilder put( final String key, final GenericValue value )
         {
-            builder.put( Objects.requireNonNull( key ), Objects.requireNonNull( value ) );
+            builder.put( requireNonNull( key ), requireNonNull( value ) );
             return this;
         }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/util/Reference.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/util/Reference.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.util;
 
-import java.util.Objects;
-
 import com.enonic.xp.node.NodeId;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class Reference
@@ -11,7 +11,7 @@ public final class Reference
 
     public Reference( final NodeId nodeId )
     {
-        this.nodeId = Objects.requireNonNull( nodeId );
+        this.nodeId = requireNonNull( nodeId );
     }
 
     public static Reference from( final String value )

--- a/modules/core/core-api/src/main/java/com/enonic/xp/webapp/WebappDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/webapp/WebappDescriptor.java
@@ -1,11 +1,12 @@
 package com.enonic.xp.webapp;
 
-import java.util.Objects;
-
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.descriptor.DescriptorKeys;
 import com.enonic.xp.schema.LocalizedText;
 import com.enonic.xp.util.GenericValue;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class WebappDescriptor
@@ -22,8 +23,8 @@ public final class WebappDescriptor
 
     private WebappDescriptor( final Builder builder )
     {
-        this.applicationKey = Objects.requireNonNull( builder.applicationKey );
-        this.apiMounts = Objects.requireNonNullElse( builder.apiMounts, DescriptorKeys.empty() );
+        this.applicationKey = requireNonNull( builder.applicationKey );
+        this.apiMounts = requireNonNullElse( builder.apiMounts, DescriptorKeys.empty() );
         this.description = builder.description;
         this.descriptionI18nKey = builder.descriptionI18nKey;
         this.schemaConfig = builder.schemaConfig.build();

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationRepoInitializer.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationRepoInitializer.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.app;
 
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,6 +8,8 @@ import com.enonic.xp.node.CreateNodeParams;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.NodeService;
 import com.enonic.xp.node.RefreshMode;
+
+import static java.util.Objects.requireNonNull;
 
 public class ApplicationRepoInitializer
     extends ExternalInitializer
@@ -75,7 +75,7 @@ public class ApplicationRepoInitializer
         protected void validate()
         {
             super.validate();
-            Objects.requireNonNull( nodeService );
+            requireNonNull( nodeService );
         }
 
         public ApplicationRepoInitializer build()

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/CreateDynamicCmsParams.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/CreateDynamicCmsParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.core.impl.app;
 
-import java.util.Objects;
-
 import com.enonic.xp.app.ApplicationKey;
+
+import static java.util.Objects.requireNonNull;
 
 public final class CreateDynamicCmsParams
 {
@@ -51,8 +51,8 @@ public final class CreateDynamicCmsParams
 
         private void validate()
         {
-            Objects.requireNonNull( key, "key is required" );
-            Objects.requireNonNull( resource, "resource is required" );
+            requireNonNull( key, "key is required" );
+            requireNonNull( resource, "resource is required" );
         }
 
         public CreateDynamicCmsParams build()

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/VirtualAppInitializer.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/VirtualAppInitializer.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.app;
 
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,6 +7,8 @@ import com.enonic.xp.context.Context;
 import com.enonic.xp.init.ExternalInitializer;
 import com.enonic.xp.repository.CreateRepositoryParams;
 import com.enonic.xp.repository.internal.InternalRepositoryService;
+
+import static java.util.Objects.requireNonNull;
 
 public class VirtualAppInitializer
     extends ExternalInitializer
@@ -74,7 +74,7 @@ public class VirtualAppInitializer
         protected void validate()
         {
             super.validate();
-            Objects.requireNonNull( repositoryService );
+            requireNonNull( repositoryService );
         }
 
         public VirtualAppInitializer build()

--- a/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/AuditLogRepoInitializer.java
+++ b/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/AuditLogRepoInitializer.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.core.impl.audit;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.Context;
 import com.enonic.xp.init.ExternalInitializer;
 import com.enonic.xp.repository.CreateRepositoryParams;
 import com.enonic.xp.repository.internal.InternalRepositoryService;
+
+import static java.util.Objects.requireNonNull;
 
 public class AuditLogRepoInitializer
     extends ExternalInitializer
@@ -69,7 +69,7 @@ public class AuditLogRepoInitializer
         protected void validate()
         {
             super.validate();
-            Objects.requireNonNull( repositoryService );
+            requireNonNull( repositoryService );
         }
 
         public AuditLogRepoInitializer build()

--- a/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/CleanUpAuditLogCommand.java
+++ b/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/CleanUpAuditLogCommand.java
@@ -2,8 +2,6 @@ package com.enonic.xp.core.impl.audit;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,6 +19,9 @@ import com.enonic.xp.query.expr.OrderExpr;
 import com.enonic.xp.query.filter.RangeFilter;
 import com.enonic.xp.query.filter.ValueFilter;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElseGet;
+
 public class CleanUpAuditLogCommand
     extends NodeServiceCommand<CleanUpAuditLogResult>
 {
@@ -36,7 +37,7 @@ public class CleanUpAuditLogCommand
     {
         super( builder );
         until = builder.ageThreshold.isBlank() ? Instant.EPOCH : Instant.now().minus( Duration.parse( builder.ageThreshold ) );
-        listener = Objects.requireNonNullElseGet( builder.listener, EmptyCleanUpAuditLogListener::new );
+        listener = requireNonNullElseGet( builder.listener, EmptyCleanUpAuditLogListener::new );
     }
 
     @Override
@@ -136,7 +137,7 @@ public class CleanUpAuditLogCommand
 
         private void validate()
         {
-            Objects.requireNonNull( ageThreshold, "ageThreshold is required" );
+            requireNonNull( ageThreshold, "ageThreshold is required" );
         }
 
         public CleanUpAuditLogCommand build()

--- a/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/CreateAuditLogCommand.java
+++ b/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/CreateAuditLogCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.audit;
 
-import java.util.Objects;
-
 import com.enonic.xp.audit.AuditLog;
 import com.enonic.xp.audit.LogAuditLogParams;
 import com.enonic.xp.core.impl.audit.serializer.AuditLogSerializer;
@@ -9,6 +7,8 @@ import com.enonic.xp.node.CreateNodeParams;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodePath;
+
+import static java.util.Objects.requireNonNull;
 
 public class CreateAuditLogCommand
     extends NodeServiceCommand<AuditLog>
@@ -65,7 +65,7 @@ public class CreateAuditLogCommand
 
         private void validate()
         {
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public CreateAuditLogCommand build()

--- a/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/FindAuditLogCommand.java
+++ b/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/FindAuditLogCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.audit;
 
-import java.util.Objects;
-
 import com.enonic.xp.audit.AuditLogUri;
 import com.enonic.xp.audit.AuditLogs;
 import com.enonic.xp.audit.FindAuditLogParams;
@@ -15,6 +13,8 @@ import com.enonic.xp.query.filter.IdFilter;
 import com.enonic.xp.query.filter.RangeFilter;
 import com.enonic.xp.query.filter.ValueFilter;
 import com.enonic.xp.security.PrincipalKey;
+
+import static java.util.Objects.requireNonNull;
 
 public class FindAuditLogCommand
     extends NodeServiceCommand<FindAuditLogResult>
@@ -145,7 +145,7 @@ public class FindAuditLogCommand
 
         private void validate()
         {
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public FindAuditLogCommand build()

--- a/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/GetAuditLogCommand.java
+++ b/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/GetAuditLogCommand.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.core.impl.audit;
 
-import java.util.Objects;
-
 import com.enonic.xp.audit.AuditLog;
 import com.enonic.xp.audit.AuditLogId;
 import com.enonic.xp.core.impl.audit.serializer.AuditLogSerializer;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeNotFoundException;
+
+import static java.util.Objects.requireNonNull;
 
 public class GetAuditLogCommand
     extends NodeServiceCommand<AuditLog>
@@ -62,7 +62,7 @@ public class GetAuditLogCommand
 
         private void validate()
         {
-            Objects.requireNonNull( auditLogId, "auditLogId is required" );
+            requireNonNull( auditLogId, "auditLogId is required" );
         }
 
         public GetAuditLogCommand build()

--- a/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/serializer/AuditLogSerializer.java
+++ b/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/serializer/AuditLogSerializer.java
@@ -1,7 +1,6 @@
 package com.enonic.xp.core.impl.audit.serializer;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -20,6 +19,8 @@ import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.security.PrincipalKey;
 
+import static java.util.Objects.requireNonNullElseGet;
+
 public class AuditLogSerializer
 {
 
@@ -36,7 +37,7 @@ public class AuditLogSerializer
         data.addInstant( AuditLogPropertyNames.TIME, auditLogParams.getTime() );
         data.addString( AuditLogPropertyNames.SOURCE, auditLogParams.getSource() );
 
-        final PrincipalKey userKey = Objects.requireNonNullElseGet( auditLogParams.getUser(),
+        final PrincipalKey userKey = requireNonNullElseGet( auditLogParams.getUser(),
                                                                     () -> ContextAccessor.current().getAuthInfo().getUser() != null
                                                                         ? ContextAccessor.current().getAuthInfo().getUser().getKey()
                                                                         : PrincipalKey.ofAnonymous() );

--- a/modules/core/core-audit/src/test/java/com/enonic/xp/core/impl/audit/AuditLogServiceImplTest.java
+++ b/modules/core/core-audit/src/test/java/com/enonic/xp/core/impl/audit/AuditLogServiceImplTest.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.audit;
 
-import java.util.Objects;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -35,6 +33,7 @@ import com.enonic.xp.node.Nodes;
 import com.enonic.xp.repository.internal.InternalRepositoryService;
 import com.enonic.xp.security.PrincipalKey;
 
+import static java.util.Objects.requireNonNullElse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -221,7 +220,7 @@ class AuditLogServiceImplTest
         assertEquals( auditLogParams.getTime(), log.getTime() );
         assertNotNull( log.getSource() );
         assertEquals( auditLogParams.getSource(), log.getSource() );
-        assertEquals( Objects.requireNonNullElse( auditLogParams.getUser(), PrincipalKey.ofAnonymous() ), log.getUser() );
+        assertEquals( requireNonNullElse( auditLogParams.getUser(), PrincipalKey.ofAnonymous() ), log.getUser() );
         assertNotNull( log.getObjectUris() );
         assertEquals( 2, log.getObjectUris().getSize() );
         assertEquals( auditLogParams.getObjectUris(), log.getObjectUris() );

--- a/modules/core/core-blobstore/src/main/java/com/enonic/xp/internal/blobstore/cache/CachedBlobStore.java
+++ b/modules/core/core-blobstore/src/main/java/com/enonic/xp/internal/blobstore/cache/CachedBlobStore.java
@@ -2,7 +2,6 @@ package com.enonic.xp.internal.blobstore.cache;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
@@ -19,6 +18,8 @@ import com.enonic.xp.blob.BlobStore;
 import com.enonic.xp.blob.BlobStoreException;
 import com.enonic.xp.blob.CachingBlobStore;
 import com.enonic.xp.blob.Segment;
+
+import static java.util.Objects.requireNonNullElse;
 
 public final class CachedBlobStore
     implements BlobStore, CachingBlobStore
@@ -113,7 +114,7 @@ public final class CachedBlobStore
             LOG.warn( "Could not cache blob-record with key {}", key, e );
         }
         // If we could not load the blob into cache, we return the original record
-        return Objects.requireNonNullElse( this.cache.getIfPresent( key ), record );
+        return requireNonNullElse( this.cache.getIfPresent( key ), record );
     }
 
     @Override

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/AbstractContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/AbstractContentCommand.java
@@ -2,7 +2,6 @@ package com.enonic.xp.core.impl.content;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.function.Predicate;
 
@@ -44,6 +43,8 @@ import com.enonic.xp.schema.content.ContentTypeService;
 import com.enonic.xp.schema.content.GetContentTypeParams;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.util.GenericValue;
+
+import static java.util.Objects.requireNonNull;
 
 abstract class AbstractContentCommand
 {
@@ -347,9 +348,9 @@ abstract class AbstractContentCommand
 
         void validate()
         {
-            Objects.requireNonNull( nodeService );
-            Objects.requireNonNull( contentTypeService );
-            Objects.requireNonNull( eventPublisher );
+            requireNonNull( nodeService );
+            requireNonNull( contentTypeService );
+            requireNonNull( eventPublisher );
         }
     }
 }

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/AbstractContentEventSyncCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/AbstractContentEventSyncCommand.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.core.impl.content;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentInheritType;
 import com.enonic.xp.content.ContentName;
 import com.enonic.xp.content.ContentPath;
+
+import static java.util.Objects.requireNonNull;
 
 public abstract class AbstractContentEventSyncCommand
 {
@@ -76,8 +76,8 @@ public abstract class AbstractContentEventSyncCommand
 
         void validate()
         {
-            Objects.requireNonNull( layersContentService );
-            Objects.requireNonNull( contentToSync, "contentToSync cannot be null" );
+            requireNonNull( layersContentService );
+            requireNonNull( contentToSync, "contentToSync cannot be null" );
         }
 
         public abstract <T extends AbstractContentEventSyncCommand> T build();

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ArchiveContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ArchiveContentCommand.java
@@ -3,8 +3,6 @@ package com.enonic.xp.core.impl.content;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Objects;
-
 import com.enonic.xp.archive.ArchiveConstants;
 import com.enonic.xp.archive.ArchiveContentException;
 import com.enonic.xp.archive.ArchiveContentParams;
@@ -36,6 +34,7 @@ import static com.enonic.xp.content.ContentPropertyNames.ARCHIVED_BY;
 import static com.enonic.xp.content.ContentPropertyNames.ARCHIVED_TIME;
 import static com.enonic.xp.content.ContentPropertyNames.ORIGINAL_NAME;
 import static com.enonic.xp.content.ContentPropertyNames.ORIGINAL_PARENT_PATH;
+import static java.util.Objects.requireNonNull;
 
 final class ArchiveContentCommand
     extends AbstractCreatingOrUpdatingContentCommand
@@ -200,7 +199,7 @@ final class ArchiveContentCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public ArchiveContentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentNodeHelper.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentNodeHelper.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentAccessException;
 import com.enonic.xp.content.ContentConstants;
 import com.enonic.xp.content.ContentId;
@@ -20,6 +18,7 @@ import com.enonic.xp.node.NodePaths;
 import static com.enonic.xp.archive.ArchiveConstants.ARCHIVE_ROOT_NAME;
 import static com.enonic.xp.content.ContentConstants.CONTENT_ROOT_NAME;
 import static com.enonic.xp.content.ContentConstants.CONTENT_ROOT_PATH_ATTRIBUTE;
+import static java.util.Objects.requireNonNullElse;
 
 public class ContentNodeHelper
 {
@@ -89,7 +88,7 @@ public class ContentNodeHelper
 
     public static NodePath getContentRoot()
     {
-        return Objects.requireNonNullElse( (NodePath) ContextAccessor.current().getAttribute( CONTENT_ROOT_PATH_ATTRIBUTE ),
+        return requireNonNullElse( (NodePath) ContextAccessor.current().getAttribute( CONTENT_ROOT_PATH_ATTRIBUTE ),
                                            ContentConstants.CONTENT_ROOT_PATH );
     }
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentServiceImpl.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentServiceImpl.java
@@ -2,7 +2,6 @@ package com.enonic.xp.core.impl.content;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 
@@ -108,6 +107,8 @@ import com.enonic.xp.site.Site;
 import com.enonic.xp.site.SiteConfigService;
 import com.enonic.xp.trace.Tracer;
 import com.enonic.xp.util.BinaryReference;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 @Component(configurationPid = "com.enonic.xp.content")
 public class ContentServiceImpl
@@ -678,7 +679,7 @@ public class ContentServiceImpl
         final Instant now = Instant.now();
 
         final Contents contents = ContextBuilder.from( ContextAccessor.current() )
-            .branch( Objects.requireNonNullElseGet( params.getTarget(), ContextAccessor.current()::getBranch ) )
+            .branch( requireNonNullElseGet( params.getTarget(), ContextAccessor.current()::getBranch ) )
             .attribute( "ignorePublishTimes", Boolean.TRUE )
             .build()
             .callWith( () -> this.getByIds( GetContentByIdsParams.create().contentIds( params.getContentIds() ).build() ) );

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentSyncParams.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentSyncParams.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.core.impl.content;
 
 import java.util.Collection;
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentIds;
 import com.enonic.xp.project.ProjectName;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ContentSyncParams
 {
@@ -92,8 +92,8 @@ public final class ContentSyncParams
 
         private void validate()
         {
-            Objects.requireNonNull( sourceProject, "sourceProject is required" );
-            Objects.requireNonNull( targetProject, "targetProject is required" );
+            requireNonNull( sourceProject, "sourceProject is required" );
+            requireNonNull( targetProject, "targetProject is required" );
         }
 
         public ContentSyncParams build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentToSync.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentToSync.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.context.Context;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ContentToSync
 {
@@ -110,8 +110,8 @@ public final class ContentToSync
 
         private void validate()
         {
-            Objects.requireNonNull( sourceCtx, "sourceCtx is required" );
-            Objects.requireNonNull( targetCtx, "targetCtx is required" );
+            requireNonNull( sourceCtx, "sourceCtx is required" );
+            requireNonNull( targetCtx, "targetCtx is required" );
             Preconditions.checkArgument( sourceContent != null || targetContent != null, "source or target content is required" );
         }
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateContentCommand.java
@@ -2,8 +2,6 @@ package com.enonic.xp.core.impl.content;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
-
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentAlreadyExistsException;
 import com.enonic.xp.content.ContentConstants;
@@ -36,6 +34,8 @@ import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.site.SiteConfigsDataSerializer;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 final class CreateContentCommand
     extends AbstractCreatingOrUpdatingContentCommand
@@ -157,7 +157,7 @@ final class CreateContentCommand
             .creator( getCurrentUserKey() )
             .owner( getDefaultOwner( processedContent ) );
         populateName( builder );
-        builder.childOrder( Objects.requireNonNullElse( this.params.getChildOrder(), ContentConstants.DEFAULT_CHILD_ORDER ) );
+        builder.childOrder( requireNonNullElse( this.params.getChildOrder(), ContentConstants.DEFAULT_CHILD_ORDER ) );
         populateLanguage( builder );
 
         populateValid( builder );
@@ -313,7 +313,7 @@ final class CreateContentCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public CreateContentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateContentTranslatorParams.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateContentTranslatorParams.java
@@ -2,8 +2,6 @@ package com.enonic.xp.core.impl.content;
 
 import java.time.Instant;
 import java.util.Locale;
-import java.util.Objects;
-
 import com.enonic.xp.attachment.CreateAttachments;
 import com.enonic.xp.content.ContentIds;
 import com.enonic.xp.content.ContentName;
@@ -19,6 +17,8 @@ import com.enonic.xp.page.Page;
 import com.enonic.xp.schema.content.ContentTypeName;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.acl.AccessControlList;
+
+import static java.util.Objects.requireNonNull;
 
 public class CreateContentTranslatorParams
 {
@@ -417,14 +417,14 @@ public class CreateContentTranslatorParams
 
         private void validate()
         {
-            Objects.requireNonNull( parent, "parentPath cannot be null" );
-            Objects.requireNonNull( data, "data cannot be null" );
-            Objects.requireNonNull( displayName, "displayName cannot be null" );
-            Objects.requireNonNull( createAttachments, "createAttachments cannot be null" );
-            Objects.requireNonNull( type, "type cannot be null" );
-            Objects.requireNonNull( creator, "creator cannot be null" );
-            Objects.requireNonNull( name, "name cannot be null" );
-            Objects.requireNonNull( childOrder, "childOrder cannot be null" );
+            requireNonNull( parent, "parentPath cannot be null" );
+            requireNonNull( data, "data cannot be null" );
+            requireNonNull( displayName, "displayName cannot be null" );
+            requireNonNull( createAttachments, "createAttachments cannot be null" );
+            requireNonNull( type, "type cannot be null" );
+            requireNonNull( creator, "creator cannot be null" );
+            requireNonNull( name, "name cannot be null" );
+            requireNonNull( childOrder, "childOrder cannot be null" );
         }
 
         public CreateContentTranslatorParams build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateMediaCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateMediaCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.core.impl.content;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.enonic.xp.attachment.CreateAttachment;
 import com.enonic.xp.attachment.CreateAttachments;
 import com.enonic.xp.content.Content;
@@ -14,6 +12,8 @@ import com.enonic.xp.media.MediaInfo;
 import com.enonic.xp.media.MediaInfoService;
 import com.enonic.xp.schema.content.ContentTypeFromMimeTypeResolver;
 import com.enonic.xp.schema.content.ContentTypeName;
+
+import static java.util.Objects.requireNonNull;
 
 final class CreateMediaCommand
     extends AbstractCreatingOrUpdatingContentCommand
@@ -45,7 +45,7 @@ final class CreateMediaCommand
             params.mimeType( mediaInfo.getMediaType() );
         }
 
-        Objects.requireNonNull( params.getMimeType(), "Unable to resolve media type" );
+        requireNonNull( params.getMimeType(), "Unable to resolve media type" );
 
         final ContentTypeName resolvedTypeFromMimeType = ContentTypeFromMimeTypeResolver.resolve( params.getMimeType() );
         final ContentTypeName type = resolvedTypeFromMimeType != null
@@ -141,7 +141,7 @@ final class CreateMediaCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public CreateMediaCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateNodeParamsFactory.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateNodeParamsFactory.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.core.impl.content;
 
 import java.util.Locale;
-import java.util.Objects;
-
 import com.enonic.xp.attachment.CreateAttachment;
 import com.enonic.xp.content.ContentConstants;
 import com.enonic.xp.content.ContentName;
@@ -26,6 +24,7 @@ import com.enonic.xp.site.SiteConfigs;
 import com.enonic.xp.site.SiteConfigsDataSerializer;
 
 import static com.google.common.base.Strings.nullToEmpty;
+import static java.util.Objects.requireNonNull;
 
 public class CreateNodeParamsFactory
 {
@@ -192,11 +191,11 @@ public class CreateNodeParamsFactory
 
         void validate()
         {
-            Objects.requireNonNull( params, "params cannot be null" );
-            Objects.requireNonNull( contentTypeService );
-            Objects.requireNonNull( pageDescriptorService );
-            Objects.requireNonNull( cmsService );
-            Objects.requireNonNull( mixinService );
+            requireNonNull( params, "params cannot be null" );
+            requireNonNull( contentTypeService );
+            requireNonNull( pageDescriptorService );
+            requireNonNull( cmsService );
+            requireNonNull( mixinService );
         }
 
         public CreateNodeParamsFactory build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/DeleteContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/DeleteContentCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.core.impl.content;
 
 
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentIds;
 import com.enonic.xp.content.ContentNotFoundException;
@@ -20,6 +18,8 @@ import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeIds;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.RefreshMode;
+
+import static java.util.Objects.requireNonNull;
 
 
 final class DeleteContentCommand
@@ -130,7 +130,7 @@ final class DeleteContentCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         DeleteContentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/DuplicateContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/DuplicateContentCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentIds;
 import com.enonic.xp.content.ContentPropertyNames;
@@ -16,6 +14,8 @@ import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.node.VersionAttributesResolver;
+
+import static java.util.Objects.requireNonNull;
 
 final class DuplicateContentCommand
     extends AbstractContentCommand
@@ -105,7 +105,7 @@ final class DuplicateContentCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         DuplicateContentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/FindContentByParentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/FindContentByParentCommand.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.Contents;
 import com.enonic.xp.content.FindContentByParentParams;
 import com.enonic.xp.content.FindContentByParentResult;
 import com.enonic.xp.content.FindContentIdsByParentResult;
 import com.enonic.xp.content.GetContentByIdsParams;
+
+import static java.util.Objects.requireNonNull;
 
 final class FindContentByParentCommand
     extends AbstractContentCommand
@@ -58,7 +58,7 @@ final class FindContentByParentCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public FindContentByParentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/FindContentIdsByParentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/FindContentIdsByParentCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.core.impl.content;
 
 import java.util.Locale;
-import java.util.Objects;
-
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentIds;
 import com.enonic.xp.content.ContentIndexPath;
@@ -15,6 +13,8 @@ import com.enonic.xp.node.FindNodesByParentResult;
 import com.enonic.xp.query.expr.FieldOrderExpr;
 import com.enonic.xp.query.expr.OrderExpr;
 import com.enonic.xp.query.filter.Filters;
+
+import static java.util.Objects.requireNonNull;
 
 final class FindContentIdsByParentCommand
     extends AbstractContentCommand
@@ -115,7 +115,7 @@ final class FindContentIdsByParentCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public FindContentIdsByParentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/FindContentIdsByQueryCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/FindContentIdsByQueryCommand.java
@@ -2,8 +2,6 @@ package com.enonic.xp.core.impl.content;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentQuery;
 import com.enonic.xp.content.FindContentIdsByQueryResult;
@@ -11,6 +9,8 @@ import com.enonic.xp.highlight.HighlightedProperties;
 import com.enonic.xp.node.FindNodesByQueryResult;
 import com.enonic.xp.node.NodeQuery;
 import com.enonic.xp.sortvalues.SortValuesProperty;
+
+import static java.util.Objects.requireNonNull;
 
 final class FindContentIdsByQueryCommand
     extends AbstractContentCommand
@@ -93,7 +93,7 @@ final class FindContentIdsByQueryCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( query, "query is required" );
+            requireNonNull( query, "query is required" );
         }
 
     }

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/FindContentPathsByQueryCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/FindContentPathsByQueryCommand.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentPaths;
 import com.enonic.xp.content.ContentQuery;
 import com.enonic.xp.content.FindContentPathsByQueryResult;
 import com.enonic.xp.node.FindNodesByQueryResult;
 import com.enonic.xp.node.NodeHit;
 import com.enonic.xp.node.NodeQuery;
+
+import static java.util.Objects.requireNonNull;
 
 final class FindContentPathsByQueryCommand
     extends AbstractContentCommand
@@ -69,7 +69,7 @@ final class FindContentPathsByQueryCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( contentQuery, "contentQuery is required" );
+            requireNonNull( contentQuery, "contentQuery is required" );
         }
 
     }

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/FindNearestContentByPathCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/FindNearestContentByPathCommand.java
@@ -1,11 +1,12 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
 import java.util.function.Predicate;
 
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentName;
 import com.enonic.xp.content.ContentPath;
+
+import static java.util.Objects.requireNonNull;
 
 public final class FindNearestContentByPathCommand
     extends AbstractContentCommand
@@ -93,8 +94,8 @@ public final class FindNearestContentByPathCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( contentPath, "contentPath must be set" );
-            Objects.requireNonNull( predicate, "predicate must be set" );
+            requireNonNull( contentPath, "contentPath must be set" );
+            requireNonNull( predicate, "predicate must be set" );
         }
 
         public FindNearestContentByPathCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetActiveContentVersionsCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetActiveContentVersionsCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.core.impl.content;
 
 import java.util.Map;
-import java.util.Objects;
-
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -14,6 +12,8 @@ import com.enonic.xp.node.GetActiveNodeVersionsResult;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeVersion;
 
+import static java.util.Objects.requireNonNull;
+
 public class GetActiveContentVersionsCommand
     extends AbstractContentCommand
 {
@@ -23,7 +23,7 @@ public class GetActiveContentVersionsCommand
     private GetActiveContentVersionsCommand( final Builder builder )
     {
         super( builder );
-        this.params = Objects.requireNonNull( builder.params );
+        this.params = requireNonNull( builder.params );
     }
 
     public static Builder create()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetBinaryCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetBinaryCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.core.impl.content;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
 
 import com.enonic.xp.content.ContentId;
@@ -11,6 +9,8 @@ import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.util.BinaryReference;
+
+import static java.util.Objects.requireNonNull;
 
 
 final class GetBinaryCommand
@@ -67,8 +67,8 @@ final class GetBinaryCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( contentId, "contentId is required" );
-            Objects.requireNonNull( binaryReference, "binaryReference is required" );
+            requireNonNull( contentId, "contentId is required" );
+            requireNonNull( binaryReference, "binaryReference is required" );
         }
 
         public GetBinaryCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetContentByIdAndVersionIdCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetContentByIdAndVersionIdCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentNotFoundException;
@@ -11,6 +9,8 @@ import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeNotFoundException;
 import com.enonic.xp.node.NodeVersionId;
+
+import static java.util.Objects.requireNonNull;
 
 public final class GetContentByIdAndVersionIdCommand
     extends AbstractContentCommand
@@ -84,8 +84,8 @@ public final class GetContentByIdAndVersionIdCommand
         {
             super.validate();
 
-            Objects.requireNonNull( this.contentId, "contentId is required" );
-            Objects.requireNonNull( this.versionId, "versionId is required" );
+            requireNonNull( this.contentId, "contentId is required" );
+            requireNonNull( this.versionId, "versionId is required" );
         }
 
         public GetContentByIdAndVersionIdCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetContentByIdsCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetContentByIdsCommand.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.Contents;
 import com.enonic.xp.content.GetContentByIdsParams;
 import com.enonic.xp.node.NodeIds;
 import com.enonic.xp.node.Nodes;
+
+import static java.util.Objects.requireNonNull;
 
 
 final class GetContentByIdsCommand
@@ -53,7 +53,7 @@ final class GetContentByIdsCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public GetContentByIdsCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetContentByPathCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetContentByPathCommand.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodePath;
+
+import static java.util.Objects.requireNonNull;
 
 final class GetContentByPathCommand
     extends AbstractContentCommand
@@ -15,7 +15,7 @@ final class GetContentByPathCommand
     private GetContentByPathCommand( final Builder builder )
     {
         super( builder );
-        Objects.requireNonNull( builder.contentPath, "contentPath is required" );
+        requireNonNull( builder.contentPath, "contentPath is required" );
         this.contentPath = builder.contentPath;
     }
 
@@ -64,7 +64,7 @@ final class GetContentByPathCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( contentPath, "contentPath is required" );
+            requireNonNull( contentPath, "contentPath is required" );
         }
 
         public GetContentByPathCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetContentByPathsCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetContentByPathsCommand.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentPaths;
 import com.enonic.xp.content.Contents;
 import com.enonic.xp.node.NodePaths;
 import com.enonic.xp.node.Nodes;
+
+import static java.util.Objects.requireNonNull;
 
 
 final class GetContentByPathsCommand
@@ -52,7 +52,7 @@ final class GetContentByPathsCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( contentPaths, "contentPaths is required" );
+            requireNonNull( contentPaths, "contentPaths is required" );
         }
 
         public GetContentByPathsCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetContentVersionsCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/GetContentVersionsCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -12,6 +10,8 @@ import com.enonic.xp.node.GetNodeVersionsParams;
 import com.enonic.xp.node.GetNodeVersionsResult;
 import com.enonic.xp.node.NodeId;
 
+import static java.util.Objects.requireNonNull;
+
 public class GetContentVersionsCommand
     extends AbstractContentCommand
 {
@@ -21,7 +21,7 @@ public class GetContentVersionsCommand
     private GetContentVersionsCommand( final Builder builder )
     {
         super( builder );
-        this.params = Objects.requireNonNull( builder.params );
+        this.params = requireNonNull( builder.params );
     }
 
     public static Builder create()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ImportContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ImportContentCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.ImportContentParams;
 import com.enonic.xp.content.ImportContentResult;
 import com.enonic.xp.node.BinaryAttachment;
@@ -11,6 +9,8 @@ import com.enonic.xp.node.ImportNodeResult;
 import com.enonic.xp.node.InsertManualStrategy;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.RefreshMode;
+
+import static java.util.Objects.requireNonNull;
 
 final class ImportContentCommand
     extends AbstractContentCommand
@@ -82,7 +82,7 @@ final class ImportContentCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public ImportContentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ImportContentFactory.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ImportContentFactory.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.enonic.xp.content.ContentConstants;
@@ -14,6 +13,7 @@ import com.enonic.xp.node.NodePath;
 
 import static com.enonic.xp.content.ContentPropertyNames.ORIGIN_PROJECT;
 import static com.enonic.xp.content.ContentPropertyNames.PUBLISH_INFO;
+import static java.util.Objects.requireNonNull;
 
 public class ImportContentFactory
 {
@@ -83,7 +83,7 @@ public class ImportContentFactory
 
         private void validate()
         {
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public ImportContentFactory build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/MediaFormDataBuilder.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/MediaFormDataBuilder.java
@@ -1,7 +1,6 @@
 package com.enonic.xp.core.impl.content;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
@@ -12,6 +11,8 @@ import com.enonic.xp.data.PropertySet;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.data.ValueFactory;
 import com.enonic.xp.schema.content.ContentTypeName;
+
+import static java.util.Objects.requireNonNull;
 
 final class MediaFormDataBuilder
 {
@@ -89,7 +90,7 @@ final class MediaFormDataBuilder
 
     void build( PropertyTree data )
     {
-        Objects.requireNonNull( type, "type is required" );
+        requireNonNull( type, "type is required" );
         Preconditions.checkArgument( focalX >= 0.0 && focalX <= 1.0, "Image focal point x value must be between 0 and 1 : %s", focalX );
         Preconditions.checkArgument( focalY >= 0.0 && focalY <= 1.0, "Image focal point y value must be between 0 and 1 : %s", focalY );
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/MoveContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/MoveContentCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentAlreadyExistsException;
 import com.enonic.xp.content.ContentId;
@@ -31,6 +29,7 @@ import com.enonic.xp.page.Page;
 import com.enonic.xp.schema.content.ContentTypeName;
 
 import static com.enonic.xp.core.impl.content.ContentNodeHelper.translateNodePathToContentPath;
+import static java.util.Objects.requireNonNull;
 
 final class MoveContentCommand
     extends AbstractCreatingOrUpdatingContentCommand
@@ -184,7 +183,7 @@ final class MoveContentCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         MoveContentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/PatchNodeParamsFactory.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/PatchNodeParamsFactory.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import org.osgi.util.function.Function;
 
 import com.google.common.collect.ImmutableSet;
@@ -27,6 +25,8 @@ import com.enonic.xp.schema.content.ContentTypeService;
 import com.enonic.xp.schema.mixin.MixinService;
 import com.enonic.xp.site.CmsService;
 import com.enonic.xp.site.SiteConfigsDataSerializer;
+
+import static java.util.Objects.requireNonNull;
 
 public class PatchNodeParamsFactory
 {
@@ -212,14 +212,14 @@ public class PatchNodeParamsFactory
 
         void validate()
         {
-            Objects.requireNonNull( contentEditor, "contentSupplier cannot be null" );
-            Objects.requireNonNull( createAttachments, "createAttachments cannot be null" );
+            requireNonNull( contentEditor, "contentSupplier cannot be null" );
+            requireNonNull( createAttachments, "createAttachments cannot be null" );
 
-            Objects.requireNonNull( contentTypeService );
-            Objects.requireNonNull( mixinService );
-            Objects.requireNonNull( pageDescriptorService );
-            Objects.requireNonNull( partDescriptorService );
-            Objects.requireNonNull( layoutDescriptorService );
+            requireNonNull( contentTypeService );
+            requireNonNull( mixinService );
+            requireNonNull( pageDescriptorService );
+            requireNonNull( partDescriptorService );
+            requireNonNull( layoutDescriptorService );
         }
 
         public PatchNodeParamsFactory build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ProjectSyncCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ProjectSyncCommand.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.ProjectSyncParams;
 import com.enonic.xp.project.Project;
 import com.enonic.xp.project.ProjectName;
 import com.enonic.xp.project.ProjectService;
+
+import static java.util.Objects.requireNonNull;
 
 
 final class ProjectSyncCommand
@@ -73,9 +73,9 @@ final class ProjectSyncCommand
 
         void validate()
         {
-            Objects.requireNonNull( this.projectService );
-            Objects.requireNonNull( this.contentSynchronizer );
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( this.projectService );
+            requireNonNull( this.contentSynchronizer );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public ProjectSyncCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/PublishContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/PublishContentCommand.java
@@ -2,8 +2,6 @@ package com.enonic.xp.core.impl.content;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.content.CompareContentResults;
@@ -29,6 +27,8 @@ import com.enonic.xp.node.NodeVersionIds;
 import com.enonic.xp.node.PushNodeParams;
 import com.enonic.xp.node.PushNodeResult;
 import com.enonic.xp.node.PushNodesResult;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 public class PublishContentCommand
     extends AbstractContentCommand
@@ -184,7 +184,7 @@ public class PublishContentCommand
         return ( PropertyTree data, NodePath _ ) -> {
             var toBeEdited = data.copy();
 
-            final PropertySet publishInfo = Objects.requireNonNullElseGet( toBeEdited.getSet( ContentPropertyNames.PUBLISH_INFO ),
+            final PropertySet publishInfo = requireNonNullElseGet( toBeEdited.getSet( ContentPropertyNames.PUBLISH_INFO ),
                                                                            () -> toBeEdited.addSet( ContentPropertyNames.PUBLISH_INFO ) );
 
             publishInfo.setInstant( ContentPropertyNames.PUBLISH_TIME, Millis.now() );

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ResetContentInheritanceCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ResetContentInheritanceCommand.java
@@ -2,7 +2,6 @@ package com.enonic.xp.core.impl.content;
 
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -22,6 +21,8 @@ import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.User;
 import com.enonic.xp.security.auth.AuthenticationInfo;
+
+import static java.util.Objects.requireNonNull;
 
 
 final class ResetContentInheritanceCommand
@@ -158,9 +159,9 @@ final class ResetContentInheritanceCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.projectService );
-            Objects.requireNonNull( this.contentService );
-            Objects.requireNonNull( this.contentSynchronizer );
+            requireNonNull( this.projectService );
+            requireNonNull( this.contentService );
+            requireNonNull( this.contentSynchronizer );
         }
 
         public ResetContentInheritanceCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ResolveContentsToBePublishedCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ResolveContentsToBePublishedCommand.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
 import java.util.Set;
 
 import com.enonic.xp.archive.ArchiveConstants;
@@ -14,6 +13,8 @@ import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeIds;
 import com.enonic.xp.node.ResolveSyncWorkResult;
 import com.enonic.xp.node.SyncWorkResolverParams;
+
+import static java.util.Objects.requireNonNull;
 
 public class ResolveContentsToBePublishedCommand
     extends AbstractContentCommand
@@ -119,7 +120,7 @@ public class ResolveContentsToBePublishedCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( contentIds, "contentIds is required" );
+            requireNonNull( contentIds, "contentIds is required" );
         }
 
         public ResolveContentsToBePublishedCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ResolveRequiredDependenciesCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ResolveRequiredDependenciesCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.core.impl.content;
 
 import java.util.Collection;
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentConstants;
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentIds;
@@ -11,6 +9,8 @@ import com.enonic.xp.node.NodeComparison;
 import com.enonic.xp.node.NodeComparisons;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.NodePaths;
+
+import static java.util.Objects.requireNonNull;
 
 public class ResolveRequiredDependenciesCommand
     extends AbstractContentCommand
@@ -90,7 +90,7 @@ public class ResolveRequiredDependenciesCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( contentIds, "contentIds is required" );
+            requireNonNull( contentIds, "contentIds is required" );
         }
 
         public ResolveRequiredDependenciesCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/RestoreContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/RestoreContentCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.archive.ArchiveConstants;
 import com.enonic.xp.archive.RestoreContentException;
 import com.enonic.xp.archive.RestoreContentParams;
@@ -32,6 +30,7 @@ import static com.enonic.xp.content.ContentPropertyNames.ARCHIVED_TIME;
 import static com.enonic.xp.content.ContentPropertyNames.ORIGINAL_NAME;
 import static com.enonic.xp.content.ContentPropertyNames.ORIGINAL_PARENT_PATH;
 import static com.google.common.base.Strings.nullToEmpty;
+import static java.util.Objects.requireNonNull;
 
 final class RestoreContentCommand
     extends AbstractCreatingOrUpdatingContentCommand
@@ -226,7 +225,7 @@ final class RestoreContentCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         RestoreContentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/SortContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/SortContentCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.content;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentIds;
@@ -15,6 +13,8 @@ import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.node.ReorderChildNodeParams;
 import com.enonic.xp.node.SortNodeParams;
 import com.enonic.xp.node.SortNodeResult;
+
+import static java.util.Objects.requireNonNull;
 
 class SortContentCommand
     extends AbstractCreatingOrUpdatingContentCommand
@@ -92,7 +92,7 @@ class SortContentCommand
 
         private Builder( final SortContentParams params )
         {
-            this.params = Objects.requireNonNull( params, "params cannot be null" );
+            this.params = requireNonNull( params, "params cannot be null" );
         }
 
         @Override

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UnpublishContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UnpublishContentCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.core.impl.content;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentConstants;
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentPropertyNames;
@@ -27,6 +25,8 @@ import com.enonic.xp.node.NodeVersionIds;
 import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.node.UpdateNodeParams;
 import com.enonic.xp.node.VersionAttributesResolver;
+
+import static java.util.Objects.requireNonNull;
 
 public class UnpublishContentCommand
     extends AbstractContentCommand
@@ -145,7 +145,7 @@ public class UnpublishContentCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public UnpublishContentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateContentCommand.java
@@ -30,6 +30,8 @@ import com.enonic.xp.site.Site;
 import com.enonic.xp.site.SiteConfigsDataSerializer;
 import com.enonic.xp.util.BinaryReference;
 
+import static java.util.Objects.requireNonNull;
+
 final class UpdateContentCommand
     extends AbstractCreatingOrUpdatingContentCommand
 {
@@ -280,7 +282,7 @@ final class UpdateContentCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         UpdateContentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.core.impl.content;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.attachment.CreateAttachment;
@@ -14,6 +12,8 @@ import com.enonic.xp.media.MediaInfo;
 import com.enonic.xp.media.MediaInfoService;
 import com.enonic.xp.schema.content.ContentTypeFromMimeTypeResolver;
 import com.enonic.xp.schema.content.ContentTypeName;
+
+import static java.util.Objects.requireNonNull;
 
 final class UpdateMediaCommand
     extends AbstractCreatingOrUpdatingContentCommand
@@ -50,7 +50,7 @@ final class UpdateMediaCommand
             mediaType = mediaInfo.getMediaType();
         }
 
-        Objects.requireNonNull( mediaType, "Unable to resolve media type" );
+        requireNonNull( mediaType, "Unable to resolve media type" );
 
         final ContentTypeName resolvedTypeFromMimeType = ContentTypeFromMimeTypeResolver.resolve( mediaType );
         final ContentTypeName type = resolvedTypeFromMimeType != null
@@ -124,7 +124,7 @@ final class UpdateMediaCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public UpdateMediaCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ValidateContentDataCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ValidateContentDataCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.core.impl.content;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.enonic.xp.attachment.CreateAttachments;
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentName;
@@ -16,6 +14,8 @@ import com.enonic.xp.schema.content.ContentType;
 import com.enonic.xp.schema.content.ContentTypeName;
 import com.enonic.xp.schema.content.ContentTypeService;
 import com.enonic.xp.schema.content.GetContentTypeParams;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 final class ValidateContentDataCommand
 {
@@ -42,7 +42,7 @@ final class ValidateContentDataCommand
             .createAttachments( builder.createAttachments )
             .page( builder.page );
         contentTypeName = builder.contentTypeName;
-        resultBuilder = Objects.requireNonNullElseGet( builder.validationErrorsBuilder, ValidationErrors::create );
+        resultBuilder = requireNonNullElseGet( builder.validationErrorsBuilder, ValidationErrors::create );
     }
 
     public static Builder create()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/index/ContentIndexConfigFactory.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/index/ContentIndexConfigFactory.java
@@ -2,7 +2,6 @@ package com.enonic.xp.core.impl.content.index;
 
 import java.util.Collection;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.enonic.xp.content.Mixins;
@@ -31,6 +30,8 @@ import com.enonic.xp.schema.mixin.MixinService;
 import com.enonic.xp.site.CmsDescriptor;
 import com.enonic.xp.site.CmsService;
 import com.enonic.xp.site.SiteConfigs;
+
+import static java.util.Objects.requireNonNull;
 
 public class ContentIndexConfigFactory
 {
@@ -206,7 +207,7 @@ public class ContentIndexConfigFactory
 
         private void validate()
         {
-            Objects.requireNonNull( contentTypeService );
+            requireNonNull( contentTypeService );
         }
 
         public ContentIndexConfigFactory build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/page/PageTemplateServiceImpl.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/page/PageTemplateServiceImpl.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.core.impl.content.page;
 
 
-import java.util.Objects;
-
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -15,6 +13,8 @@ import com.enonic.xp.page.PageTemplate;
 import com.enonic.xp.page.PageTemplateKey;
 import com.enonic.xp.page.PageTemplateService;
 import com.enonic.xp.page.PageTemplates;
+
+import static java.util.Objects.requireNonNull;
 
 @Component(immediate = true)
 public final class PageTemplateServiceImpl
@@ -45,7 +45,7 @@ public final class PageTemplateServiceImpl
     @Override
     public PageTemplate getByKey( final PageTemplateKey pageTemplateKey )
     {
-        Objects.requireNonNull( pageTemplateKey, "pageTemplateKey is required" );
+        requireNonNull( pageTemplateKey, "pageTemplateKey is required" );
         return new GetPageTemplateByKeyCommand().
             pageTemplateKey( pageTemplateKey ).
             contentService( this.contentService ).
@@ -66,7 +66,7 @@ public final class PageTemplateServiceImpl
     @Override
     public PageTemplates getBySite( final ContentId siteId )
     {
-        Objects.requireNonNull( siteId, "siteId is required" );
+        requireNonNull( siteId, "siteId is required" );
         return new GetPageTemplateBySiteCommand().
             site( siteId ).
             contentService( this.contentService ).

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/page/region/CreateFragmentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/page/region/CreateFragmentCommand.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.core.impl.content.page.region;
 
-import java.util.Objects;
 import java.util.stream.IntStream;
 
 import com.enonic.xp.content.Content;
@@ -26,6 +25,8 @@ import com.enonic.xp.region.PartDescriptorService;
 import com.enonic.xp.region.TextComponent;
 import com.enonic.xp.region.TextComponentType;
 import com.enonic.xp.schema.content.ContentTypeName;
+
+import static java.util.Objects.requireNonNull;
 
 final class CreateFragmentCommand
 {
@@ -217,10 +218,10 @@ final class CreateFragmentCommand
 
         private void validate()
         {
-            Objects.requireNonNull( contentService );
-            Objects.requireNonNull( partDescriptorService );
-            Objects.requireNonNull( layoutDescriptorService );
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( contentService );
+            requireNonNull( partDescriptorService );
+            requireNonNull( layoutDescriptorService );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public CreateFragmentCommand build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/validate/InputValidator.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/validate/InputValidator.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.core.impl.content.validate;
 
-import java.util.Objects;
-
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.form.Form;
 import com.enonic.xp.inputtype.InputTypeResolver;
+
+import static java.util.Objects.requireNonNull;
 
 public final class InputValidator
 {
@@ -52,8 +52,8 @@ public final class InputValidator
 
         private void validate()
         {
-            Objects.requireNonNull( this.form );
-            Objects.requireNonNull( this.inputTypeResolver );
+            requireNonNull( this.form );
+            requireNonNull( this.inputTypeResolver );
         }
 
         public InputValidator build()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/issue/CreateIssueCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/issue/CreateIssueCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.core.impl.issue;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.core.impl.issue.serializer.IssueDataSerializer;
 import com.enonic.xp.core.internal.Millis;
@@ -28,6 +26,7 @@ import static com.enonic.xp.issue.IssuePropertyNames.CREATED_TIME;
 import static com.enonic.xp.issue.IssuePropertyNames.CREATOR;
 import static com.enonic.xp.issue.IssuePropertyNames.INDEX;
 import static com.enonic.xp.issue.IssuePropertyNames.MODIFIED_TIME;
+import static java.util.Objects.requireNonNullElseGet;
 
 public class CreateIssueCommand
     extends AbstractIssueCommand
@@ -83,7 +82,7 @@ public class CreateIssueCommand
 
     User getCurrentUser()
     {
-        return Objects.requireNonNullElseGet( ContextAccessor.current().getAuthInfo().getUser(), User::anonymous );
+        return requireNonNullElseGet( ContextAccessor.current().getAuthInfo().getUser(), User::anonymous );
     }
 
     private long countTotalIssues()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/issue/UpdateIssueCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/issue/UpdateIssueCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.issue;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.core.impl.issue.serializer.IssueDataSerializer;
 import com.enonic.xp.core.internal.Millis;
@@ -17,6 +15,8 @@ import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.node.UpdateNodeParams;
 import com.enonic.xp.security.User;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 public class UpdateIssueCommand
     extends AbstractIssueCommand
@@ -70,7 +70,7 @@ public class UpdateIssueCommand
 
     User getCurrentUser()
     {
-        return Objects.requireNonNullElseGet( ContextAccessor.current().getAuthInfo().getUser(), User::anonymous );
+        return requireNonNullElseGet( ContextAccessor.current().getAuthInfo().getUser(), User::anonymous );
     }
 
     public static Builder create()

--- a/modules/core/core-export/src/main/java/com/enonic/xp/core/impl/export/ImportNodeFactory.java
+++ b/modules/core/core-export/src/main/java/com/enonic/xp/core/impl/export/ImportNodeFactory.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.core.impl.export;
 
-import java.util.Objects;
-
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.repository.RepositoryConstants;
 import com.enonic.xp.security.acl.AccessControlList;
+
+import static java.util.Objects.requireNonNull;
 
 public class ImportNodeFactory
 {
@@ -104,8 +104,8 @@ public class ImportNodeFactory
 
         private void validate()
         {
-            Objects.requireNonNull( this.importPath, "importPath cannot be null" );
-            Objects.requireNonNull( this.serializedNode, "serializedNode cannot be null" );
+            requireNonNull( this.importPath, "importPath cannot be null" );
+            requireNonNull( this.serializedNode, "serializedNode cannot be null" );
         }
 
         public ImportNodeFactory build()

--- a/modules/core/core-export/src/main/java/com/enonic/xp/core/impl/export/NodeExporter.java
+++ b/modules/core/core-export/src/main/java/com/enonic/xp/core/impl/export/NodeExporter.java
@@ -2,8 +2,6 @@ package com.enonic.xp.core.impl.export;
 
 import java.nio.file.Path;
 import java.util.Iterator;
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +37,8 @@ import com.enonic.xp.query.expr.ValueExpr;
 import com.enonic.xp.query.parser.QueryParser;
 import com.enonic.xp.util.BinaryReference;
 
+import static java.util.Objects.requireNonNull;
+
 public class NodeExporter
 {
     private static final String LINE_SEPARATOR = System.lineSeparator();
@@ -67,7 +67,7 @@ public class NodeExporter
         this.nodeService = builder.nodeService;
         this.exportWriter = builder.exportWriter;
         this.targetDirectory = builder.targetDirectory;
-        this.xpVersion = Objects.requireNonNull( builder.xpVersion );
+        this.xpVersion = requireNonNull( builder.xpVersion );
         this.batchSize = Math.max( 1, builder.batchSize );
         this.nodeExportListener = builder.nodeExportListener;
     }

--- a/modules/core/core-export/src/test/java/com/enonic/xp/core/impl/export/xml/BaseXmlSerializerTest.java
+++ b/modules/core/core-export/src/test/java/com/enonic/xp/core/impl/export/xml/BaseXmlSerializerTest.java
@@ -2,10 +2,9 @@ package com.enonic.xp.core.impl.export.xml;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
-
 import org.w3c.dom.Document;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class BaseXmlSerializerTest
@@ -14,7 +13,7 @@ public abstract class BaseXmlSerializerTest
         throws Exception
     {
         final InputStream stream =
-            Objects.requireNonNull( getClass().getResourceAsStream( fileName ), "Resource file [" + fileName + "] not found" );
+            requireNonNull( getClass().getResourceAsStream( fileName ), "Resource file [" + fileName + "] not found" );
         try (stream)
         {
             final String xml = new String( stream.readAllBytes(), StandardCharsets.UTF_8 );

--- a/modules/core/core-i18n/src/main/java/com/enonic/xp/core/impl/i18n/LocaleServiceImpl.java
+++ b/modules/core/core-i18n/src/main/java/com/enonic/xp/core/impl/i18n/LocaleServiceImpl.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -34,6 +33,8 @@ import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceKeys;
 import com.enonic.xp.resource.ResourceService;
+
+import static java.util.Objects.requireNonNullElse;
 
 @Component(immediate = true)
 @NullMarked
@@ -68,7 +69,7 @@ public final class LocaleServiceImpl
     public MessageBundle getBundle( final ApplicationKey applicationKey, final @Nullable Locale locale, final String... bundleNames )
     {
         final String[] baseNames = bundleNames.length == 0 ? DEFAULT_BASE_NAMES : bundleNames;
-        final Locale nonNullLocale = Objects.requireNonNullElse( locale, Locale.ROOT );
+        final Locale nonNullLocale = requireNonNullElse( locale, Locale.ROOT );
 
         final String key = bundleCacheKey( applicationKey, nonNullLocale, baseNames );
         return this.bundleCache.computeIfAbsent( key, k -> createMessageBundle( applicationKey, nonNullLocale, baseNames ) );

--- a/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/ImageServiceImpl.java
+++ b/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/ImageServiceImpl.java
@@ -13,7 +13,6 @@ import java.security.MessageDigest;
 import java.util.HexFormat;
 import java.util.Iterator;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -46,6 +45,8 @@ import com.enonic.xp.image.ImageService;
 import com.enonic.xp.image.ReadImageParams;
 import com.enonic.xp.image.ScaleParams;
 import com.enonic.xp.media.ImageOrientation;
+
+import static java.util.Objects.requireNonNull;
 
 @Component
 public class ImageServiceImpl
@@ -243,7 +244,7 @@ public class ImageServiceImpl
                 {
                     BufferedImage bufferedImage = imageReader.read( 0, imageReader.getDefaultReadParam() );
                     imageReader.dispose();
-                    Objects.requireNonNull( bufferedImage, "BufferedImage is null" );
+                    requireNonNull( bufferedImage, "BufferedImage is null" );
                     if ( toRotate )
                     {
                         bufferedImage = applyRotation( bufferedImage, readImageParams.getOrientation() );

--- a/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/ImmutableFilesHelper.java
+++ b/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/ImmutableFilesHelper.java
@@ -7,7 +7,6 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Consumer;
 
@@ -15,6 +14,8 @@ import com.google.common.io.ByteSink;
 import com.google.common.io.ByteSource;
 import com.google.common.io.MoreFiles;
 import com.google.common.util.concurrent.Striped;
+
+import static java.util.Objects.requireNonNull;
 
 
 public class ImmutableFilesHelper
@@ -31,8 +32,8 @@ public class ImmutableFilesHelper
     public ByteSource computeIfAbsent( final Path path, final Consumer<ByteSink> consumer )
         throws IOException
     {
-        Objects.requireNonNull( path, "path is required" );
-        Objects.requireNonNull( consumer, "consumer is required" );
+        requireNonNull( path, "path is required" );
+        requireNonNull( consumer, "consumer is required" );
 
         if ( Files.exists( path ) )
         {

--- a/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/effect/BaseImageFilterTest.java
+++ b/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/effect/BaseImageFilterTest.java
@@ -8,9 +8,9 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.util.Objects;
-
 import javax.imageio.ImageIO;
+
+import static java.util.Objects.requireNonNull;
 
 public abstract class BaseImageFilterTest
 {
@@ -28,7 +28,7 @@ public abstract class BaseImageFilterTest
     {
         try (InputStream resourceAsStream = BaseImageFilterTest.class.getResourceAsStream( name ))
         {
-            return ImageIO.read( Objects.requireNonNull( resourceAsStream ) );
+            return ImageIO.read( requireNonNull( resourceAsStream ) );
         }
         catch ( IOException e )
         {

--- a/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/FileNames.java
+++ b/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/FileNames.java
@@ -4,10 +4,11 @@ import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Collection of utility methods for file names
@@ -54,7 +55,7 @@ public class FileNames
      */
     public static boolean isSafeFileName( final String fileName )
     {
-        Objects.requireNonNull( fileName );
+        requireNonNull( fileName );
 
         final int length = fileName.length();
         if ( length == 0 || length > MAX_LENGTH )

--- a/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/NameValidator.java
+++ b/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/NameValidator.java
@@ -1,12 +1,13 @@
 package com.enonic.xp.core.internal;
 
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
 import org.jspecify.annotations.NonNull;
+
+import static java.util.Objects.requireNonNull;
 
 public final class NameValidator
 {
@@ -77,7 +78,7 @@ public final class NameValidator
 
     public String validate( final String name, String typeOverride )
     {
-        Objects.requireNonNull( name, () -> typeOverride + " must not be null" );
+        requireNonNull( name, () -> typeOverride + " must not be null" );
 
         if ( name.isEmpty() )
         {

--- a/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/concurrent/AtomicSortedList.java
+++ b/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/concurrent/AtomicSortedList.java
@@ -2,11 +2,12 @@ package com.enonic.xp.core.internal.concurrent;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Aa atomic sorted list of elements.
@@ -27,7 +28,7 @@ public class AtomicSortedList<T>
      */
     public AtomicSortedList( final Comparator<T> comparator )
     {
-        this.comparator = Objects.requireNonNull( comparator );
+        this.comparator = requireNonNull( comparator );
     }
 
     /**

--- a/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/concurrent/SimpleExecutor.java
+++ b/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/concurrent/SimpleExecutor.java
@@ -2,7 +2,6 @@ package com.enonic.xp.core.internal.concurrent;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -12,6 +11,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.jspecify.annotations.NullMarked;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A "one size fits all" {@link Executor} for OSGi services
@@ -50,7 +51,7 @@ public final class SimpleExecutor
      */
     public static SimpleExecutor ofVirtual( final String namePrefix, final Consumer<Throwable> uncaughtExceptionHandler )
     {
-        Objects.requireNonNull( uncaughtExceptionHandler, "uncaughtExceptionHandler is required" );
+        requireNonNull( uncaughtExceptionHandler, "uncaughtExceptionHandler is required" );
         return new SimpleExecutor( Executors.newThreadPerTaskExecutor( Thread.ofVirtual()
                                                                            .name( namePrefix, 0 )
                                                                            .uncaughtExceptionHandler( ( _, e ) -> uncaughtExceptionHandler.accept( e ) )
@@ -67,7 +68,7 @@ public final class SimpleExecutor
      */
     public static SimpleExecutor ofSingle( final String name, final Consumer<Throwable> uncaughtExceptionHandler )
     {
-        Objects.requireNonNull( uncaughtExceptionHandler, "uncaughtExceptionHandler is required" );
+        requireNonNull( uncaughtExceptionHandler, "uncaughtExceptionHandler is required" );
         return new SimpleExecutor( Executors.newSingleThreadExecutor( new ThreadFactoryImpl( name, uncaughtExceptionHandler ) ) );
     }
 

--- a/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/osgi/OsgiSupport.java
+++ b/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/osgi/OsgiSupport.java
@@ -1,7 +1,6 @@
 package com.enonic.xp.core.internal.osgi;
 
 import java.util.Collection;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -10,6 +9,8 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 public final class OsgiSupport
 {
@@ -26,7 +27,7 @@ public final class OsgiSupport
 
     public static Bundle getBundle( final Class<?> clazz )
     {
-        return Objects.requireNonNullElseGet( bundle, () -> FrameworkUtil.getBundle( clazz ) );
+        return requireNonNullElseGet( bundle, () -> FrameworkUtil.getBundle( clazz ) );
     }
 
     public static <T, R> R withServiceOrElseGet( Class<T> serviceClass, String filter, Function<? super T, R> function,

--- a/modules/core/core-jsonschema/src/test/java/com/enonic/xp/core/jsonschema/AbstractSchemaValidationTest.java
+++ b/modules/core/core-jsonschema/src/test/java/com/enonic/xp/core/jsonschema/AbstractSchemaValidationTest.java
@@ -14,8 +14,6 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.Error;
 import com.networknt.schema.InputFormat;
@@ -25,6 +23,8 @@ import com.networknt.schema.SchemaRegistry;
 import com.networknt.schema.dialect.Dialects;
 
 import org.junit.jupiter.api.BeforeAll;
+
+import static java.util.Objects.requireNonNull;
 
 abstract class AbstractSchemaValidationTest
 {
@@ -53,7 +53,7 @@ abstract class AbstractSchemaValidationTest
 
     protected static Schema schemaFor( final String schemaFileName )
     {
-        return Objects.requireNonNull( schemasByFileName.get( schemaFileName ),
+        return requireNonNull( schemasByFileName.get( schemaFileName ),
                                        () -> schemaFileName + " not found in loaded schemas" );
     }
 
@@ -61,7 +61,7 @@ abstract class AbstractSchemaValidationTest
     {
         final InputStream is =
             AbstractSchemaValidationTest.class.getClassLoader().getResourceAsStream( resourcePath );
-        Objects.requireNonNull( is, () -> "Resource not found: " + resourcePath );
+        requireNonNull( is, () -> "Resource not found: " + resourcePath );
         try ( is )
         {
             return schema.validate( new String( is.readAllBytes(), StandardCharsets.UTF_8 ), InputFormat.YAML );

--- a/modules/core/core-mail/src/main/java/com/enonic/xp/mail/impl/MimeMessageConverter.java
+++ b/modules/core/core-mail/src/main/java/com/enonic/xp/mail/impl/MimeMessageConverter.java
@@ -6,7 +6,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.common.io.ByteSource;
@@ -29,6 +28,7 @@ import com.enonic.xp.mail.SendMailParams;
 import com.enonic.xp.util.MediaTypes;
 
 import static com.google.common.base.Strings.nullToEmpty;
+import static java.util.Objects.requireNonNullElseGet;
 
 class MimeMessageConverter
 {
@@ -110,7 +110,7 @@ class MimeMessageConverter
     {
         final MimeBodyPart result = new MimeBodyPart();
 
-        final String mimeType = Objects.requireNonNullElseGet( attachment.getMimeType(),
+        final String mimeType = requireNonNullElseGet( attachment.getMimeType(),
                                                          () -> MediaTypes.instance().fromFile( attachment.getFileName() ).toString() );
 
         final DataSource source = new ByteSourceDataSource( attachment.getData(), attachment.getFileName(), mimeType );

--- a/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/AbstractProjectCommand.java
+++ b/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/AbstractProjectCommand.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.core.impl.project;
 
-import java.util.Objects;
-
 import com.enonic.xp.project.ProjectName;
+
+import static java.util.Objects.requireNonNull;
 
 abstract class AbstractProjectCommand
 {
@@ -25,7 +25,7 @@ abstract class AbstractProjectCommand
 
         void validate()
         {
-            Objects.requireNonNull( projectName, "projectName is required" );
+            requireNonNull( projectName, "projectName is required" );
         }
 
     }

--- a/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/AbstractProjectRolesCommand.java
+++ b/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/AbstractProjectRolesCommand.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.core.impl.project;
 
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -10,6 +9,8 @@ import com.enonic.xp.security.PrincipalKeys;
 import com.enonic.xp.security.PrincipalRelationship;
 import com.enonic.xp.security.PrincipalRelationships;
 import com.enonic.xp.security.SecurityService;
+
+import static java.util.Objects.requireNonNull;
 
 abstract class AbstractProjectRolesCommand
     extends AbstractProjectCommand
@@ -95,7 +96,7 @@ abstract class AbstractProjectRolesCommand
         @Override
         void validate()
         {
-            Objects.requireNonNull( securityService );
+            requireNonNull( securityService );
         }
     }
 

--- a/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/CreateProjectRolesCommand.java
+++ b/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/CreateProjectRolesCommand.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.core.impl.project;
 
-import java.util.Objects;
-
 import com.enonic.xp.project.ProjectRole;
 import com.enonic.xp.security.CreateRoleParams;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.Role;
+
+import static java.util.Objects.requireNonNull;
 
 public final class CreateProjectRolesCommand
     extends AbstractProjectRolesCommand
@@ -58,7 +58,7 @@ public final class CreateProjectRolesCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.projectDisplayName, "Project display name is required" );
+            requireNonNull( this.projectDisplayName, "Project display name is required" );
         }
 
         public CreateProjectRolesCommand build()

--- a/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/CreateProjectRootAccessListCommand.java
+++ b/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/CreateProjectRootAccessListCommand.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.core.impl.project;
 
-import java.util.Objects;
-
 import com.enonic.xp.project.ProjectRole;
 import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.acl.AccessControlEntry;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.acl.Permission;
+
+import static java.util.Objects.requireNonNullElse;
 
 public final class CreateProjectRootAccessListCommand
     extends AbstractProjectCommand
@@ -16,7 +16,7 @@ public final class CreateProjectRootAccessListCommand
     private CreateProjectRootAccessListCommand( final Builder builder )
     {
         super( builder );
-        this.permissions = Objects.requireNonNullElse( builder.permissions, AccessControlList.empty() );
+        this.permissions = requireNonNullElse( builder.permissions, AccessControlList.empty() );
     }
 
     public static Builder create()

--- a/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/UpdateProjectRoleNamesCommand.java
+++ b/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/UpdateProjectRoleNamesCommand.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.core.impl.project;
 
-import java.util.Objects;
-
 import com.enonic.xp.project.ProjectRole;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.Role;
 import com.enonic.xp.security.UpdateRoleParams;
+
+import static java.util.Objects.requireNonNull;
 
 public final class UpdateProjectRoleNamesCommand
     extends AbstractProjectRolesCommand
@@ -58,7 +58,7 @@ public final class UpdateProjectRoleNamesCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.projectDisplayName, "Project display name is required" );
+            requireNonNull( this.projectDisplayName, "Project display name is required" );
         }
 
         public UpdateProjectRoleNamesCommand build()

--- a/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/UpdateProjectRolesCommand.java
+++ b/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/UpdateProjectRolesCommand.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.core.impl.project;
 
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -10,6 +9,8 @@ import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.PrincipalKeys;
 import com.enonic.xp.security.PrincipalRelationship;
 import com.enonic.xp.security.PrincipalRelationships;
+
+import static java.util.Objects.requireNonNull;
 
 public final class UpdateProjectRolesCommand
     extends AbstractProjectRolesCommand
@@ -86,7 +87,7 @@ public final class UpdateProjectRolesCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.permissions, "Project permissions is required" );
+            requireNonNull( this.permissions, "Project permissions is required" );
         }
 
         public UpdateProjectRolesCommand build()

--- a/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/init/ArchiveInitializer.java
+++ b/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/init/ArchiveInitializer.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.project.init;
 
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,6 +14,8 @@ import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.repository.BranchNotFoundException;
 import com.enonic.xp.schema.content.ContentTypeName;
+
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class ArchiveInitializer
@@ -73,7 +73,7 @@ public final class ArchiveInitializer
             data( data ).
             name( ArchiveConstants.ARCHIVE_ROOT_NAME ).
             parent( NodePath.ROOT ).
-            permissions( Objects.requireNonNullElse( accessControlList, ArchiveConstants.ARCHIVE_ROOT_DEFAULT_ACL ) ).
+            permissions( requireNonNullElse( accessControlList, ArchiveConstants.ARCHIVE_ROOT_DEFAULT_ACL ) ).
             childOrder( ArchiveConstants.DEFAULT_ARCHIVE_REPO_ROOT_ORDER ).
             refresh( RefreshMode.ALL ).
             build() );

--- a/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/init/ContentInitializer.java
+++ b/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/init/ContentInitializer.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.project.init;
 
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +23,8 @@ import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.acl.AccessControlEntry;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.acl.Permission;
+
+import static java.util.Objects.requireNonNullElse;
 
 public final class ContentInitializer
     extends RepoDependentInitializer
@@ -105,7 +105,7 @@ public final class ContentInitializer
                                                              .data( data )
                                                              .name( ContentConstants.CONTENT_ROOT_NAME )
                                                              .parent( NodePath.ROOT )
-                                                             .permissions( Objects.requireNonNullElse( this.accessControlList,
+                                                             .permissions( requireNonNullElse( this.accessControlList,
                                                                                                        CONTENT_ROOT_DEFAULT_ACL ) )
                                                              .childOrder( CONTENT_DEFAULT_CHILD_ORDER )
                                                              .refresh( RefreshMode.ALL )

--- a/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/init/ContentRepoInitializer.java
+++ b/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/init/ContentRepoInitializer.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.project.init;
 
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,6 +17,8 @@ import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.repository.RepositoryService;
 import com.enonic.xp.repository.internal.InternalRepositoryService;
 
+import static java.util.Objects.requireNonNull;
+
 public class ContentRepoInitializer
     extends ExternalInitializer
 {
@@ -35,10 +35,10 @@ public class ContentRepoInitializer
     private ContentRepoInitializer( Builder builder )
     {
         super( builder );
-        this.repositoryService = Objects.requireNonNull( builder.repositoryService );
-        this.internalRepositoryService = Objects.requireNonNull( builder.internalRepositoryService );
-        this.repositoryData = Objects.requireNonNull( builder.repositoryData );
-        this.repositoryId = Objects.requireNonNull( builder.repositoryId );
+        this.repositoryService = requireNonNull( builder.repositoryService );
+        this.internalRepositoryService = requireNonNull( builder.internalRepositoryService );
+        this.repositoryData = requireNonNull( builder.repositoryData );
+        this.repositoryId = requireNonNull( builder.repositoryId );
     }
 
     public static Builder create()

--- a/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/init/IssueInitializer.java
+++ b/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/init/IssueInitializer.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.project.init;
 
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +21,8 @@ import com.enonic.xp.security.User;
 import com.enonic.xp.security.acl.AccessControlEntry;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.acl.Permission;
+
+import static java.util.Objects.requireNonNullElse;
 
 
 public class IssueInitializer
@@ -84,7 +84,7 @@ public class IssueInitializer
                                                        .name( IssueConstants.ISSUE_ROOT_NAME )
                                                        .parent( NodePath.ROOT )
                                                        .permissions(
-                                                           Objects.requireNonNullElse( accessControlList, ISSUE_ROOT_DEFAULT_ACL ) )
+                                                           requireNonNullElse( accessControlList, ISSUE_ROOT_DEFAULT_ACL ) )
                                                        .childOrder( IssueConstants.DEFAULT_CHILD_ORDER )
                                                        .refresh( RefreshMode.ALL )
                                                        .build() );

--- a/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/init/RepoDependentInitializer.java
+++ b/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/init/RepoDependentInitializer.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.core.impl.project.init;
 
-import java.util.Objects;
-
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
@@ -14,6 +12,8 @@ import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.User;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.auth.AuthenticationInfo;
+
+import static java.util.Objects.requireNonNull;
 
 public abstract class RepoDependentInitializer
     extends ExternalInitializer
@@ -33,8 +33,8 @@ public abstract class RepoDependentInitializer
     {
         super( builder );
 
-        this.nodeService = Objects.requireNonNull( builder.nodeService );
-        this.repositoryId = Objects.requireNonNull( builder.repositoryId );
+        this.nodeService = requireNonNull( builder.nodeService );
+        this.repositoryId = requireNonNull( builder.repositoryId );
         this.accessControlList = builder.accessControlList;
     }
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/InternalContext.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/InternalContext.java
@@ -10,6 +10,9 @@ import com.enonic.xp.context.Context;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.security.PrincipalKeys;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
 
 public class InternalContext
 {
@@ -27,7 +30,7 @@ public class InternalContext
     {
         this.repositoryId = builder.repositoryId;
         this.branch = builder.branch;
-        this.principalsKeys = Objects.requireNonNullElse( builder.principalsKeys, PrincipalKeys.empty() );
+        this.principalsKeys = requireNonNullElse( builder.principalsKeys, PrincipalKeys.empty() );
         this.searchPreference = builder.searchPreference;
         this.eventMetadata = builder.eventMetadata.build();
     }
@@ -163,8 +166,8 @@ public class InternalContext
 
         private void verify()
         {
-            Objects.requireNonNull( repositoryId, "repositoryId is required" );
-            Objects.requireNonNull( branch, "branch is required" );
+            requireNonNull( repositoryId, "repositoryId is required" );
+            requireNonNull( branch, "branch is required" );
         }
 
         public InternalContext build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/NodeBranchEntry.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/NodeBranchEntry.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.repo.impl;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.NodeVersion;
 import com.enonic.xp.node.NodeVersionId;
 import com.enonic.xp.node.NodeVersionKey;
+
+import static java.util.Objects.requireNonNull;
 
 public final class NodeBranchEntry
 {
@@ -23,11 +23,11 @@ public final class NodeBranchEntry
 
     private NodeBranchEntry( Builder builder )
     {
-        this.nodeVersionId = Objects.requireNonNull( builder.nodeVersionId );
-        this.nodeVersionKey = Objects.requireNonNull( builder.nodeVersionKey );
-        this.nodePath = Objects.requireNonNull( builder.nodePath );
-        this.timestamp = Objects.requireNonNull( builder.timestamp );
-        this.nodeId = Objects.requireNonNull( builder.nodeId );
+        this.nodeVersionId = requireNonNull( builder.nodeVersionId );
+        this.nodeVersionKey = requireNonNull( builder.nodeVersionKey );
+        this.nodePath = requireNonNull( builder.nodePath );
+        this.timestamp = requireNonNull( builder.timestamp );
+        this.nodeId = requireNonNull( builder.nodeId );
     }
 
     public static Builder create()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/NodeStoreVersion.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/NodeStoreVersion.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl;
 
-import java.util.Objects;
-
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.index.ChildOrder;
 import com.enonic.xp.index.IndexConfigDocument;
@@ -11,16 +9,19 @@ import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeType;
 import com.enonic.xp.security.acl.AccessControlList;
 
+import static java.util.Objects.requireNonNullElse;
+import static java.util.Objects.requireNonNullElseGet;
+
 public record NodeStoreVersion(NodeId id, NodeType nodeType, PropertyTree data, IndexConfigDocument indexConfigDocument,
                                ChildOrder childOrder, Long manualOrderValue, AccessControlList permissions,
                                AttachedBinaries attachedBinaries)
 {
     public NodeStoreVersion
     {
-        data = Objects.requireNonNullElseGet( data, PropertyTree::new );
-        nodeType = Objects.requireNonNullElse( nodeType, NodeType.DEFAULT_NODE_COLLECTION );
-        permissions = Objects.requireNonNullElse( permissions, AccessControlList.empty() );
-        attachedBinaries = Objects.requireNonNullElse( attachedBinaries, AttachedBinaries.empty() );
+        data = requireNonNullElseGet( data, PropertyTree::new );
+        nodeType = requireNonNullElse( nodeType, NodeType.DEFAULT_NODE_COLLECTION );
+        permissions = requireNonNullElse( permissions, AccessControlList.empty() );
+        attachedBinaries = requireNonNullElse( attachedBinaries, AttachedBinaries.empty() );
     }
 
     public static NodeStoreVersion from( final Node node )

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/SingleRepoSearchSource.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/SingleRepoSearchSource.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.repo.impl;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.security.PrincipalKeys;
+
+import static java.util.Objects.requireNonNull;
 
 @NullMarked
 public class SingleRepoSearchSource
@@ -36,9 +36,9 @@ public class SingleRepoSearchSource
 
     private SingleRepoSearchSource( final Builder builder )
     {
-        repositoryId = Objects.requireNonNull( builder.repositoryId, "repositoryId is required in search-source" );
-        branch = Objects.requireNonNull( builder.branch, "branch is required in search-source" );
-        acl = Objects.requireNonNull( builder.acl, "acl is required in search-source" );
+        repositoryId = requireNonNull( builder.repositoryId, "repositoryId is required in search-source" );
+        branch = requireNonNull( builder.branch, "branch is required in search-source" );
+        acl = requireNonNull( builder.acl, "acl is required in search-source" );
     }
 
     public static SingleRepoSearchSource from( final InternalContext context )

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/cache/BranchPath.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/cache/BranchPath.java
@@ -6,6 +6,8 @@ import com.enonic.xp.branch.Branch;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.repository.RepositoryId;
 
+import static java.util.Objects.requireNonNull;
+
 public final class BranchPath
 {
     private final RepositoryId repositoryId;
@@ -16,9 +18,9 @@ public final class BranchPath
 
     public BranchPath( final RepositoryId repositoryId, final Branch branch, final NodePath path )
     {
-        this.repositoryId = Objects.requireNonNull( repositoryId );
-        this.branch = Objects.requireNonNull( branch );
-        this.path = Objects.requireNonNull( path );
+        this.repositoryId = requireNonNull( repositoryId );
+        this.branch = requireNonNull( branch );
+        this.path = requireNonNull( path );
     }
 
     public RepositoryId getRepositoryId()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/PathRef.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/PathRef.java
@@ -1,7 +1,7 @@
 package com.enonic.xp.repo.impl.dump;
 
 import java.nio.file.Path;
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
 public final class PathRef
 {
@@ -29,7 +29,7 @@ public final class PathRef
 
     private static String validate( String element )
     {
-        Objects.requireNonNull( element, "element can't be null" );
+        requireNonNull( element, "element can't be null" );
         if ( element.equals( "." ) || element.equals( ".." ) || element.contains( SEPARATOR ) )
         {
             throw new IllegalArgumentException( "Invalid element " + element );

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/RepoDumper.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/RepoDumper.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -53,6 +52,8 @@ import com.enonic.xp.repo.impl.version.VersionIndexPath;
 import com.enonic.xp.repository.RepositoryConstants;
 import com.enonic.xp.repository.RepositoryId;
 
+import static java.util.Objects.requireNonNullElse;
+
 public class RepoDumper
 {
     private static final Logger LOG = LoggerFactory.getLogger( RepoDumper.class );
@@ -91,7 +92,7 @@ public class RepoDumper
         this.maxAge = builder.maxAge;
         this.maxVersions = builder.maxVersions;
         this.nodeIds = builder.nodeIds;
-        this.listener = Objects.requireNonNullElse( builder.listener, NoopSystemDumpListener.INSTANCE );
+        this.listener = requireNonNullElse( builder.listener, NoopSystemDumpListener.INSTANCE );
     }
 
     public RepoDumpResult execute()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/blobstore/BlobReference.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/blobstore/BlobReference.java
@@ -1,19 +1,19 @@
 package com.enonic.xp.repo.impl.dump.blobstore;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NullMarked;
 
 import com.enonic.xp.blob.BlobKey;
 import com.enonic.xp.blob.Segment;
+
+import static java.util.Objects.requireNonNull;
 
 @NullMarked
 public record BlobReference(Segment segment, BlobKey key)
 {
     public BlobReference( final Segment segment, final BlobKey key )
     {
-        this.segment = Objects.requireNonNull( segment );
-        this.key = Objects.requireNonNull( key );
+        this.segment = requireNonNull( segment );
+        this.key = requireNonNull( key );
     }
 
     @Override

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/model/BranchDumpEntry.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/model/BranchDumpEntry.java
@@ -1,16 +1,16 @@
 package com.enonic.xp.repo.impl.dump.model;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.enonic.xp.node.NodeId;
+
+import static java.util.Objects.requireNonNull;
 
 public record BranchDumpEntry(NodeId nodeId, VersionMeta meta, List<String> binaryReferences)
 {
     public BranchDumpEntry
     {
-        Objects.requireNonNull( nodeId );
-        Objects.requireNonNull( meta );
+        requireNonNull( nodeId );
+        requireNonNull( meta );
         binaryReferences = List.copyOf( binaryReferences );
     }
 }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/model/CommitDumpEntry.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/model/CommitDumpEntry.java
@@ -1,17 +1,17 @@
 package com.enonic.xp.repo.impl.dump.model;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.core.internal.Millis;
 import com.enonic.xp.node.NodeCommitId;
 import com.enonic.xp.security.PrincipalKey;
+
+import static java.util.Objects.requireNonNullElse;
 
 public record CommitDumpEntry(NodeCommitId nodeCommitId, String message, Instant timestamp, PrincipalKey committer)
 {
     public CommitDumpEntry
     {
-        message = Objects.requireNonNullElse( message, "" );
+        message = requireNonNullElse( message, "" );
         timestamp = Millis.from( timestamp );
         committer = committer == null ? PrincipalKey.ofAnonymous() : committer;
     }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/model/VersionsDumpEntry.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/model/VersionsDumpEntry.java
@@ -1,16 +1,17 @@
 package com.enonic.xp.repo.impl.dump.model;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 import com.enonic.xp.node.NodeId;
+
+import static java.util.Objects.requireNonNull;
 
 public record VersionsDumpEntry(NodeId nodeId, List<VersionMeta> versions)
 {
     public VersionsDumpEntry
     {
-        Objects.requireNonNull( nodeId );
+        requireNonNull( nodeId );
         versions = List.copyOf( versions );
     }
 }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/reader/ZipDumpReaderV8.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/reader/ZipDumpReaderV8.java
@@ -11,7 +11,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
@@ -62,6 +61,8 @@ import com.enonic.xp.repository.RepositoryIds;
 import com.enonic.xp.repository.RepositorySegmentUtils;
 import com.enonic.xp.security.SystemConstants;
 
+import static java.util.Objects.requireNonNullElse;
+
 public class ZipDumpReaderV8
     implements DumpReader
 {
@@ -73,7 +74,7 @@ public class ZipDumpReaderV8
 
     private ZipDumpReaderV8( final SystemLoadListener listener, final PathRef basePath, final ZipFile zipFile )
     {
-        this.listener = Objects.requireNonNullElse( listener, NoopSystemLoadListener.INSTANCE );
+        this.listener = requireNonNullElse( listener, NoopSystemLoadListener.INSTANCE );
         this.basePath = basePath;
         this.zipFile = zipFile;
     }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/serializer/json/BranchDumpEntryJson.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/serializer/json/BranchDumpEntryJson.java
@@ -1,14 +1,14 @@
 package com.enonic.xp.repo.impl.dump.serializer.json;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.repo.impl.dump.model.BranchDumpEntry;
+
+import static java.util.Objects.requireNonNullElse;
 
 @JsonPropertyOrder(value = {"nodeId", "meta", "nodePath", "binaries"})
 public class BranchDumpEntryJson
@@ -45,7 +45,7 @@ public class BranchDumpEntryJson
     public static BranchDumpEntry fromJson( final BranchDumpEntryJson json )
     {
         return new BranchDumpEntry( NodeId.from( json.getNodeId() ), VersionDumpEntryJson.fromJson( json.getMeta() ),
-                                    Objects.requireNonNullElse( json.getBinaries(), List.of() ) );
+                                    requireNonNullElse( json.getBinaries(), List.of() ) );
     }
 
     public static BranchDumpEntryJson from( final BranchDumpEntry branchDumpEntry )

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/upgrade/DumpUpgraderRunner.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/upgrade/DumpUpgraderRunner.java
@@ -2,8 +2,6 @@ package com.enonic.xp.repo.impl.dump.upgrade;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,6 +18,8 @@ import com.enonic.xp.repo.impl.dump.writer.ZipDumpWriterV8;
 import com.enonic.xp.upgrade.UpgradeListener;
 import com.enonic.xp.util.Version;
 
+import static java.util.Objects.requireNonNullElse;
+
 public class DumpUpgraderRunner
 {
     private static final Logger LOG = LoggerFactory.getLogger( DumpUpgraderRunner.class );
@@ -32,7 +32,7 @@ public class DumpUpgraderRunner
 
         try (DumpReaderV7 dumpReader = ZipDumpReaderV7.create( basePath, dumpName ))
         {
-            final Version modelVersion = Objects.requireNonNullElse( dumpReader.getDumpMeta().getModelVersion(), Version.emptyVersion );
+            final Version modelVersion = requireNonNullElse( dumpReader.getDumpMeta().getModelVersion(), Version.emptyVersion );
 
             result.initialVersion( modelVersion );
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/writer/ZipDumpWriterV8.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/writer/ZipDumpWriterV8.java
@@ -5,8 +5,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Objects;
-
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.jspecify.annotations.Nullable;
 
@@ -34,6 +32,8 @@ import com.enonic.xp.repo.impl.dump.serializer.json.JsonDumpSerializer;
 import com.enonic.xp.repo.impl.node.NodeConstants;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.repository.RepositorySegmentUtils;
+
+import static java.util.Objects.requireNonNull;
 
 public class ZipDumpWriterV8
     implements DumpWriter
@@ -205,7 +205,7 @@ public class ZipDumpWriterV8
 
     private void addBlob( final Segment segment, final BlobKey blobKey )
     {
-        Objects.requireNonNull( store, "Source blob store is required for writeNodeVersionBlobs/writeBinaryBlob" )
+        requireNonNull( store, "Source blob store is required for writeNodeVersionBlobs/writeBinaryBlob" )
             .add( new BlobReference( segment, blobKey ) );
     }
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/NodeStoreDocumentFactory.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/NodeStoreDocumentFactory.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.repo.impl.elasticsearch;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.data.Property;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.data.PropertyVisitor;
@@ -25,6 +23,8 @@ import com.enonic.xp.repo.impl.elasticsearch.document.indexitem.IndexItems;
 import com.enonic.xp.security.acl.AccessControlList;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNullElse;
+import static java.util.Objects.requireNonNullElseGet;
 
 
 public class NodeStoreDocumentFactory
@@ -51,9 +51,9 @@ public class NodeStoreDocumentFactory
     {
         this.nodeId = builder.nodeId;
         this.indexConfigDocument = builder.indexConfigDocument;
-        this.nodeType = Objects.requireNonNullElse( builder.nodeType, NodeType.DEFAULT_NODE_COLLECTION );
-        this.permissions = Objects.requireNonNullElse( builder.permissions, AccessControlList.empty() );
-        this.data = Objects.requireNonNullElseGet( builder.data, PropertyTree::new );
+        this.nodeType = requireNonNullElse( builder.nodeType, NodeType.DEFAULT_NODE_COLLECTION );
+        this.permissions = requireNonNullElse( builder.permissions, AccessControlList.empty() );
+        this.data = requireNonNullElseGet( builder.data, PropertyTree::new );
         this.manualOrderValue = builder.manualOrderValue;
         this.nodePath = builder.nodePath;
         this.versionId = builder.versionId;

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/SearchRequestBuilderFactory.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/SearchRequestBuilderFactory.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.repo.impl.elasticsearch;
 
 import java.util.List;
-import java.util.Objects;
-
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Client;
@@ -17,6 +15,9 @@ import com.enonic.xp.query.highlight.constants.TagsSchema;
 import com.enonic.xp.repo.impl.SearchPreference;
 import com.enonic.xp.repo.impl.elasticsearch.query.ElasticHighlightQuery;
 import com.enonic.xp.repo.impl.elasticsearch.query.ElasticsearchQuery;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 public class SearchRequestBuilderFactory
 {
@@ -76,7 +77,7 @@ public class SearchRequestBuilderFactory
             .setQuery( query.getQuery() )
             .setPostFilter( query.getFilter() )
             .setFrom( query.getFrom() )
-            .setPreference( Objects.requireNonNullElse( query.getSearchPreference(), SearchPreference.LOCAL ).getName() );
+            .setPreference( requireNonNullElse( query.getSearchPreference(), SearchPreference.LOCAL ).getName() );
 
         if ( query.getHighlight() != null )
         {
@@ -173,8 +174,8 @@ public class SearchRequestBuilderFactory
 
         private void validate()
         {
-            Objects.requireNonNull( this.client );
-            Objects.requireNonNull( this.query );
+            requireNonNull( this.client );
+            requireNonNull( this.query );
         }
 
         public SearchRequestBuilderFactory build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/document/indexitem/IndexItemFactory.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/document/indexitem/IndexItemFactory.java
@@ -19,12 +19,14 @@ import com.enonic.xp.repo.impl.index.IndexLanguageController;
 import com.enonic.xp.repo.impl.index.IndexValueType;
 import com.enonic.xp.repo.impl.index.StaticIndexValueType;
 
+import static java.util.Objects.requireNonNull;
+
 public class IndexItemFactory
 {
     public static List<IndexItem<?>> create( final IndexPath indexPath, final Value value, final IndexConfigDocument indexConfigDocument )
     {
-        Objects.requireNonNull( indexPath );
-        Objects.requireNonNull( value );
+        requireNonNull( indexPath );
+        requireNonNull( value );
 
         Value processedPropertyValue = applyValueProcessors( value, indexConfigDocument.getConfigForPath( indexPath ) );
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/ElasticsearchQuery.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/ElasticsearchQuery.java
@@ -19,6 +19,8 @@ import com.enonic.xp.node.SearchOptimizer;
 import com.enonic.xp.repo.impl.ReturnFields;
 import com.enonic.xp.repo.impl.SearchPreference;
 
+import static java.util.Objects.requireNonNullElse;
+
 public class ElasticsearchQuery
 {
     private static final int DEFAULT_SIZE = 10;
@@ -66,7 +68,7 @@ public class ElasticsearchQuery
         this.aggregations = ImmutableList.copyOf( builder.aggregations );
         this.suggestions = ImmutableList.copyOf( builder.suggestions );
         this.highlight = builder.highlight;
-        this.returnFields = Objects.requireNonNullElse( builder.returnFields, ReturnFields.empty() );
+        this.returnFields = requireNonNullElse( builder.returnFields, ReturnFields.empty() );
         this.searchOptimizer = builder.searchOptimizer;
         this.explain = builder.explain;
         this.searchPreference = builder.searchPreference;

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/factory/DiffQueryFactory.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/factory/DiffQueryFactory.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.elasticsearch.query.translator.factory;
 
-import java.util.Objects;
-
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.HasChildQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -14,6 +12,8 @@ import com.enonic.xp.node.NodePaths;
 import com.enonic.xp.repo.impl.branch.storage.BranchIndexPath;
 import com.enonic.xp.repo.impl.storage.StaticStorageType;
 import com.enonic.xp.repo.impl.version.search.NodeVersionDiffQuery;
+
+import static java.util.Objects.requireNonNull;
 
 public class DiffQueryFactory
 {
@@ -105,7 +105,7 @@ public class DiffQueryFactory
 
         private void validate()
         {
-            Objects.requireNonNull( this.query, "query is required" );
+            requireNonNull( this.query, "query is required" );
         }
 
         public DiffQueryFactory build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/factory/FilterBuilderFactory.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/factory/FilterBuilderFactory.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -28,6 +27,8 @@ import com.enonic.xp.query.filter.ValueFilter;
 import com.enonic.xp.repo.impl.elasticsearch.query.translator.resolver.QueryFieldNameResolver;
 import com.enonic.xp.repo.impl.index.IndexFieldNameNormalizer;
 import com.enonic.xp.repo.impl.index.StaticIndexValueType;
+
+import static java.util.Objects.requireNonNullElse;
 
 public class FilterBuilderFactory
     extends AbstractBuilderFactory
@@ -164,7 +165,7 @@ public class FilterBuilderFactory
             return null;
         }
 
-        final String queryFieldName = this.fieldNameResolver.resolve( filter.getFieldName(), Objects.requireNonNullElse( from, to ) );
+        final String queryFieldName = this.fieldNameResolver.resolve( filter.getFieldName(), requireNonNullElse( from, to ) );
 
         return new RangeQueryBuilder( queryFieldName ).from( from )
             .to( to )

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/factory/QueryBuilderFactory.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/factory/QueryBuilderFactory.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.elasticsearch.query.translator.factory;
 
-import java.util.Objects;
-
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -12,6 +10,8 @@ import com.enonic.xp.query.filter.Filter;
 import com.enonic.xp.query.filter.Filters;
 import com.enonic.xp.repo.impl.elasticsearch.query.translator.factory.query.ConstraintExpressionBuilder;
 import com.enonic.xp.repo.impl.elasticsearch.query.translator.resolver.QueryFieldNameResolver;
+
+import static java.util.Objects.requireNonNull;
 
 public class QueryBuilderFactory
     extends AbstractBuilderFactory
@@ -100,7 +100,7 @@ public class QueryBuilderFactory
 
         private void validate()
         {
-            Objects.requireNonNull( fieldNameResolver );
+            requireNonNull( fieldNameResolver );
         }
 
         public QueryBuilderFactory build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/factory/dsl/StemmedQueryBuilder.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/factory/dsl/StemmedQueryBuilder.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.repo.impl.elasticsearch.query.translator.factory.dsl;
 
 import java.util.Locale;
-import java.util.Objects;
-
 import org.elasticsearch.index.query.QueryBuilder;
 
 import com.enonic.xp.data.PropertySet;
 import com.enonic.xp.repo.impl.index.IndexLanguageController;
 import com.enonic.xp.repo.impl.index.IndexValueType;
+
+import static java.util.Objects.requireNonNull;
 
 class StemmedQueryBuilder
     extends SimpleQueryStringBuilder
@@ -20,7 +20,7 @@ class StemmedQueryBuilder
     {
         super( expression );
 
-        language = Locale.forLanguageTag( Objects.requireNonNull( getString( "language" ), "language is required" ) );
+        language = Locale.forLanguageTag( requireNonNull( getString( "language" ), "language is required" ) );
     }
 
     @Override

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/factory/function/StemmedFunctionArguments.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/query/translator/factory/function/StemmedFunctionArguments.java
@@ -2,12 +2,12 @@ package com.enonic.xp.repo.impl.elasticsearch.query.translator.factory.function;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
-
 import com.enonic.xp.query.expr.ValueExpr;
 import com.enonic.xp.repo.impl.elasticsearch.query.translator.resolver.SearchQueryFieldNameResolver;
 import com.enonic.xp.repo.impl.index.IndexLanguageController;
 import com.enonic.xp.repo.impl.index.IndexValueType;
+
+import static java.util.Objects.requireNonNull;
 
 public class StemmedFunctionArguments
     extends AbstractSimpleQueryStringFunctionArguments
@@ -22,7 +22,7 @@ public class StemmedFunctionArguments
     @Override
     protected String resolveAnalyzer( final String language )
     {
-        this.language = Locale.forLanguageTag( Objects.requireNonNull( language, "language is required" ) );
+        this.language = Locale.forLanguageTag( requireNonNull( language, "language is required" ) );
         return IndexLanguageController.resolveAnalyzer( this.language );
     }
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/storage/StorageDaoImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/storage/StorageDaoImpl.java
@@ -2,7 +2,6 @@ package com.enonic.xp.repo.impl.elasticsearch.storage;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.elasticsearch.action.delete.DeleteAction;
@@ -36,6 +35,8 @@ import com.enonic.xp.repo.impl.storage.RoutableId;
 import com.enonic.xp.repo.impl.storage.StorageDao;
 import com.enonic.xp.repo.impl.storage.StoreRequest;
 import com.enonic.xp.repository.IndexException;
+
+import static java.util.Objects.requireNonNullElse;
 
 @Component
 public class StorageDaoImpl
@@ -146,7 +147,7 @@ public class StorageDaoImpl
             new GetRequest( storageSource.getStorageName().getName() ).type( storageSource.getStorageType().getName() )
                 .fetchSourceContext(
                     request.getReturnFields() == null ? FetchSourceContext.DO_NOT_FETCH_SOURCE : FetchSourceContext.FETCH_SOURCE )
-                .preference( Objects.requireNonNullElse( request.getSearchPreference(), SearchPreference.LOCAL ).getName() )
+                .preference( requireNonNullElse( request.getSearchPreference(), SearchPreference.LOCAL ).getName() )
                 .id( request.getId() )
                 .routing( request.getRouting() );
 
@@ -165,7 +166,7 @@ public class StorageDaoImpl
 
         final MultiGetRequestBuilder multiGetRequestBuilder =
             new MultiGetRequestBuilder( this.client, MultiGetAction.INSTANCE ).setPreference(
-                Objects.requireNonNullElse( requests.getSearchPreference(), SearchPreference.LOCAL ).getName() );
+                requireNonNullElse( requests.getSearchPreference(), SearchPreference.LOCAL ).getName() );
 
         for ( final GetByIdRequest request : requests.getRequests() )
         {

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/index/IndexLanguageController.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/index/IndexLanguageController.java
@@ -3,10 +3,10 @@ package com.enonic.xp.repo.impl.index;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
-
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 public class IndexLanguageController
 {
@@ -90,7 +90,7 @@ public class IndexLanguageController
 
     private static String normalizeBase( final Locale language )
     {
-        final String lang = Objects.requireNonNull( language ).getLanguage();
+        final String lang = requireNonNull( language ).getLanguage();
         if ( "no".equals( lang ) )
         {
             return "nb";
@@ -100,7 +100,7 @@ public class IndexLanguageController
 
     private static String normalize( final Locale language )
     {
-        final Locale locale = Objects.requireNonNull( language );
+        final Locale locale = requireNonNull( language );
         if ( "pt".equals( locale.getLanguage() ) && "BR".equals( language.getCountry() ) )
         {
             return "pt-BR";

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/AbstractCompareNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/AbstractCompareNodeCommand.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.repo.impl.storage.NodeStorageService;
+
+import static java.util.Objects.requireNonNull;
 
 class AbstractCompareNodeCommand
 {
@@ -40,8 +40,8 @@ class AbstractCompareNodeCommand
 
         void validate()
         {
-            Objects.requireNonNull( nodeStorageService );
-            Objects.requireNonNull( target, "target is required" );
+            requireNonNull( nodeStorageService );
+            requireNonNull( target, "target is required" );
         }
     }
 }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/AbstractGetBinaryCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/AbstractGetBinaryCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
 
 import com.enonic.xp.context.ContextAccessor;
@@ -9,6 +7,8 @@ import com.enonic.xp.node.AttachedBinaries;
 import com.enonic.xp.node.AttachedBinary;
 import com.enonic.xp.repo.impl.binary.BinaryService;
 import com.enonic.xp.util.BinaryReference;
+
+import static java.util.Objects.requireNonNull;
 
 abstract class AbstractGetBinaryCommand
     extends AbstractNodeCommand
@@ -68,8 +68,8 @@ abstract class AbstractGetBinaryCommand
 
         @Override
         void validate() {
-            Objects.requireNonNull( binaryService );
-            Objects.requireNonNull( binaryReference, "binaryReference is required" );
+            requireNonNull( binaryService );
+            requireNonNull( binaryReference, "binaryReference is required" );
         }
     }
 }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/AbstractNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/AbstractNodeCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -19,6 +17,8 @@ import com.enonic.xp.repo.impl.search.NodeSearchService;
 import com.enonic.xp.repo.impl.storage.NodeStorageService;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.auth.AuthenticationInfo;
+
+import static java.util.Objects.requireNonNull;
 
 abstract class AbstractNodeCommand
 {
@@ -115,9 +115,9 @@ abstract class AbstractNodeCommand
 
         void validate()
         {
-            Objects.requireNonNull( indexServiceInternal );
-            Objects.requireNonNull( nodeStorageService );
-            Objects.requireNonNull( nodeSearchService );
+            requireNonNull( indexServiceInternal );
+            requireNonNull( nodeStorageService );
+            requireNonNull( nodeSearchService );
         }
     }
 }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ApplyNodePermissionsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ApplyNodePermissionsCommand.java
@@ -36,6 +36,8 @@ import com.enonic.xp.security.acl.AccessControlEntry;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.acl.Permission;
 
+import static java.util.Objects.requireNonNullElse;
+
 public class ApplyNodePermissionsCommand
     extends AbstractNodeCommand
 {
@@ -55,7 +57,7 @@ public class ApplyNodePermissionsCommand
         this.params = builder.params;
         this.results = ApplyPermissionsResult.create();
         this.appliedVersions = new NodePatchCache<>();
-        this.listener = Objects.requireNonNullElse( params.getListener(), NoopApplyNodePermissionsListener.INSTANCE );
+        this.listener = requireNonNullElse( params.getListener(), NoopApplyNodePermissionsListener.INSTANCE );
         this.branches = params.getBranches().isEmpty() ? Branches.from( ContextAccessor.current().getBranch() ) : params.getBranches();
     }
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CheckNodeExistsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CheckNodeExistsCommand.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.node.NodeAlreadyExistAtPathException;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.NodeBranchEntry;
 import com.enonic.xp.repo.impl.SearchPreference;
+
+import static java.util.Objects.requireNonNull;
 
 public class CheckNodeExistsCommand
     extends AbstractNodeCommand
@@ -98,7 +98,7 @@ public class CheckNodeExistsCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.nodePath, "nodePath is required" );
+            requireNonNull( this.nodePath, "nodePath is required" );
         }
 
         public CheckNodeExistsCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CompareNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CompareNodeCommand.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.node.NodeComparison;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.NodeBranchEntry;
+
+import static java.util.Objects.requireNonNull;
 
 public class CompareNodeCommand
     extends AbstractCompareNodeCommand
@@ -57,7 +57,7 @@ public class CompareNodeCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( nodeId, "nodeId is required" );
+            requireNonNull( nodeId, "nodeId is required" );
         }
 
         public CompareNodeCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CompareNodesCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CompareNodesCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.google.common.collect.Sets;
 
 import com.enonic.xp.context.Context;
@@ -13,6 +11,8 @@ import com.enonic.xp.node.NodeIds;
 import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.NodeBranchEntries;
 import com.enonic.xp.repo.impl.NodeBranchEntry;
+
+import static java.util.Objects.requireNonNull;
 
 public class CompareNodesCommand
     extends AbstractCompareNodeCommand
@@ -72,7 +72,7 @@ public class CompareNodesCommand
         protected void validate()
         {
             super.validate();
-            Objects.requireNonNull( nodeIds, "nodeIds is required" );
+            requireNonNull( nodeIds, "nodeIds is required" );
         }
 
         public CompareNodesCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CompareStatusResolver.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CompareStatusResolver.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.node.NodeCompareStatus;
 import com.enonic.xp.node.NodeComparison;
@@ -10,6 +8,8 @@ import com.enonic.xp.node.NodeVersion;
 import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.NodeBranchEntry;
 import com.enonic.xp.repo.impl.storage.NodeStorageService;
+
+import static java.util.Objects.requireNonNull;
 
 class CompareStatusResolver
 {
@@ -127,7 +127,7 @@ class CompareStatusResolver
 
         private void validate()
         {
-            Objects.requireNonNull( this.nodeStorageService );
+            requireNonNull( this.nodeStorageService );
         }
 
         CompareStatusResolver build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CreateNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CreateNodeCommand.java
@@ -2,8 +2,6 @@ package com.enonic.xp.repo.impl.node;
 
 import java.time.Instant;
 import java.util.List;
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.core.internal.Millis;
 import com.enonic.xp.data.Property;
@@ -29,6 +27,8 @@ import com.enonic.xp.repo.impl.storage.StoreNodeParams;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.acl.Permission;
+
+import static java.util.Objects.requireNonNull;
 
 public final class CreateNodeCommand
     extends AbstractNodeCommand
@@ -242,7 +242,7 @@ public final class CreateNodeCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public CreateNodeCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/DeleteNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/DeleteNodeCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.repo.impl.node;
 
 import java.util.List;
-import java.util.Objects;
-
 import com.google.common.collect.Iterables;
 
 import com.enonic.xp.context.Context;
@@ -33,6 +31,8 @@ import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.acl.Permission;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 
+import static java.util.Objects.requireNonNullElse;
+
 public class DeleteNodeCommand
     extends AbstractNodeCommand
 {
@@ -51,7 +51,7 @@ public class DeleteNodeCommand
         super( builder );
         this.nodeId = builder.nodeId;
         this.nodePath = builder.nodePath;
-        this.deleteNodeListener = Objects.requireNonNullElse( builder.deleteNodeListener, _ -> {
+        this.deleteNodeListener = requireNonNullElse( builder.deleteNodeListener, _ -> {
         } );
         this.refresh = builder.refresh;
     }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/DuplicateNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/DuplicateNodeCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +30,9 @@ import com.enonic.xp.repo.impl.search.NodeSearchService;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.util.Reference;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
 public final class DuplicateNodeCommand
     extends AbstractNodeCommand
 {
@@ -51,7 +52,7 @@ public final class DuplicateNodeCommand
         this.params = builder.params;
         this.binaryService = builder.binaryService;
         this.result = DuplicateNodeResult.create();
-        this.listener = Objects.requireNonNullElse( params.getDuplicateListener(), NoopDuplicateNodeListener.INSTANCE );
+        this.listener = requireNonNullElse( params.getDuplicateListener(), NoopDuplicateNodeListener.INSTANCE );
     }
 
     public static Builder create()
@@ -309,8 +310,8 @@ public final class DuplicateNodeCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.binaryService );
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( this.binaryService );
+            requireNonNull( params, "params cannot be null" );
         }
     }
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodeCommitsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodeCommitsCommand.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.node.NodeCommitQuery;
 import com.enonic.xp.node.NodeCommitQueryResult;
 import com.enonic.xp.repo.impl.commit.search.NodeCommitQueryResultFactory;
 import com.enonic.xp.repo.impl.search.NodeSearchService;
 import com.enonic.xp.repo.impl.search.result.SearchResult;
+
+import static java.util.Objects.requireNonNull;
 
 public class FindNodeCommitsCommand
 {
@@ -56,8 +56,8 @@ public class FindNodeCommitsCommand
 
         private void validate()
         {
-            Objects.requireNonNull( this.nodeSearchService );
-            Objects.requireNonNull( this.query, "query is required" );
+            requireNonNull( this.nodeSearchService );
+            requireNonNull( this.query, "query is required" );
         }
 
         public FindNodeCommitsCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodeIdsByParentCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodeIdsByParentCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.index.ChildOrder;
 import com.enonic.xp.node.FindNodesByParentResult;
@@ -20,6 +18,8 @@ import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.SingleRepoSearchSource;
 import com.enonic.xp.repo.impl.search.NodeSearchService;
 import com.enonic.xp.repo.impl.search.result.SearchResult;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 public class FindNodeIdsByParentCommand
     extends AbstractNodeCommand
@@ -45,7 +45,7 @@ public class FindNodeIdsByParentCommand
         super( builder );
         parentPath = builder.parentPath;
         parentId = builder.parentId;
-        queryFilters = Objects.requireNonNullElseGet( builder.queryFilters, Filters::empty );
+        queryFilters = requireNonNullElseGet( builder.queryFilters, Filters::empty );
         size = builder.size;
         from = builder.from;
         childOrder = builder.childOrder;

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodeVersionsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodeVersionsCommand.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.node.NodeVersionQuery;
 import com.enonic.xp.node.NodeVersionQueryResult;
 import com.enonic.xp.repo.impl.search.NodeSearchService;
 import com.enonic.xp.repo.impl.search.result.SearchResult;
 import com.enonic.xp.repo.impl.version.search.NodeVersionQueryResultFactory;
+
+import static java.util.Objects.requireNonNull;
 
 public class FindNodeVersionsCommand
 {
@@ -56,8 +56,8 @@ public class FindNodeVersionsCommand
 
         private void validate()
         {
-            Objects.requireNonNull( this.nodeSearchService );
-            Objects.requireNonNull( this.query, "query is required" );
+            requireNonNull( this.nodeSearchService );
+            requireNonNull( this.query, "query is required" );
         }
 
         public FindNodeVersionsCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodesByMultiRepoQueryCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodesByMultiRepoQueryCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.node.FindNodesByMultiRepoQueryResult;
 import com.enonic.xp.node.MultiRepoNodeQuery;
@@ -11,6 +9,8 @@ import com.enonic.xp.repo.impl.MultiRepoSearchSource;
 import com.enonic.xp.repo.impl.SingleRepoSearchSource;
 import com.enonic.xp.repo.impl.search.result.SearchResult;
 import com.enonic.xp.security.PrincipalKeys;
+
+import static java.util.Objects.requireNonNull;
 
 public class FindNodesByMultiRepoQueryCommand
     extends AbstractNodeCommand
@@ -73,7 +73,7 @@ public class FindNodesByMultiRepoQueryCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.query, "query is required" );
+            requireNonNull( this.query, "query is required" );
         }
 
         public FindNodesByMultiRepoQueryCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodesByQueryCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodesByQueryCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.node.FindNodesByQueryResult;
 import com.enonic.xp.node.NodeQuery;
@@ -9,6 +7,8 @@ import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.ReturnFields;
 import com.enonic.xp.repo.impl.SingleRepoSearchSource;
 import com.enonic.xp.repo.impl.search.result.SearchResult;
+
+import static java.util.Objects.requireNonNull;
 
 public class FindNodesByQueryCommand
     extends AbstractNodeCommand
@@ -65,7 +65,7 @@ public class FindNodesByQueryCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.query, "query is required" );
+            requireNonNull( this.query, "query is required" );
         }
 
         public FindNodesByQueryCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetActiveNodeVersionsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetActiveNodeVersionsCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.branch.Branches;
 import com.enonic.xp.context.ContextAccessor;
@@ -9,6 +7,8 @@ import com.enonic.xp.node.GetActiveNodeVersionsResult;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.NodeBranchEntry;
+
+import static java.util.Objects.requireNonNull;
 
 public class GetActiveNodeVersionsCommand
     extends AbstractNodeCommand
@@ -72,8 +72,8 @@ public class GetActiveNodeVersionsCommand
         @Override
         void validate()
         {
-            Objects.requireNonNull( this.nodeId, "nodeId is required" );
-            Objects.requireNonNull( this.branches, "branches is required" );
+            requireNonNull( this.nodeId, "nodeId is required" );
+            requireNonNull( this.branches, "branches is required" );
         }
 
         public GetActiveNodeVersionsCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetBinaryByVersionCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetBinaryByVersionCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
 
 import com.enonic.xp.context.ContextAccessor;
@@ -10,6 +8,8 @@ import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeNotFoundException;
 import com.enonic.xp.node.NodeVersionId;
 import com.enonic.xp.repo.impl.InternalContext;
+
+import static java.util.Objects.requireNonNull;
 
 public class GetBinaryByVersionCommand
     extends AbstractGetBinaryCommand
@@ -75,8 +75,8 @@ public class GetBinaryByVersionCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.nodeVersionId, "nodeVersionId is required" );
-            Objects.requireNonNull( this.nodeId, "nodeId is required" );
+            requireNonNull( this.nodeVersionId, "nodeVersionId is required" );
+            requireNonNull( this.nodeId, "nodeId is required" );
         }
 
         public GetBinaryByVersionCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetBinaryCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetBinaryCommand.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
 
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeNotFoundException;
+
+import static java.util.Objects.requireNonNull;
 
 public class GetBinaryCommand
     extends AbstractGetBinaryCommand
@@ -51,7 +51,7 @@ public class GetBinaryCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( nodeId, "nodeId is required" );
+            requireNonNull( nodeId, "nodeId is required" );
         }
 
         public GetBinaryCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetNodeByIdAndVersionIdCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetNodeByIdAndVersionIdCommand.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeVersionId;
 import com.enonic.xp.repo.impl.InternalContext;
+
+import static java.util.Objects.requireNonNull;
 
 public class GetNodeByIdAndVersionIdCommand
     extends AbstractNodeCommand
@@ -69,8 +69,8 @@ public class GetNodeByIdAndVersionIdCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.nodeId, "nodeId is required" );
-            Objects.requireNonNull( this.versionId, "versionId is required" );
+            requireNonNull( this.nodeId, "nodeId is required" );
+            requireNonNull( this.versionId, "versionId is required" );
         }
 
         public GetNodeByIdAndVersionIdCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetNodeByIdCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetNodeByIdCommand.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
+
+import static java.util.Objects.requireNonNull;
 
 public class GetNodeByIdCommand
     extends AbstractNodeCommand
@@ -46,7 +46,7 @@ public class GetNodeByIdCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.id, "id is required" );
+            requireNonNull( this.id, "id is required" );
         }
 
         public GetNodeByIdCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetNodeByPathCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetNodeByPathCommand.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.repo.impl.InternalContext;
+
+import static java.util.Objects.requireNonNull;
 
 public class GetNodeByPathCommand
     extends AbstractNodeCommand
@@ -58,7 +58,7 @@ public class GetNodeByPathCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.path, "path is required" );
+            requireNonNull( this.path, "path is required" );
         }
 
         public GetNodeByPathCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetNodeVersionsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetNodeVersionsCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.data.ValueFactory;
 import com.enonic.xp.node.GetNodeVersionsParams;
 import com.enonic.xp.node.GetNodeVersionsResult;
@@ -16,6 +14,8 @@ import com.enonic.xp.query.filter.RangeFilter;
 import com.enonic.xp.query.filter.ValueFilter;
 import com.enonic.xp.repo.impl.search.NodeSearchService;
 import com.enonic.xp.repo.impl.version.VersionIndexPath;
+
+import static java.util.Objects.requireNonNull;
 
 public class GetNodeVersionsCommand
 {
@@ -68,7 +68,7 @@ public class GetNodeVersionsCommand
         final String nextCursor;
         if ( versions.getSize() > 0 && queryResult.getTotalHits() > versions.getSize() )
         {
-            final NodeVersion last = Objects.requireNonNull( versions.last() );
+            final NodeVersion last = requireNonNull( versions.last() );
             nextCursor = VersionCursorHelper.encodeCursor( new VersionCursorHelper.CursorData( last.getTimestamp(), last.getNodeVersionId()) );
         }
         else
@@ -112,8 +112,8 @@ public class GetNodeVersionsCommand
 
         private void validate()
         {
-            Objects.requireNonNull( this.nodeSearchService );
-            Objects.requireNonNull( this.params, "params is required" );
+            requireNonNull( this.nodeSearchService );
+            requireNonNull( this.params, "params is required" );
         }
 
         public GetNodeVersionsCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetNodesByIdsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetNodesByIdsCommand.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.node.NodeIds;
 import com.enonic.xp.node.Nodes;
 import com.enonic.xp.repo.impl.InternalContext;
+
+import static java.util.Objects.requireNonNull;
 
 public class GetNodesByIdsCommand
     extends AbstractNodeCommand
@@ -48,7 +48,7 @@ public class GetNodesByIdsCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.ids, "ids is required" );
+            requireNonNull( this.ids, "ids is required" );
         }
 
         public GetNodesByIdsCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetNodesByPathsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/GetNodesByPathsCommand.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.node.NodePaths;
 import com.enonic.xp.node.Nodes;
 import com.enonic.xp.repo.impl.InternalContext;
+
+import static java.util.Objects.requireNonNull;
 
 public class GetNodesByPathsCommand
     extends AbstractNodeCommand
@@ -47,7 +47,7 @@ public class GetNodesByPathsCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( this.paths, "paths is required" );
+            requireNonNull( this.paths, "paths is required" );
         }
 
         public GetNodesByPathsCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/MoveNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/MoveNodeCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.context.ContextBuilder;
@@ -32,6 +30,10 @@ import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.acl.Permission;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+import static java.util.Objects.requireNonNullElseGet;
+
 public class MoveNodeCommand
     extends AbstractNodeCommand
 {
@@ -45,7 +47,7 @@ public class MoveNodeCommand
     {
         super( builder );
         this.params = builder.params;
-        this.moveListener = Objects.requireNonNullElse( builder.params.getMoveListener(), count -> {
+        this.moveListener = requireNonNullElse( builder.params.getMoveListener(), count -> {
         } );
         this.result = MoveNodeResult.create();
     }
@@ -71,7 +73,7 @@ public class MoveNodeCommand
 
         final NodeName newNodeName = resolveNodeName( existingNode );
 
-        final NodePath newParentPath = Objects.requireNonNullElseGet( params.getNewParentPath(), existingNode::parentPath );
+        final NodePath newParentPath = requireNonNullElseGet( params.getNewParentPath(), existingNode::parentPath );
 
         final Context context = ContextAccessor.current();
 
@@ -219,7 +221,7 @@ public class MoveNodeCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
     }
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/PatchNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/PatchNodeCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.repo.impl.node;
 
 import java.util.Map;
-import java.util.Objects;
-
 import com.google.common.base.Preconditions;
 
 import com.enonic.xp.branch.Branch;
@@ -27,6 +25,9 @@ import com.enonic.xp.repo.impl.branch.storage.NodeFactory;
 import com.enonic.xp.repo.impl.storage.NodeVersionData;
 import com.enonic.xp.repo.impl.storage.StoreNodeParams;
 import com.enonic.xp.security.acl.Permission;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 public final class PatchNodeCommand
     extends AbstractNodeCommand
@@ -65,7 +66,7 @@ public final class PatchNodeCommand
         final Node persistedNode = params.getId() != null ? doGetById( params.getId() ) : doGetByPath( params.getPath() );
         if ( persistedNode == null )
         {
-            throw new NodeNotFoundException( "Node not found: " + Objects.requireNonNullElse( params.getId(), params.getPath() ) );
+            throw new NodeNotFoundException( "Node not found: " + requireNonNullElse( params.getId(), params.getPath() ) );
         }
 
         this.results.nodeId( persistedNode.id() );
@@ -190,7 +191,7 @@ public final class PatchNodeCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
             Preconditions.checkArgument( this.params.getBranches().getSize() <= 1 || this.params.getPath() == null,
                                          "Only one branch is allowed with path" );
         }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/PushNodesCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/PushNodesCommand.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -46,6 +45,9 @@ import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.acl.Permission;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
 public class PushNodesCommand
     extends AbstractNodeCommand
 {
@@ -57,7 +59,7 @@ public class PushNodesCommand
     {
         super( builder );
         this.params = builder.params;
-        this.pushListener = Objects.requireNonNullElse( params.getPushListener(), _ -> {
+        this.pushListener = requireNonNullElse( params.getPushListener(), _ -> {
         } );
     }
 
@@ -287,7 +289,7 @@ public class PushNodesCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannon be null" );
+            requireNonNull( params, "params cannon be null" );
         }
     }
 }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/RefreshCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/RefreshCommand.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.Objects;
 import java.util.Set;
 
 import org.elasticsearch.index.IndexNotFoundException;
@@ -12,6 +11,8 @@ import com.enonic.xp.repo.impl.repository.IndexNameResolver;
 import com.enonic.xp.repository.IndexException;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.security.SystemConstants;
+
+import static java.util.Objects.requireNonNullElse;
 
 public class RefreshCommand
 {
@@ -28,7 +29,7 @@ public class RefreshCommand
     public void execute()
     {
         final RepositoryId repositoryId =
-            Objects.requireNonNullElse( ContextAccessor.current().getRepositoryId(), SystemConstants.SYSTEM_REPO_ID );
+            requireNonNullElse( ContextAccessor.current().getRepositoryId(), SystemConstants.SYSTEM_REPO_ID );
 
         final Set<String> indices = switch ( refreshMode )
         {

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ResolveSyncWorkCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ResolveSyncWorkCommand.java
@@ -1,7 +1,6 @@
 package com.enonic.xp.repo.impl.node;
 
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -22,6 +21,8 @@ import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.node.ResolveSyncWorkResult;
 import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.NodeBranchEntry;
+
+import static java.util.Objects.requireNonNull;
 
 public class ResolveSyncWorkCommand
     extends AbstractNodeCommand
@@ -305,8 +306,8 @@ public class ResolveSyncWorkCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( nodeId, "nodeId is required" );
-            Objects.requireNonNull( target, "target branch is required" );
+            requireNonNull( nodeId, "nodeId is required" );
+            requireNonNull( target, "target branch is required" );
         }
 
         public ResolveSyncWorkCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/SortNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/SortNodeCommand.java
@@ -29,6 +29,9 @@ import com.enonic.xp.repo.impl.search.NodeSearchService;
 import com.enonic.xp.repo.impl.storage.StoreNodeParams;
 import com.enonic.xp.security.acl.Permission;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
 public class SortNodeCommand
     extends AbstractNodeCommand
 {
@@ -61,7 +64,7 @@ public class SortNodeCommand
         {
             if ( !node.getChildOrder().isManualOrder() )
             {
-                orderChildNodes( node.path(), Objects.requireNonNullElse( params.getManualOrderSeed(), node.getChildOrder() ),
+                orderChildNodes( node.path(), requireNonNullElse( params.getManualOrderSeed(), node.getChildOrder() ),
                                  params.getReorderChildNodes(), result );
             }
             else
@@ -263,7 +266,7 @@ public class SortNodeCommand
         void validate()
         {
             super.validate();
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         public SortNodeCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/event/NodeEventData.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/event/NodeEventData.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.repo.impl.node.event;
 
 import java.util.Map;
-import java.util.Objects;
-
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodePath;
+
+import static java.util.Objects.requireNonNull;
 
 class NodeEventData
 {
@@ -21,8 +21,8 @@ class NodeEventData
 
     static NodeEventData create( final Map<String, String> valueMap )
     {
-        Objects.requireNonNull( valueMap.get( "id" ), "Expected field 'id' not found" );
-        Objects.requireNonNull( valueMap.get( "path" ), "Expected field 'path' not found" );
+        requireNonNull( valueMap.get( "id" ), "Expected field 'id' not found" );
+        requireNonNull( valueMap.get( "path" ), "Expected field 'path' not found" );
 
         return new NodeEventData( NodeId.from( valueMap.get( "id" ) ), new NodePath( valueMap.get( "path" ) ) );
     }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/repository/IndexMigrator.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/repository/IndexMigrator.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.repo.impl.repository;
 
 import java.util.Map;
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +9,8 @@ import com.enonic.xp.node.BinaryAttachments;
 import com.enonic.xp.repo.impl.Model;
 import com.enonic.xp.repo.impl.index.IndexServiceInternal;
 import com.enonic.xp.repository.RepositoryId;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * This class is useful for online repository migrations when needed.
@@ -32,9 +32,9 @@ public class IndexMigrator
     public IndexMigrator( final RepositoryEntryService repositoryEntryService, final NodeRepositoryService nodeRepositoryService,
                           final IndexServiceInternal indexServiceInternal )
     {
-        this.repositoryEntryService = Objects.requireNonNull( repositoryEntryService );
-        this.nodeRepositoryService = Objects.requireNonNull( nodeRepositoryService );
-        this.indexServiceInternal = Objects.requireNonNull( indexServiceInternal );
+        this.repositoryEntryService = requireNonNull( repositoryEntryService );
+        this.nodeRepositoryService = requireNonNull( nodeRepositoryService );
+        this.indexServiceInternal = requireNonNull( indexServiceInternal );
     }
 
     public void upgradeRepository( final RepositoryId repositoryId )

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/repository/RepositoryCreator.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/repository/RepositoryCreator.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.repository;
 
-import java.util.Objects;
-
 import org.elasticsearch.indices.IndexAlreadyExistsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +19,8 @@ import com.enonic.xp.repository.RepositoryConstants;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.security.SystemConstants;
 
+import static java.util.Objects.requireNonNull;
+
 public class RepositoryCreator
 {
     private static final Logger LOG = LoggerFactory.getLogger( RepositoryCreator.class );
@@ -34,9 +34,9 @@ public class RepositoryCreator
     public RepositoryCreator( final NodeRepositoryService nodeRepositoryService, final NodeStorageService nodeStorageService,
                               final RepositoryEntryService repositoryEntryService )
     {
-        this.nodeRepositoryService = Objects.requireNonNull( nodeRepositoryService );
-        this.nodeStorageService = Objects.requireNonNull( nodeStorageService );
-        this.repositoryEntryService = Objects.requireNonNull( repositoryEntryService );
+        this.nodeRepositoryService = requireNonNull( nodeRepositoryService );
+        this.nodeStorageService = requireNonNull( nodeStorageService );
+        this.repositoryEntryService = requireNonNull( repositoryEntryService );
     }
 
     public boolean isInitialized( RepositoryId repositoryId )

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/repository/RepositoryEntry.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/repository/RepositoryEntry.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.repo.impl.repository;
 
-import java.util.Objects;
-
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.node.AttachedBinaries;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.util.Version;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 public final class RepositoryEntry
 {
@@ -25,8 +25,8 @@ public final class RepositoryEntry
     {
         this.id = builder.id;
         this.settings = builder.settings == null ? RepositorySettings.create().build() : builder.settings;
-        this.data = Objects.requireNonNullElseGet( builder.data, PropertyTree::new );
-        this.attachments = Objects.requireNonNullElseGet( builder.attachments, AttachedBinaries::empty );
+        this.data = requireNonNullElseGet( builder.data, PropertyTree::new );
+        this.attachments = requireNonNullElseGet( builder.attachments, AttachedBinaries::empty );
         this.transientFlag = builder.transientFlag;
         this.modelVersion = builder.modelVersion;
     }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/repository/RepositoryNodeTranslator.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/repository/RepositoryNodeTranslator.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.repo.impl.repository;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import com.enonic.xp.data.PropertySet;
@@ -15,6 +14,8 @@ import com.enonic.xp.repository.RepositoryConstants;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.security.SystemConstants;
 import com.enonic.xp.util.Version;
+
+import static java.util.Objects.requireNonNullElse;
 
 public class RepositoryNodeTranslator
 {
@@ -70,7 +71,7 @@ public class RepositoryNodeTranslator
             .settings( toRepositorySettings( nodeData ) )
             .data( repositoryData )
             .attachments( node.getAttachedBinaries() )
-            .transientFlag( Objects.requireNonNullElse( nodeData.getBoolean( TRANSIENT_KEY ), false ) )
+            .transientFlag( requireNonNullElse( nodeData.getBoolean( TRANSIENT_KEY ), false ) )
             .modelVersion( modelVersion )
             .build();
     }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/repository/SystemRepoInitializer.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/repository/SystemRepoInitializer.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.repository;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.context.ContextBuilder;
@@ -20,6 +18,8 @@ import com.enonic.xp.security.SystemConstants;
 import com.enonic.xp.security.User;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 
+import static java.util.Objects.requireNonNull;
+
 public class SystemRepoInitializer
     extends Initializer
 {
@@ -32,8 +32,8 @@ public class SystemRepoInitializer
     private SystemRepoInitializer( final Builder builder )
     {
         super( builder );
-        this.indexServiceInternal = Objects.requireNonNull( builder.indexServiceInternal );
-        this.nodeStorageService = Objects.requireNonNull( builder.nodeStorageService );
+        this.indexServiceInternal = requireNonNull( builder.indexServiceInternal );
+        this.nodeStorageService = requireNonNull( builder.nodeStorageService );
         this.repositoryCreator =
             new RepositoryCreator( builder.nodeRepositoryService, builder.nodeStorageService, builder.repositoryEntryService );
     }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/storage/StorageData.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/storage/StorageData.java
@@ -2,12 +2,12 @@ package com.enonic.xp.repo.impl.storage;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
-
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMultimap;
 
 import com.enonic.xp.index.IndexPath;
+
+import static java.util.Objects.requireNonNull;
 
 public class StorageData
 {
@@ -38,8 +38,8 @@ public class StorageData
 
         public Builder add( final IndexPath key, final Object value )
         {
-            Objects.requireNonNull( key );
-            Objects.requireNonNull( value );
+            requireNonNull( key );
+            requireNonNull( value );
 
             if ( value instanceof Iterable )
             {

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/vacuum/VacuumServiceImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/vacuum/VacuumServiceImpl.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -25,6 +24,8 @@ import com.enonic.xp.vacuum.VacuumParameters;
 import com.enonic.xp.vacuum.VacuumResult;
 import com.enonic.xp.vacuum.VacuumService;
 import com.enonic.xp.vacuum.VacuumTaskResult;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 @Component(immediate = true, configurationPid = "com.enonic.xp.vacuum")
 public class VacuumServiceImpl
@@ -77,7 +78,7 @@ public class VacuumServiceImpl
         }
 
         final long ageThreshold =
-            Objects.requireNonNullElseGet( params.getAgeThreshold(), () -> Duration.parse( config.ageThreshold() ) ).toMillis();
+            requireNonNullElseGet( params.getAgeThreshold(), () -> Duration.parse( config.ageThreshold() ) ).toMillis();
 
         final VacuumResult.Builder taskResults = VacuumResult.create();
         for ( final VacuumTask task : tasks )

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/vacuum/VacuumTaskParams.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/vacuum/VacuumTaskParams.java
@@ -2,9 +2,9 @@ package com.enonic.xp.repo.impl.vacuum;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.vacuum.VacuumListener;
+
+import static java.util.Objects.requireNonNull;
 
 public final class VacuumTaskParams
 {
@@ -23,7 +23,7 @@ public final class VacuumTaskParams
         ageThreshold = builder.ageThreshold;
         listener = builder.listener;
         versionsBatchSize = builder.versionsBatchSize;
-        vacuumStartedAt = Objects.requireNonNull( builder.vacuumStartedAt );
+        vacuumStartedAt = requireNonNull( builder.vacuumStartedAt );
     }
 
     public long getAgeThreshold()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/vacuum/blob/IsBlobUsedByVersionCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/vacuum/blob/IsBlobUsedByVersionCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.repo.impl.vacuum.blob;
 
-import java.util.Objects;
-
 import com.enonic.xp.blob.BlobKey;
 import com.enonic.xp.data.ValueFactory;
 import com.enonic.xp.index.IndexPath;
@@ -9,6 +7,8 @@ import com.enonic.xp.node.NodeService;
 import com.enonic.xp.node.NodeVersionQuery;
 import com.enonic.xp.node.NodeVersionQueryResult;
 import com.enonic.xp.query.filter.ValueFilter;
+
+import static java.util.Objects.requireNonNull;
 
 public class IsBlobUsedByVersionCommand
 {
@@ -82,9 +82,9 @@ public class IsBlobUsedByVersionCommand
 
         public IsBlobUsedByVersionCommand build()
         {
-            Objects.requireNonNull( nodeService );
-            Objects.requireNonNull( fieldPath, "fieldPath is required" );
-            Objects.requireNonNull( blobKey, "blobKey is required" );
+            requireNonNull( nodeService );
+            requireNonNull( fieldPath, "fieldPath is required" );
+            requireNonNull( blobKey, "blobKey is required" );
             return new IsBlobUsedByVersionCommand( this );
         }
     }

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/AbstractSchedulerCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/AbstractSchedulerCommand.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.impl.scheduler;
 
-import java.util.Objects;
-
 import com.enonic.xp.node.NodeService;
+
+import static java.util.Objects.requireNonNull;
 
 public abstract class AbstractSchedulerCommand
 {
@@ -29,7 +29,7 @@ public abstract class AbstractSchedulerCommand
 
         protected void validate()
         {
-            Objects.requireNonNull( nodeService );
+            requireNonNull( nodeService );
         }
 
         abstract AbstractSchedulerCommand build();

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/CreateScheduledJobCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/CreateScheduledJobCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.impl.scheduler;
 
-import java.util.Objects;
-
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.impl.scheduler.serializer.SchedulerSerializer;
 import com.enonic.xp.node.CreateNodeParams;
@@ -12,6 +10,8 @@ import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.scheduler.CreateScheduledJobParams;
 import com.enonic.xp.scheduler.ScheduledJob;
 import com.enonic.xp.scheduler.SchedulerConstants;
+
+import static java.util.Objects.requireNonNull;
 
 public class CreateScheduledJobCommand
     extends AbstractSchedulerCommand
@@ -71,7 +71,7 @@ public class CreateScheduledJobCommand
         @Override
         protected void validate()
         {
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         @Override

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/DeleteScheduledJobCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/DeleteScheduledJobCommand.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.impl.scheduler;
 
-import java.util.Objects;
-
 import com.enonic.xp.node.DeleteNodeParams;
 import com.enonic.xp.node.NodeName;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.scheduler.ScheduledJobName;
+
+import static java.util.Objects.requireNonNull;
 
 public class DeleteScheduledJobCommand
     extends AbstractSchedulerCommand
@@ -55,7 +55,7 @@ public class DeleteScheduledJobCommand
         @Override
         protected void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
+            requireNonNull( name, "name is required" );
         }
 
         @Override

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/GetScheduledJobCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/GetScheduledJobCommand.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.impl.scheduler;
 
-import java.util.Objects;
-
 import com.enonic.xp.impl.scheduler.serializer.SchedulerSerializer;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeName;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.scheduler.ScheduledJob;
 import com.enonic.xp.scheduler.ScheduledJobName;
+
+import static java.util.Objects.requireNonNull;
 
 public class GetScheduledJobCommand
     extends AbstractSchedulerCommand
@@ -59,7 +59,7 @@ public class GetScheduledJobCommand
         @Override
         protected void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
+            requireNonNull( name, "name is required" );
         }
 
         @Override

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/ModifyScheduledJobCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/ModifyScheduledJobCommand.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.impl.scheduler;
 
-import java.util.Objects;
-
 import com.enonic.xp.impl.scheduler.serializer.SchedulerSerializer;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeName;
@@ -10,6 +8,8 @@ import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.node.UpdateNodeParams;
 import com.enonic.xp.scheduler.ModifyScheduledJobParams;
 import com.enonic.xp.scheduler.ScheduledJob;
+
+import static java.util.Objects.requireNonNull;
 
 public class ModifyScheduledJobCommand
     extends AbstractSchedulerCommand
@@ -69,7 +69,7 @@ public class ModifyScheduledJobCommand
         @Override
         protected void validate()
         {
-            Objects.requireNonNull( params, "params cannot be null" );
+            requireNonNull( params, "params cannot be null" );
         }
 
         @Override

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/SchedulerRepoInitializer.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/SchedulerRepoInitializer.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.impl.scheduler;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.Context;
 import com.enonic.xp.init.ExternalInitializer;
 import com.enonic.xp.repository.CreateRepositoryParams;
 import com.enonic.xp.repository.internal.InternalRepositoryService;
 import com.enonic.xp.scheduler.SchedulerConstants;
+
+import static java.util.Objects.requireNonNull;
 
 public class SchedulerRepoInitializer
     extends ExternalInitializer
@@ -70,7 +70,7 @@ public class SchedulerRepoInitializer
         protected void validate()
         {
             super.validate();
-            Objects.requireNonNull( repositoryService );
+            requireNonNull( repositoryService );
         }
 
         public SchedulerRepoInitializer build()

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/UnscheduleJobCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/UnscheduleJobCommand.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.impl.scheduler;
 
-import java.util.Objects;
-
 import com.enonic.xp.scheduler.ScheduledJobName;
+
+import static java.util.Objects.requireNonNull;
 
 final class UnscheduleJobCommand
 {
@@ -46,8 +46,8 @@ final class UnscheduleJobCommand
 
         private void validate()
         {
-            Objects.requireNonNull( schedulerExecutorService );
-            Objects.requireNonNull( name, "name is required" );
+            requireNonNull( schedulerExecutorService );
+            requireNonNull( name, "name is required" );
         }
 
         public UnscheduleJobCommand build()

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommand.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.impl.scheduler;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.impl.scheduler.serializer.SchedulerSerializer;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeName;
@@ -12,6 +10,8 @@ import com.enonic.xp.node.UpdateNodeParams;
 import com.enonic.xp.scheduler.ScheduledJob;
 import com.enonic.xp.scheduler.ScheduledJobName;
 import com.enonic.xp.task.TaskId;
+
+import static java.util.Objects.requireNonNull;
 
 public class UpdateLastRunCommand
     extends AbstractSchedulerCommand
@@ -90,8 +90,8 @@ public class UpdateLastRunCommand
         @Override
         protected void validate()
         {
-            Objects.requireNonNull( name, "name is required" );
-            Objects.requireNonNull( lastRun, "lastRun is required" );
+            requireNonNull( name, "name is required" );
+            requireNonNull( lastRun, "lastRun is required" );
         }
 
         @Override

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/distributed/CronCalendarImpl.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/distributed/CronCalendarImpl.java
@@ -3,7 +3,6 @@ package com.enonic.xp.impl.scheduler.distributed;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.TimeZone;
 
@@ -16,6 +15,8 @@ import com.cronutils.parser.CronParser;
 
 import com.enonic.xp.scheduler.CronCalendar;
 import com.enonic.xp.scheduler.ScheduleCalendarType;
+
+import static java.util.Objects.requireNonNull;
 
 public final class CronCalendarImpl
     implements CronCalendar
@@ -130,8 +131,8 @@ public final class CronCalendarImpl
 
         protected void validate()
         {
-            Objects.requireNonNull( value, "value is required" );
-            Objects.requireNonNull( timeZone, "timeZone is required" );
+            requireNonNull( value, "value is required" );
+            requireNonNull( timeZone, "timeZone is required" );
         }
 
         public CronCalendarImpl build()

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/distributed/OneTimeCalendarImpl.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/distributed/OneTimeCalendarImpl.java
@@ -1,11 +1,12 @@
 package com.enonic.xp.impl.scheduler.distributed;
 
 import java.time.Instant;
-import java.util.Objects;
 import java.util.Optional;
 
 import com.enonic.xp.scheduler.OneTimeCalendar;
 import com.enonic.xp.scheduler.ScheduleCalendarType;
+
+import static java.util.Objects.requireNonNull;
 
 public final class OneTimeCalendarImpl
     implements OneTimeCalendar
@@ -54,7 +55,7 @@ public final class OneTimeCalendarImpl
 
         protected void validate()
         {
-            Objects.requireNonNull( value, "value is required" );
+            requireNonNull( value, "value is required" );
         }
 
         public OneTimeCalendarImpl build()

--- a/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/PHCEncoder.java
+++ b/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/PHCEncoder.java
@@ -3,7 +3,6 @@ package com.enonic.xp.core.impl.security;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import javax.crypto.SecretKeyFactory;
@@ -13,6 +12,8 @@ import org.jspecify.annotations.NullMarked;
 
 import com.google.common.base.Strings;
 import com.google.common.base.Suppliers;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 @NullMarked
 final class PHCEncoder
@@ -62,7 +63,7 @@ final class PHCEncoder
     @Override
     public boolean verify( final char[] plainPassword, final String phc )
     {
-        final PHCParser.PHCData phcData = PHCParser.parse( Objects.requireNonNullElseGet( Strings.emptyToNull( phc ), this.dummyHash ) );
+        final PHCParser.PHCData phcData = PHCParser.parse( requireNonNullElseGet( Strings.emptyToNull( phc ), this.dummyHash ) );
 
         if ( !PHC_ID.equals( phcData.id() ) )
         {

--- a/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/PHCParser.java
+++ b/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/PHCParser.java
@@ -3,9 +3,10 @@ package com.enonic.xp.core.impl.security;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
 
 final class PHCParser
 {
@@ -66,7 +67,7 @@ final class PHCParser
     {
         int paramInt( String param )
         {
-            return Integer.parseInt( Objects.requireNonNull( params.get( param ), "PHC string missing required parameter: " + param ) );
+            return Integer.parseInt( requireNonNull( params.get( param ), "PHC string missing required parameter: " + param ) );
         }
     }
 }

--- a/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/PrincipalNodeTranslator.java
+++ b/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/PrincipalNodeTranslator.java
@@ -1,7 +1,6 @@
 package com.enonic.xp.core.impl.security;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
@@ -25,6 +24,8 @@ import com.enonic.xp.security.PrincipalType;
 import com.enonic.xp.security.Principals;
 import com.enonic.xp.security.Role;
 import com.enonic.xp.security.User;
+
+import static java.util.Objects.requireNonNull;
 
 abstract class PrincipalNodeTranslator
 {
@@ -79,7 +80,7 @@ abstract class PrincipalNodeTranslator
 
     public static CreateNodeParams toCreateNodeParams( final Principal principal )
     {
-        Objects.requireNonNull( principal );
+        requireNonNull( principal );
 
         final CreateNodeParams.Builder builder = CreateNodeParams.create().
             name( PrincipalKeyNodeTranslator.toNodeName( principal.getKey() ) ).
@@ -117,7 +118,7 @@ abstract class PrincipalNodeTranslator
 
     public static UpdateNodeParams toUpdateNodeParams( final Principal principal )
     {
-        Objects.requireNonNull( principal );
+        requireNonNull( principal );
 
         return UpdateNodeParams.create().
             path( principal.getKey().toPath() ).
@@ -143,7 +144,7 @@ abstract class PrincipalNodeTranslator
 
     static UpdateNodeParams addRelationshipToUpdateNodeParams( final PrincipalRelationship relationship )
     {
-        Objects.requireNonNull( relationship );
+        requireNonNull( relationship );
 
         return UpdateNodeParams.create().
             path( relationship.getFrom().toPath() ).
@@ -166,7 +167,7 @@ abstract class PrincipalNodeTranslator
 
     static UpdateNodeParams removeRelationshipToUpdateNodeParams( final PrincipalRelationship relationship )
     {
-        Objects.requireNonNull( relationship );
+        requireNonNull( relationship );
 
         return UpdateNodeParams.create().
             path( relationship.getFrom().toPath() ).
@@ -187,7 +188,7 @@ abstract class PrincipalNodeTranslator
 
     static UpdateNodeParams removeAllRelationshipsToUpdateNodeParams( final PrincipalKey from )
     {
-        Objects.requireNonNull( from );
+        requireNonNull( from );
 
         return UpdateNodeParams.create().
             path( from.toPath() ).
@@ -247,7 +248,7 @@ abstract class PrincipalNodeTranslator
 
     private static User createUserFromNode( final Node node )
     {
-        Objects.requireNonNull( node );
+        requireNonNull( node );
 
         final PropertyTree nodeAsTree = node.data();
 
@@ -272,7 +273,7 @@ abstract class PrincipalNodeTranslator
 
     private static Group createGroupFromNode( final Node node )
     {
-        Objects.requireNonNull( node );
+        requireNonNull( node );
 
         final PropertyTree nodeAsTree = node.data();
 
@@ -285,7 +286,7 @@ abstract class PrincipalNodeTranslator
 
     private static Role createRoleFromNode( final Node node )
     {
-        Objects.requireNonNull( node );
+        requireNonNull( node );
 
         final PropertyTree nodeAsTree = node.data();
 

--- a/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/SecurityInitializer.java
+++ b/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/SecurityInitializer.java
@@ -3,8 +3,6 @@ package com.enonic.xp.core.impl.security;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.List;
-import java.util.Objects;
-
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 
@@ -44,6 +42,7 @@ import com.enonic.xp.security.auth.AuthenticationInfo;
 
 import static com.enonic.xp.security.acl.IdProviderAccess.ADMINISTRATOR;
 import static com.enonic.xp.security.acl.IdProviderAccess.READ;
+import static java.util.Objects.requireNonNull;
 
 public final class SecurityInitializer
     extends ExternalInitializer
@@ -382,8 +381,8 @@ public final class SecurityInitializer
         protected void validate()
         {
             super.validate();
-            Objects.requireNonNull( securityService );
-            Objects.requireNonNull( nodeService );
+            requireNonNull( securityService );
+            requireNonNull( nodeService );
         }
 
         public SecurityInitializer build()

--- a/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/SecurityServiceImpl.java
+++ b/modules/core/core-security/src/main/java/com/enonic/xp/core/impl/security/SecurityServiceImpl.java
@@ -2,7 +2,6 @@ package com.enonic.xp.core.impl.security;
 
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -88,6 +87,8 @@ import com.enonic.xp.security.auth.PasswordAuthToken;
 import com.enonic.xp.security.auth.UsernamePasswordAuthToken;
 import com.enonic.xp.security.auth.VerifiedEmailAuthToken;
 import com.enonic.xp.security.auth.VerifiedUsernameAuthToken;
+
+import static java.util.Objects.requireNonNull;
 
 public final class SecurityServiceImpl
     implements SecurityService
@@ -674,7 +675,7 @@ public final class SecurityServiceImpl
     @Override
     public Optional<? extends Principal> getPrincipal( final PrincipalKey principalKey )
     {
-        return switch ( Objects.requireNonNull( principalKey, "Principal key was null" ).getType() )
+        return switch ( requireNonNull( principalKey, "Principal key was null" ).getType() )
         {
             case USER -> getUser( principalKey );
             case GROUP -> getGroup( principalKey );

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskRunnable.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskRunnable.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.impl.task;
 
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,6 +11,7 @@ import com.enonic.xp.security.User;
 import com.enonic.xp.trace.Tracer;
 
 import static com.enonic.xp.content.ContentConstants.CONTENT_ROOT_PATH_ATTRIBUTE;
+import static java.util.Objects.requireNonNullElseGet;
 
 final class TaskRunnable
     implements Runnable
@@ -39,7 +38,7 @@ final class TaskRunnable
             User user = runnableTask.getTaskContext().getAuthInfo() != null ? runnableTask.getTaskContext().getAuthInfo().getUser() : null;
             Tracer.trace( "task.run", trace -> {
                 trace.put( "taskId", runnableTask.getTaskId() );
-                trace.put( "user", Objects.requireNonNullElseGet( user, User::anonymous ).getKey() );
+                trace.put( "user", requireNonNullElseGet( user, User::anonymous ).getKey() );
                 trace.put( "app", runnableTask.getApplicationKey() );
             }, this::doRun, ( trace, success ) -> trace.put( "success", success ) );
         }

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/distributed/DistributableTask.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/distributed/DistributableTask.java
@@ -2,7 +2,6 @@ package com.enonic.xp.impl.task.distributed;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Objects;
 import java.util.UUID;
 
 import com.enonic.xp.app.ApplicationKey;
@@ -15,6 +14,9 @@ import com.enonic.xp.task.ProgressReporter;
 import com.enonic.xp.task.TaskDescriptor;
 import com.enonic.xp.task.TaskDescriptorService;
 import com.enonic.xp.task.TaskId;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElseGet;
 
 public final class DistributableTask
     implements DescribedTask, Serializable
@@ -37,7 +39,7 @@ public final class DistributableTask
     public DistributableTask( final DescriptorKey key, final String name, final PropertyTree data, final TaskContext context )
     {
         this.taskId = TaskId.from( UUID.randomUUID().toString() );
-        this.name = Objects.requireNonNullElseGet( name, key::toString );
+        this.name = requireNonNullElseGet( name, key::toString );
         this.key = key;
         this.data = data;
         this.context = context;
@@ -88,7 +90,7 @@ public final class DistributableTask
         if ( taskDescriptor == null )
         {
             taskDescriptor = OsgiSupport.withService( TaskDescriptorService.class, tds -> tds.getTask( key ) );
-            Objects.requireNonNull( taskDescriptor, "TaskDescriptor not found for key: " + key );
+            requireNonNull( taskDescriptor, "TaskDescriptor not found for key: " + key );
 
             data = OsgiSupport.withService( PropertyTreeMarshallerService.class,
                                             ptms -> ptms.marshal( data.toMap(), taskDescriptor.getConfig(), false ) );

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/AbstractNodeTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/AbstractNodeTest.java
@@ -2,7 +2,6 @@ package com.enonic.xp.core;
 
 import java.nio.file.Path;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.AfterEach;
@@ -91,6 +90,7 @@ import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.util.Reference;
 
+import static java.util.Objects.requireNonNullElse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
@@ -569,7 +569,7 @@ public abstract class AbstractNodeTest
 
     private void doPrintChildren( int ident, final Node root )
     {
-        System.out.println( " ".repeat( ident ) + "'--" + Objects.requireNonNullElse( root.name(), "" ) + " (" + root.id() + ")" );
+        System.out.println( " ".repeat( ident ) + "'--" + requireNonNullElse( root.name(), "" ) + " (" + root.id() + ")" );
 
         ident += 3;
 

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/AbstractContentServiceTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/content/AbstractContentServiceTest.java
@@ -11,7 +11,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -120,6 +119,7 @@ import com.enonic.xp.util.GenericValue;
 import com.enonic.xp.util.GeoPoint;
 import com.enonic.xp.util.Reference;
 
+import static java.util.Objects.requireNonNullElse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -648,7 +648,7 @@ public abstract class AbstractContentServiceTest
         StringBuilder builder = new StringBuilder();
         builder.append( new String( new char[indent] ).replace( '\0', ' ' ) );
         builder.append( "'--" );
-        builder.append( Objects.requireNonNullElse( content.getName(), "" ) );
+        builder.append( requireNonNullElse( content.getName(), "" ) );
         builder.append( " (" );
         builder.append( content.getId().toString(), 0, 8 );
         builder.append( ")" );

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/dump/DumpUpgradeIntegrationTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/dump/DumpUpgradeIntegrationTest.java
@@ -6,8 +6,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-import java.util.Objects;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +32,7 @@ import com.enonic.xp.security.SystemConstants;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.util.Version;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -188,7 +187,7 @@ class DumpUpgradeIntegrationTest
     {
         try (InputStream is = DumpUpgradeIntegrationTest.class.getClassLoader().getResourceAsStream( resourceName ))
         {
-            Files.copy( Objects.requireNonNull( is ), targetDir.resolve( resourceName ) );
+            Files.copy( requireNonNull( is ), targetDir.resolve( resourceName ) );
         }
         catch ( IOException e )
         {

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/export/NodeImporterIntegrationTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/export/NodeImporterIntegrationTest.java
@@ -3,8 +3,6 @@ package com.enonic.xp.core.export;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -34,6 +32,7 @@ import com.enonic.xp.util.BinaryReference;
 import com.enonic.xp.vfs.VirtualFile;
 import com.enonic.xp.vfs.VirtualFiles;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -816,7 +815,7 @@ class NodeImporterIntegrationTest
         throws Exception
     {
         final InputStream stream =
-            Objects.requireNonNull( getClass().getResourceAsStream( resourceName ), "Resource file [" + resourceName + "] not found" );
+            requireNonNull( getClass().getResourceAsStream( resourceName ), "Resource file [" + resourceName + "] not found" );
         try (stream)
         {
             Files.copy( stream, target );

--- a/modules/jaxrs/jaxrs-impl/src/main/java/com/enonic/xp/jaxrs/impl/JaxRsServiceImpl.java
+++ b/modules/jaxrs/jaxrs-impl/src/main/java/com/enonic/xp/jaxrs/impl/JaxRsServiceImpl.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.jaxrs.impl;
 
 import java.util.Iterator;
-import java.util.Objects;
-
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
@@ -13,6 +11,8 @@ import com.enonic.xp.jaxrs.JaxRsComponent;
 import com.enonic.xp.jaxrs.JaxRsService;
 import com.enonic.xp.web.dispatch.MappingBuilder;
 import com.enonic.xp.web.dispatch.ServletMapping;
+
+import static java.util.Objects.requireNonNull;
 
 final class JaxRsServiceImpl
     implements JaxRsService, ServiceTrackerCustomizer<JaxRsComponent, JaxRsComponent>
@@ -34,8 +34,8 @@ final class JaxRsServiceImpl
     JaxRsServiceImpl( final BundleContext context, final String group, final String path, final String connector )
     {
         this.context = context;
-        this.group = Objects.requireNonNull( group );
-        this.path = Objects.requireNonNull( path );
+        this.group = requireNonNull( group );
+        this.path = requireNonNull( path );
         this.connector = connector;
         this.servlet = new JaxRsServlet();
         this.tracker = new ServiceTracker<>( this.context, JaxRsComponent.class, this );

--- a/modules/jaxrs/jaxrs-impl/src/main/java/com/enonic/xp/jaxrs/impl/exception/JsonExceptionMapper.java
+++ b/modules/jaxrs/jaxrs-impl/src/main/java/com/enonic/xp/jaxrs/impl/exception/JsonExceptionMapper.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.jaxrs.impl.exception;
 
-import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +20,8 @@ import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.web.WebException;
 
+import static java.util.Objects.requireNonNullElseGet;
+
 @Provider
 public final class JsonExceptionMapper
     implements ExceptionMapper<Throwable>
@@ -40,11 +40,11 @@ public final class JsonExceptionMapper
         };
         if ( status >= 500 )
         {
-            LOG.error( Objects.requireNonNullElseGet( cause.getMessage(), cause.getClass()::getSimpleName ), cause );
+            LOG.error( requireNonNullElseGet( cause.getMessage(), cause.getClass()::getSimpleName ), cause );
         }
         else if ( LOG.isDebugEnabled() )
         {
-            LOG.debug( Objects.requireNonNullElseGet( cause.getMessage(), cause.getClass()::getSimpleName ), cause );
+            LOG.debug( requireNonNullElseGet( cause.getMessage(), cause.getClass()::getSimpleName ), cause );
         }
         return Response.status( status ).entity( createErrorJson( cause, status ) ).type( MediaType.APPLICATION_JSON_TYPE ).build();
     }

--- a/modules/jaxrs/jaxrs-impl/src/testFixtures/java/com/enonic/xp/jaxrs/impl/JaxRsResourceTestSupport.java
+++ b/modules/jaxrs/jaxrs-impl/src/testFixtures/java/com/enonic/xp/jaxrs/impl/JaxRsResourceTestSupport.java
@@ -4,8 +4,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Locale;
-import java.util.Objects;
-
 import org.jboss.resteasy.mock.MockDispatcherFactory;
 import org.jboss.resteasy.spi.Dispatcher;
 import org.junit.jupiter.api.AfterEach;
@@ -29,6 +27,8 @@ import com.enonic.xp.jaxrs.impl.multipart.MultipartFormReader;
 import com.enonic.xp.session.Session;
 import com.enonic.xp.session.SessionMock;
 import com.enonic.xp.web.multipart.MultipartService;
+
+import static java.util.Objects.requireNonNull;
 
 public abstract class JaxRsResourceTestSupport
 {
@@ -133,7 +133,7 @@ public abstract class JaxRsResourceTestSupport
         throws Exception
     {
         final InputStream stream =
-            Objects.requireNonNull( getClass().getResourceAsStream( fileName ), "Resource file [" + fileName + "] not found" );
+            requireNonNull( getClass().getResourceAsStream( fileName ), "Resource file [" + fileName + "] not found" );
         try (stream)
         {
             return new String( stream.readAllBytes(), StandardCharsets.UTF_8 );

--- a/modules/launcher/launcher-impl/src/main/java/com/enonic/xp/launcher/impl/config/ConfigLoader.java
+++ b/modules/launcher/launcher-impl/src/main/java/com/enonic/xp/launcher/impl/config/ConfigLoader.java
@@ -10,10 +10,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 
 import com.enonic.xp.launcher.impl.env.Environment;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ConfigLoader
 {
@@ -42,7 +43,7 @@ public final class ConfigLoader
         throws IOException
     {
         final InputStream stream = getClass().getResourceAsStream( DEFAULT_CONFIG );
-        Objects.requireNonNull( stream, "Could not find " + DEFAULT_CONFIG );
+        requireNonNull( stream, "Could not find " + DEFAULT_CONFIG );
 
         try (stream; Reader reader = new BufferedReader( new InputStreamReader( stream, StandardCharsets.UTF_8 ) ))
         {

--- a/modules/launcher/launcher-impl/src/main/java/com/enonic/xp/launcher/impl/env/EnvironmentImpl.java
+++ b/modules/launcher/launcher-impl/src/main/java/com/enonic/xp/launcher/impl/env/EnvironmentImpl.java
@@ -2,9 +2,9 @@ package com.enonic.xp.launcher.impl.env;
 
 import java.nio.file.Path;
 import java.util.Map;
-import java.util.Objects;
-
 import com.enonic.xp.launcher.impl.SharedConstants;
+
+import static java.util.Objects.requireNonNull;
 
 final class EnvironmentImpl
     implements Environment
@@ -15,9 +15,9 @@ final class EnvironmentImpl
 
     EnvironmentImpl( final Path installDir, final Path homeDir )
     {
-        this.homeDir = Objects.requireNonNull( homeDir, String.format( "Home directory not set. Please set [%s] system property variable.",
+        this.homeDir = requireNonNull( homeDir, String.format( "Home directory not set. Please set [%s] system property variable.",
                                                                        SharedConstants.XP_HOME_DIR ) ).toAbsolutePath().normalize();
-        this.installDir = Objects.requireNonNull( installDir,
+        this.installDir = requireNonNull( installDir,
                                                   String.format( "Install directory not set. Please set [%s] system property variable.",
                                                                  SharedConstants.XP_INSTALL_DIR ) ).toAbsolutePath().normalize();
     }

--- a/modules/launcher/launcher-impl/src/main/java/com/enonic/xp/launcher/impl/env/EnvironmentResolver.java
+++ b/modules/launcher/launcher-impl/src/main/java/com/enonic/xp/launcher/impl/env/EnvironmentResolver.java
@@ -1,11 +1,12 @@
 package com.enonic.xp.launcher.impl.env;
 
 import java.nio.file.Path;
-import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import com.enonic.xp.launcher.impl.SharedConstants;
+
+import static java.util.Objects.requireNonNullElse;
 
 public final class EnvironmentResolver
 {
@@ -36,8 +37,8 @@ public final class EnvironmentResolver
 
     private Path resolveHomeDir( final Path installDir )
     {
-        final String propValue = Objects.requireNonNullElse( this.properties.get( SharedConstants.XP_HOME_DIR ), "" );
-        final String envValue = Objects.requireNonNullElse( this.properties.getEnv( SharedConstants.XP_HOME_DIR_ENV ), "" );
+        final String propValue = requireNonNullElse( this.properties.get( SharedConstants.XP_HOME_DIR ), "" );
+        final String envValue = requireNonNullElse( this.properties.getEnv( SharedConstants.XP_HOME_DIR_ENV ), "" );
 
         return Stream.of( propValue, envValue ).filter( Predicate.not( String::isEmpty ) ).findFirst().
             map( Path::of ).orElseGet( () -> installDir != null ? installDir.resolve( "home" ) : null );

--- a/modules/lib/lib-app/src/main/java/com/enonic/xp/lib/app/mapper/IconByteSource.java
+++ b/modules/lib/lib-app/src/main/java/com/enonic/xp/lib/app/mapper/IconByteSource.java
@@ -2,14 +2,14 @@ package com.enonic.xp.lib.app.mapper;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Objects;
-
 import com.google.common.base.Optional;
 import com.google.common.io.ByteProcessor;
 import com.google.common.io.ByteSource;
 import com.google.common.io.ByteStreams;
 
 import com.enonic.xp.icon.Icon;
+
+import static java.util.Objects.requireNonNull;
 
 public final class IconByteSource
     extends ByteSource
@@ -18,7 +18,7 @@ public final class IconByteSource
 
     public IconByteSource( final Icon icon )
     {
-        this.icon = Objects.requireNonNull( icon );
+        this.icon = requireNonNull( icon );
     }
 
     @Override

--- a/modules/lib/lib-auditlog/src/test/java/com/enonic/xp/lib/audit/BaseAuditLogHandlerTest.java
+++ b/modules/lib/lib-auditlog/src/test/java/com/enonic/xp/lib/audit/BaseAuditLogHandlerTest.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.lib.audit;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import org.mockito.Mockito;
 
 import com.enonic.xp.audit.AuditLog;
@@ -12,6 +10,8 @@ import com.enonic.xp.audit.LogAuditLogParams;
 import com.enonic.xp.form.PropertyTreeMarshallerService;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.testing.ScriptTestSupport;
+
+import static java.util.Objects.requireNonNullElse;
 
 public abstract class BaseAuditLogHandlerTest
     extends ScriptTestSupport
@@ -39,7 +39,7 @@ public abstract class BaseAuditLogHandlerTest
             type( p.getType() ).
             time( Instant.ofEpochMilli( 1565599442767L ) ).
             source( p.getSource() ).
-            user( Objects.requireNonNullElse( p.getUser(), PrincipalKey.ofAnonymous()) ).
+            user( requireNonNullElse( p.getUser(), PrincipalKey.ofAnonymous()) ).
             objectUris( p.getObjectUris() ).
             data( p.getData() );
     }

--- a/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/BaseContentHandler.java
+++ b/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/BaseContentHandler.java
@@ -2,7 +2,6 @@ package com.enonic.xp.lib.content;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -30,6 +29,8 @@ import com.enonic.xp.schema.mixin.MixinService;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.site.CmsService;
 import com.enonic.xp.util.BinaryReferences;
+
+import static java.util.Objects.requireNonNull;
 
 public abstract class BaseContentHandler
     extends BaseContextHandler
@@ -121,7 +122,7 @@ public abstract class BaseContentHandler
         if ( map.containsKey( key ) )
         {
             fieldEditor.accept( Optional.ofNullable( map.get( key ) )
-                                    .map( v -> Objects.requireNonNull( Converters.convert( v, type ), "cannot convert" ) ) );
+                                    .map( v -> requireNonNull( Converters.convert( v, type ), "cannot convert" ) ) );
         }
     }
 }

--- a/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/ResetInheritanceHandler.java
+++ b/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/ResetInheritanceHandler.java
@@ -1,7 +1,6 @@
 package com.enonic.xp.lib.content;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -10,6 +9,8 @@ import com.enonic.xp.content.ResetContentInheritParams;
 import com.enonic.xp.content.SyncContentService;
 import com.enonic.xp.project.ProjectName;
 import com.enonic.xp.script.bean.BeanContext;
+
+import static java.util.Objects.requireNonNull;
 
 public class ResetInheritanceHandler
     extends BaseContextHandler
@@ -61,8 +62,8 @@ public class ResetInheritanceHandler
 
     private void validate()
     {
-        Objects.requireNonNull( key, "key is required" );
-        Objects.requireNonNull( projectName, "projectName is required" );
-        Objects.requireNonNull( inherit, "inherit is required" );
+        requireNonNull( key, "key is required" );
+        requireNonNull( projectName, "projectName is required" );
+        requireNonNull( inherit, "inherit is required" );
     }
 }

--- a/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/mapper/IconByteSource.java
+++ b/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/mapper/IconByteSource.java
@@ -2,14 +2,14 @@ package com.enonic.xp.lib.content.mapper;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Objects;
-
 import com.google.common.base.Optional;
 import com.google.common.io.ByteProcessor;
 import com.google.common.io.ByteSource;
 import com.google.common.io.ByteStreams;
 
 import com.enonic.xp.icon.Icon;
+
+import static java.util.Objects.requireNonNull;
 
 public final class IconByteSource
     extends ByteSource
@@ -18,7 +18,7 @@ public final class IconByteSource
 
     IconByteSource( final Icon icon )
     {
-        this.icon = Objects.requireNonNull( icon );
+        this.icon = requireNonNull( icon );
     }
 
     @Override

--- a/modules/lib/lib-i18n/src/main/java/com/enonic/xp/lib/i18n/LocaleScriptBean.java
+++ b/modules/lib/lib-i18n/src/main/java/com/enonic/xp/lib/i18n/LocaleScriptBean.java
@@ -2,7 +2,6 @@ package com.enonic.xp.lib.i18n;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.enonic.xp.app.ApplicationKey;
@@ -16,6 +15,7 @@ import com.enonic.xp.script.serializer.MapSerializable;
 import com.enonic.xp.site.Site;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNullElse;
 
 public final class LocaleScriptBean
     implements ScriptBean
@@ -41,7 +41,7 @@ public final class LocaleScriptBean
         final String locale = getPreferredLocale( locales, bundleArray );
         final MessageBundle messageBundle = getMessageBundle( locale, bundleArray );
         final String localizedMessage = messageBundle.localize( key, toArray( values ) );
-        return Objects.requireNonNullElse( localizedMessage, fallbackMessage );
+        return requireNonNullElse( localizedMessage, fallbackMessage );
     }
 
     public MapSerializable getPhrases( final List<String> locales, final List<String> bundleNames )

--- a/modules/lib/lib-node/src/main/java/com/enonic/xp/lib/node/DuplicateNodeHandlerParams.java
+++ b/modules/lib/lib-node/src/main/java/com/enonic/xp/lib/node/DuplicateNodeHandlerParams.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.lib.node;
 
-import java.util.Objects;
-
 import com.enonic.xp.lib.common.PropertyTreeMapper;
 import com.enonic.xp.lib.value.ScriptValueTranslator;
 import com.enonic.xp.node.NodeDataProcessor;
@@ -9,6 +7,8 @@ import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.script.ScriptValue;
+
+import static java.util.Objects.requireNonNull;
 
 public class DuplicateNodeHandlerParams
 {
@@ -26,7 +26,7 @@ public class DuplicateNodeHandlerParams
 
     public void setNodeId( final String nodeId )
     {
-        this.nodeId = NodeId.from( Objects.requireNonNull( nodeId ) );
+        this.nodeId = NodeId.from( requireNonNull( nodeId ) );
     }
 
     public void setName( final String name )

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentComponentHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentComponentHandler.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.lib.portal.current;
 
-import java.util.Objects;
-
 import com.enonic.xp.lib.content.mapper.ComponentMapper;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.region.Component;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
+
+import static java.util.Objects.requireNonNull;
 
 public final class GetCurrentComponentHandler
     implements ScriptBean
@@ -22,6 +22,6 @@ public final class GetCurrentComponentHandler
     @Override
     public void initialize( final BeanContext context )
     {
-        this.request = Objects.requireNonNull( context.getBinding( PortalRequest.class ).get(), "no request bound" );
+        this.request = requireNonNull( context.getBinding( PortalRequest.class ).get(), "no request bound" );
     }
 }

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentContentHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentContentHandler.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.lib.portal.current;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.Content;
 import com.enonic.xp.lib.content.mapper.ContentMapper;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
+
+import static java.util.Objects.requireNonNull;
 
 public final class GetCurrentContentHandler
     implements ScriptBean
@@ -22,6 +22,6 @@ public final class GetCurrentContentHandler
     @Override
     public void initialize( final BeanContext context )
     {
-        this.request = Objects.requireNonNull( context.getBinding( PortalRequest.class ).get(), "no request bound" );
+        this.request = requireNonNull( context.getBinding( PortalRequest.class ).get(), "no request bound" );
     }
 }

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentIdProviderKeyHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentIdProviderKeyHandler.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.lib.portal.current;
 
-import java.util.Objects;
-
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
@@ -9,6 +7,8 @@ import com.enonic.xp.security.IdProvider;
 import com.enonic.xp.security.IdProviderKey;
 import com.enonic.xp.web.vhost.VirtualHost;
 import com.enonic.xp.web.vhost.VirtualHostHelper;
+
+import static java.util.Objects.requireNonNull;
 
 public final class GetCurrentIdProviderKeyHandler
     implements ScriptBean
@@ -44,6 +44,6 @@ public final class GetCurrentIdProviderKeyHandler
     @Override
     public void initialize( final BeanContext context )
     {
-        this.request = Objects.requireNonNull( context.getBinding( PortalRequest.class ).get(), "no request bound" );
+        this.request = requireNonNull( context.getBinding( PortalRequest.class ).get(), "no request bound" );
     }
 }

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentSiteConfigHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentSiteConfigHandler.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.lib.portal.current;
 
-import java.util.Objects;
-
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.lib.common.PropertyTreeMapper;
 import com.enonic.xp.portal.PortalRequest;
@@ -10,6 +8,8 @@ import com.enonic.xp.script.bean.ScriptBean;
 import com.enonic.xp.site.SiteConfig;
 import com.enonic.xp.site.SiteConfigs;
 import com.enonic.xp.site.SiteConfigsDataSerializer;
+
+import static java.util.Objects.requireNonNull;
 
 public final class GetCurrentSiteConfigHandler
     implements ScriptBean
@@ -37,6 +37,6 @@ public final class GetCurrentSiteConfigHandler
     @Override
     public void initialize( final BeanContext context )
     {
-        this.request = Objects.requireNonNull( context.getBinding( PortalRequest.class ).get(), "no request bound" );
+        this.request = requireNonNull( context.getBinding( PortalRequest.class ).get(), "no request bound" );
     }
 }

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentSiteHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentSiteHandler.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.lib.portal.current;
 
-import java.util.Objects;
-
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.lib.content.mapper.SiteMapper;
 import com.enonic.xp.portal.PortalRequest;
@@ -9,6 +7,8 @@ import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
 import com.enonic.xp.security.acl.Permission;
 import com.enonic.xp.site.Site;
+
+import static java.util.Objects.requireNonNull;
 
 public final class GetCurrentSiteHandler
     implements ScriptBean
@@ -38,6 +38,6 @@ public final class GetCurrentSiteHandler
     @Override
     public void initialize( final BeanContext context )
     {
-        this.request = Objects.requireNonNull( context.getBinding( PortalRequest.class ).get(), "no request bound" );
+        this.request = requireNonNull( context.getBinding( PortalRequest.class ).get(), "no request bound" );
     }
 }

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/multipart/MultipartHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/multipart/MultipartHandler.java
@@ -2,8 +2,6 @@ package com.enonic.xp.lib.portal.multipart;
 
 
 import java.util.List;
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
 import com.google.common.net.MediaType;
 
@@ -13,6 +11,8 @@ import com.enonic.xp.script.bean.ScriptBean;
 import com.enonic.xp.web.multipart.MultipartForm;
 import com.enonic.xp.web.multipart.MultipartItem;
 import com.enonic.xp.web.multipart.MultipartService;
+
+import static java.util.Objects.requireNonNull;
 
 public final class MultipartHandler
     implements ScriptBean
@@ -57,7 +57,7 @@ public final class MultipartHandler
     @Override
     public void initialize( final BeanContext context )
     {
-        final PortalRequest request = Objects.requireNonNull( context.getBinding( PortalRequest.class ).get(), "no request bound" );
+        final PortalRequest request = requireNonNull( context.getBinding( PortalRequest.class ).get(), "no request bound" );
         final MultipartService service = context.getService( MultipartService.class ).get();
         this.form = service.parse( request.getRawRequest() );
     }

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/url/AttachmentUrlHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/url/AttachmentUrlHandler.java
@@ -2,13 +2,13 @@ package com.enonic.xp.lib.portal.url;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-
 import com.enonic.xp.portal.url.AttachmentUrlParams;
 import com.enonic.xp.portal.url.PortalUrlService;
 import com.enonic.xp.script.ScriptValue;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
+
+import static java.util.Objects.requireNonNullElse;
 
 public final class AttachmentUrlHandler
     implements ScriptBean
@@ -83,7 +83,7 @@ public final class AttachmentUrlHandler
 
     public void setDownload( final Boolean download )
     {
-        this.download = Objects.requireNonNullElse( download, false );
+        this.download = requireNonNullElse( download, false );
     }
 
     public void setQueryParams( final ScriptValue params )

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/url/ImagePlaceholderHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/url/ImagePlaceholderHandler.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.lib.portal.url;
 
-import java.util.Objects;
-
 import com.enonic.xp.image.ImageHelper;
+
+import static java.util.Objects.requireNonNullElse;
 
 public final class ImagePlaceholderHandler
 {
@@ -12,7 +12,7 @@ public final class ImagePlaceholderHandler
 
     public String createImagePlaceholder()
     {
-        return ImageHelper.createImagePlaceholder( Objects.requireNonNullElse( width, 0 ), Objects.requireNonNullElse( height, 0 ) );
+        return ImageHelper.createImagePlaceholder( requireNonNullElse( width, 0 ), requireNonNullElse( height, 0 ) );
     }
 
     public void setWidth( final Integer width )

--- a/modules/lib/lib-project/src/main/java/com/enonic/xp/lib/project/CreateProjectHandler.java
+++ b/modules/lib/lib-project/src/main/java/com/enonic/xp/lib/project/CreateProjectHandler.java
@@ -3,7 +3,6 @@ package com.enonic.xp.lib.project;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
@@ -23,6 +22,7 @@ import com.enonic.xp.site.SiteConfig;
 import com.enonic.xp.site.SiteConfigs;
 
 import static com.google.common.base.Strings.nullToEmpty;
+import static java.util.Objects.requireNonNull;
 
 public final class CreateProjectHandler
     extends BaseProjectHandler
@@ -104,7 +104,7 @@ public final class CreateProjectHandler
 
     public void setId( final String value )
     {
-        this.id = ProjectName.from( Objects.requireNonNull( value, "Project name is required" ) );
+        this.id = ProjectName.from( requireNonNull( value, "Project name is required" ) );
     }
 
     public void setDisplayName( final String value )

--- a/modules/lib/lib-project/src/main/java/com/enonic/xp/lib/project/command/AbstractProjectRootCommand.java
+++ b/modules/lib/lib-project/src/main/java/com/enonic/xp/lib/project/command/AbstractProjectRootCommand.java
@@ -1,13 +1,13 @@
 package com.enonic.xp.lib.project.command;
 
-import java.util.Objects;
-
 import com.enonic.xp.content.ContentConstants;
 import com.enonic.xp.content.ContentService;
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.context.ContextBuilder;
 import com.enonic.xp.project.ProjectName;
+
+import static java.util.Objects.requireNonNull;
 
 abstract class AbstractProjectRootCommand
 {
@@ -50,8 +50,8 @@ abstract class AbstractProjectRootCommand
 
         void validate()
         {
-            Objects.requireNonNull( contentService );
-            Objects.requireNonNull( projectName, "projectName is required" );
+            requireNonNull( contentService );
+            requireNonNull( projectName, "projectName is required" );
         }
     }
 

--- a/modules/lib/lib-project/src/main/java/com/enonic/xp/lib/project/mapper/ProjectMapper.java
+++ b/modules/lib/lib-project/src/main/java/com/enonic/xp/lib/project/mapper/ProjectMapper.java
@@ -1,14 +1,14 @@
 package com.enonic.xp.lib.project.mapper;
 
 import java.util.Locale;
-import java.util.Objects;
-
 import com.enonic.xp.lib.common.PropertyTreeMapper;
 import com.enonic.xp.project.Project;
 import com.enonic.xp.project.ProjectPermissions;
 import com.enonic.xp.script.serializer.MapGenerator;
 import com.enonic.xp.script.serializer.MapSerializable;
 import com.enonic.xp.site.SiteConfig;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ProjectMapper
     implements MapSerializable
@@ -132,7 +132,7 @@ public final class ProjectMapper
 
         private void validate()
         {
-            Objects.requireNonNull( project, "project is required" );
+            requireNonNull( project, "project is required" );
         }
 
 

--- a/modules/lib/lib-scheduler/src/main/java/com/enonic/xp/lib/scheduler/mapper/ScheduledJobMapper.java
+++ b/modules/lib/lib-scheduler/src/main/java/com/enonic/xp/lib/scheduler/mapper/ScheduledJobMapper.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.lib.scheduler.mapper;
 
-import java.util.Objects;
-
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.lib.common.PropertyTreeMapper;
 import com.enonic.xp.scheduler.CronCalendar;
@@ -10,6 +8,8 @@ import com.enonic.xp.scheduler.ScheduleCalendar;
 import com.enonic.xp.scheduler.ScheduledJob;
 import com.enonic.xp.script.serializer.MapGenerator;
 import com.enonic.xp.script.serializer.MapSerializable;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ScheduledJobMapper
     implements MapSerializable
@@ -92,7 +92,7 @@ public final class ScheduledJobMapper
 
         private void validate()
         {
-            Objects.requireNonNull( job, "job is required" );
+            requireNonNull( job, "job is required" );
         }
 
         public ScheduledJobMapper build()

--- a/modules/lib/lib-schema/src/main/java/com/enonic/xp/lib/schema/mapper/IconByteSource.java
+++ b/modules/lib/lib-schema/src/main/java/com/enonic/xp/lib/schema/mapper/IconByteSource.java
@@ -2,14 +2,14 @@ package com.enonic.xp.lib.schema.mapper;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Objects;
-
 import com.google.common.base.Optional;
 import com.google.common.io.ByteProcessor;
 import com.google.common.io.ByteSource;
 import com.google.common.io.ByteStreams;
 
 import com.enonic.xp.icon.Icon;
+
+import static java.util.Objects.requireNonNull;
 
 public final class IconByteSource
     extends ByteSource
@@ -18,7 +18,7 @@ public final class IconByteSource
 
     public IconByteSource( final Icon icon )
     {
-        this.icon = Objects.requireNonNull( icon );
+        this.icon = requireNonNull( icon );
     }
 
     @Override

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/ApiUrlGeneratorParams.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/ApiUrlGeneratorParams.java
@@ -3,12 +3,13 @@ package com.enonic.xp.portal.url;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.enonic.xp.descriptor.DescriptorKey;
 
 import static com.google.common.base.Strings.emptyToNull;
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class ApiUrlGeneratorParams
@@ -26,8 +27,8 @@ public final class ApiUrlGeneratorParams
     private ApiUrlGeneratorParams( final Builder builder )
     {
         this.baseUrl = builder.baseUrl;
-        this.urlType = Objects.requireNonNullElse( builder.urlType, UrlTypeConstants.SERVER_RELATIVE );
-        this.descriptorKey = Objects.requireNonNull( builder.descriptorKey );
+        this.urlType = requireNonNullElse( builder.urlType, UrlTypeConstants.SERVER_RELATIVE );
+        this.descriptorKey = requireNonNull( builder.descriptorKey );
         this.pathSupplier = builder.pathSupplier;
         this.queryParams = builder.queryParams.build();
     }

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/ApiUrlParams.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/ApiUrlParams.java
@@ -3,11 +3,11 @@ package com.enonic.xp.portal.url;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-
 import com.google.common.base.MoreObjects;
 
 import com.enonic.xp.descriptor.DescriptorKey;
+
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class ApiUrlParams
@@ -26,7 +26,7 @@ public final class ApiUrlParams
 
     private ApiUrlParams( final Builder builder )
     {
-        this.type = Objects.requireNonNullElse( builder.type, UrlTypeConstants.SERVER_RELATIVE );
+        this.type = requireNonNullElse( builder.type, UrlTypeConstants.SERVER_RELATIVE );
         this.api = builder.api;
         this.path = builder.path;
         this.pathSegments = builder.pathSegments;

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/AttachmentUrlGeneratorParams.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/AttachmentUrlGeneratorParams.java
@@ -3,12 +3,14 @@ package com.enonic.xp.portal.url;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.content.Content;
 import com.enonic.xp.project.ProjectName;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class AttachmentUrlGeneratorParams
@@ -34,10 +36,10 @@ public final class AttachmentUrlGeneratorParams
     private AttachmentUrlGeneratorParams( final Builder builder )
     {
         this.baseUrl = builder.baseUrl;
-        this.urlType = Objects.requireNonNullElse( builder.urlType, UrlTypeConstants.SERVER_RELATIVE );
-        this.contentSupplier = Objects.requireNonNull( builder.contentSupplier );
-        this.projectName = Objects.requireNonNull( builder.projectNameSupplier );
-        this.branch = Objects.requireNonNull( builder.branchSupplier );
+        this.urlType = requireNonNullElse( builder.urlType, UrlTypeConstants.SERVER_RELATIVE );
+        this.contentSupplier = requireNonNull( builder.contentSupplier );
+        this.projectName = requireNonNull( builder.projectNameSupplier );
+        this.branch = requireNonNull( builder.branchSupplier );
         this.download = builder.download;
         this.name = builder.name;
         this.label = builder.label;

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/BaseUrlParams.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/BaseUrlParams.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.portal.url;
 
-import java.util.Objects;
-
 import com.google.common.base.MoreObjects;
+
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class BaseUrlParams
@@ -19,7 +19,7 @@ public final class BaseUrlParams
 
     private BaseUrlParams( final Builder builder )
     {
-        this.urlType = Objects.requireNonNullElse( builder.urlType, UrlTypeConstants.SERVER_RELATIVE );
+        this.urlType = requireNonNullElse( builder.urlType, UrlTypeConstants.SERVER_RELATIVE );
         this.projectName = builder.projectName;
         this.branch = builder.branch;
         this.id = builder.id;

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/HtmlProcessorParams.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/HtmlProcessorParams.java
@@ -1,11 +1,12 @@
 package com.enonic.xp.portal.url;
 
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import com.enonic.xp.portal.html.HtmlDocument;
 import com.enonic.xp.portal.html.HtmlElement;
+
+import static java.util.Objects.requireNonNull;
 
 
 public final class HtmlProcessorParams
@@ -19,8 +20,8 @@ public final class HtmlProcessorParams
     private HtmlProcessorParams( Builder builder )
     {
         this.htmlDocument = builder.htmlDocument;
-        this.defaultProcessor = Objects.requireNonNull( builder.defaultProcessor );
-        this.defaultElementProcessor = Objects.requireNonNull( builder.defaultElementProcessor );
+        this.defaultProcessor = requireNonNull( builder.defaultProcessor );
+        this.defaultElementProcessor = requireNonNull( builder.defaultElementProcessor );
     }
 
     public HtmlDocument getDocument()

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/ImageUrlGeneratorParams.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/ImageUrlGeneratorParams.java
@@ -3,12 +3,14 @@ package com.enonic.xp.portal.url;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.content.Media;
 import com.enonic.xp.project.ProjectName;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 
 public final class ImageUrlGeneratorParams
@@ -38,11 +40,11 @@ public final class ImageUrlGeneratorParams
     private ImageUrlGeneratorParams( final Builder builder )
     {
         this.baseUrl = builder.baseUrl;
-        this.urlType = Objects.requireNonNullElse( builder.urlType, UrlTypeConstants.SERVER_RELATIVE );
-        this.mediaSupplier = Objects.requireNonNull( builder.mediaSupplier );
-        this.projectNameSupplier = Objects.requireNonNull( builder.projectNameSupplier );
-        this.branchSupplier = Objects.requireNonNull( builder.branchSupplier );
-        this.scale = Objects.requireNonNull( builder.scale );
+        this.urlType = requireNonNullElse( builder.urlType, UrlTypeConstants.SERVER_RELATIVE );
+        this.mediaSupplier = requireNonNull( builder.mediaSupplier );
+        this.projectNameSupplier = requireNonNull( builder.projectNameSupplier );
+        this.branchSupplier = requireNonNull( builder.branchSupplier );
+        this.scale = requireNonNull( builder.scale );
         this.background = builder.background;
         this.quality = builder.quality;
         this.filter = builder.filter;

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/MediaHashResolver.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/MediaHashResolver.java
@@ -2,14 +2,14 @@ package com.enonic.xp.portal.impl;
 
 import java.security.MessageDigest;
 import java.util.HexFormat;
-import java.util.Objects;
-
 import com.enonic.xp.attachment.Attachment;
 import com.enonic.xp.content.Media;
 import com.enonic.xp.core.internal.security.MessageDigests;
 import com.enonic.xp.image.Cropping;
 import com.enonic.xp.image.FocalPoint;
 import com.enonic.xp.media.ImageOrientation;
+
+import static java.util.Objects.requireNonNullElse;
 
 public final class MediaHashResolver
 {
@@ -24,18 +24,18 @@ public final class MediaHashResolver
 
         digest.update( HexFormat.of().parseHex( hash ) );
 
-        final FocalPoint focalPoint = Objects.requireNonNullElse( media.getFocalPoint(), FocalPoint.DEFAULT );
+        final FocalPoint focalPoint = requireNonNullElse( media.getFocalPoint(), FocalPoint.DEFAULT );
         MessageDigests.updateWithDoubleLE( digest, focalPoint.xOffset() );
         MessageDigests.updateWithDoubleLE( digest, focalPoint.yOffset() );
 
-        final Cropping cropping = Objects.requireNonNullElse( media.getCropping(), Cropping.DEFAULT );
+        final Cropping cropping = requireNonNullElse( media.getCropping(), Cropping.DEFAULT );
         MessageDigests.updateWithDoubleLE( digest, cropping.top() );
         MessageDigests.updateWithDoubleLE( digest, cropping.left() );
         MessageDigests.updateWithDoubleLE( digest, cropping.bottom() );
         MessageDigests.updateWithDoubleLE( digest, cropping.right() );
         MessageDigests.updateWithDoubleLE( digest, cropping.zoom() );
 
-        final ImageOrientation orientation = Objects.requireNonNullElse( media.getOrientation(), ImageOrientation.DEFAULT );
+        final ImageOrientation orientation = requireNonNullElse( media.getOrientation(), ImageOrientation.DEFAULT );
         MessageDigests.updateWithIntLE( digest, orientation.ordinal() );
 
         return HexFormat.of().formatHex( digest.digest(), 0, 16 );

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/controller/PortalResponseSerializer.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/controller/PortalResponseSerializer.java
@@ -3,8 +3,6 @@ package com.enonic.xp.portal.impl.controller;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 
@@ -15,6 +13,8 @@ import com.enonic.xp.portal.postprocess.HtmlTag;
 import com.enonic.xp.script.ScriptValue;
 import com.enonic.xp.web.HttpStatus;
 import com.enonic.xp.web.websocket.WebSocketConfig;
+
+import static java.util.Objects.requireNonNull;
 
 public final class PortalResponseSerializer
 {
@@ -36,7 +36,7 @@ public final class PortalResponseSerializer
     public PortalResponseSerializer( final ScriptValue value, final HttpStatus defaultStatus )
     {
         this.value = value;
-        this.defaultStatus = Objects.requireNonNull( defaultStatus );
+        this.defaultStatus = requireNonNull( defaultStatus );
         this.defaultPostProcess = true;
     }
 

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/error/PortalError.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/error/PortalError.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.portal.impl.error;
 
 
-import java.util.Objects;
-
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.web.HttpStatus;
+
+import static java.util.Objects.requireNonNull;
 
 public final class PortalError
 {
@@ -18,8 +18,8 @@ public final class PortalError
 
     private PortalError( final Builder builder )
     {
-        this.status = Objects.requireNonNull( builder.status, "status cannot be null" );
-        this.request = Objects.requireNonNull( builder.request, "request cannot be null" );
+        this.status = requireNonNull( builder.status, "status cannot be null" );
+        this.request = requireNonNull( builder.request, "request cannot be null" );
         this.message = builder.message == null ? "" : builder.message;
         this.exception = builder.exception;
     }

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/api/ApiIndexHandler.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/api/ApiIndexHandler.java
@@ -4,7 +4,6 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Activate;
@@ -31,6 +30,8 @@ import com.enonic.xp.web.WebResponse;
 import com.enonic.xp.web.handler.BaseWebHandler;
 import com.enonic.xp.web.handler.WebHandler;
 import com.enonic.xp.web.handler.WebHandlerChain;
+
+import static java.util.Objects.requireNonNullElse;
 
 @Component(immediate = true, service = WebHandler.class, configurationPid = "com.enonic.xp.api")
 public class ApiIndexHandler
@@ -96,7 +97,7 @@ public class ApiIndexHandler
         result.put( "descriptor", descriptorKey.toString() );
         result.put( "application", descriptorKey.getApplicationKey().toString() );
         result.put( "name", descriptorKey.getName() );
-        result.put( "allowedPrincipals", Objects.requireNonNullElse( apiDescriptor.getAllowedPrincipals(), PrincipalKeys.empty() )
+        result.put( "allowedPrincipals", requireNonNullElse( apiDescriptor.getAllowedPrincipals(), PrincipalKeys.empty() )
             .stream()
             .map( PrincipalKey::toString )
             .toList() );

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/image/ImageHandlerWorker.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/image/ImageHandlerWorker.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.portal.impl.handler.image;
 
 import java.io.IOException;
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
 import com.google.common.io.Files;
 import com.google.common.net.MediaType;
@@ -27,6 +25,8 @@ import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.WebRequest;
 
 import static com.google.common.base.Strings.nullToEmpty;
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 public final class ImageHandlerWorker
     extends AbstractAttachmentHandlerWorker<Media>
@@ -102,7 +102,7 @@ public final class ImageHandlerWorker
                                     final MediaType contentType )
         throws IOException
     {
-        final ImageOrientation imageOrientation = Objects.requireNonNullElse( content.getOrientation(), ImageOrientation.TopLeft );
+        final ImageOrientation imageOrientation = requireNonNullElse( content.getOrientation(), ImageOrientation.TopLeft );
 
         final int imageQuality = nullToEmpty( this.qualityParam ).isEmpty() ? DEFAULT_QUALITY : Integer.parseInt( this.qualityParam );
 
@@ -111,7 +111,7 @@ public final class ImageHandlerWorker
             : Integer.parseInt( this.backgroundParam.startsWith( "0x" ) ? this.backgroundParam.substring( 2 ) : this.backgroundParam, 16 );
         try
         {
-            Objects.requireNonNull( content.getMediaAttachment(), "Media content must have an attachment" );
+            requireNonNull( content.getMediaAttachment(), "Media content must have an attachment" );
 
             final ReadImageParams readImageParams = ReadImageParams.newImageParams()
                 .contentId( content.getId() )

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/idprovider/IdProviderControllerServiceImpl.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/idprovider/IdProviderControllerServiceImpl.java
@@ -3,7 +3,6 @@ package com.enonic.xp.portal.impl.idprovider;
 
 import java.io.IOException;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.concurrent.Callable;
 
 import org.osgi.service.component.annotations.Component;
@@ -31,6 +30,8 @@ import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.web.serializer.WebSerializerService;
 import com.enonic.xp.web.vhost.VirtualHost;
 import com.enonic.xp.web.vhost.VirtualHostHelper;
+
+import static java.util.Objects.requireNonNull;
 
 @Component
 public class IdProviderControllerServiceImpl
@@ -70,7 +71,7 @@ public class IdProviderControllerServiceImpl
             }
             else
             {
-                portalRequest = Objects.requireNonNull( params.getPortalRequest() );
+                portalRequest = requireNonNull( params.getPortalRequest() );
             }
 
             portalRequest.setApplicationKey( idProviderDescriptor.getKey() );

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/service/ServiceDescriptorServiceImpl.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/service/ServiceDescriptorServiceImpl.java
@@ -2,8 +2,6 @@ package com.enonic.xp.portal.impl.service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -20,6 +18,8 @@ import com.enonic.xp.resource.ResourceService;
 import com.enonic.xp.service.ServiceDescriptor;
 import com.enonic.xp.service.ServiceDescriptorService;
 import com.enonic.xp.service.ServiceDescriptors;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 @Component(immediate = true)
 public final class ServiceDescriptorServiceImpl
@@ -46,7 +46,7 @@ public final class ServiceDescriptorServiceImpl
         final ResourceProcessor<DescriptorKey, ServiceDescriptor> processor = newRootProcessor( descriptorKey );
         final ServiceDescriptor descriptor = this.resourceService.processResource( processor );
 
-        return Objects.requireNonNullElseGet( descriptor, () -> createDefaultDescriptor( descriptorKey ) );
+        return requireNonNullElseGet( descriptor, () -> createDefaultDescriptor( descriptorKey ) );
     }
 
     @Override

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ApiUrlBaseUrlResolver.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ApiUrlBaseUrlResolver.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.portal.impl.url;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.enonic.xp.descriptor.DescriptorKey;
@@ -8,6 +7,8 @@ import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.portal.impl.PortalRequestHelper;
 import com.enonic.xp.project.ProjectName;
+
+import static java.util.Objects.requireNonNull;
 
 final class ApiUrlBaseUrlResolver
     implements Supplier<String>
@@ -20,7 +21,7 @@ final class ApiUrlBaseUrlResolver
 
     ApiUrlBaseUrlResolver( final Builder builder )
     {
-        this.descriptorKey = Objects.requireNonNull( builder.descriptorKey, "DescriptorKey must be set" );
+        this.descriptorKey = requireNonNull( builder.descriptorKey, "DescriptorKey must be set" );
         this.baseUrl = builder.baseUrl;
         this.urlType = builder.urlType;
     }

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/AppKeyResolver.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/AppKeyResolver.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.portal.impl.url;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import org.jspecify.annotations.NonNull;
@@ -10,14 +9,16 @@ import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalRequestAccessor;
 
+import static java.util.Objects.requireNonNull;
+
 class AppKeyResolver
 {
     static @NonNull ApplicationKey resolve( @Nullable String appKey )
     {
         return Optional.ofNullable( appKey ).map( ApplicationKey::from ).orElseGet( () -> {
-            final PortalRequest portalRequest = Objects.requireNonNull( PortalRequestAccessor.get(), "no request bound" );
+            final PortalRequest portalRequest = requireNonNull( PortalRequestAccessor.get(), "no request bound" );
 
-            return Objects.requireNonNull( portalRequest.getApplicationKey(), "no application in request" );
+            return requireNonNull( portalRequest.getApplicationKey(), "no application in request" );
         } );
     }
 }

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/AssetBaseUrlSupplier.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/AssetBaseUrlSupplier.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.portal.impl.url;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,6 +12,8 @@ import com.enonic.xp.web.servlet.ServletRequestUrlHelper;
 import com.enonic.xp.web.servlet.UriRewritingResult;
 import com.enonic.xp.web.vhost.VirtualHost;
 import com.enonic.xp.web.vhost.VirtualHostHelper;
+
+import static java.util.Objects.requireNonNull;
 
 final class AssetBaseUrlSupplier
     implements Supplier<String>
@@ -27,7 +28,7 @@ final class AssetBaseUrlSupplier
     @Override
     public String get()
     {
-        final PortalRequest portalRequest = Objects.requireNonNull( PortalRequestAccessor.get(), "no request bound" );
+        final PortalRequest portalRequest = requireNonNull( PortalRequestAccessor.get(), "no request bound" );
 
         final StringBuilder uriBuilder = new StringBuilder();
 

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/AssetPathSupplier.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/AssetPathSupplier.java
@@ -1,7 +1,6 @@
 package com.enonic.xp.portal.impl.url;
 
 import java.util.HexFormat;
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.enonic.xp.app.ApplicationKey;
@@ -10,6 +9,8 @@ import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceService;
 import com.enonic.xp.server.RunMode;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 final class AssetPathSupplier
     implements Supplier<String>
@@ -51,6 +52,6 @@ final class AssetPathSupplier
     private static long stableTime()
     {
         final Long localScopeTime = (Long) ContextAccessor.current().getLocalScope().getAttribute( "__currentTimeMillis" );
-        return Objects.requireNonNullElseGet( localScopeTime, System::currentTimeMillis );
+        return requireNonNullElseGet( localScopeTime, System::currentTimeMillis );
     }
 }

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/AttachmentMediaPathSupplier.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/AttachmentMediaPathSupplier.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.portal.impl.url;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.enonic.xp.attachment.Attachment;
@@ -12,6 +11,8 @@ import com.enonic.xp.portal.impl.MediaHashResolver;
 import com.enonic.xp.project.ProjectName;
 
 import static com.enonic.xp.portal.impl.url.UrlBuilderHelper.appendPart;
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 final class AttachmentMediaPathSupplier
     implements Supplier<String>
@@ -38,9 +39,9 @@ final class AttachmentMediaPathSupplier
     @Override
     public String get()
     {
-        final Content content = Objects.requireNonNull( contentSupplier.get() );
-        final ProjectName project = Objects.requireNonNull( projectNameSupplier.get() );
-        final Branch branch = Objects.requireNonNull( branchSupplier.get() );
+        final Content content = requireNonNull( contentSupplier.get() );
+        final ProjectName project = requireNonNull( projectNameSupplier.get() );
+        final Branch branch = requireNonNull( branchSupplier.get() );
 
         final StringBuilder url = new StringBuilder();
 
@@ -71,7 +72,7 @@ final class AttachmentMediaPathSupplier
         }
         else
         {
-            final String targetLabel = Objects.requireNonNullElse( label, "source" );
+            final String targetLabel = requireNonNullElse( label, "source" );
             attachment = attachments.byLabel( targetLabel );
             if ( attachment == null )
             {

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/BaseUrlExtractor.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/BaseUrlExtractor.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.portal.impl.url;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import com.enonic.xp.app.ApplicationKey;
@@ -24,12 +23,15 @@ import com.enonic.xp.site.SiteConfig;
 import com.enonic.xp.site.SiteConfigs;
 import com.enonic.xp.site.SiteConfigsDataSerializer;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
 record BaseUrlExtractor(ContentService contentService, ProjectService projectService)
 {
     BaseUrlExtractor( final ContentService contentService, final ProjectService projectService )
     {
-        this.contentService = Objects.requireNonNull( contentService );
-        this.projectService = Objects.requireNonNull( projectService );
+        this.contentService = requireNonNull( contentService );
+        this.projectService = requireNonNull( projectService );
     }
 
     BaseUrlMetadata extract( final BaseUrlParams params )
@@ -66,7 +68,7 @@ record BaseUrlExtractor(ContentService contentService, ProjectService projectSer
             final Context context =
                 ContextBuilder.copyOf( ContextAccessor.current() ).repositoryId( projectName.getRepoId() ).branch( branch ).build();
 
-            final Content content = context.callWith( () -> getContent( Objects.requireNonNullElse( params.getId(), params.getPath() ) ) );
+            final Content content = context.callWith( () -> getContent( requireNonNullElse( params.getId(), params.getPath() ) ) );
 
             builder.setContent( content );
 

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ComponentPathSupplier.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ComponentPathSupplier.java
@@ -1,7 +1,8 @@
 package com.enonic.xp.portal.impl.url;
 
-import java.util.Objects;
 import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
 
 final class ComponentPathSupplier
     implements Supplier<String>
@@ -10,7 +11,7 @@ final class ComponentPathSupplier
 
     ComponentPathSupplier( final Supplier<String> componentPath )
     {
-        this.componentPath = Objects.requireNonNull( componentPath );
+        this.componentPath = requireNonNull( componentPath );
     }
 
     @Override

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/DefaultImageLinkProcessor.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/DefaultImageLinkProcessor.java
@@ -1,7 +1,6 @@
 package com.enonic.xp.portal.impl.url;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -23,6 +22,8 @@ import com.enonic.xp.portal.url.ProcessHtmlParams;
 import com.enonic.xp.portal.url.UrlGeneratorParams;
 import com.enonic.xp.project.ProjectName;
 import com.enonic.xp.style.ImageStyle;
+
+import static java.util.Objects.requireNonNullElse;
 
 final class DefaultImageLinkProcessor
 {
@@ -132,7 +133,7 @@ final class DefaultImageLinkProcessor
             final String horizontalProportion = matcher.group( "horizontalProportion" );
             final String verticalProportion = matcher.group( "verticalProportion" );
 
-            final int width = Objects.requireNonNullElse( expectedWidth, DEFAULT_WIDTH );
+            final int width = requireNonNullElse( expectedWidth, DEFAULT_WIDTH );
             final int height = width / Integer.parseInt( horizontalProportion ) * Integer.parseInt( verticalProportion );
 
             return "block(" + width + "," + height + ")";

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/IdentityBaseUrlSupplier.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/IdentityBaseUrlSupplier.java
@@ -1,12 +1,13 @@
 package com.enonic.xp.portal.impl.url;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.web.vhost.VirtualHost;
 import com.enonic.xp.web.vhost.VirtualHostHelper;
+
+import static java.util.Objects.requireNonNull;
 
 final class IdentityBaseUrlSupplier
     implements Supplier<String>
@@ -21,7 +22,7 @@ final class IdentityBaseUrlSupplier
     @Override
     public String get()
     {
-        final PortalRequest portalRequest = Objects.requireNonNull( PortalRequestAccessor.get(), "no request bound" );
+        final PortalRequest portalRequest = requireNonNull( PortalRequestAccessor.get(), "no request bound" );
 
         final VirtualHost virtualHost = VirtualHostHelper.getVirtualHost( portalRequest.getRawRequest() );
 

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/IdentityPathSupplier.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/IdentityPathSupplier.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.portal.impl.url;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.enonic.xp.portal.PortalRequest;
@@ -10,6 +9,7 @@ import com.enonic.xp.security.IdProviderKey;
 import com.enonic.xp.web.vhost.VirtualHost;
 import com.enonic.xp.web.vhost.VirtualHostHelper;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElseGet;
 
 final class IdentityPathSupplier
@@ -30,7 +30,7 @@ final class IdentityPathSupplier
         UrlBuilderHelper.appendSubPath( url, "idprovider" );
 
         final IdProviderKey idProviderKey = requireNonNullElseGet( this.params.getIdProviderKey(), () -> {
-            final PortalRequest portalRequest = Objects.requireNonNull( PortalRequestAccessor.get(), "no request bound" );
+            final PortalRequest portalRequest = requireNonNull( PortalRequestAccessor.get(), "no request bound" );
             final VirtualHost virtualHost = VirtualHostHelper.getVirtualHost( portalRequest.getRawRequest() );
             return virtualHost.getDefaultIdProviderKey();
         } );

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ImageMediaPathSupplier.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ImageMediaPathSupplier.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.portal.impl.url;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.google.common.io.Files;
@@ -14,6 +13,7 @@ import com.enonic.xp.project.ProjectName;
 
 import static com.enonic.xp.portal.impl.url.UrlBuilderHelper.appendPart;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
 
 final class ImageMediaPathSupplier
     implements Supplier<String>
@@ -30,7 +30,7 @@ final class ImageMediaPathSupplier
 
     private ImageMediaPathSupplier( final Builder builder )
     {
-        this.scale = Objects.requireNonNull( builder.scale );
+        this.scale = requireNonNull( builder.scale );
         this.mediaSupplier = builder.mediaSupplier;
         this.projectNameSupplier = builder.projectNameSupplier;
         this.branchSupplier = builder.branchSupplier;
@@ -45,9 +45,9 @@ final class ImageMediaPathSupplier
     @Override
     public String get()
     {
-        final Media media = Objects.requireNonNull( mediaSupplier.get() );
-        final ProjectName project = Objects.requireNonNull( projectNameSupplier.get() );
-        final Branch branch = Objects.requireNonNull( branchSupplier.get() );
+        final Media media = requireNonNull( mediaSupplier.get() );
+        final ProjectName project = requireNonNull( projectNameSupplier.get() );
+        final Branch branch = requireNonNull( branchSupplier.get() );
 
         final String hash = MediaHashResolver.resolveImageHash( media );
         final String resolvedScale = resolveScale( scale );

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/MediaResolver.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/MediaResolver.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.portal.impl.url;
 
-import java.util.Objects;
-
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentId;
@@ -13,6 +11,9 @@ import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalRequestAccessor;
 import com.enonic.xp.portal.impl.PortalRequestHelper;
 import com.enonic.xp.project.ProjectName;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElseGet;
 
 final class MediaResolver
 {
@@ -30,9 +31,9 @@ final class MediaResolver
 
     private MediaResolver( final Builder builder )
     {
-        this.projectName = Objects.requireNonNull( builder.projectName );
-        this.branch = Objects.requireNonNull( builder.branch );
-        this.contentService = Objects.requireNonNull( builder.contentService );
+        this.projectName = requireNonNull( builder.projectName );
+        this.branch = requireNonNull( builder.branch );
+        this.contentService = requireNonNull( builder.contentService );
         this.baseUrl = builder.baseUrl;
         this.id = builder.id;
         this.path = builder.path;
@@ -40,13 +41,13 @@ final class MediaResolver
 
     public MediaResolverResult resolve()
     {
-        final String contentKey = Objects.requireNonNullElseGet( id, () -> {
+        final String contentKey = requireNonNullElseGet( id, () -> {
             if ( baseUrl != null )
             {
-                return Objects.requireNonNull( path );
+                return requireNonNull( path );
             }
 
-            return Objects.requireNonNullElseGet( path, () -> {
+            return requireNonNullElseGet( path, () -> {
                 final PortalRequest portalRequest = PortalRequestAccessor.get();
                 if ( PortalRequestHelper.isSiteBase( portalRequest ) )
                 {

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/PortalUrlServiceImpl.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/PortalUrlServiceImpl.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.portal.impl.url;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.osgi.service.component.annotations.Activate;
@@ -40,6 +39,8 @@ import com.enonic.xp.project.ProjectName;
 import com.enonic.xp.project.ProjectService;
 import com.enonic.xp.resource.ResourceService;
 import com.enonic.xp.style.StyleDescriptorService;
+
+import static java.util.Objects.requireNonNull;
 
 @Component(immediate = true, configurationPid = "com.enonic.xp.portal")
 public final class PortalUrlServiceImpl
@@ -285,7 +286,7 @@ public final class PortalUrlServiceImpl
             final StringBuilder url = new StringBuilder();
             UrlBuilderHelper.appendAndEncodePathParts( url, params.getPath() );
             UrlBuilderHelper.appendPathSegments( url, params.getPathSegments() );
-            return UrlBuilderHelper.rewriteUri( Objects.requireNonNull( PortalRequestAccessor.get(), "no request bound" ).getRawRequest(),
+            return UrlBuilderHelper.rewriteUri( requireNonNull( PortalRequestAccessor.get(), "no request bound" ).getRawRequest(),
                                                 params.getType(), url.toString() );
         } );
 

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ServiceRequestBaseUrlSupplier.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ServiceRequestBaseUrlSupplier.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.portal.impl.url;
 
-import java.util.Objects;
 import java.util.function.Supplier;
 
 import com.enonic.xp.portal.PortalRequest;
@@ -9,6 +8,9 @@ import com.enonic.xp.portal.impl.PortalRequestHelper;
 import com.enonic.xp.portal.url.UrlTypeConstants;
 import com.enonic.xp.project.ProjectName;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
 final class ServiceRequestBaseUrlSupplier
     implements Supplier<String>
 {
@@ -16,13 +18,13 @@ final class ServiceRequestBaseUrlSupplier
 
     private ServiceRequestBaseUrlSupplier( final Builder builder )
     {
-        this.urlType = Objects.requireNonNullElse( builder.urlType, UrlTypeConstants.SERVER_RELATIVE );
+        this.urlType = requireNonNullElse( builder.urlType, UrlTypeConstants.SERVER_RELATIVE );
     }
 
     @Override
     public String get()
     {
-        final PortalRequest portalRequest = Objects.requireNonNull( PortalRequestAccessor.get(), "no request bound" );
+        final PortalRequest portalRequest = requireNonNull( PortalRequestAccessor.get(), "no request bound" );
 
         final StringBuilder uriBuilder = new StringBuilder();
 

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/MapSerializableAssert.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/MapSerializableAssert.java
@@ -4,13 +4,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
-
 import com.enonic.xp.script.ScriptFixturesFacade;
 import com.enonic.xp.script.ScriptValue;
 import com.enonic.xp.script.impl.value.ScriptValueFactory;
 import com.enonic.xp.script.serializer.MapSerializable;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public final class MapSerializableAssert
@@ -49,7 +48,7 @@ public final class MapSerializableAssert
     private static String readFromFile( final Class<?> clazz, final String resource )
     {
         final InputStream stream =
-            Objects.requireNonNull( clazz.getResourceAsStream( resource ), "Resource file [" + resource + "] not found" );
+            requireNonNull( clazz.getResourceAsStream( resource ), "Resource file [" + resource + "] not found" );
         try (stream)
         {
             return new String( stream.readAllBytes(), StandardCharsets.UTF_8 );

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/filter/PortalRequestSerializerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/filter/PortalRequestSerializerTest.java
@@ -6,8 +6,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +18,7 @@ import com.enonic.xp.script.ScriptValue;
 import com.enonic.xp.script.impl.value.ScriptValueFactory;
 import com.enonic.xp.web.HttpMethod;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -189,7 +188,7 @@ class PortalRequestSerializerTest
     {
         try (InputStream stream = getClass().getResourceAsStream( resourceName ))
         {
-            return new String( Objects.requireNonNull( stream ).readAllBytes(), StandardCharsets.UTF_8 );
+            return new String( requireNonNull( stream ).readAllBytes(), StandardCharsets.UTF_8 );
         }
     }
 }

--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/ScriptRuntimeFactoryImpl.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/ScriptRuntimeFactoryImpl.java
@@ -3,7 +3,6 @@ package com.enonic.xp.script.impl;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.graalvm.polyglot.Engine;
@@ -35,6 +34,8 @@ import com.enonic.xp.script.impl.standard.ScriptRuntimeImpl;
 import com.enonic.xp.script.runtime.ScriptRuntime;
 import com.enonic.xp.script.runtime.ScriptRuntimeFactory;
 import com.enonic.xp.script.runtime.ScriptSettings;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 @Component
 public class ScriptRuntimeFactoryImpl
@@ -152,7 +153,7 @@ public class ScriptRuntimeFactoryImpl
             final AppBundleData appBundleData = getAppBundleData( applicationKey );
 
             final String appScriptEngine = normalizeEngineName(
-                Objects.requireNonNullElseGet( appBundleData.bundle.getHeaders().get( "X-Script-Engine" ),
+                requireNonNullElseGet( appBundleData.bundle.getHeaders().get( "X-Script-Engine" ),
                                                ScriptRuntimeFactoryImpl::defaultEngineName ) );
 
             final ClassLoader appClassloader = appBundleData.appClassloader;

--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/service/ServiceRegistryImpl.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/impl/service/ServiceRegistryImpl.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.script.impl.service;
 
-import java.util.Objects;
-
 import org.osgi.framework.BundleContext;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ServiceRegistryImpl
     implements ServiceRegistry
@@ -11,7 +11,7 @@ public final class ServiceRegistryImpl
 
     public ServiceRegistryImpl( final BundleContext bundleContext )
     {
-        this.bundleContext = Objects.requireNonNull( bundleContext );
+        this.bundleContext = requireNonNull( bundleContext );
     }
 
     @Override

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/ExportNodesRequestJson.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/ExportNodesRequestJson.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.impl.server.rest.model;
 
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
 
 public class ExportNodesRequestJson
 {
@@ -16,8 +16,8 @@ public class ExportNodesRequestJson
                                    @JsonProperty("exportName") final String exportName, //
                                    @JsonProperty("batchSize") final Integer batchSize )
     {
-        Objects.requireNonNull( sourceRepoPath, "sourceRepoPath is required" );
-        Objects.requireNonNull( exportName, "exportName is required" );
+        requireNonNull( sourceRepoPath, "sourceRepoPath is required" );
+        requireNonNull( exportName, "exportName is required" );
 
         this.sourceRepoPath = RepoPath.from( sourceRepoPath );
         this.exportName = exportName;

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJson.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJson.java
@@ -1,10 +1,10 @@
 package com.enonic.xp.impl.server.rest.model;
 
 import java.util.Map;
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ImportNodesRequestJson
 {
@@ -30,8 +30,8 @@ public final class ImportNodesRequestJson
 
     {
 
-        Objects.requireNonNull( exportName, "exportName is required" );
-        Objects.requireNonNull( targetRepoPath, "targetRepoPath is required" );
+        requireNonNull( exportName, "exportName is required" );
+        requireNonNull( targetRepoPath, "targetRepoPath is required" );
 
         this.targetRepoPath = RepoPath.from( targetRepoPath );
         this.exportName = exportName;

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/TaskInfoJson.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/TaskInfoJson.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.impl.server.rest.model;
 
 import java.time.Instant;
-import java.util.Objects;
-
 import com.enonic.xp.task.TaskInfo;
+
+import static java.util.Objects.requireNonNull;
 
 public class TaskInfoJson
 {
@@ -11,7 +11,7 @@ public class TaskInfoJson
 
     public TaskInfoJson( final TaskInfo taskInfo )
     {
-        this.taskInfo = Objects.requireNonNull( taskInfo );
+        this.taskInfo = requireNonNull( taskInfo );
     }
 
     public String getId()

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/TaskProgressJson.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/TaskProgressJson.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.impl.server.rest.model;
 
-import java.util.Objects;
-
 import com.enonic.xp.task.TaskProgress;
+
+import static java.util.Objects.requireNonNull;
 
 public class TaskProgressJson
 {
@@ -10,7 +10,7 @@ public class TaskProgressJson
 
     public TaskProgressJson( final TaskProgress taskProgress )
     {
-        this.taskProgress = Objects.requireNonNull( taskProgress );
+        this.taskProgress = requireNonNull( taskProgress );
     }
 
     public int getCurrent()

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/task/ProjectsSyncTask.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/task/ProjectsSyncTask.java
@@ -4,7 +4,6 @@ import java.util.ArrayDeque;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -18,6 +17,8 @@ import com.enonic.xp.project.Projects;
 import com.enonic.xp.task.ProgressReporter;
 import com.enonic.xp.task.RunnableTask;
 import com.enonic.xp.task.TaskId;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ProjectsSyncTask
     implements RunnableTask
@@ -110,8 +111,8 @@ public final class ProjectsSyncTask
 
         private void validate()
         {
-            Objects.requireNonNull( this.projectService );
-            Objects.requireNonNull( this.syncContentService );
+            requireNonNull( this.projectService );
+            requireNonNull( this.syncContentService );
         }
 
         public ProjectsSyncTask build()

--- a/modules/tools/testing/src/main/java/com/enonic/xp/testing/helper/JsonAssert.java
+++ b/modules/tools/testing/src/main/java/com/enonic/xp/testing/helper/JsonAssert.java
@@ -3,8 +3,6 @@ package com.enonic.xp.testing.helper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.Objects;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -12,6 +10,7 @@ import com.enonic.xp.core.internal.json.ObjectMapperHelper;
 import com.enonic.xp.script.serializer.MapSerializable;
 import com.enonic.xp.testing.serializer.JsonMapGenerator;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -50,7 +49,7 @@ public final class JsonAssert
     private static JsonNode readFromFile( final Class<?> context, final String fileName )
     {
         final InputStream stream =
-            Objects.requireNonNull( context.getResourceAsStream( fileName ), "Resource file [" + fileName + "] not found" );
+            requireNonNull( context.getResourceAsStream( fileName ), "Resource file [" + fileName + "] not found" );
         try (stream)
         {
             return MAPPER.readTree( stream.readAllBytes() );

--- a/modules/tools/testing/src/main/java/com/enonic/xp/testing/resource/ClassLoaderResourceService.java
+++ b/modules/tools/testing/src/main/java/com/enonic/xp/testing/resource/ClassLoaderResourceService.java
@@ -3,8 +3,6 @@ package com.enonic.xp.testing.resource;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Objects;
-
 import com.google.common.io.ByteSource;
 import com.google.common.io.CharSource;
 import com.google.common.io.Resources;
@@ -19,6 +17,8 @@ import com.enonic.xp.resource.UrlResource;
 import com.enonic.xp.vfs.VirtualFile;
 import com.enonic.xp.vfs.VirtualFilePath;
 import com.enonic.xp.vfs.VirtualFilePaths;
+
+import static java.util.Objects.requireNonNull;
 
 public final class ClassLoaderResourceService
     implements ResourceService
@@ -94,13 +94,13 @@ public final class ClassLoaderResourceService
             @Override
             public CharSource getCharSource()
             {
-                return Resources.asCharSource( Objects.requireNonNull( url ), StandardCharsets.UTF_8 );
+                return Resources.asCharSource( requireNonNull( url ), StandardCharsets.UTF_8 );
             }
 
             @Override
             public ByteSource getByteSource()
             {
-                return Resources.asByteSource( Objects.requireNonNull( url ) );
+                return Resources.asByteSource( requireNonNull( url ) );
             }
 
             @Override

--- a/modules/web/web-api/src/main/java/com/enonic/xp/web/WebException.java
+++ b/modules/web/web-api/src/main/java/com/enonic/xp/web/WebException.java
@@ -1,11 +1,11 @@
 package com.enonic.xp.web;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.NonNull;
 
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.security.auth.AuthenticationInfo;
+
+import static java.util.Objects.requireNonNull;
 
 public final class WebException
     extends RuntimeException
@@ -17,28 +17,28 @@ public final class WebException
     public WebException( final @NonNull HttpStatus status, final String message )
     {
         super( message );
-        this.status = Objects.requireNonNull( status );
+        this.status = requireNonNull( status );
         this.loggable = this.status.is5xxServerError();
     }
 
     public WebException( final @NonNull HttpStatus status, final String message, final boolean loggable )
     {
         super( message );
-        this.status = Objects.requireNonNull( status );
+        this.status = requireNonNull( status );
         this.loggable = loggable;
     }
 
     public WebException( final @NonNull HttpStatus status, final Throwable cause )
     {
         super( cause.getMessage(), cause );
-        this.status = Objects.requireNonNull( status );
+        this.status = requireNonNull( status );
         this.loggable = this.status.is5xxServerError();
     }
 
     public WebException( final @NonNull HttpStatus status, final String message, final Throwable cause )
     {
         super( message, cause );
-        this.status = Objects.requireNonNull( status );
+        this.status = requireNonNull( status );
         this.loggable = this.status.is5xxServerError();
     }
 

--- a/modules/web/web-api/src/main/java/com/enonic/xp/web/WebRequest.java
+++ b/modules/web/web-api/src/main/java/com/enonic/xp/web/WebRequest.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TreeMap;
 
 import org.jspecify.annotations.NonNull;
@@ -19,6 +18,8 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import com.enonic.xp.security.IdProvider;
 import com.enonic.xp.web.websocket.WebSocketContext;
+
+import static java.util.Objects.requireNonNull;
 
 
 public class WebRequest
@@ -163,7 +164,7 @@ public class WebRequest
 
     public void setRawPath( final String rawPath )
     {
-        this.rawPath = Objects.requireNonNull( rawPath );
+        this.rawPath = requireNonNull( rawPath );
         final int endpointPathIndex = rawPath.indexOf( "/_/" );
         if ( endpointPathIndex > -1 )
         {

--- a/modules/web/web-api/src/main/java/com/enonic/xp/web/WebResponse.java
+++ b/modules/web/web-api/src/main/java/com/enonic/xp/web/WebResponse.java
@@ -3,7 +3,6 @@ package com.enonic.xp.web;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TreeMap;
 
 import com.google.common.collect.ImmutableList;
@@ -14,6 +13,8 @@ import com.google.common.net.MediaType;
 import jakarta.servlet.http.Cookie;
 
 import com.enonic.xp.web.websocket.WebSocketConfig;
+
+import static java.util.Objects.requireNonNull;
 
 
 public class WebResponse
@@ -186,7 +187,7 @@ public class WebResponse
 
         private void putHeader( final String key, final String value )
         {
-            this.headers.put( key.toLowerCase( Locale.ROOT ), Objects.requireNonNull( value ) );
+            this.headers.put( key.toLowerCase( Locale.ROOT ), requireNonNull( value ) );
         }
 
         public void addAllCookies( final List<Cookie> cookies )

--- a/modules/web/web-api/src/main/java/com/enonic/xp/web/dispatch/MappingBuilder.java
+++ b/modules/web/web-api/src/main/java/com/enonic/xp/web/dispatch/MappingBuilder.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -15,6 +14,7 @@ import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
 
 public final class MappingBuilder
 {
@@ -156,13 +156,13 @@ public final class MappingBuilder
 
     public FilterMapping filter( final Filter filter )
     {
-        Objects.requireNonNull( filter, "Filter cannot not be null" );
+        requireNonNull( filter, "Filter cannot not be null" );
         return new FilterMappingImpl( this, filter );
     }
 
     public ServletMapping servlet( final Servlet servlet )
     {
-        Objects.requireNonNull( servlet, "Servlet cannot not be null" );
+        requireNonNull( servlet, "Servlet cannot not be null" );
         return new ServletMappingImpl( this, servlet );
     }
 

--- a/modules/web/web-api/src/main/java/com/enonic/xp/web/servlet/ServletRequestUrlHelper.java
+++ b/modules/web/web-api/src/main/java/com/enonic/xp/web/servlet/ServletRequestUrlHelper.java
@@ -3,7 +3,6 @@ package com.enonic.xp.web.servlet;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Splitter;
@@ -13,6 +12,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import com.enonic.xp.web.vhost.VirtualHost;
 import com.enonic.xp.web.vhost.VirtualHostHelper;
 
+import static java.util.Objects.requireNonNullElse;
+
 
 public final class ServletRequestUrlHelper
 {
@@ -21,7 +22,7 @@ public final class ServletRequestUrlHelper
 
     public static String createUri( final HttpServletRequest req, final String path )
     {
-        return Objects.requireNonNullElse( rewriteUri( VirtualHostHelper.getVirtualHost( req ), path ), path );
+        return requireNonNullElse( rewriteUri( VirtualHostHelper.getVirtualHost( req ), path ), path );
     }
 
     public static String getServerUrl( final HttpServletRequest req )
@@ -91,7 +92,7 @@ public final class ServletRequestUrlHelper
 
         return resultBuilder.deletedUriPrefix( target )
             .newUriPrefix( source )
-            .rewrittenUri( Objects.requireNonNullElse( rewrittenUri, uri ) )
+            .rewrittenUri( requireNonNullElse( rewrittenUri, uri ) )
             .outOfScope( rewrittenUri == null )
             .build();
     }

--- a/modules/web/web-dispatch/src/main/java/com/enonic/xp/web/impl/dispatch/DispatchServletImpl.java
+++ b/modules/web/web-dispatch/src/main/java/com/enonic/xp/web/impl/dispatch/DispatchServletImpl.java
@@ -2,8 +2,6 @@ package com.enonic.xp.web.impl.dispatch;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Objects;
-
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -21,6 +19,8 @@ import com.enonic.xp.web.dispatch.DispatchServlet;
 import com.enonic.xp.web.impl.dispatch.pipeline.FilterPipeline;
 import com.enonic.xp.web.impl.dispatch.pipeline.ServletPipeline;
 
+import static java.util.Objects.requireNonNull;
+
 @Component(factory = "dispatchServlet", service = DispatchServlet.class)
 public final class DispatchServletImpl
     extends HttpServlet
@@ -36,7 +36,7 @@ public final class DispatchServletImpl
     public DispatchServletImpl( final Map<String, ?> properties )
     {
         final String connectorValue = (String) properties.get( DispatchConstants.CONNECTOR_PROPERTY );
-        this.connector = Objects.requireNonNull( connectorValue, "Connector property must not be null" );
+        this.connector = requireNonNull( connectorValue, "Connector property must not be null" );
     }
 
     @Override

--- a/modules/web/web-dispatch/src/main/java/com/enonic/xp/web/impl/dispatch/pipeline/ResourcePipelineImpl.java
+++ b/modules/web/web-dispatch/src/main/java/com/enonic/xp/web/impl/dispatch/pipeline/ResourcePipelineImpl.java
@@ -3,7 +3,6 @@ package com.enonic.xp.web.impl.dispatch.pipeline;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.servlet.ServletContext;
@@ -12,6 +11,8 @@ import jakarta.servlet.ServletException;
 import com.enonic.xp.core.internal.concurrent.AtomicSortedList;
 import com.enonic.xp.web.dispatch.DispatchConstants;
 import com.enonic.xp.web.impl.dispatch.mapping.ResourceDefinition;
+
+import static java.util.Objects.requireNonNull;
 
 public abstract class ResourcePipelineImpl<T extends ResourceDefinition<?>>
     implements ResourcePipeline<T>
@@ -27,14 +28,14 @@ public abstract class ResourcePipelineImpl<T extends ResourceDefinition<?>>
     public ResourcePipelineImpl( final Map<String, ?> properties )
     {
         final String connectorValue = (String) properties.get( DispatchConstants.CONNECTOR_PROPERTY );
-        this.connector = Objects.requireNonNull( connectorValue, "Connector property must not be null" );
+        this.connector = requireNonNull( connectorValue, "Connector property must not be null" );
     }
 
     @Override
     public final void init( final ServletContext context )
         throws ServletException
     {
-        this.context = Objects.requireNonNull( context );
+        this.context = requireNonNull( context );
         this.list.snapshot().forEach( r -> r.init( this.context ) );
     }
 

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/multipart/MultipartItemImpl.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/multipart/MultipartItemImpl.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
-
 import com.google.common.base.Optional;
 import com.google.common.io.ByteSource;
 import com.google.common.net.MediaType;
@@ -13,6 +11,8 @@ import com.google.common.net.MediaType;
 import jakarta.servlet.http.Part;
 
 import com.enonic.xp.web.multipart.MultipartItem;
+
+import static java.util.Objects.requireNonNull;
 
 final class MultipartItemImpl
     extends ByteSource
@@ -22,7 +22,7 @@ final class MultipartItemImpl
 
     MultipartItemImpl( final Part item )
     {
-        this.item = Objects.requireNonNull( item );
+        this.item = requireNonNull( item );
     }
 
     @Override

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/configurator/RequestLogConfigurator.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/configurator/RequestLogConfigurator.java
@@ -1,12 +1,12 @@
 package com.enonic.xp.web.jetty.impl.configurator;
 
-import java.util.Objects;
-
 import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.RequestLogWriter;
 import org.eclipse.jetty.server.Server;
 
 import com.enonic.xp.home.HomeDir;
+
+import static java.util.Objects.requireNonNullElseGet;
 
 public final class RequestLogConfigurator
     extends JettyConfigurator<Server>
@@ -19,7 +19,7 @@ public final class RequestLogConfigurator
             return;
         }
 
-        final String fileName = Objects.requireNonNullElseGet( this.config.log_file(), () -> HomeDir.get()
+        final String fileName = requireNonNullElseGet( this.config.log_file(), () -> HomeDir.get()
             .toPath()
             .resolve( "logs" )
             .resolve( "jetty-yyyy_mm_dd.request.log" )

--- a/modules/web/web-vhost/src/main/java/com/enonic/xp/web/vhost/impl/mapping/VirtualHostMapping.java
+++ b/modules/web/web-vhost/src/main/java/com/enonic/xp/web/vhost/impl/mapping/VirtualHostMapping.java
@@ -2,11 +2,12 @@ package com.enonic.xp.web.vhost.impl.mapping;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Objects;
-
 import com.enonic.xp.security.IdProviderKey;
 import com.enonic.xp.security.IdProviderKeys;
 import com.enonic.xp.web.vhost.VirtualHost;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 public final class VirtualHostMapping
     implements VirtualHost
@@ -34,11 +35,11 @@ public final class VirtualHostMapping
     public VirtualHostMapping( final String name, final String host, final String source, final String target,
                                final VirtualHostIdProvidersMapping idProvidersMapping, final int order, final Map<String, String> context )
     {
-        Objects.requireNonNull( name, "name must be set" );
-        Objects.requireNonNull( host, "host must be set" );
-        Objects.requireNonNull( source, "source must be set" );
-        Objects.requireNonNull( target, "target must be set" );
-        Objects.requireNonNull( idProvidersMapping, "idProvidersMapping must be set" );
+        requireNonNull( name, "name must be set" );
+        requireNonNull( host, "host must be set" );
+        requireNonNull( source, "source must be set" );
+        requireNonNull( target, "target must be set" );
+        requireNonNull( idProvidersMapping, "idProvidersMapping must be set" );
 
         this.name = name;
         this.host = host;
@@ -46,7 +47,7 @@ public final class VirtualHostMapping
         this.target = target;
         this.idProvidersMapping = idProvidersMapping;
         this.order = order;
-        this.context = Collections.unmodifiableMap( Objects.requireNonNullElse( context, Map.of() ) );
+        this.context = Collections.unmodifiableMap( requireNonNullElse( context, Map.of() ) );
     }
 
     @Override

--- a/modules/web/web-vhost/src/test/java/com/enonic/xp/web/vhost/impl/VirtualHostResolverImplTest.java
+++ b/modules/web/web-vhost/src/test/java/com/enonic/xp/web/vhost/impl/VirtualHostResolverImplTest.java
@@ -4,8 +4,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +15,7 @@ import com.enonic.xp.web.vhost.VirtualHostService;
 import com.enonic.xp.web.vhost.impl.mapping.VirtualHostIdProvidersMapping;
 import com.enonic.xp.web.vhost.impl.mapping.VirtualHostMapping;
 
+import static java.util.Objects.requireNonNullElse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -289,7 +288,7 @@ class VirtualHostResolverImplTest
                                                          Map<String, String> contextConfig )
     {
         return new VirtualHostMapping( name, host, source, target, VirtualHostIdProvidersMapping.create().build(),
-                                       Objects.requireNonNullElse( order, Integer.MAX_VALUE ), contextConfig );
+                                       requireNonNullElse( order, Integer.MAX_VALUE ), contextConfig );
     }
 
     private VirtualHostMapping createVirtualHostMapping( String name, String host, String source, String target, Integer order )


### PR DESCRIPTION
Replace `Objects.requireNonNull`, `Objects.requireNonNullElse`, and `Objects.requireNonNullElseGet` qualified calls with static-imported equivalents for consistency and readability.