### PR TITLE
lib-event JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-event/src/main/resources/lib/xp/event.ts
+++ b/modules/lib/lib-event/src/main/resources/lib/xp/event.ts
@@ -90,7 +90,7 @@ interface EventListenerHelper {
  * @param {object} params Listener parameters.
  * @param {string} params.type Event type pattern. Works like a Java Pattern, with two key differences: `.` is treated as a literal dot, not a wildcard. `*` acts as `.*`, matching any sequence of characters.
  * @param {function} params.callback Callback event listener.
- * @param {boolean} params.localOnly Local events only (default to false).
+ * @param {boolean} [params.localOnly=false] Local events only.
  */
 export function listener<EventData extends object = EnonicEventData>(params: ListenerParams<EventData>): void {
     const helper: EventListenerHelper = __.newBean<EventListenerHelper>('com.enonic.xp.lib.event.EventListenerHelper');
@@ -109,8 +109,8 @@ export function listener<EventData extends object = EnonicEventData>(params: Lis
  *
  * @param {object} event Event to send.
  * @param {string} event.type Event type.
- * @param {boolean} event.distributed True if it should be distributed in cluster.
- * @param {object} event.data Additional data for event.
+ * @param {boolean} [event.distributed=false] True if it should be distributed in cluster.
+ * @param {object} [event.data] Additional data for event.
  */
 export function send<EventData extends object = object>(event: SendParams<EventData>): void {
     const helper: EventSenderHelper = __.newBean<EventSenderHelper>('com.enonic.xp.lib.event.EventSenderHelper');


### PR DESCRIPTION
Part of #11991.

Audit findings for `lib-event`:

- `listener` — `params.localOnly` is optional in the TS interface (`localOnly?: boolean`) but the JSDoc didn't use the `[name]` brackets convention. Updated to `[params.localOnly=false]`, matching the project convention used in `lib-auth` / `lib-context` and the `setLocalOnly(params.localOnly === true)` runtime default.
- `send` — `event.distributed` is optional in the TS interface (`distributed?: boolean`); the Java `EventSenderHelper.initialize` sets the default to `false`. Updated JSDoc to `[event.distributed=false]`.
- `send` — `event.data` is optional in the TS interface (`data?: EventData`); the Java handler only sets data when the value is a non-null object. Updated JSDoc to `[event.data]`.

Java handler behavior is unchanged — only JSDoc annotations on `event.ts` were updated to match the TypeScript declarations and the Java runtime defaults.