### PR TITLE
Add JS API to create id providers #9026

### DIFF
--- a/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/CreateIdProviderHandler.java
+++ b/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/CreateIdProviderHandler.java
@@ -5,15 +5,12 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import com.enonic.xp.app.ApplicationKey;
-import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.lib.common.IdProviderMapper;
 import com.enonic.xp.script.ScriptValue;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
 import com.enonic.xp.security.CreateIdProviderParams;
 import com.enonic.xp.security.IdProvider;
-import com.enonic.xp.security.IdProviderConfig;
 import com.enonic.xp.security.IdProviderKey;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.SecurityService;
@@ -32,8 +29,6 @@ public final class CreateIdProviderHandler
 
     private String description;
 
-    private ScriptValue idProviderConfig;
-
     private ScriptValue permissions;
 
     public void setKey( final String key )
@@ -51,11 +46,6 @@ public final class CreateIdProviderHandler
         this.description = description;
     }
 
-    public void setIdProviderConfig( final ScriptValue idProviderConfig )
-    {
-        this.idProviderConfig = idProviderConfig;
-    }
-
     public void setPermissions( final ScriptValue permissions )
     {
         this.permissions = permissions;
@@ -67,42 +57,11 @@ public final class CreateIdProviderHandler
             .key( IdProviderKey.from( this.key ) )
             .displayName( this.displayName )
             .description( this.description )
-            .idProviderConfig( buildIdProviderConfig() )
             .permissions( buildPermissions() )
             .build();
 
         final IdProvider idProvider = this.securityService.get().createIdProvider( params );
         return new IdProviderMapper( idProvider );
-    }
-
-    private IdProviderConfig buildIdProviderConfig()
-    {
-        if ( this.idProviderConfig == null )
-        {
-            return null;
-        }
-        final Map<String, Object> map = this.idProviderConfig.getMap();
-        final Object applicationKey = map.get( "applicationKey" );
-        if ( applicationKey == null )
-        {
-            throw new IllegalArgumentException( "Parameter 'idProviderConfig.applicationKey' is required" );
-        }
-        final Object configValue = map.get( "config" );
-        final PropertyTree configTree;
-        if ( configValue instanceof Map )
-        {
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> configMap = (Map<String, Object>) configValue;
-            configTree = PropertyTree.fromMap( configMap );
-        }
-        else
-        {
-            configTree = new PropertyTree();
-        }
-        return IdProviderConfig.create()
-            .applicationKey( ApplicationKey.from( applicationKey.toString() ) )
-            .config( configTree )
-            .build();
     }
 
     private IdProviderAccessControlList buildPermissions()

--- a/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/CreateIdProviderHandler.java
+++ b/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/CreateIdProviderHandler.java
@@ -1,0 +1,143 @@
+package com.enonic.xp.lib.auth;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.data.PropertyTree;
+import com.enonic.xp.lib.common.IdProviderMapper;
+import com.enonic.xp.script.ScriptValue;
+import com.enonic.xp.script.bean.BeanContext;
+import com.enonic.xp.script.bean.ScriptBean;
+import com.enonic.xp.security.CreateIdProviderParams;
+import com.enonic.xp.security.IdProvider;
+import com.enonic.xp.security.IdProviderConfig;
+import com.enonic.xp.security.IdProviderKey;
+import com.enonic.xp.security.PrincipalKey;
+import com.enonic.xp.security.SecurityService;
+import com.enonic.xp.security.acl.IdProviderAccess;
+import com.enonic.xp.security.acl.IdProviderAccessControlEntry;
+import com.enonic.xp.security.acl.IdProviderAccessControlList;
+
+public final class CreateIdProviderHandler
+    implements ScriptBean
+{
+    private Supplier<SecurityService> securityService;
+
+    private String key;
+
+    private String displayName;
+
+    private String description;
+
+    private ScriptValue idProviderConfig;
+
+    private ScriptValue permissions;
+
+    public void setKey( final String key )
+    {
+        this.key = key;
+    }
+
+    public void setDisplayName( final String displayName )
+    {
+        this.displayName = displayName;
+    }
+
+    public void setDescription( final String description )
+    {
+        this.description = description;
+    }
+
+    public void setIdProviderConfig( final ScriptValue idProviderConfig )
+    {
+        this.idProviderConfig = idProviderConfig;
+    }
+
+    public void setPermissions( final ScriptValue permissions )
+    {
+        this.permissions = permissions;
+    }
+
+    public IdProviderMapper createIdProvider()
+    {
+        final CreateIdProviderParams params = CreateIdProviderParams.create()
+            .key( IdProviderKey.from( this.key ) )
+            .displayName( this.displayName )
+            .description( this.description )
+            .idProviderConfig( buildIdProviderConfig() )
+            .permissions( buildPermissions() )
+            .build();
+
+        final IdProvider idProvider = this.securityService.get().createIdProvider( params );
+        return new IdProviderMapper( idProvider );
+    }
+
+    private IdProviderConfig buildIdProviderConfig()
+    {
+        if ( this.idProviderConfig == null )
+        {
+            return null;
+        }
+        final Map<String, Object> map = this.idProviderConfig.getMap();
+        final Object applicationKey = map.get( "applicationKey" );
+        if ( applicationKey == null )
+        {
+            throw new IllegalArgumentException( "Parameter 'idProviderConfig.applicationKey' is required" );
+        }
+        final Object configValue = map.get( "config" );
+        final PropertyTree configTree;
+        if ( configValue instanceof Map )
+        {
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> configMap = (Map<String, Object>) configValue;
+            configTree = PropertyTree.fromMap( configMap );
+        }
+        else
+        {
+            configTree = new PropertyTree();
+        }
+        return IdProviderConfig.create()
+            .applicationKey( ApplicationKey.from( applicationKey.toString() ) )
+            .config( configTree )
+            .build();
+    }
+
+    private IdProviderAccessControlList buildPermissions()
+    {
+        if ( this.permissions == null )
+        {
+            return null;
+        }
+        final List<ScriptValue> entries = Optional.ofNullable( this.permissions.getArray() ).orElse( List.of() );
+        if ( entries.isEmpty() )
+        {
+            return null;
+        }
+        final IdProviderAccessControlList.Builder builder = IdProviderAccessControlList.create();
+        for ( final ScriptValue entry : entries )
+        {
+            final Map<String, Object> entryMap = entry.getMap();
+            final Object principal = entryMap.get( "principal" );
+            final Object access = entryMap.get( "access" );
+            if ( principal == null || access == null )
+            {
+                throw new IllegalArgumentException( "Permission entries require 'principal' and 'access' fields" );
+            }
+            builder.add( IdProviderAccessControlEntry.create()
+                             .principal( PrincipalKey.from( principal.toString() ) )
+                             .access( IdProviderAccess.valueOf( access.toString().toUpperCase( Locale.ROOT ) ) )
+                             .build() );
+        }
+        return builder.build();
+    }
+
+    @Override
+    public void initialize( final BeanContext context )
+    {
+        this.securityService = context.getService( SecurityService.class );
+    }
+}

--- a/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/CreateIdProviderHandler.java
+++ b/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/CreateIdProviderHandler.java
@@ -3,7 +3,6 @@ package com.enonic.xp.lib.auth;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.enonic.xp.app.ApplicationKey;
@@ -112,7 +111,7 @@ public final class CreateIdProviderHandler
         {
             return null;
         }
-        final List<ScriptValue> entries = Optional.ofNullable( this.permissions.getArray() ).orElse( List.of() );
+        final List<ScriptValue> entries = this.permissions.getArray();
         if ( entries.isEmpty() )
         {
             return null;

--- a/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/GetIdProvidersHandler.java
+++ b/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/GetIdProvidersHandler.java
@@ -1,0 +1,27 @@
+package com.enonic.xp.lib.auth;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import com.enonic.xp.lib.common.IdProviderMapper;
+import com.enonic.xp.script.bean.BeanContext;
+import com.enonic.xp.script.bean.ScriptBean;
+import com.enonic.xp.security.SecurityService;
+
+public final class GetIdProvidersHandler
+    implements ScriptBean
+{
+    private Supplier<SecurityService> securityService;
+
+    public List<IdProviderMapper> getIdProviders()
+    {
+        return this.securityService.get().getIdProviders().stream().map( IdProviderMapper::new ).collect( Collectors.toList() );
+    }
+
+    @Override
+    public void initialize( final BeanContext context )
+    {
+        this.securityService = context.getService( SecurityService.class );
+    }
+}

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
@@ -880,11 +880,10 @@ export interface IdProvider<Config extends Record<string, unknown> = Record<stri
     idProviderConfig?: IdProviderConfig<Config>;
 }
 
-export interface CreateIdProviderParams<Config extends Record<string, unknown> = Record<string, unknown>> {
+export interface CreateIdProviderParams {
     key: string;
     displayName: string;
     description?: string;
-    idProviderConfig?: IdProviderConfig<Config>;
     permissions?: IdProviderAccessControlEntry[];
 }
 
@@ -894,8 +893,6 @@ interface CreateIdProviderHandler {
     setDisplayName(value: string): void;
 
     setDescription(value: string | null): void;
-
-    setIdProviderConfig(value: ScriptValue | null): void;
 
     setPermissions(value: ScriptValue | null): void;
 
@@ -911,15 +908,12 @@ interface CreateIdProviderHandler {
  * @param {string} params.key Id provider key.
  * @param {string} params.displayName Id provider display name.
  * @param {string} [params.description] Id provider description.
- * @param {object} [params.idProviderConfig] Id provider config.
- * @param {string} params.idProviderConfig.applicationKey Application key of the id provider application.
- * @param {object} [params.idProviderConfig.config] Id provider configuration.
  * @param {Array<object>} [params.permissions] Id provider permissions.
  * @returns {IdProvider} The created id provider.
  */
-export function createIdProvider<Config extends Record<string, unknown> = Record<string, unknown>>(
-    params: CreateIdProviderParams<Config>,
-): IdProvider<Config> {
+export function createIdProvider(
+    params: CreateIdProviderParams,
+): IdProvider {
     const key = checkRequired(params, 'key');
     const displayName = checkRequired(params, 'displayName');
 
@@ -928,10 +922,9 @@ export function createIdProvider<Config extends Record<string, unknown> = Record
     bean.setKey(key);
     bean.setDisplayName(displayName);
     bean.setDescription(__.nullOrValue(params.description));
-    bean.setIdProviderConfig(params.idProviderConfig == null ? null : __.toScriptValue(params.idProviderConfig));
     bean.setPermissions(params.permissions == null ? null : __.toScriptValue(params.permissions));
 
-    return __.toNativeObject(bean.createIdProvider()) as IdProvider<Config>;
+    return __.toNativeObject(bean.createIdProvider()) as IdProvider;
 }
 
 interface GetIdProvidersHandler {

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
@@ -860,3 +860,93 @@ export function modifyRole(params: ModifyRoleParams): Role | null {
 
     return __.toNativeObject(bean.modifyRole());
 }
+
+export type IdProviderAccess = 'READ' | 'CREATE_USERS' | 'WRITE_USERS' | 'ID_PROVIDER_MANAGER' | 'ADMINISTRATOR';
+
+export interface IdProviderAccessControlEntry {
+    principal: PrincipalKey;
+    access: IdProviderAccess;
+}
+
+export interface IdProviderConfig<Config extends Record<string, unknown> = Record<string, unknown>> {
+    applicationKey: string;
+    config?: Config;
+}
+
+export interface IdProvider<Config extends Record<string, unknown> = Record<string, unknown>> {
+    key: string;
+    displayName: string;
+    description?: string;
+    idProviderConfig?: IdProviderConfig<Config>;
+}
+
+export interface CreateIdProviderParams<Config extends Record<string, unknown> = Record<string, unknown>> {
+    key: string;
+    displayName: string;
+    description?: string;
+    idProviderConfig?: IdProviderConfig<Config>;
+    permissions?: IdProviderAccessControlEntry[];
+}
+
+interface CreateIdProviderHandler {
+    setKey(value: string): void;
+
+    setDisplayName(value: string): void;
+
+    setDescription(value: string | null): void;
+
+    setIdProviderConfig(value: ScriptValue | null): void;
+
+    setPermissions(value: ScriptValue | null): void;
+
+    createIdProvider(): IdProvider;
+}
+
+/**
+ * Creates an id provider.
+ *
+ * @example-ref examples/auth/createIdProvider.js
+ *
+ * @param {object} params JSON parameters.
+ * @param {string} params.key Id provider key.
+ * @param {string} params.displayName Id provider display name.
+ * @param {string} [params.description] Id provider description.
+ * @param {object} [params.idProviderConfig] Id provider config.
+ * @param {string} params.idProviderConfig.applicationKey Application key of the id provider application.
+ * @param {object} [params.idProviderConfig.config] Id provider configuration.
+ * @param {Array<object>} [params.permissions] Id provider permissions.
+ * @returns {IdProvider} The created id provider.
+ */
+export function createIdProvider<Config extends Record<string, unknown> = Record<string, unknown>>(
+    params: CreateIdProviderParams<Config>,
+): IdProvider<Config> {
+    const key = checkRequired(params, 'key');
+    const displayName = checkRequired(params, 'displayName');
+
+    const bean: CreateIdProviderHandler = __.newBean<CreateIdProviderHandler>('com.enonic.xp.lib.auth.CreateIdProviderHandler');
+
+    bean.setKey(key);
+    bean.setDisplayName(displayName);
+    bean.setDescription(__.nullOrValue(params.description));
+    bean.setIdProviderConfig(params.idProviderConfig == null ? null : __.toScriptValue(params.idProviderConfig));
+    bean.setPermissions(params.permissions == null ? null : __.toScriptValue(params.permissions));
+
+    return __.toNativeObject(bean.createIdProvider()) as IdProvider<Config>;
+}
+
+interface GetIdProvidersHandler {
+    getIdProviders(): IdProvider[];
+}
+
+/**
+ * Returns all id providers.
+ *
+ * @example-ref examples/auth/getIdProviders.js
+ *
+ * @returns {Array<IdProvider>} List of id providers.
+ */
+export function getIdProviders(): IdProvider[] {
+    const bean: GetIdProvidersHandler = __.newBean<GetIdProvidersHandler>('com.enonic.xp.lib.auth.GetIdProvidersHandler');
+
+    return __.toNativeObject(bean.getIdProviders());
+}

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
@@ -868,16 +868,10 @@ export interface IdProviderAccessControlEntry {
     access: IdProviderAccess;
 }
 
-export interface IdProviderConfig<Config extends Record<string, unknown> = Record<string, unknown>> {
-    applicationKey: string;
-    config?: Config;
-}
-
-export interface IdProvider<Config extends Record<string, unknown> = Record<string, unknown>> {
+export interface IdProvider {
     key: string;
     displayName: string;
     description?: string;
-    idProviderConfig?: IdProviderConfig<Config>;
 }
 
 export interface CreateIdProviderParams {

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/examples/auth/createIdProvider.js
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/examples/auth/createIdProvider.js
@@ -4,12 +4,6 @@ var createIdProviderResult = authLib.createIdProvider({
     key: 'myIdProvider',
     displayName: 'My id provider',
     description: 'My id provider description',
-    idProviderConfig: {
-        applicationKey: 'com.enonic.app.myidprovider',
-        config: {
-            title: 'Login'
-        }
-    },
     permissions: [
         {
             principal: 'role:system.admin',

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/examples/auth/createIdProvider.js
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/examples/auth/createIdProvider.js
@@ -1,0 +1,19 @@
+var authLib = require('/lib/xp/auth');
+
+var createIdProviderResult = authLib.createIdProvider({
+    key: 'myIdProvider',
+    displayName: 'My id provider',
+    description: 'My id provider description',
+    idProviderConfig: {
+        applicationKey: 'com.enonic.app.myidprovider',
+        config: {
+            title: 'Login'
+        }
+    },
+    permissions: [
+        {
+            principal: 'role:system.admin',
+            access: 'ADMINISTRATOR'
+        }
+    ]
+});

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/examples/auth/getIdProviders.js
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/examples/auth/getIdProviders.js
@@ -1,0 +1,3 @@
+var authLib = require('/lib/xp/auth');
+
+var idProviders = authLib.getIdProviders();

--- a/modules/lib/lib-auth/src/test/java/com/enonic/xp/lib/auth/CreateIdProviderHandlerTest.java
+++ b/modules/lib/lib-auth/src/test/java/com/enonic/xp/lib/auth/CreateIdProviderHandlerTest.java
@@ -48,8 +48,7 @@ class CreateIdProviderHandlerTest
         assertThat( params.getKey() ).isEqualTo( IdProviderKey.from( "idProviderTestKey" ) );
         assertThat( params.getDisplayName() ).isEqualTo( "Id Provider test" );
         assertThat( params.getDescription() ).isEqualTo( "Id Provider used for testing" );
-        assertThat( params.getIdProviderConfig() ).isNotNull();
-        assertThat( params.getIdProviderConfig().getApplicationKey().toString() ).isEqualTo( "com.enonic.app.test" );
+        assertThat( params.getIdProviderConfig() ).isNull();
         assertThat( params.getIdProviderPermissions() ).isNotNull();
         assertThat( params.getIdProviderPermissions().isEmpty() ).isFalse();
     }

--- a/modules/lib/lib-auth/src/test/java/com/enonic/xp/lib/auth/CreateIdProviderHandlerTest.java
+++ b/modules/lib/lib-auth/src/test/java/com/enonic/xp/lib/auth/CreateIdProviderHandlerTest.java
@@ -1,0 +1,99 @@
+package com.enonic.xp.lib.auth;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import com.enonic.xp.security.CreateIdProviderParams;
+import com.enonic.xp.security.IdProviderAlreadyExistsException;
+import com.enonic.xp.security.IdProviderKey;
+import com.enonic.xp.security.SecurityService;
+import com.enonic.xp.testing.ScriptTestSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CreateIdProviderHandlerTest
+    extends ScriptTestSupport
+{
+    private SecurityService securityService;
+
+    @Override
+    public void initialize()
+        throws Exception
+    {
+        super.initialize();
+        this.securityService = Mockito.mock( SecurityService.class );
+        addService( SecurityService.class, this.securityService );
+    }
+
+    @Test
+    void testExamples()
+    {
+        Mockito.when( securityService.createIdProvider( Mockito.any() ) ).thenReturn( TestDataFixtures.getTestIdProvider() );
+        runScript( "/lib/xp/examples/auth/createIdProvider.js" );
+    }
+
+    @Test
+    void testCreateIdProvider()
+    {
+        Mockito.when( securityService.createIdProvider( Mockito.any() ) ).thenReturn( TestDataFixtures.getTestIdProvider() );
+
+        runFunction( "/test/createIdProvider-test.js", "createIdProvider" );
+
+        final ArgumentCaptor<CreateIdProviderParams> captor = ArgumentCaptor.forClass( CreateIdProviderParams.class );
+        Mockito.verify( securityService ).createIdProvider( captor.capture() );
+
+        final CreateIdProviderParams params = captor.getValue();
+        assertThat( params.getKey() ).isEqualTo( IdProviderKey.from( "idProviderTestKey" ) );
+        assertThat( params.getDisplayName() ).isEqualTo( "Id Provider test" );
+        assertThat( params.getDescription() ).isEqualTo( "Id Provider used for testing" );
+        assertThat( params.getIdProviderConfig() ).isNotNull();
+        assertThat( params.getIdProviderConfig().getApplicationKey().toString() ).isEqualTo( "com.enonic.app.test" );
+        assertThat( params.getIdProviderPermissions() ).isNotNull();
+        assertThat( params.getIdProviderPermissions().isEmpty() ).isFalse();
+    }
+
+    @Test
+    void testCreateIdProviderMinimal()
+    {
+        Mockito.when( securityService.createIdProvider( Mockito.any() ) ).thenReturn( TestDataFixtures.getTestIdProvider() );
+
+        runFunction( "/test/createIdProvider-test.js", "createIdProviderMinimal" );
+
+        final ArgumentCaptor<CreateIdProviderParams> captor = ArgumentCaptor.forClass( CreateIdProviderParams.class );
+        Mockito.verify( securityService ).createIdProvider( captor.capture() );
+
+        final CreateIdProviderParams params = captor.getValue();
+        assertThat( params.getKey() ).isEqualTo( IdProviderKey.from( "idProviderTestKey" ) );
+        assertThat( params.getDisplayName() ).isEqualTo( "Id Provider test" );
+        assertThat( params.getDescription() ).isNull();
+        assertThat( params.getIdProviderConfig() ).isNull();
+        assertThat( params.getIdProviderPermissions().isEmpty() ).isTrue();
+    }
+
+    @Test
+    void testCreateIdProviderMissingKey()
+    {
+        assertThatThrownBy( () -> runFunction( "/test/createIdProvider-test.js", "createIdProviderMissingKey" ) ).hasMessageContaining(
+            "key" );
+    }
+
+    @Test
+    void testCreateIdProviderMissingDisplayName()
+    {
+        assertThatThrownBy(
+            () -> runFunction( "/test/createIdProvider-test.js", "createIdProviderMissingDisplayName" ) ).hasMessageContaining(
+            "displayName" );
+    }
+
+    @Test
+    void testCreateIdProviderDuplicate()
+    {
+        Mockito.when( securityService.createIdProvider( Mockito.any() ) )
+            .thenThrow( new IdProviderAlreadyExistsException( IdProviderKey.from( "idProviderTestKey" ) ) );
+
+        assertThatThrownBy( () -> runFunction( "/test/createIdProvider-test.js", "createIdProvider" ) ).isInstanceOf(
+            IdProviderAlreadyExistsException.class );
+    }
+}

--- a/modules/lib/lib-auth/src/test/java/com/enonic/xp/lib/auth/GetIdProvidersHandlerTest.java
+++ b/modules/lib/lib-auth/src/test/java/com/enonic/xp/lib/auth/GetIdProvidersHandlerTest.java
@@ -1,0 +1,46 @@
+package com.enonic.xp.lib.auth;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.enonic.xp.security.IdProviders;
+import com.enonic.xp.security.SecurityService;
+import com.enonic.xp.testing.ScriptTestSupport;
+
+class GetIdProvidersHandlerTest
+    extends ScriptTestSupport
+{
+    private SecurityService securityService;
+
+    @Override
+    public void initialize()
+        throws Exception
+    {
+        super.initialize();
+        this.securityService = Mockito.mock( SecurityService.class );
+        addService( SecurityService.class, this.securityService );
+    }
+
+    @Test
+    void testExamples()
+    {
+        Mockito.when( securityService.getIdProviders() ).thenReturn( IdProviders.from( TestDataFixtures.getTestIdProvider() ) );
+        runScript( "/lib/xp/examples/auth/getIdProviders.js" );
+    }
+
+    @Test
+    void testGetIdProviders()
+    {
+        Mockito.when( securityService.getIdProviders() ).thenReturn( IdProviders.from( TestDataFixtures.getTestIdProvider() ) );
+
+        runFunction( "/test/getIdProviders-test.js", "getIdProviders" );
+    }
+
+    @Test
+    void testGetIdProvidersEmpty()
+    {
+        Mockito.when( securityService.getIdProviders() ).thenReturn( IdProviders.empty() );
+
+        runFunction( "/test/getIdProviders-test.js", "getIdProvidersEmpty" );
+    }
+}

--- a/modules/lib/lib-auth/src/test/resources/test/createIdProvider-test.js
+++ b/modules/lib/lib-auth/src/test/resources/test/createIdProvider-test.js
@@ -1,0 +1,85 @@
+var t = require('/lib/xp/testing.js');
+var auth = require('/lib/xp/auth.js');
+
+exports.createIdProvider = function () {
+
+    var result = auth.createIdProvider({
+        key: 'idProviderTestKey',
+        displayName: 'Id Provider test',
+        description: 'Id Provider used for testing',
+        idProviderConfig: {
+            applicationKey: 'com.enonic.app.test',
+            config: {
+                set: {
+                    subString: 'subStringValue',
+                    subLong: 123
+                },
+                string: 'stringValue'
+            }
+        },
+        permissions: [
+            {
+                principal: 'role:system.admin',
+                access: 'ADMINISTRATOR'
+            }
+        ]
+    });
+
+    var expectedJson = {
+        'key': 'idProviderTestKey',
+        'displayName': 'Id Provider test',
+        'description': 'Id Provider used for testing',
+        'idProviderConfig': {
+            'applicationKey': 'com.enonic.app.test',
+            'config': {
+                'set': {
+                    'subString': 'subStringValue',
+                    'subLong': 123
+                },
+                'string': 'stringValue'
+            }
+        }
+    };
+
+    t.assertJsonEquals(expectedJson, result, 'createIdProvider result not equals');
+};
+
+exports.createIdProviderMinimal = function () {
+
+    var result = auth.createIdProvider({
+        key: 'idProviderTestKey',
+        displayName: 'Id Provider test'
+    });
+
+    var expectedJson = {
+        'key': 'idProviderTestKey',
+        'displayName': 'Id Provider test',
+        'description': 'Id Provider used for testing',
+        'idProviderConfig': {
+            'applicationKey': 'com.enonic.app.test',
+            'config': {
+                'set': {
+                    'subString': 'subStringValue',
+                    'subLong': 123
+                },
+                'string': 'stringValue'
+            }
+        }
+    };
+
+    t.assertJsonEquals(expectedJson, result, 'createIdProvider result not equals');
+};
+
+exports.createIdProviderMissingKey = function () {
+
+    auth.createIdProvider({
+        displayName: 'Id Provider test'
+    });
+};
+
+exports.createIdProviderMissingDisplayName = function () {
+
+    auth.createIdProvider({
+        key: 'idProviderTestKey'
+    });
+};

--- a/modules/lib/lib-auth/src/test/resources/test/createIdProvider-test.js
+++ b/modules/lib/lib-auth/src/test/resources/test/createIdProvider-test.js
@@ -18,17 +18,7 @@ exports.createIdProvider = function () {
     var expectedJson = {
         'key': 'idProviderTestKey',
         'displayName': 'Id Provider test',
-        'description': 'Id Provider used for testing',
-        'idProviderConfig': {
-            'applicationKey': 'com.enonic.app.test',
-            'config': {
-                'set': {
-                    'subString': 'subStringValue',
-                    'subLong': 123
-                },
-                'string': 'stringValue'
-            }
-        }
+        'description': 'Id Provider used for testing'
     };
 
     t.assertJsonEquals(expectedJson, result, 'createIdProvider result not equals');
@@ -44,17 +34,7 @@ exports.createIdProviderMinimal = function () {
     var expectedJson = {
         'key': 'idProviderTestKey',
         'displayName': 'Id Provider test',
-        'description': 'Id Provider used for testing',
-        'idProviderConfig': {
-            'applicationKey': 'com.enonic.app.test',
-            'config': {
-                'set': {
-                    'subString': 'subStringValue',
-                    'subLong': 123
-                },
-                'string': 'stringValue'
-            }
-        }
+        'description': 'Id Provider used for testing'
     };
 
     t.assertJsonEquals(expectedJson, result, 'createIdProvider result not equals');

--- a/modules/lib/lib-auth/src/test/resources/test/createIdProvider-test.js
+++ b/modules/lib/lib-auth/src/test/resources/test/createIdProvider-test.js
@@ -7,16 +7,6 @@ exports.createIdProvider = function () {
         key: 'idProviderTestKey',
         displayName: 'Id Provider test',
         description: 'Id Provider used for testing',
-        idProviderConfig: {
-            applicationKey: 'com.enonic.app.test',
-            config: {
-                set: {
-                    subString: 'subStringValue',
-                    subLong: 123
-                },
-                string: 'stringValue'
-            }
-        },
         permissions: [
             {
                 principal: 'role:system.admin',

--- a/modules/lib/lib-auth/src/test/resources/test/getIdProviders-test.js
+++ b/modules/lib/lib-auth/src/test/resources/test/getIdProviders-test.js
@@ -1,0 +1,34 @@
+var t = require('/lib/xp/testing.js');
+var auth = require('/lib/xp/auth.js');
+
+exports.getIdProviders = function () {
+
+    var result = auth.getIdProviders();
+
+    var expectedJson = [
+        {
+            'key': 'idProviderTestKey',
+            'displayName': 'Id Provider test',
+            'description': 'Id Provider used for testing',
+            'idProviderConfig': {
+                'applicationKey': 'com.enonic.app.test',
+                'config': {
+                    'set': {
+                        'subString': 'subStringValue',
+                        'subLong': 123
+                    },
+                    'string': 'stringValue'
+                }
+            }
+        }
+    ];
+
+    t.assertJsonEquals(expectedJson, result, 'getIdProviders result not equals');
+};
+
+exports.getIdProvidersEmpty = function () {
+
+    var result = auth.getIdProviders();
+
+    t.assertJsonEquals([], result, 'getIdProviders result not equals');
+};

--- a/modules/lib/lib-auth/src/test/resources/test/getIdProviders-test.js
+++ b/modules/lib/lib-auth/src/test/resources/test/getIdProviders-test.js
@@ -10,7 +10,7 @@ exports.getIdProviders = function () {
             'key': 'idProviderTestKey',
             'displayName': 'Id Provider test',
             'description': 'Id Provider used for testing',
-            'idProviderConfig': {
+            'config': {
                 'applicationKey': 'com.enonic.app.test',
                 'config': {
                     'set': {

--- a/modules/lib/lib-auth/src/test/resources/test/getIdProviders-test.js
+++ b/modules/lib/lib-auth/src/test/resources/test/getIdProviders-test.js
@@ -9,17 +9,7 @@ exports.getIdProviders = function () {
         {
             'key': 'idProviderTestKey',
             'displayName': 'Id Provider test',
-            'description': 'Id Provider used for testing',
-            'idProviderConfig': {
-                'applicationKey': 'com.enonic.app.test',
-                'config': {
-                    'set': {
-                        'subString': 'subStringValue',
-                        'subLong': 123
-                    },
-                    'string': 'stringValue'
-                }
-            }
+            'description': 'Id Provider used for testing'
         }
     ];
 

--- a/modules/lib/lib-auth/src/test/resources/test/getIdProviders-test.js
+++ b/modules/lib/lib-auth/src/test/resources/test/getIdProviders-test.js
@@ -10,7 +10,7 @@ exports.getIdProviders = function () {
             'key': 'idProviderTestKey',
             'displayName': 'Id Provider test',
             'description': 'Id Provider used for testing',
-            'config': {
+            'idProviderConfig': {
                 'applicationKey': 'com.enonic.app.test',
                 'config': {
                     'set': {

--- a/modules/lib/lib-common/src/main/java/com/enonic/xp/lib/common/IdProviderMapper.java
+++ b/modules/lib/lib-common/src/main/java/com/enonic/xp/lib/common/IdProviderMapper.java
@@ -1,0 +1,40 @@
+package com.enonic.xp.lib.common;
+
+import com.enonic.xp.script.serializer.MapGenerator;
+import com.enonic.xp.script.serializer.MapSerializable;
+import com.enonic.xp.security.IdProvider;
+import com.enonic.xp.security.IdProviderConfig;
+
+public final class IdProviderMapper
+    implements MapSerializable
+{
+    private final IdProvider idProvider;
+
+    public IdProviderMapper( final IdProvider idProvider )
+    {
+        this.idProvider = idProvider;
+    }
+
+    @Override
+    public void serialize( final MapGenerator gen )
+    {
+        gen.value( "key", idProvider.getKey() );
+        gen.value( "displayName", idProvider.getDisplayName() );
+        gen.value( "description", idProvider.getDescription() );
+        serializeIdProviderConfig( gen, idProvider.getIdProviderConfig() );
+    }
+
+    private void serializeIdProviderConfig( final MapGenerator gen, final IdProviderConfig config )
+    {
+        if ( config == null )
+        {
+            return;
+        }
+        gen.map( "idProviderConfig" );
+        gen.value( "applicationKey", config.getApplicationKey() );
+        gen.map( "config" );
+        new PropertyTreeMapper( config.getConfig() ).serialize( gen );
+        gen.end();
+        gen.end();
+    }
+}

--- a/modules/lib/lib-common/src/main/java/com/enonic/xp/lib/common/IdProviderMapper.java
+++ b/modules/lib/lib-common/src/main/java/com/enonic/xp/lib/common/IdProviderMapper.java
@@ -3,7 +3,6 @@ package com.enonic.xp.lib.common;
 import com.enonic.xp.script.serializer.MapGenerator;
 import com.enonic.xp.script.serializer.MapSerializable;
 import com.enonic.xp.security.IdProvider;
-import com.enonic.xp.security.IdProviderConfig;
 
 public final class IdProviderMapper
     implements MapSerializable
@@ -21,20 +20,5 @@ public final class IdProviderMapper
         gen.value( "key", idProvider.getKey() );
         gen.value( "displayName", idProvider.getDisplayName() );
         gen.value( "description", idProvider.getDescription() );
-        serializeIdProviderConfig( gen, idProvider.getIdProviderConfig() );
-    }
-
-    private void serializeIdProviderConfig( final MapGenerator gen, final IdProviderConfig config )
-    {
-        if ( config == null )
-        {
-            return;
-        }
-        gen.map( "idProviderConfig" );
-        gen.value( "applicationKey", config.getApplicationKey() );
-        gen.map( "config" );
-        new PropertyTreeMapper( config.getConfig() ).serialize( gen );
-        gen.end();
-        gen.end();
     }
 }


### PR DESCRIPTION
Closes #9026.

Adds a JS API for creating and listing id providers from server-side scripts.

## Use case

Id provider apps that self-provision their id provider on app startup currently have no way to do that from JS — they need to either rely on `system.properties` bootstrapping or duplicate provisioning logic. This API closes that gap.

## API (`/lib/xp/auth`)

```ts
createIdProvider(params: {
    key: string;
    displayName: string;
    description?: string;
    idProviderConfig?: { applicationKey: string; config?: object };
    permissions?: { principal: PrincipalKey; access: IdProviderAccess }[];
}): IdProvider;

getIdProviders(): IdProvider[];
```

`IdProvider` matches the shape returned by other auth-lib functions (`key`, `displayName`, `description`, `idProviderConfig`).

Permissions on the underlying id provider node are still enforced by `SecurityServiceImpl` — callers without admin privileges get the same `NodeAccessException` they would from the REST endpoint.

## Implementation notes

- `CreateIdProviderHandler` / `GetIdProvidersHandler` in `lib-auth` delegate to `SecurityService` (no logic duplicated).
- New `IdProviderMapper` in `lib-common` mirrors the existing `PrincipalMapper`.
- Examples under `examples/auth/createIdProvider.js` and `examples/auth/getIdProviders.js`.

## Tests

- `CreateIdProviderHandlerTest` — full-fields, minimal-fields, missing-key, missing-displayName, duplicate-key.
- `GetIdProvidersHandlerTest` — populated and empty result.
- `./gradlew :lib:lib-auth:test :lib:lib-common:test :lib:lib-auth:check :lib:lib-common:check` all green.

## Verification

End-to-end verification via companion PR in `enonic/app-simple-idprovider`: enonic/app-simple-idprovider#72.