### PR TITLE
lib-websocket JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-websocket/src/main/resources/lib/xp/websocket.ts
+++ b/modules/lib/lib-websocket/src/main/resources/lib/xp/websocket.ts
@@ -83,6 +83,8 @@ export function sendToGroup(group: string, message: string): void {
  * @example-ref examples/websocket/addToGroup.js
  *
  * @param {string} group Group name.
+ *
+ * @returns {number} Number of sockets in the group.
  */
 export function getGroupSize(group: string): number {
     const bean: WebSocketManagerBean = __.newBean<WebSocketManagerBean>('com.enonic.xp.lib.websocket.WebSocketManagerBean');


### PR DESCRIPTION
Part of #11991.

Audit findings for lib-websocket:
- `getGroupSize` was missing a JSDoc `@returns` tag. The Java handler (`WebSocketManagerBean.getGroupSize`) returns `int` and the TS signature returns `number`, but the JSDoc gave no clue about the return value. Added `@returns {number} Number of sockets in the group.`

All other functions (`addToGroup`, `removeFromGroup`, `send`, `sendToGroup`) — JSDoc, TypeScript types, and Java handler signatures already agree.

Java handler behavior is unchanged — only JSDoc was updated to match what the code does.