### PR TITLE
lib-io JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-io/src/main/resources/lib/xp/io.ts
+++ b/modules/lib/lib-io/src/main/resources/lib/xp/io.ts
@@ -49,7 +49,7 @@ const bean: IOHandlerBean = __.newBean<IOHandlerBean>('com.enonic.xp.lib.io.IOHa
  * @example-ref examples/io/readText.js
  *
  * @param stream Stream to read text from.
- * @returns {string} Returns the text read from stream or string.
+ * @returns {string} Returns the text read from the stream.
  */
 export function readText(stream: ByteSource): string {
     return bean.readText(stream);
@@ -120,7 +120,7 @@ export function newStream(text: string): ByteSource {
  *
  * @example-ref examples/io/getResource.js
  *
- * @param {string} key Resource key to look up.
+ * @param {string|ResourceKey} key Resource key to look up.
  * @returns {Resource} Resource reference.
  */
 export function getResource(key: string | ResourceKey): Resource {


### PR DESCRIPTION
Part of #11991.

## Audit findings for `lib-io`

Cross-referenced `IOHandlerBean.java` against the JSDoc + TypeScript signatures in `modules/lib/lib-io/src/main/resources/lib/xp/io.ts`. Two discrepancies between JSDoc and the Java/TS runtime contract:

- **`readText`**: `@returns` description said the function returns text read "from stream or string". The Java handler (`IOHandlerBean.readText`) only accepts a `ByteSource` — anything else is coerced via `toByteSource(...)` to an empty source. The "or string" wording is stale; updated to "Returns the text read from the stream."
- **`getResource`**: JSDoc declared `@param {string} key`, but the TypeScript export signature is `key: string | ResourceKey`, and `IOHandlerBean.getResource` (via `toResourceKey`) explicitly handles both `ResourceKey` instances and arbitrary objects via `toString()`. Updated JSDoc to `@param {string|ResourceKey}` to match.

Java handler behavior is unchanged — only JSDoc tags were updated to match what the code does.

## Verification

- `./gradlew :lib:lib-io:test` — green locally (no `integrationTest` source set in this module).