### PR TITLE
lib-auditlog JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-auditlog/src/main/resources/lib/xp/auditlog.ts
+++ b/modules/lib/lib-auditlog/src/main/resources/lib/xp/auditlog.ts
@@ -111,7 +111,7 @@ interface GetAuditLogHandler {
  * @param {object} params     JSON with the parameters.
  * @param {string} params.id  Id of the audit log.
  *
- * @returns {object} Audit log as JSON.
+ * @returns {object|null} Audit log as JSON, or `null` if no audit log exists with the given id.
  */
 export function get(params: GetAuditLogParams): AuditLog | null {
     const id = checkRequired(params, 'id');
@@ -171,7 +171,7 @@ interface FindAuditLogHandler {
  *
  * @param {object} params     JSON with the parameters.
  * @param {number} [params.start=0] Start index (used for paging).
- * @param {number} [params.count=10] Number of contents to fetch.
+ * @param {number} [params.count=10] Number of audit logs to fetch.
  * @param {array} [params.ids] Filter by ids of audit logs.
  * @param {string} [params.from] Filter by logs younger than from.
  * @param {string} [params.to] Filter by logs older than to.


### PR DESCRIPTION
Part of #11991.

Audit findings for `lib-auditlog`:

- `get()` JSDoc: `@returns {object}` did not match the Java handler. `GetAuditLogHandler.doExecute()` returns `null` when no audit log exists for the given id, and the TS signature already says `AuditLog | null`. JSDoc updated to `{object|null}` with a description note.
- `find()` JSDoc: `@param {number} [params.count=10] Number of contents to fetch.` is a stale copy-paste from content-oriented libs — `lib-auditlog` returns audit logs, not contents. Description corrected to "Number of audit logs to fetch."

Java handler behavior is unchanged — only JSDoc was updated to match what the code actually does. TS type declarations were already correct and untouched.

Verified with `./gradlew :lib:lib-auditlog:test` — green.