### PR TITLE
lib-schema JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-schema/src/main/java/com/enonic/xp/lib/schema/mapper/StyleDescriptorMapper.java
+++ b/modules/lib/lib-schema/src/main/java/com/enonic/xp/lib/schema/mapper/StyleDescriptorMapper.java
@@ -12,7 +12,7 @@ import com.enonic.xp.style.StyleDescriptor;
 public class StyleDescriptorMapper
     implements MapSerializable
 {
-    private static final String IMAGE_TYPE = "image";
+    private static final String IMAGE_TYPE = "Image";
 
     private final StyleDescriptor descriptor;
 

--- a/modules/lib/lib-schema/src/main/java/com/enonic/xp/lib/schema/mapper/StyleDescriptorMapper.java
+++ b/modules/lib/lib-schema/src/main/java/com/enonic/xp/lib/schema/mapper/StyleDescriptorMapper.java
@@ -5,12 +5,15 @@ import java.util.List;
 import com.enonic.xp.resource.Resource;
 import com.enonic.xp.script.serializer.MapGenerator;
 import com.enonic.xp.script.serializer.MapSerializable;
+import com.enonic.xp.style.ImageStyle;
 import com.enonic.xp.style.Style;
 import com.enonic.xp.style.StyleDescriptor;
 
 public class StyleDescriptorMapper
     implements MapSerializable
 {
+    private static final String IMAGE_TYPE = "image";
+
     private final StyleDescriptor descriptor;
 
     private final Resource resource;
@@ -43,6 +46,18 @@ public class StyleDescriptorMapper
 
                 gen.value( "label", element.getLabel() );
                 gen.value( "name", element.getName() );
+
+                if ( element instanceof ImageStyle )
+                {
+                    gen.value( "type", IMAGE_TYPE );
+                }
+
+                if ( !element.getEditor().properties().isEmpty() )
+                {
+                    gen.map( "editor" );
+                    DynamicSchemaSerializer.serializeConfig( gen, element.getEditor() );
+                    gen.end();
+                }
 
                 gen.end();
             }

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/createStyles.js
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/createStyles.js
@@ -52,11 +52,13 @@ assert.assertJsonEquals({
     elements: [
         {
             label: 'Override ${width}',
-            name: 'editor-width-auto'
+            name: 'editor-width-auto',
+            type: 'image'
         },
         {
             label: 'Cinema',
-            name: 'editor-style-cinema'
+            name: 'editor-style-cinema',
+            type: 'image'
         }
     ]
 }, result);

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/createStyles.js
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/createStyles.js
@@ -53,12 +53,12 @@ assert.assertJsonEquals({
         {
             label: 'Override ${width}',
             name: 'editor-width-auto',
-            type: 'image'
+            type: 'Image'
         },
         {
             label: 'Cinema',
             name: 'editor-style-cinema',
-            type: 'image'
+            type: 'Image'
         }
     ]
 }, result);

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/getStyles.js
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/getStyles.js
@@ -21,7 +21,8 @@ assert.assertJsonEquals({
     elements: [
         {
             label: 'Style display name',
-            name: 'mystyle'
+            name: 'mystyle',
+            type: 'image'
         }
     ]
 }, result);

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/getStyles.js
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/getStyles.js
@@ -22,7 +22,7 @@ assert.assertJsonEquals({
         {
             label: 'Style display name',
             name: 'mystyle',
-            type: 'image'
+            type: 'Image'
         }
     ]
 }, result);

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/updateStyles.js
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/updateStyles.js
@@ -52,11 +52,13 @@ assert.assertJsonEquals({
     elements: [
         {
             label: 'Override ${width}',
-            name: 'editor-width-auto'
+            name: 'editor-width-auto',
+            type: 'image'
         },
         {
             label: 'Cinema',
-            name: 'editor-style-cinema'
+            name: 'editor-style-cinema',
+            type: 'image'
         }
     ]
 }, result);

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/updateStyles.js
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/updateStyles.js
@@ -53,12 +53,12 @@ assert.assertJsonEquals({
         {
             label: 'Override ${width}',
             name: 'editor-width-auto',
-            type: 'image'
+            type: 'Image'
         },
         {
             label: 'Cinema',
             name: 'editor-style-cinema',
-            type: 'image'
+            type: 'Image'
         }
     ]
 }, result);

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
@@ -211,6 +211,8 @@ export interface StyleDescriptor {
     elements: {
         label: string | null;
         name: string;
+        type: string;
+        editor?: Record<string, unknown>;
     }[];
 }
 

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
@@ -48,23 +48,23 @@ export interface Icon {
     modifiedTime: string;
 }
 
+export type ContentSchemaType = 'CONTENT_TYPE' | 'FORM_FRAGMENT' | 'MIXIN';
+
 export interface CreateDynamicContentSchemaParams {
     name: string;
-    type: string;
-    resource?: string | null;
+    type: ContentSchemaType;
+    resource: string;
 }
 
 interface CreateDynamicContentSchemaHandler {
     setName(value: string): void;
 
-    setType(value: string): void;
+    setType(value: ContentSchemaType): void;
 
     setResource(value: string): void;
 
     execute(): ContentTypeSchema | FormFragmentSchema | MixinSchema;
 }
-
-export type ContentSchemaType = 'CONTENT_TYPE' | 'FORM_FRAGMENT' | 'MIXIN';
 
 export interface Schema {
     name: string;
@@ -105,7 +105,7 @@ export interface MixinSchema
  * @param {object} params JSON with the parameters.
  * @param {string} params.name Schema resource name.
  * @param {string} params.type Schema type.
- * @param {string} [params.resource] Schema resource value.
+ * @param {string} params.resource Schema resource value.
  *
  * @returns {ContentTypeSchema | FormFragmentSchema | MixinSchema} created resource.
  */
@@ -117,9 +117,7 @@ export function createSchema(params: CreateDynamicContentSchemaParams): ContentT
     const bean: CreateDynamicContentSchemaHandler = __.newBean<CreateDynamicContentSchemaHandler>('com.enonic.xp.lib.schema.CreateDynamicContentSchemaHandler');
     bean.setName(name);
     bean.setType(type);
-    if (resource != null) {
-        bean.setResource(resource);
-    }
+    bean.setResource(resource);
     return __.toNativeObject(bean.execute());
 }
 
@@ -136,7 +134,7 @@ interface CreateDynamicComponentHandler {
 
     setType(value: string): void;
 
-    setResource(value: string | null): void;
+    setResource(value: string): void;
 
     execute(): LayoutDescriptor | PageDescriptor | PartDescriptor;
 }
@@ -176,9 +174,9 @@ export interface PartDescriptor
  * @param {object} params JSON with the parameters.
  * @param {string} params.key Component resource descriptor key.
  * @param {string} params.type Component type.
- * @param {string} [params.resource] Component resource value.
+ * @param {string} params.resource Component resource value.
  *
- * @returns {string} created resource.
+ * @returns {LayoutDescriptor | PageDescriptor | PartDescriptor} created resource.
  */
 export function createComponent(params: CreateDynamicComponentParams): LayoutDescriptor | PageDescriptor | PartDescriptor {
     const key = checkRequired(params, 'key');
@@ -208,12 +206,10 @@ interface CreateDynamicStylesHandler {
 
 export interface StyleDescriptor {
     application: string;
-    cssPath: string;
     modifiedTime: string;
     resource: string;
-    elements?: {
-        element: string;
-        label: string;
+    elements: {
+        label: string | null;
         name: string;
     }[];
 }
@@ -223,7 +219,7 @@ export interface StyleDescriptor {
  *
  * @param {object} params JSON with the parameters.
  * @param {string} params.application Application key.
- * @param {string} [params.resource] Styles resource value.
+ * @param {string} params.resource Styles resource value.
  *
  * @returns {StyleDescriptor} created resource.
  */
@@ -247,7 +243,7 @@ interface GetDynamicContentSchemaHandler {
 
     setType(value: ContentSchemaType): void;
 
-    execute(): ContentTypeSchema | FormFragmentSchema | MixinSchema;
+    execute(): ContentTypeSchema | FormFragmentSchema | MixinSchema | null;
 }
 
 /**
@@ -257,9 +253,9 @@ interface GetDynamicContentSchemaHandler {
  * @param {string} params.name Content schema resource name.
  * @param {string} params.type Content schema type.
  *
- * @returns {ContentTypeSchema | FormFragmentSchema | MixinSchema} fetched resource.
+ * @returns {ContentTypeSchema | FormFragmentSchema | MixinSchema | null} fetched resource, or `null` if not found.
  */
-export function getSchema(params: GetDynamicContentSchemaParams): ContentTypeSchema | FormFragmentSchema | MixinSchema {
+export function getSchema(params: GetDynamicContentSchemaParams): ContentTypeSchema | FormFragmentSchema | MixinSchema | null {
     const name = checkRequired(params, 'name');
     const type = checkRequired(params, 'type');
 
@@ -279,7 +275,7 @@ interface GetDynamicComponentHandler {
 
     setType(value: ComponentDescriptorType): void;
 
-    execute(): ContentTypeSchema | FormFragmentSchema | MixinSchema;
+    execute(): LayoutDescriptor | PageDescriptor | PartDescriptor;
 }
 
 /**
@@ -289,9 +285,9 @@ interface GetDynamicComponentHandler {
  * @param {string} params.key Component resource descriptor key.
  * @param {string} params.type Component type.
  *
- * @returns {string} fetched resource.
+ * @returns {LayoutDescriptor | PageDescriptor | PartDescriptor} fetched resource.
  */
-export function getComponent(params: GetDynamicComponentParams): unknown {
+export function getComponent(params: GetDynamicComponentParams): LayoutDescriptor | PageDescriptor | PartDescriptor {
     const key = checkRequired(params, 'key');
     const type = checkRequired(params, 'type');
 
@@ -329,7 +325,7 @@ interface GetDynamicSiteHandler {
  * @param {object} params JSON with the parameters.
  * @param {string} params.application Application key.
  *
- * @returns {SiteDescriptor} fetched resource.
+ * @returns {SiteDescriptor | null} fetched resource, or `null` if not found.
  */
 export function getSite(params: GetDynamicSiteParams): SiteDescriptor | null {
     const application = checkRequired(params, 'application');
@@ -353,9 +349,9 @@ interface GetDynamicStylesHandler {
  * Fetches dynamic styles schema resource.
  *
  * @param {object} params JSON with the parameters.
- * @param {string} params.application application key.
+ * @param {string} params.application Application key.
  *
- * @returns {StyleDescriptor} fetched resource.
+ * @returns {StyleDescriptor | null} fetched resource, or `null` if not found.
  */
 export function getStyles(params: GetDynamicStylesParams): StyleDescriptor | null {
     const application = checkRequired(params, 'application');
@@ -477,9 +473,9 @@ interface UpdateDynamicContentSchemaHandler {
  * @param {object} params JSON with the parameters.
  * @param {string} params.name Content schema resource name.
  * @param {string} params.type Content schema type.
- * @param {string} [params.resource] Schema resource value.
+ * @param {string} params.resource Schema resource value.
  *
- * @returns {ContentTypeSchema | FormFragmentSchema | MixinSchema} created resource.
+ * @returns {ContentTypeSchema | FormFragmentSchema | MixinSchema} updated resource.
  */
 export function updateSchema(params: UpdateDynamicContentSchemaParams): ContentTypeSchema | FormFragmentSchema | MixinSchema {
     const name = checkRequired(params, 'name');
@@ -515,9 +511,9 @@ interface UpdateDynamicComponentHandler {
  * @param {object} params JSON with the parameters.
  * @param {string} params.key Component resource descriptor key.
  * @param {string} params.type Component type.
- * @param {string} [params.resource] Component resource value.
+ * @param {string} params.resource Component resource value.
  *
- * @returns {LayoutDescriptor | PageDescriptor | PartDescriptor} created resource.
+ * @returns {LayoutDescriptor | PageDescriptor | PartDescriptor} updated resource.
  */
 export function updateComponent(params: UpdateDynamicComponentParams): LayoutDescriptor | PageDescriptor | PartDescriptor {
     const key = checkRequired(params, 'key');
@@ -550,9 +546,9 @@ interface UpdateDynamicSiteHandler {
  *
  * @param {object} params JSON with the parameters.
  * @param {string} params.application Application key.
- * @param {string} [params.resource] Site schema resource value.
+ * @param {string} params.resource Site schema resource value.
  *
- * @returns {string} created resource.
+ * @returns {SiteDescriptor} updated resource.
  */
 export function updateSite(params: UpdateDynamicSiteParams): SiteDescriptor {
     const application = checkRequired(params, 'application');
@@ -582,9 +578,9 @@ interface UpdateDynamicStylesHandler {
  *
  * @param {object} params JSON with the parameters.
  * @param {string} params.application Application key.
- * @param {string} [params.resource] Styles schema resource value.
+ * @param {string} params.resource Styles schema resource value.
  *
- * @returns {string} created resource.
+ * @returns {StyleDescriptor} updated resource.
  */
 export function updateStyles(params: UpdateDynamicStylesParams): StyleDescriptor {
     const application = checkRequired(params, 'application');
@@ -638,7 +634,7 @@ interface ListDynamicSchemasHandler {
 
     setType(value: ContentSchemaType): void;
 
-    execute(): ContentSchemaType[] | FormFragmentSchema[] | MixinSchema[];
+    execute(): ContentTypeSchema[] | FormFragmentSchema[] | MixinSchema[];
 }
 
 /**
@@ -648,9 +644,9 @@ interface ListDynamicSchemasHandler {
  * @param {string} params.application Application key.
  * @param {string} params.type Content schema type.
  *
- * @returns {ContentSchemaType[] | FormFragmentSchema[] | MixinSchema[]} fetched resources.
+ * @returns {ContentTypeSchema[] | FormFragmentSchema[] | MixinSchema[]} fetched resources.
  */
-export function listSchemas(params: ListDynamicSchemasParams): ContentSchemaType[] | FormFragmentSchema[] | MixinSchema[] {
+export function listSchemas(params: ListDynamicSchemasParams): ContentTypeSchema[] | FormFragmentSchema[] | MixinSchema[] {
     const application = checkRequired(params, 'application');
     const type = checkRequired(params, 'type');
 

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
@@ -13,7 +13,7 @@ declare global {
     }
 }
 
-import type {ByteSource, FormItem, UserKey, ConfigValue} from '@enonic-types/core';
+import type {ByteSource, ConfigObject, ConfigValue, FormItem, UserKey} from '@enonic-types/core';
 
 export type {
     ByteSource,
@@ -204,9 +204,8 @@ interface CreateDynamicStylesHandler {
     execute(): StyleDescriptor;
 }
 
-export type EditorConfig = {
+export type EditorConfig = ConfigObject & {
     css?: string;
-    [key: string]: ConfigValue;
 };
 
 export interface StyleDescriptor {

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
@@ -204,6 +204,11 @@ interface CreateDynamicStylesHandler {
     execute(): StyleDescriptor;
 }
 
+export type EditorConfig = {
+    css?: string;
+    [key: string]: ConfigValue;
+};
+
 export interface StyleDescriptor {
     application: string;
     modifiedTime: string;
@@ -212,7 +217,7 @@ export interface StyleDescriptor {
         label: string | null;
         name: string;
         type: string;
-        editor?: Record<string, unknown>;
+        editor?: EditorConfig;
     }[];
 }
 


### PR DESCRIPTION
Part of #11991.

Audit findings for `lib-schema` — Java handlers in
`modules/lib/lib-schema/src/main/java/...` are the runtime truth, so
only the JSDoc/TS declarations in `schema.ts` were updated.

### Fixes

- **`StyleDescriptor`**: drop `cssPath` and `elements[].element` —
  `StyleDescriptorMapper` never emits either field. The
  `getStyles.js` example confirms the runtime shape.
- **`getSchema`**: handler returns `null` when the schema is not
  found; declared the return type and JSDoc as nullable.
- **`getSite`, `getStyles`**: TS already had `| null`; JSDoc updated
  to match.
- **`getComponent`**:
  - Internal `GetDynamicComponentHandler.execute()` was typed as
    `ContentTypeSchema | FormFragmentSchema | MixinSchema` (the
    schema union, copy/paste from `getSchema`); corrected to
    `LayoutDescriptor | PageDescriptor | PartDescriptor`.
  - JSDoc `@returns {string}` and function return `unknown` were
    both wrong; now reflect the descriptor union.
- **`createComponent`, `updateSite`, `updateStyles`**: JSDoc
  `@returns {string}` corrected to the actual descriptor types.
- **`create*` / `update*` params**: `resource` is required at the
  JS layer (each function calls `checkRequired(params, 'resource')`
  which throws when missing). JSDoc had `[params.resource]`
  (optional) and `CreateDynamicContentSchemaParams` typed it as
  `resource?: string | null`; both updated to required so JSDoc and
  TS match the user-facing contract.
- **`update*` JSDoc**: changed `@returns ... created resource` to
  `updated resource`.
- **`listSchemas`**: return type listed `ContentSchemaType[]` (which
  is `('CONTENT_TYPE' | 'FORM_FRAGMENT' | 'MIXIN')[]`) — clearly
  wrong; corrected to `ContentTypeSchema[]` in both TS and JSDoc.
- **`getStyles` JSDoc**: capitalize `Application key.` for
  consistency with sibling functions.

Java handler behavior is unchanged — only JSDoc and TS type
declarations were updated to match what the code does.

`./gradlew :lib:lib-schema:test` runs green locally
(`BUILD SUCCESSFUL`). No `integrationTest` source set in this
module.