### PR TITLE
lib-app JSDoc/TS fixes #11991

### DIFF
--- a/modules/lib/lib-app/src/main/java/com/enonic/xp/lib/app/mapper/ApplicationDescriptorMapper.java
+++ b/modules/lib/lib-app/src/main/java/com/enonic/xp/lib/app/mapper/ApplicationDescriptorMapper.java
@@ -20,6 +20,7 @@ public class ApplicationDescriptorMapper
     {
         gen.value( "key", descriptor.getKey() );
         gen.value( "description", descriptor.getDescription() );
+        gen.value( "descriptionI18nKey", descriptor.getDescriptionI18nKey() );
         gen.value( "title", descriptor.getTitle() );
         gen.value( "titleI18nKey", descriptor.getTitleI18nKey() );
         gen.value( "vendorName", descriptor.getVendorName() );

--- a/modules/lib/lib-app/src/main/resources/lib/xp/app.ts
+++ b/modules/lib/lib-app/src/main/resources/lib/xp/app.ts
@@ -143,6 +143,7 @@ export interface Icon {
 export interface ApplicationDescriptor {
     key: string;
     description: string;
+    descriptionI18nKey: string | null;
     title: string | null;
     titleI18nKey: string | null;
     vendorName: string | null;

--- a/modules/lib/lib-app/src/test/java/com/enonic/xp/lib/app/GetApplicationDescriptorHandlerTest.java
+++ b/modules/lib/lib-app/src/test/java/com/enonic/xp/lib/app/GetApplicationDescriptorHandlerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import com.enonic.xp.app.ApplicationDescriptor;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.icon.Icon;
+import com.enonic.xp.schema.LocalizedText;
 
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
@@ -40,7 +41,7 @@ class GetApplicationDescriptorHandlerTest
 
             return ApplicationDescriptor.create()
                 .key( applicationKey )
-                .description( "my app description" )
+                .description( new LocalizedText( "my app description", "app.description.key" ) )
                 .title( "Title" )
                 .titleI18nKey( "app.title.key" )
                 .vendorName(  "Vendor Name" )

--- a/modules/lib/lib-app/src/test/resources/test/GetApplicationDescriptorHandlerTest.js
+++ b/modules/lib/lib-app/src/test/resources/test/GetApplicationDescriptorHandlerTest.js
@@ -9,6 +9,7 @@ exports.getWithoutIcon = function () {
     assert.assertJsonEquals({
         'key': '123456',
         'description': 'my app description',
+        'descriptionI18nKey': 'app.description.key',
         'title': 'Title',
         'titleI18nKey': 'app.title.key',
         'vendorName': 'Vendor Name',


### PR DESCRIPTION
Adds `descriptionI18nKey` to the `ApplicationDescriptor` JS API output, matching how `title` / `titleI18nKey` are exposed. Underlying model already carries the field.

Part of #11991.

🤖 Generated with [Claude Code](https://claude.com/claude-code)