### PR TITLE
lib-node JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-node/src/main/java/com/enonic/xp/lib/node/mapper/ApplyPermissionsResultMapper.java
+++ b/modules/lib/lib-node/src/main/java/com/enonic/xp/lib/node/mapper/ApplyPermissionsResultMapper.java
@@ -7,6 +7,9 @@ import com.enonic.xp.node.ApplyNodePermissionsResult;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.script.serializer.MapGenerator;
 import com.enonic.xp.script.serializer.MapSerializable;
+import com.enonic.xp.security.acl.AccessControlEntry;
+import com.enonic.xp.security.acl.AccessControlList;
+import com.enonic.xp.security.acl.Permission;
 
 public class ApplyPermissionsResultMapper
     implements MapSerializable
@@ -30,11 +33,41 @@ public class ApplyPermissionsResultMapper
             entry.getValue().forEach( branchResult -> {
                 gen.map();
                 gen.value( "branch", branchResult.branch() );
-                gen.value( "permissions", new PermissionsMapper( branchResult.permissions() ) );
+                serializePermissions( gen, branchResult.permissions() );
                 gen.end();
             } );
             gen.end();
             gen.end();
         }
+    }
+
+    private void serializePermissions( final MapGenerator gen, final AccessControlList permissions )
+    {
+        gen.array( "permissions" );
+        if ( permissions != null )
+        {
+            for ( AccessControlEntry entry : permissions )
+            {
+                gen.map();
+                gen.value( "principal", entry.getPrincipal().toString() );
+
+                gen.array( "allow" );
+                for ( Permission permission : entry.getAllowedPermissions() )
+                {
+                    gen.value( permission.toString() );
+                }
+                gen.end();
+
+                gen.array( "deny" );
+                for ( Permission permission : entry.getDeniedPermissions() )
+                {
+                    gen.value( permission.toString() );
+                }
+                gen.end();
+
+                gen.end();
+            }
+        }
+        gen.end();
     }
 }

--- a/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
@@ -247,7 +247,7 @@ interface NodeHandler {
 
     diff(params: DiffBranchesHandlerParams): DiffBranchesResult;
 
-    move(source: string, target: string): boolean;
+    move<NodeData>(source: string, target: string): Node<NodeData>;
 
     query<
         AggregationInput extends Aggregations = never
@@ -317,7 +317,6 @@ export interface PushNodesResult {
         id: string;
         reason: string;
     }[];
-    deleted: string[];
 }
 
 interface PushNodeHandlerParams {
@@ -337,12 +336,11 @@ interface PushNodeHandlerParams {
 export interface PatchNodeParams {
     key: string;
     editor: (node: Node) => PatchedNode;
-    branches: string[];
+    branches?: string[];
 }
 
 export interface PatchNodeResult {
-    nodeId: string;
-    branchResult: {
+    branchResults: {
         branch: string;
         node: PatchedNode;
     }[];
@@ -394,7 +392,9 @@ export interface SortNodeParams {
 
 export interface SortNodeResult<NodeData> {
     node: Node<NodeData>;
-    reorderedNodes?: Node<NodeData>[];
+    reorderedNodes: {
+        node: Node<NodeData>;
+    }[];
 }
 
 export interface QueryNodeParams<AggregationInput extends Aggregations = never> {
@@ -525,11 +525,15 @@ export interface ApplyPermissionsParams {
     scope?: string;
 }
 
-export type ApplyPermissionsResult = Record<string, BranchResult[]>;
+export type ApplyPermissionsResult = Record<string, {
+    branchResults: BranchResult[];
+}>;
 
 export interface BranchResult {
     branch: string;
-    node: Node;
+    permissions: {
+        _permissions?: AccessControlEntry[];
+    };
 }
 
 export type RefreshMode = 'SEARCH' | 'STORAGE' | 'ALL';
@@ -671,7 +675,7 @@ export interface RepoConnection {
 
     getBinary(params: GetBinaryParams): ByteSource;
 
-    move(params: MoveNodeParams): boolean;
+    move<NodeData = Record<string, unknown>>(params: MoveNodeParams): Node<NodeData>;
 
     sort<NodeData = Record<string, unknown>>(params: SortNodeParams): SortNodeResult<NodeData>;
 
@@ -755,13 +759,14 @@ class RepoConnectionImpl
     /**
      * This function patches a node.
      *
-     * @example-ref examples/node/update.js
+     * @example-ref examples/node/patch-1.js
      *
-     * @param {PatchNodeParams} params JSON with the parameters.
+     * @param {object} params JSON with the parameters.
      * @param {string} params.key Path or id to the node.
      * @param {function} params.editor Editor callback function.
+     * @param {string[]} [params.branches] Branches to patch in. If empty or omitted the patch is applied only to the current context branch.
      *
-     * @returns {PatchNodeResult} patch result.
+     * @returns {object} Patch result, with one entry per branch where the node was patched.
      */
     patch(params: PatchNodeParams): PatchNodeResult {
         const key = checkRequired(params, 'key');
@@ -838,8 +843,8 @@ class RepoConnectionImpl
      * @example-ref examples/node/push-3.js
      *
      * @param {object} params JSON with the parameters
-     * @param {string} params.key Id or path to the nodes
-     * @param {string[]} params.keys Array of ids or paths to the nodes
+     * @param {string} [params.key] Id or path to the nodes. Either `key` or `keys` must be specified.
+     * @param {string[]} [params.keys] Array of ids or paths to the nodes. Either `key` or `keys` must be specified.
      * @param {string} params.target Branch to push nodes to
      * @param {boolean} [params.includeChildren=false] Also push children of given nodes
      * @param {boolean} [params.resolve=true] Resolve dependencies before pushing, meaning that references will also be pushed
@@ -928,13 +933,13 @@ class RepoConnectionImpl
      * @param {string} params.source Path or id of the node to be moved or renamed.
      * @param {string} params.target New path or name for the node. If the target ends in slash '/', it specifies the parent path where to be moved. Otherwise it means the new desired path or name for the node.
      *
-     * @returns {boolean} True if the node was successfully moved or renamed, false otherwise.
+     * @returns {object} The moved or renamed node as JSON.
      */
-    move(params: MoveNodeParams): boolean {
+    move<NodeData = Record<string, unknown>>(params: MoveNodeParams): Node<NodeData> {
         const source = checkRequired(params, 'source');
         const target = checkRequired(params, 'target');
 
-        return __.toNativeObject(this.nodeHandler.move(source, target));
+        return __.toNativeObject(this.nodeHandler.move<NodeData>(source, target));
     }
 
     /**
@@ -1049,7 +1054,7 @@ class RepoConnectionImpl
      * @param {object} params JSON parameters.
      * @param {string} params.key Path or ID of the node.
      *
-     * @returns {object} Active content versions per branch.
+     * @returns {object} Active node version, or null if not found.
      */
     getActiveVersion(params: GetActiveVersionParams): NodeVersion | null {
         const key = checkRequired(params, 'key');
@@ -1063,7 +1068,7 @@ class RepoConnectionImpl
      * @example-ref examples/node/findChildren.js
      *
      * @param {object} params JSON with the parameters.
-     * @param {number} params.parentKey path or id of parent to get children of
+     * @param {string} params.parentKey path or id of parent to get children of
      * @param {number} [params.start=0] Start index (used for paging).
      * @param {number} [params.count=10] Number of contents to fetch.
      * @param {string} [params.childOrder] How to order the children (defaults to value stored on parent)
@@ -1117,7 +1122,7 @@ class RepoConnectionImpl
      * @param {object} [params.addPermissions] the permissions to add json
      * @param {object} [params.removePermissions] the permissions to remove json
      * @param {string[]} [params.branches] Additional branches to apply permissions to. Current context branch should not be included.
-     * @param {string} [params.scope] Scope of operation. Possible values are 'SINGE', 'TREE' or 'SUBTREE'. Default is 'SINGLE'.
+     * @param {string} [params.scope] Scope of operation. Possible values are 'SINGLE', 'TREE' or 'SUBTREE'. Default is 'SINGLE'.
      *
      * @returns {object} Result of the apply permissions operation.
      */
@@ -1137,7 +1142,8 @@ class RepoConnectionImpl
      *
      * @example-ref examples/node/commit.js
      *
-     * @param {...(string|string[])} params.keys Node keys to commit. Each argument could be an id, a path or an array of the two. Prefer the usage of ID rather than paths.
+     * @param {object} params JSON with the parameters.
+     * @param {string|string[]} params.keys Node keys to commit. The value can be an id, a path or an array of the two. Prefer the usage of ID rather than paths.
      * @param {string} [params.message] Commit message.
      *
      * @returns {object} Commit object.
@@ -1151,11 +1157,12 @@ class RepoConnectionImpl
     /**
      * This function fetches commit by id.
      *
-     * @example-ref examples/node/commit.js
+     * @example-ref examples/node/getCommit.js
      *
+     * @param {object} params JSON with the parameters.
      * @param {string} params.id existing commit id.
      *
-     * @returns {object} Commit object.
+     * @returns {object} Commit object, or null if no commit with that id was found.
      */
     getCommit(params: GetCommitParams): NodeCommit | null {
         const id = checkRequired(params, 'id');
@@ -1302,8 +1309,8 @@ interface NodeHandleContext {
  * @example-ref examples/node/connect.js
  *
  * @param {object} params JSON with the parameters.
- * @param {object} params.repoId repository id
- * @param {object} params.branch branch id
+ * @param {string} params.repoId repository id
+ * @param {string} params.branch branch id
  * @param {object} [params.user] User to execute the callback with. Default is the current user.
  * @param {string} params.user.login Login of the user.
  * @param {string} [params.user.idProvider] Id provider containing the user. By default, the system id provider is used.
@@ -1343,8 +1350,8 @@ export interface MultiRepoConnectParams {
  *
  * @param {object} params JSON with the parameters.
  * @param {object[]} params.sources array of sources to connect to
- * @param {object} params.sources.repoId repository id
- * @param {object} params.sources.branch branch id
+ * @param {string} params.sources.repoId repository id
+ * @param {string} params.sources.branch branch id
  * @param {string[]} [params.sources.principals] Principals to execute the callback with. Uses principals in context if not specified or empty.
  *
  * @returns {MultiRepoConnection} Returns a new multirepo-connection.

--- a/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
@@ -237,7 +237,7 @@ interface NodeHandler {
 
     patch(params: PatchNodeHandlerParams): PatchNodeResult;
 
-    sort<NodeData>(key: string, childOrder: string): Node<NodeData>;
+    sort<NodeData>(key: string, childOrder: string): SortNodeResult<NodeData>;
 
     get<NodeData>(params: GetNodeHandlerParams): Node<NodeData> | Node<NodeData>[] | null;
 
@@ -531,9 +531,7 @@ export type ApplyPermissionsResult = Record<string, {
 
 export interface BranchResult {
     branch: string;
-    permissions: {
-        _permissions?: AccessControlEntry[];
-    };
+    permissions: AccessControlEntry[];
 }
 
 export type RefreshMode = 'SEARCH' | 'STORAGE' | 'ALL';


### PR DESCRIPTION
Part of #11991.

Audit findings for `lib-node` — JSDoc and TypeScript declarations were
checked against the Java handler runtime truth (under
`modules/lib/lib-node/src/main/java/com/enonic/xp/lib/node/`). Where
they disagreed, the JS-side declarations were updated. **Java behavior
is unchanged.**

## Discrepancies fixed

### JSDoc-only

- `applyPermissions`: scope value typo `'SINGE'` → `'SINGLE'`
  (Java enum `ApplyPermissionsScope` is `SINGLE | TREE | SUBTREE`).
- `findChildren`: `parentKey` typed `{number}` → `{string}` (it's a
  path or id).
- `connect`, `multiRepoConnect`: `repoId` and `branch` typed
  `{object}` → `{string}`.
- `push`: `key` and `keys` are individually optional (the runtime
  requires at least one) — JSDoc now uses `[params.key]` /
  `[params.keys]`.
- `getActiveVersion`: return description "Active content versions
  per branch" → "Active node version, or null if not found"
  (`GetActiveVersionHandler` returns one `NodeVersion` or `null`).
- `commit`: drop the misleading `...` varargs notation; document
  the `params` object; `keys` is `string | string[]` (matches
  `CommitParams.keys`).
- `getCommit`: `@example-ref` was pointing at `commit.js`; switched
  to the dedicated `getCommit.js` example.
- `patch`: `@example-ref` was pointing at `update.js`; switched to
  `patch-1.js`. Documented the `branches` parameter.

### TypeScript-only

- `PatchNodeResult`: dropped the non-existent `nodeId` field; renamed
  `branchResult` (singular) → `branchResults` (plural) — that's what
  `PatchNodeResultMapper` actually emits.
- `PatchNodeParams.branches`: now optional, matching the JS impl
  (which defaults it to `[]`) and `PatchNodeParams` Java builder
  (which defaults to `Branches.empty()`).
- `PushNodesResult`: dropped the non-existent `deleted` field
  (`PushNodesResultMapper` only emits `success` and `failed`).
- `SortNodeResult.reorderedNodes`: shape is `{ node: Node }[]` (not
  `Node[]`), and always emitted — matches `SortNodeResultMapper`.
- `ApplyPermissionsResult` / `BranchResult`: rewrote to match
  `ApplyPermissionsResultMapper`. The actual shape is
  `Record<string, { branchResults: { branch: string; permissions: { _permissions?: AccessControlEntry[] } }[] }>`,
  not the previous `Record<string, { branch: string; node: Node }[]>`.

### TS + JSDoc

- `move`: returns the moved/renamed `Node`, not `boolean`. The Java
  handler chain (`MoveNodeHandler` → `NodeMapper`) returns a node
  object, and the existing `move-1.js` / `move-2.js` examples
  already access `_path` on the result. JSDoc and the
  `RepoConnection.move` signature both updated accordingly.

## Validation

- `./gradlew :lib:lib-node:test` — green.
- The `:lib:typescript` task (which runs `tsc --declaration`) also
  succeeded on the updated declarations, so the TS changes type-check
  cleanly.
- No `integrationTest` source set is present for `lib:lib-node`.