### PR TITLE
lib-scheduler JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-scheduler/src/main/resources/lib/xp/scheduler.ts
+++ b/modules/lib/lib-scheduler/src/main/resources/lib/xp/scheduler.ts
@@ -97,7 +97,7 @@ interface CreateScheduledJobHandler<Config extends Record<string, unknown>> {
  * @param {object} params.schedule task time run config.
  * @param {string} params.schedule.value schedule value according to its type.
  * @param {string} params.schedule.type schedule type (CRON | ONE_TIME).
- * @param {string} params.schedule.timezone time zone of cron scheduling.
+ * @param {string} [params.schedule.timeZone] time zone of cron scheduling. Only applies when type is `CRON`.
  * @param {string} [params.user] key of the user that submitted the task.
  * @param {boolean} params.enabled job is active or not.
  */


### PR DESCRIPTION
Part of #11991.

Audit findings for `lib-scheduler` (`modules/lib/lib-scheduler/src/main/resources/lib/xp/scheduler.ts`):

- `create()` JSDoc documented the field as `params.schedule.timezone` (lowercase z), but:
  - The Java handler reads it as `timeZone` (`BaseSchedulerHandler.buildCalendar` line 44: `calendarScriptValue.get("timeZone")`).
  - The TypeScript `CronSchedule` interface defines it as `timeZone`.
  - All in-tree examples (`examples/scheduler/create.js`) and unit tests (`CreateScheduledJobHandlerTest.js`) use `timeZone`.
- The same JSDoc line listed `timeZone` as required, but the TypeScript types use a discriminated union — `timeZone` is part of `CronSchedule` only, never `OneTimeSchedule` — so the field should be marked optional with a note that it applies only to CRON schedules.

Fix: rename to `timeZone`, mark optional, clarify CRON-only applicability. Java handler behavior is unchanged.

`./gradlew :lib:lib-scheduler:test` runs green; the module has no `integrationTest` source set.