### PR TITLE
lib-repo JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-repo/src/main/resources/lib/xp/repo.ts
+++ b/modules/lib/lib-repo/src/main/resources/lib/xp/repo.ts
@@ -64,13 +64,13 @@ interface RefreshHandler {
  *
  * @example-ref examples/repo/refresh.js
  *
- * @param {object?} params JSON with the parameters.
+ * @param {object} [params] JSON with the parameters.
  * @param {string} [params.mode='all'] Index type to be refreshed. Possible values: 'all' | 'search' | 'storage'.
- * @param {string} [params.repo='com.enonic.cms.default'] Repository id: 'com.enonic.cms.default' | 'system-repo'. Default is the current repository set in portal.
- * @param {string} [params.branch='master'] Branch. Default is the current repository set in portal.
+ * @param {string} [params.repo] Repository id. Defaults to the repository of the current context.
+ * @param {string} [params.branch] Branch. Defaults to the branch of the current context.
  *
  */
-export function refresh(params: RefreshParams): void {
+export function refresh(params?: RefreshParams): void {
     const {
         mode = 'all',
         repo,
@@ -199,7 +199,7 @@ interface GetRepositoryHandler {
  * @example-ref examples/repo/get.js
  *
  * @param {string} id Repository ID.
- * @return {object} The repository (as JSON).
+ * @return {object | null} The repository (as JSON), or `null` if no repository exists with the given id.
  *
  */
 export function get(id: string): Repository | null {
@@ -350,7 +350,7 @@ interface GetRepositoryBinaryHandler {
  *
  * @param {object} params JSON with the parameters.
  * @param {string} params.repoId Repository ID.
- * @param {string} params.binaryReference to the binary.
+ * @param {string} params.binaryReference Reference to the binary.
  *
  * @returns {*} Stream of the attachment data.
  */


### PR DESCRIPTION
Part of #11991.

Audit findings for lib-repo:

- `refresh()`: JSDoc listed `[params.repo='com.enonic.cms.default']` and `[params.branch='master']` as defaults, but `RefreshHandler` inherits both from `ContextAccessor.current()` and only overrides them when the JS layer passes a non-null value. Dropped the bogus literal defaults and described the real fallback. Also fixed the copy-paste in the `branch` description ("Default is the current repository set in portal." -> branch).
- `refresh()`: TS signature marked `params` as required, but the body uses `params ?? {}` and the example calls `repoLib.refresh()` with no args. Marked `params?` optional in the TS signature too.
- `get()`: JSDoc said `@return {object}` unconditionally, but `GetRepositoryHandler.execute()` returns `null` when the repository is not found (and the TS return type already reflected that). Documented the null case.
- `getBinary()`: fixed grammar in `params.binaryReference` description ("binaryReference to the binary." -> "Reference to the binary.").

Java handler behavior is unchanged — only the JSDoc and TS type declarations in `repo.ts` were updated to match what the runtime actually does.

Tests: `./gradlew :lib:lib-repo:test` green locally; the `:lib:typescript` task also re-emits the published `repo.d.ts` cleanly with these edits.