### PR TITLE
lib-value JSDoc fixes #11991

### DIFF
--- a/modules/lib/lib-value/src/main/resources/lib/xp/value.ts
+++ b/modules/lib/lib-value/src/main/resources/lib/xp/value.ts
@@ -200,7 +200,7 @@ interface LocalDateHandler {
 
 /**
  * Creates a LocalDate java-type.
- * @param {string|Date} value A ISO local date-time string (e.g '2011-12-03'), or a Date object.
+ * @param {string|Date} value An ISO local date string (e.g '2011-12-03'), or a Date object.
  *
  * @returns {*} LocalDate java-type
  */
@@ -230,7 +230,7 @@ interface LocalTimeHandler {
 
 /**
  * Creates a LocalTime java-type.
- * @param {string|Date} value A ISO local date-time string (e.g '10:15:30'), or a Date object.
+ * @param {string|Date} value An ISO local time string (e.g '10:15:30'), or a Date object.
  *
  * @returns {*} LocalTime java-type
  */


### PR DESCRIPTION
Part of #11991.

Audit findings for lib-value:
- `localDate(value)` — JSDoc described the input as "A ISO local **date-time** string (e.g '2011-12-03')". The Java handler `LocalDateHandler.parse(String)` calls `LocalDate.parse(String)`, which expects an ISO local date. The example was already correct; fixed the description (and the leading "A" → "An" since "ISO" begins with a vowel sound).
- `localTime(value)` — same copy-paste error: "A ISO local **date-time** string (e.g '10:15:30')". The Java handler `LocalTimeHandler.parse(String)` calls `LocalTime.parse(String)`, which expects an ISO local time. Description corrected.

Everything else in `value.ts` already agrees with the Java handlers (`GeoPointHandler`, `InstantHandler`, `ReferenceHandler`, `LocalDateTimeHandler`, `BinaryReferenceHandler`, `BinaryAttachmentHandler`).

Java handler behavior is unchanged — only the JSDoc descriptions were updated to match what the code does.

`./gradlew :lib:lib-value:test` is green locally.