### PR TITLE
lib-context JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-context/src/main/resources/lib/xp/context.ts
+++ b/modules/lib/lib-context/src/main/resources/lib/xp/context.ts
@@ -18,15 +18,15 @@ import type {PrincipalKey, ScriptValue, User} from '@enonic-types/core';
 export type {PrincipalKey, UserKey, Principal, ScriptValue, User} from '@enonic-types/core';
 
 export interface AuthInfo {
-    user?: User | null;
-    principals?: PrincipalKey[] | null;
+    user?: User;
+    principals?: PrincipalKey[];
 }
 
 export type ContextAttributes = Record<string, number | string | boolean | Record<string, unknown>>;
 
 export interface Context {
-    branch: string;
-    repository: string;
+    branch?: string;
+    repository?: string;
     authInfo?: AuthInfo;
     attributes: ContextAttributes;
 }
@@ -84,7 +84,7 @@ const bean: ContextHandler = __.newBean<ContextHandler>('com.enonic.xp.lib.conte
  * @param {array} [context.principals] Additional principals to execute the callback with.
  * @param {object} [context.attributes] Additional Context attributes.
  * @param {function} callback Function to execute.
- * @returns {object} Result of the function execution.
+ * @returns {*} Result of the function execution.
  */
 export function run<T>(context: ContextParams, callback: () => T): T {
     const params: ContextRunParams = bean.newRunParams();


### PR DESCRIPTION
Part of #11991.

Audit findings for lib-context — JSDoc and TS types disagreed with what the Java handler (`ContextHandlerBean` / `ContextMapper`) actually does. Fixed:

- `run` `@returns {object}` → `{*}` — the function returns whatever the callback returns (generic `T`), not necessarily an object. Tests demonstrate string returns.
- `Context.branch` / `Context.repository` typed as required `string` → made optional. `ContextMapper.serialize` only emits these keys when `getBranch() != null` / `getRepositoryId() != null`.
- `AuthInfo.user?: User | null` and `principals?: PrincipalKey[] | null` → dropped the `| null`. `ContextMapper.serializeUser` and `serializePrincipals` skip the field when null and never emit a literal `null`, so the runtime shape is "present or absent", not "present or null".

Java handler behavior is unchanged — only JSDoc and TS type declarations were updated to match what the code does.

`./gradlew :lib:lib-context:test` is green locally.