### PR TITLE
lib-grid JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-grid/src/main/resources/lib/xp/grid.ts
+++ b/modules/lib/lib-grid/src/main/resources/lib/xp/grid.ts
@@ -29,7 +29,7 @@ interface JavaSharedMap<Map extends GridMap> {
 
     set<Key extends keyof Map>(key: Key, value: ConvertedType, ttlSeconds?: number | null): void;
 
-    modify<Key extends keyof Map>(key: Key, modifier: SharedMapModifierFn<Map, Key>, ttlSeconds?: number | null): Map[Key];
+    modify<Key extends keyof Map>(key: Key, modifier: SharedMapModifierFn<Map, Key>, ttlSeconds?: number | null): Map[Key] | null;
 }
 
 interface SharedMapHandler<Map extends GridMap> {
@@ -53,7 +53,7 @@ export interface SharedMap<Map extends GridMap> {
 
     set<Key extends keyof Map>(params: SetParams<Map, Key>): void;
 
-    modify<Key extends keyof Map>(params: ModifyParams<Map, Key>): Map[Key];
+    modify<Key extends keyof Map>(params: ModifyParams<Map, Key>): Map[Key] | null;
 
     delete(key: keyof Map): void;
 }
@@ -62,7 +62,7 @@ export interface SharedMap<Map extends GridMap> {
  * Shared Map is similar to other Map, but its instances are shared across all applications and even cluster nodes.
  *
  *  WARNING: Due to distributed nature of the Shared Map not all types of keys and values can be used.
- *  Strings, numbers, and pure JSON objects are supported. There is no runtime check for type compatibility due to performance reasons.
+ *  Strings, numbers, booleans, and pure JSON objects are supported. There is no runtime check for type compatibility due to performance reasons.
  *  The developer is also responsible for not modifying shared objects (keys and values) in place.
  *
  * @constructor
@@ -82,7 +82,7 @@ class SharedMapImpl<Map extends GridMap>
     /**
      * Returns the value to which the specified key is mapped, or null if this map contains no mapping for the key.
      *
-     * @param {string} key - key the key whose associated value is to be returned
+     * @param {string} key the key whose associated value is to be returned
      * @returns {string|number|boolean|JSON|null} the value to which the specified key is mapped, or null if this map contains no mapping for the key
      */
     get<Key extends keyof Map>(key: Key): Map[Key] | null {
@@ -118,9 +118,9 @@ class SharedMapImpl<Map extends GridMap>
      *                            The returned value replaces the existing mapped value for the specified key.
      *                            If returned value is null then the value is removed from the map
      * @param {number} [params.ttlSeconds] maximum time to live in seconds for this entry to stay in the map. (0 means infinite, negative means map config default or infinite if map config is not available)
-     * @returns the new value to which the specified key is mapped, or null if this map no longer contains mapping for the key
+     * @returns {string|number|boolean|JSON|null} the new value to which the specified key is mapped, or null if this map no longer contains mapping for the key
      */
-    modify<Key extends keyof Map>(params: ModifyParams<Map, Key>): Map[Key] {
+    modify<Key extends keyof Map>(params: ModifyParams<Map, Key>): Map[Key] | null {
         const key = requireNotNull(params.key, 'key');
         const func = requireNotNull(params.func, 'func');
         if (typeof func !== 'function') {


### PR DESCRIPTION
Part of #11991.

Audit findings for lib-grid (`modules/lib/lib-grid`):

- `modify()` declared a non-nullable `Map[Key]` return type, but the Java `SharedMap.modify` (see `LocalSharedMap.modify`) returns `null` when the modifier callback returns `null` and the entry is removed. The JSDoc `@returns` text already mentioned the null case — only the TS type was wrong. Fixed in `JavaSharedMap.modify`, `SharedMap.modify`, and `SharedMapImpl.modify`.
- `modify()` JSDoc was missing a `@returns {string|number|boolean|JSON|null}` type annotation (the other methods include it). Added.
- `get()` JSDoc had a duplicate word: `@param {string} key - key the key whose...`. Cleaned up to match `delete()`'s style.
- The class-level WARNING listed "Strings, numbers, and pure JSON objects" as supported, but `SharedMapValueType` and the `set()` JSDoc both list `boolean` explicitly. Added "booleans" to the WARNING.

Java handler behavior is unchanged — only JSDoc and TS type declarations were updated to match what the Java code does.

Tests: `./gradlew :lib:lib-grid:test` is green. No integration test source set in this module.