### PR TITLE
lib-sse JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-sse/src/main/resources/lib/xp/sse.ts
+++ b/modules/lib/lib-sse/src/main/resources/lib/xp/sse.ts
@@ -179,6 +179,7 @@ export function removeFromGroup(params: RemoveFromGroupParams): void {
  *
  * @param {object} params JSON with the parameters.
  * @param {string} params.group Group name.
+ * @returns {number} Number of connections in the group, or 0 if the group has no members.
  */
 export function getGroupSize(params: GetGroupSizeParams): number {
     const bean = __.newBean<SseManagerBean>('com.enonic.xp.lib.sse.SseManagerBean');


### PR DESCRIPTION
Part of #11991.

Audit findings for lib-sse:
- `getGroupSize` JSDoc was missing `@returns {number}` even though the TypeScript signature already returns `number` and the Java handler (`SseManagerBean.getGroupSize`) returns `int`. Added the tag with a short description noting that an unknown/empty group yields `0` (the underlying `SseManagerImpl` counts the registry stream and returns `0` when the group has no members; it does not throw).

All other functions (`send`, `sendToGroup`, `close`, `isOpen`, `addToGroup`, `removeFromGroup`) had JSDoc, TS types, and Java handler signatures in agreement.

Java handler behavior is unchanged — only JSDoc was updated to match what the code does.