### PR TITLE
lib-admin JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-admin/src/main/resources/lib/xp/admin.ts
+++ b/modules/lib/lib-admin/src/main/resources/lib/xp/admin.ts
@@ -72,7 +72,7 @@ export function getHomeToolUrl(params?: GetHomeToolUrlParams): string {
 }
 
 export interface GetHomeToolUrlParams {
-    type: HomeToolUrlType;
+    type?: HomeToolUrlType;
 }
 
 export type HomeToolUrlType = 'server' | 'absolute';
@@ -107,7 +107,7 @@ export interface WidgetUrlParams {
  *
  * Returns the URL for a widget.
  *
- * @param {object} [params] Parameter object
+ * @param {object} params Parameter object
  * @param {string} params.application Application to reference to a widget.
  * @param {string} params.widget Name of the widget.
  * @param {string} [params.type=server] URL type. Either `server` (server-relative URL) or `absolute`.
@@ -139,7 +139,7 @@ export interface ExtensionUrlParams {
 /**
  * Returns the URL for an extension.
  *
- * @param {object} [params] Parameter object
+ * @param {object} params Parameter object
  * @param {string} params.application Application to reference to an extension.
  * @param {string} params.extension Name of the extension.
  * @param {string} [params.type=server] URL type. Either `server` (server-relative URL) or `absolute`.


### PR DESCRIPTION
Part of #11991.

Audit findings for lib-admin (`modules/lib/lib-admin/src/main/resources/lib/xp/admin.ts`):

- `widgetUrl`: JSDoc marked `[params]` optional, but the TS signature has `params: WidgetUrlParams` (required) and the implementation calls `checkRequired(params, 'application')` which throws if missing. Removed the brackets so JSDoc matches TS / runtime behavior.
- `extensionUrl`: same issue as `widgetUrl`. Removed the brackets on `[params]`.
- `GetHomeToolUrlParams`: TS interface declared `type: HomeToolUrlType` (required), but the JSDoc says `[params.type=server]` (optional) and the Java handler accepts a null URL type via `__.nullOrValue(params?.type)`. Made the field optional (`type?: HomeToolUrlType`).

Java handler behavior is unchanged — only JSDoc and TS type declarations were updated to match what the code does.