### PR TITLE
lib-portal JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -102,7 +102,6 @@ export type ImageUrlParams = IdXorPath & {
     background?: string;
     format?: string;
     filter?: string;
-    server?: string;
     params?: object;
     type?: 'server' | 'absolute';
     scale:
@@ -152,9 +151,9 @@ interface ImageUrlHandler {
  * @example-ref examples/portal/imageUrl.js
  *
  * @param {object} params Input parameters as JSON.
- * @param {string} params.id ID of the image content.
- * @param {string} params.path Path to the image. If `id` is specified, this parameter is not used.
- * @param {string} params.scale Required. Options are width(px), height(px), block(width,height) and square(px).
+ * @param {string} [params.id] ID of the image content. Either `id` or `path` is required.
+ * @param {string} [params.path] Path to the image. If `id` is specified, this parameter is not used.
+ * @param {string} params.scale Required. Options are `width(px)`, `height(px)`, `block(width,height)`, `square(px)`, `max(px)`, `wide(width,height)` and `full`.
  * @param {number} [params.quality=85] Quality for JPEG images, ranges from 0 (max compression) to 100 (min compression).
  * @param {string} [params.background] Background color.
  * @param {string} [params.format] Format of the image.
@@ -481,6 +480,7 @@ export function loginUrl(params?: LoginUrlParams): string {
     bean.setIdProvider(__.nullOrValue(params?.idProvider));
     bean.setRedirect(__.nullOrValue(params?.redirect));
     bean.setUrlType(__.nullOrValue(params?.type));
+    bean.setQueryParams(__.toScriptValue(params?.params));
 
     return bean.createUrl();
 }
@@ -717,7 +717,7 @@ interface GetCurrentIdProviderKeyHandler {
  *
  * @example-ref examples/portal/getIdProviderKey.js
  *
- * @returns {string|null} The current id provider as JSON.
+ * @returns {string|null} The current id provider key, or `null` if no id provider is bound to the current context.
  */
 export function getIdProviderKey(): string | null {
     const bean: GetCurrentIdProviderKeyHandler = __.newBean<GetCurrentIdProviderKeyHandler>(
@@ -745,7 +745,7 @@ interface MultipartHandler {
 }
 
 /**
- * This function returns a JSON containing multipart items. If not a multipart request, then this function returns `undefined`.
+ * This function returns a JSON containing multipart items. If the request is not multipart, an empty object is returned.
  *
  * @example-ref examples/portal/getMultipartForm.js
  *
@@ -757,7 +757,7 @@ export function getMultipartForm(): MultipartForm {
 }
 
 /**
- * This function returns a JSON containing a named multipart item. If the item does not exists, it returns `undefined`.
+ * This function returns a JSON containing a named multipart item. If the item does not exist, it returns `null`.
  *
  * @example-ref examples/portal/getMultipartItem.js
  *
@@ -772,14 +772,14 @@ export function getMultipartItem(name: string, index = 0): MultipartItem | null 
 }
 
 /**
- * This function returns a data-stream for a named multipart item.
+ * This function returns a data-stream for a named multipart item. If the item does not exist, it returns `null`.
  *
  * @example-ref examples/portal/getMultipartStream.js
  *
  * @param {string} name Name of the multipart item.
  * @param {number} [index] Optional zero-based index. It should be specified if there are multiple items with the same name.
  *
- * @returns {*} Stream of multipart item data.
+ * @returns {object|null} Stream of multipart item data.
  */
 export function getMultipartStream(name: string, index = 0): ByteSource | null {
     const bean: MultipartHandler = __.newBean<MultipartHandler>('com.enonic.xp.lib.portal.multipart.MultipartHandler');

--- a/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/url/UrlServiceScriptTest.java
+++ b/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/url/UrlServiceScriptTest.java
@@ -15,6 +15,7 @@ import com.enonic.xp.portal.url.AttachmentUrlParams;
 import com.enonic.xp.portal.url.BaseUrlParams;
 import com.enonic.xp.portal.url.ComponentUrlParams;
 import com.enonic.xp.portal.url.GenerateUrlParams;
+import com.enonic.xp.portal.url.IdentityUrlParams;
 import com.enonic.xp.portal.url.ImageUrlParams;
 import com.enonic.xp.portal.url.PageUrlParams;
 import com.enonic.xp.portal.url.PortalUrlService;
@@ -143,6 +144,12 @@ class UrlServiceScriptTest
 
         when( portalUrlService.baseUrl( any( BaseUrlParams.class ) ) ).thenAnswer( invocation -> "/site/mocksite" );
 
+        when( portalUrlService.identityUrl( any( IdentityUrlParams.class ) ) ).thenAnswer( invocation -> {
+            final IdentityUrlParams params = invocation.getArgument( 0, IdentityUrlParams.class );
+            final String idProviderKey = params.getIdProviderKey() != null ? params.getIdProviderKey().toString() : "default";
+            return "/site/mocksite/_/idprovider/" + idProviderKey + "/" + params.getIdProviderFunction() + buildQueryString( params.getParams() );
+        } );
+
         when( portalUrlService.generateUrl( any( GenerateUrlParams.class ) ) ).thenAnswer( invocation -> {
             final GenerateUrlParams params = invocation.getArgument( 0, GenerateUrlParams.class );
             String pathStr;
@@ -218,6 +225,17 @@ class UrlServiceScriptTest
         assertEquals( expectedService, captor.getValue().getService() );
     }
 
+    private void verifyLoginUrl( final String expectedIdProvider )
+    {
+        final ArgumentCaptor<IdentityUrlParams> captor = ArgumentCaptor.forClass( IdentityUrlParams.class );
+        verify( portalUrlService ).identityUrl( captor.capture() );
+        assertEquals( expectedIdProvider, captor.getValue().getIdProviderKey().toString() );
+        assertEquals( "login", captor.getValue().getIdProviderFunction() );
+        assertNotNull( captor.getValue().getParams() );
+        assertTrue( captor.getValue().getParams().containsKey( "a" ) );
+        assertTrue( captor.getValue().getParams().containsKey( "b" ) );
+    }
+
     private void verifyProcessHtml()
     {
         final ArgumentCaptor<ProcessHtmlParams> captor = ArgumentCaptor.forClass( ProcessHtmlParams.class );
@@ -285,6 +303,20 @@ class UrlServiceScriptTest
     {
         assertTrue( execute( "imageUrlTest_unknownProperty" ) );
         verifyImageUrl( "123" );
+    }
+
+    @Test
+    void loginUrlTest()
+    {
+        assertTrue( execute( "loginUrlTest" ) );
+        verifyLoginUrl( "system" );
+    }
+
+    @Test
+    void loginUrlTest_unknownProperty()
+    {
+        assertTrue( execute( "loginUrlTest_unknownProperty" ) );
+        verifyLoginUrl( "system" );
     }
 
     @Test

--- a/modules/lib/lib-portal/src/test/resources/test/url-test.js
+++ b/modules/lib/lib-portal/src/test/resources/test/url-test.js
@@ -136,6 +136,33 @@ exports.imageUrlTest_unknownProperty = function () {
     return true;
 };
 
+exports.loginUrlTest = function () {
+    var result = portal.loginUrl({
+        idProvider: 'system',
+        params: {
+            a: 1,
+            b: [1, 2]
+        }
+    });
+
+    assert.assertEquals('/site/mocksite/_/idprovider/system/login?a=1&b=1&b=2', result);
+    return true;
+};
+
+exports.loginUrlTest_unknownProperty = function () {
+    var result = portal.loginUrl({
+        idProvider: 'system',
+        unknownProperty: 'value',
+        params: {
+            a: 1,
+            b: [1, 2]
+        }
+    });
+
+    assert.assertEquals('/site/mocksite/_/idprovider/system/login?a=1&b=1&b=2', result);
+    return true;
+};
+
 exports.pageUrlTest = function () {
     var result = portal.pageUrl({
         path: 'a/b',


### PR DESCRIPTION
Part of #11991.

Audit findings for `lib-portal` (JS / TS / JSDoc layer aligned with the Java handler runtime truth):

- **`ImageUrlParams`**: dropped unused `server?: string` field. There is no `setServer` on `ImageUrlHandler` and the JS body never reads `params.server`.
- **`imageUrl` JSDoc**: `params.id` and `params.path` were marked required, but the JS layer only validates `scale`. Both are now optional with a note that one of them is required. Also expanded the `scale` options list (`max(px)`, `wide(width,height)`, `full`) that the TS template-literal type already allowed.
- **`loginUrl`**: the JSDoc / TS type / Java handler all expose `params.params`, but the JS body never called `bean.setQueryParams(...)`, silently dropping the value. Added the missing call so the runtime matches what the API advertises.
- **`getMultipartForm` JSDoc**: removed the incorrect "returns `undefined` when not a multipart request" claim. `MultipartServiceImpl.parse` always returns a non-null `MultipartForm` (possibly empty), so the function returns an empty object on non-multipart requests.
- **`getMultipartItem` JSDoc**: changed "returns `undefined`" to "returns `null`" (handler returns `null`).
- **`getMultipartStream` JSDoc**: tightened `@returns` from `{*}` to `{object|null}` and documented the null-on-missing-item case.
- **`getIdProviderKey` JSDoc**: removed the "as JSON" wording — the handler returns the provider key as a plain string.

Java handler behavior is unchanged — only JSDoc and the TS type declaration were updated to match what the code does, plus the one JS-layer bug fix in `loginUrl` so its runtime now matches what its docs already promised.

Tests run locally:
- `./gradlew :lib:lib-portal:test` — green
- `./gradlew :lib:lib-portal:integrationTest` — task does not exist for this module