### PR TITLE
lib-content JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -176,20 +176,19 @@ export interface PatchableContent<
     createdTime: string;
     modifier: UserKey;
     modifiedTime: string;
-    publishInfo: PublishInfo;
+    publish: PublishInfo;
     processedReferences: string[];
-    workflowInfo: Workflow;
+    workflow: Workflow;
     manualOrderValue: number;
     inherit: ContentInheritValue[];
     variantOf: string;
-    modifyAttachments: Attachment;
-    removeAttachments: string[];
-    createAttachments: AddAttachmentParam[];
+    attachments: Attachments;
     validationErrors: ValidationError[];
     type: Type;
     childOrder: string;
     originProject: string;
     originalParentPath: string;
+    originalName: string;
     archivedTime: string;
     archivedBy: UserKey;
 }
@@ -637,7 +636,9 @@ interface CreateContentHandler {
  * @param {string} [params.language] The language tag representing the content’s locale.
  * @param {string} [params.childOrder] Default ordering of children when doing getChildren if no order is given in query
  * @param {object} params.data Actual content data.
+ * @param {object} [params.page] Page configuration to use.
  * @param {object} [params.x] eXtra data to use.
+ * @param {function} [params.idGenerator] Function used to generate the id-suffix appended to the content name.
  * @param {object} [params.workflow] Workflow information to use. Default has state READY and empty check list.
  *
  * @returns {object} Content created as JSON.
@@ -725,11 +726,12 @@ interface QueryContentHandler {
  * @param {object} params JSON with the parameters.
  * @param {number} [params.start=0] Start index (used for paging).
  * @param {number} [params.count=10] Number of contents to fetch.
- * @param {string|object} params.query Query expression.
+ * @param {string|object} [params.query] Query expression.
  * @param {object|object[]} [params.filters] Filters to apply to query result
  * @param {string|object|object[]} [params.sort] Sorting expression.
  * @param {object} [params.aggregations] Aggregations expression.
  * @param {string[]} [params.contentTypes] Content types to filter on.
+ * @param {object} [params.highlight] Highlight expression.
  *
  * @returns {object} Result of query.
  */
@@ -767,10 +769,33 @@ export interface UpdateContentParams<Data, Type extends string> {
     requireValid?: boolean;
 }
 
+export interface ModifyAttachmentParam {
+    name: string;
+    label?: string;
+    mimeType?: string;
+    textContent?: string;
+    sha512?: string;
+    size?: number;
+}
+
+export interface CreateAttachmentParam {
+    name: string;
+    label?: string;
+    mimeType?: string;
+    textContent?: string;
+    data?: ByteSource | string;
+}
+
+export interface PatchAttachmentsParam {
+    createAttachments?: CreateAttachmentParam[];
+    modifyAttachments?: ModifyAttachmentParam[];
+    removeAttachments?: string[];
+}
+
 export interface PatchContentParams {
     key: string;
-    patcher: (v: PatchableContent) => PatchableContent;
-    attachments?: AddAttachmentParam[];
+    patcher: (v: PatchableContent) => PatchableContent | void;
+    attachments?: PatchAttachmentsParam;
     branches?: string[];
     skipSync?: boolean;
 }
@@ -880,6 +905,10 @@ export function update<Data extends Record<string, unknown> = Record<string, unk
  * @param {object} params JSON with the parameters.
  * @param {string} params.key Path or id to the content.
  * @param {function} params.patcher Patcher callback function.
+ * @param {object} [params.attachments] Attachments to create, modify or remove on the patched content.
+ * @param {object[]} [params.attachments.createAttachments] Attachments to add to the content.
+ * @param {object[]} [params.attachments.modifyAttachments] Existing attachments to modify on the content.
+ * @param {string[]} [params.attachments.removeAttachments] Names of attachments to remove from the content.
  * @param {boolean} [params.skipSync=false] If true, the content will not be immediately synced to the child projects.
  * @param {string[]} [params.branches=[]] List of branches to patch the content in. If not specified, the context's branch is used.
  *
@@ -1000,7 +1029,6 @@ export function updateWorkflow(params: UpdateWorkflowParams): UpdateWorkflowResu
 export interface PublishContentParams {
     keys: string[];
     schedule?: Schedule;
-    includeChildren?: boolean;
     /**
      * @deprecated Use excludeDescendantsOf instead.
      */
@@ -1109,7 +1137,8 @@ interface ContentExistsHandler {
  *
  * @example-ref examples/content/exists.js
  *
- * @param {string} params.key content id.
+ * @param {object} params JSON with the parameters.
+ * @param {string} params.key Path or id of the content.
  *
  * @returns {boolean} True if exist, false otherwise.
  */
@@ -1277,7 +1306,7 @@ export function archive(params: ArchiveContentParams): string[] {
 
 export interface RestoreContentParams {
     content: string;
-    path: string;
+    path?: string;
 }
 
 interface RestoreContentHandler {
@@ -1295,7 +1324,7 @@ interface RestoreContentHandler {
  *
  * @param {object} params JSON with the parameters.
  * @param {string} params.content Path or id of the content to be restored.
- * @param {string} params.path Path of parent for restored content.
+ * @param {string} [params.path] Path of parent for restored content.
  *
  * @returns {string[]} List with ids of the contents that were restored.
  */
@@ -1356,11 +1385,11 @@ interface ApplyPermissionsHandler {
  *
  * @param {object} params JSON parameters.
  * @param {string} params.key Path or id of the content.
- * @param {string} [params.scope] Scope of operation. Possible values are 'SINGE', 'TREE' or 'SUBTREE'. Default is 'SINGLE'.
+ * @param {string} [params.scope] Scope of operation. Possible values are 'SINGLE', 'TREE' or 'SUBTREE'. Default is 'SINGLE'.
  * @param {array} [params.permissions] Array of permissions. Cannot be used together with addPermissions and removePermissions.
  * @param {string} params.permissions.principal Principal key.
- * @param {array} params.permissions.allow Allowed permissions.
- * @param {array} params.permissions.deny Denied permissions.
+ * @param {array} [params.permissions.allow] Allowed permissions.
+ * @param {array} [params.permissions.deny] Denied permissions.
  * @param {array} [params.addPermissions] Array of permissions to add. Cannot be used together with permissions.
  * @param {array} [params.removePermissions] Array of permissions to remove. Cannot be used together with permissions.
  *
@@ -1432,6 +1461,7 @@ export interface Icon {
  * @property {boolean} abstract Whether or not content of this type may be instantiated.
  * @property {boolean} final Whether or not it may be used as super type of other content types.
  * @property {boolean} allowChildContent Whether or not allow creating child items on content of this type.
+ * @property {string} modifiedTime Modified time of the content type.
  * @property {object} [icon] Icon of the content type.
  * @property {object} [icon.data] Stream with the binary data for the icon.
  * @property {string} [icon.mimeType] Mime type of the icon image.
@@ -1466,7 +1496,7 @@ interface ContentTypeHandler {
  *
  * @example-ref examples/content/getType.js
  *
- * @param name Name of the content type, as 'app:name' (e.g. 'com.enonic.myapp:article').
+ * @param {string} name Name of the content type, as 'app:name' (e.g. 'com.enonic.myapp:article').
  * @returns {ContentType} The content type object if found, or null otherwise. See ContentType type definition below.
  */
 export function getType(name: string): ContentType | null {
@@ -1502,7 +1532,7 @@ interface GetOutboundDependenciesHandler {
  *
  * @param {object} params JSON parameters.
  * @param {string} params.key Path or id of the content.
- * @returns {object} Content Ids.
+ * @returns {string[]} List of content ids.
  */
 export function getOutboundDependencies(params: GetOutboundDependenciesParams): string[] {
     const key = checkRequired(params, 'key');
@@ -1565,7 +1595,6 @@ export interface ModifyMediaParams {
     focalX?: number;
     focalY?: number;
     tags?: string | string[];
-    workflow?: Workflow;
 }
 
 export interface UpdateMediaParams {
@@ -1578,7 +1607,6 @@ export interface UpdateMediaParams {
     focalX?: number;
     focalY?: number;
     tags?: string | string[];
-    workflow?: Workflow;
 }
 
 /**
@@ -1640,7 +1668,6 @@ interface UpdateMediaHandler {
  * @param {string} [params.caption] Caption to the content.
  * @param {string} [params.copyright] Copyright to the content.
  * @param {string|string[]} [params.tags] Tags to the content.
- * @param {object} [params.workflow] Workflow information to use. Default has state READY and empty check list.
  * @param {number} [params.focalX] Focal point for X axis (if it's an image).
  * @param {number} [params.focalY] Focal point for Y axis (if it's an image).
  *
@@ -1662,7 +1689,6 @@ export function modifyMedia<Data = Record<string, unknown>, Type extends string 
         copyright,
         focalX,
         focalY,
-        workflow,
         artist = [],
         tags = [],
     } = params;
@@ -1699,7 +1725,6 @@ export function modifyMedia<Data = Record<string, unknown>, Type extends string 
  * @param {string} [params.caption] Caption to the content.
  * @param {string} [params.copyright] Copyright to the content.
  * @param {string|string[]} [params.tags] Tags to the content.
- * @param {object} [params.workflow] Workflow information to use. Default has state READY and empty check list.
  * @param {number} [params.focalX] Focal point for X axis (if it's an image).
  * @param {number} [params.focalY] Focal point for Y axis (if it's an image).
  *
@@ -1721,7 +1746,6 @@ export function updateMedia<Data = Record<string, unknown>, Type extends string 
         copyright,
         focalX,
         focalY,
-        workflow,
         artist = [],
         tags = [],
     } = params;


### PR DESCRIPTION
Part of #11991.

Audit findings for lib-content — JSDoc and TypeScript declarations brought in line with the Java handlers (the runtime truth). No Java behavior was changed.

### Discrepancies fixed

- **`exists`** — JSDoc described `params.key` as "content id"; handler accepts both id and path. Added missing parent `@param {object} params`.
- **`getOutboundDependencies`** — JSDoc said `@returns {object}`, but the handler returns a list of ids (`string[]`).
- **`getType`** — `@param name` was missing its `{string}` type annotation.
- **`ContentType` typedef** — Missing `modifiedTime` property; `ContentTypeMapper` serializes it and the TS `ContentType` interface already has it.
- **`applyPermissions`** — Fixed `'SINGE'` typo → `'SINGLE'`; marked `permissions.allow` / `permissions.deny` optional (handler treats them as optional).
- **`query`** — `params.query` is optional in the handler (defaults to empty constraint) — fixed the `[]` brackets. Added missing `params.highlight` JSDoc.
- **`create`** — JSDoc was missing `params.page` and `params.idGenerator`; handler has both setters.
- **`updateMedia` / `modifyMedia`** — Removed `workflow` parameter from JSDoc and TS interfaces. `UpdateMediaHandler` has no `setWorkflow`, and the JS function destructures `workflow` but never passes it through.
- **`restore`** — `RestoreContentParams.path` is optional in Java (`RestoreContentParams.Builder.validate()` only requires `contentId`). Marked optional in TS and JSDoc.
- **`publish`** — Removed `includeChildren` from `PublishContentParams`. The `publish()` JS function never reads it and `PublishContentHandler` has no setter for it.
- **`patch`** —
  - Replaced `attachments?: AddAttachmentParam[]` with a proper `PatchAttachmentsParam` shape (`createAttachments` / `modifyAttachments` / `removeAttachments`) matching what `PatchContentHandler` actually reads (verified against the existing `PatchContentHandlerTest.js`).
  - Documented `params.attachments` in JSDoc.
- **`PatchableContent`** —
  - Renamed `publishInfo` → `publish` and `workflowInfo` → `workflow` to match the keys `ContentMapper` actually serializes for the patcher's argument (also matches existing test JS using `c.publish.from` / `c.workflow.state`).
  - Removed the spurious `modifyAttachments` / `removeAttachments` / `createAttachments` fields — those are parts of the `patch` params, not of the patcher's argument.
  - Added `originalName` (handler's `patchContent` writes it back) and `attachments` (mapper exposes it).

### Build / tests

- `./gradlew :lib:lib-content:test` — green.
- `./gradlew :lib:typescript` — green (declaration build with `tsc --declaration`).
- No integrationTest sourceset for lib-content.