### PR TITLE
Fix lib-auth JSDoc #11991

### DIFF
--- a/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
@@ -160,14 +160,14 @@ export function getUser<Profile extends Record<string, unknown> = Record<string,
     includeProfile: true
 }): UserWithProfile<Profile> | null;
 /**
- * Returns the logged-in user. If not logged-in, this will return *undefined*.
+ * Returns the logged-in user. If not logged-in, this will return *null*.
  *
  * @example-ref examples/auth/getUser.js
  *
  * @param {object} [params] JSON parameters.
  * @param {boolean} [params.includeProfile=false] Include profile.
  *
- * @returns {User} Information for logged-in user.
+ * @returns {User | null} Information for the logged-in user, or null if not logged in.
  */
 export function getUser(params?: GetUserParams): User | null {
     const {
@@ -365,6 +365,7 @@ interface CreateUserHandler {
  * @param {string} params.name User login name to set.
  * @param {string} [params.displayName] User display name.
  * @param {string} [params.email] User email.
+ * @returns {User} The created user.
  */
 export function createUser(params: CreateUserParams): User {
     const name = checkRequired(params, 'name');
@@ -401,7 +402,7 @@ interface ModifyUserHandler {
  * @param {object} params JSON parameters.
  * @param {string} params.key Principal key of the user to modify.
  * @param {function} params.editor User editor function to apply to user.
- * @returns {User} the updated user or null if a  user not found.
+ * @returns {User | null} The updated user, or null if user not found.
  */
 export function modifyUser(params: ModifyUserParams): User | null {
     const key = checkRequired(params, 'key');
@@ -443,7 +444,8 @@ interface CreateGroupHandler {
  * @param {string} params.idProvider Key for id provider where group has to be created.
  * @param {string} params.name Group name.
  * @param {string} [params.displayName] Group display name.
- * @param {string} [params.description] as principal description .
+ * @param {string} [params.description] Group description.
+ * @returns {Group} The created group.
  */
 export function createGroup(params: CreateGroupParams): Group {
     const idProvider = checkRequired(params, 'idProvider');
@@ -480,7 +482,7 @@ interface ModifyGroupHandler {
  * @param {object} params JSON parameters.
  * @param {string} params.key Principal key of the group to modify.
  * @param {function} params.editor Group editor function to apply to group.
- * @returns {Group} the updated group or null if a group not found.
+ * @returns {Group | null} The updated group, or null if group not found.
  */
 export function modifyGroup(params: ModifyGroupParams): Group | null {
     const key = checkRequired(params, 'key');
@@ -503,12 +505,12 @@ interface AddMembersHandler {
 }
 
 /**
- * Adds members to a principal (user or role).
+ * Adds members to a principal (group or role).
  *
  * @example-ref examples/auth/addMembers.js
  *
  * @param {string} principalKey Key of the principal to add members to.
- * @param {Array<string>} members Keys of users and groups to add.
+ * @param {string[]} members Keys of users and groups to add.
  */
 export function addMembers(principalKey: GroupKey | RoleKey, members: (UserKey | GroupKey)[]): void {
     checkRequiredArg(principalKey, 'principalKey');
@@ -530,12 +532,12 @@ interface RemoveMembersHandler {
 }
 
 /**
- * Removes members from a principal (user or role).
+ * Removes members from a principal (group or role).
  *
  * @example-ref examples/auth/removeMembers.js
  *
  * @param {string} principalKey Key of the principal to remove members from.
- * @param {string} members Keys of the principals to remove.
+ * @param {string[]} members Keys of the principals to remove.
  */
 export function removeMembers(principalKey: GroupKey | RoleKey, members: (UserKey | GroupKey)[]): void {
     checkRequiredArg(principalKey, 'principalKey');
@@ -763,7 +765,7 @@ export function findUsers(params: FindUsersParams): FindPrincipalsResult<User | 
  *
  * @param {object} params JSON with the parameters.
  * @param {number} [params.start=0] Start index (used for paging).
- * @param {number} [params.count=10] Number of contents to fetch.
+ * @param {number} [params.count=10] Number of users to fetch.
  * @param {string} params.query Query expression.
  * @param {string} [params.sort] Sorting expression.
  * @param {boolean} [params.includeProfile=false] Include profile.
@@ -810,9 +812,11 @@ interface CreateRoleHandler {
  *
  * @example-ref examples/auth/createRole.js
  *
+ * @param {object} params JSON parameters.
  * @param {string} params.name Role name.
  * @param {string} [params.displayName] Role display name.
- * @param {string} [params.description] as principal description .
+ * @param {string} [params.description] Role description.
+ * @returns {Role} The created role.
  */
 export function createRole(params: CreateRoleParams): Role {
     const name = checkRequired(params, 'name');
@@ -847,7 +851,7 @@ interface ModifyRoleHandler {
  * @param {object} params JSON parameters.
  * @param {string} params.key Principal key of the role to modify.
  * @param {function} params.editor Role editor function to apply to role.
- * @returns {Role} the updated role or null if a role not found.
+ * @returns {Role | null} The updated role, or null if role not found.
  */
 export function modifyRole(params: ModifyRoleParams): Role | null {
     const key = checkRequired(params, 'key');


### PR DESCRIPTION
Part of #11991.

Audited `modules/lib/lib-auth/` against the Java handlers and TypeScript types. The Java handler is the runtime truth; this PR only updates JSDoc and JSDoc-only wording in `auth.ts`. No Java behavior or TS signatures are changed.

## Findings fixed

- **`getUser`** — said "returns *undefined*" when not logged in; Java returns `null`. Also updated `@returns {User}` to `@returns {User | null}` (TS signature is already `User | null`).
- **`createUser`** — was missing `@returns {User}`.
- **`createGroup`** — was missing `@returns {Group}`; the description for `params.description` was the broken "`as principal description .`" — replaced with `Group description.`.
- **`createRole`** — was missing `@param {object} params JSON parameters.`, missing `@returns {Role}`, and had the same broken `params.description` text — replaced with `Role description.`.
- **`modifyUser`** — `@returns {User}` had a stray double-space typo and dropped the `null` case; tightened to `@returns {User | null}` and cleaned the wording.
- **`modifyGroup` / `modifyRole`** — same null-case fix applied to `@returns`.
- **`addMembers`** — description said "Adds members to a principal (user or role)"; you don't add members to a user. The `principalKey` parameter is typed `GroupKey | RoleKey` in TS — corrected to "(group or role)".
- **`removeMembers`** — same "user or role" wording fix as `addMembers`. Also `@param {string} members` was wrong: `members` is an array (`string[]` / `(UserKey | GroupKey)[]`).
- **`findUsers`** — `params.count` comment said "Number of contents to fetch" (stale copy from `lib-content`) — corrected to "Number of users to fetch".

## Verification

- `./gradlew :lib:lib-auth:test` — green (TypeScript declarations regenerate as part of the build).
- No `integrationTest` source set in `lib-auth` and no `itest-lib-auth` module.