### PR TITLE
lib-schema ImageStyle fields #11991

### DIFF
--- a/modules/lib/lib-schema/src/main/java/com/enonic/xp/lib/schema/mapper/StyleDescriptorMapper.java
+++ b/modules/lib/lib-schema/src/main/java/com/enonic/xp/lib/schema/mapper/StyleDescriptorMapper.java
@@ -47,9 +47,11 @@ public class StyleDescriptorMapper
                 gen.value( "label", element.getLabel() );
                 gen.value( "name", element.getName() );
 
-                if ( element instanceof ImageStyle )
+                if ( element instanceof ImageStyle imageStyle )
                 {
                     gen.value( "type", IMAGE_TYPE );
+                    gen.value( "aspectRatio", imageStyle.getAspectRatio() );
+                    gen.value( "filter", imageStyle.getFilter() );
                 }
 
                 if ( !element.getEditor().properties().isEmpty() )

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/createStyles.js
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/createStyles.js
@@ -58,7 +58,9 @@ assert.assertJsonEquals({
         {
             label: 'Cinema',
             name: 'editor-style-cinema',
-            type: 'Image'
+            type: 'Image',
+            aspectRatio: '21:9',
+            filter: 'pixelate(10)'
         }
     ]
 }, result);

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/getStyles.js
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/getStyles.js
@@ -22,6 +22,13 @@ assert.assertJsonEquals({
         {
             label: 'Style display name',
             name: 'mystyle',
+            type: 'Image',
+            aspectRatio: '16:9',
+            filter: 'sharpen()'
+        },
+        {
+            label: 'Plain',
+            name: 'plain',
             type: 'Image'
         }
     ]

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/updateStyles.js
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/examples/schema/updateStyles.js
@@ -58,7 +58,9 @@ assert.assertJsonEquals({
         {
             label: 'Cinema',
             name: 'editor-style-cinema',
-            type: 'Image'
+            type: 'Image',
+            aspectRatio: '21:9',
+            filter: 'pixelate(10)'
         }
     ]
 }, result);

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
@@ -216,6 +216,8 @@ export interface StyleDescriptor {
         label: string | null;
         name: string;
         type: string;
+        aspectRatio?: string | null;
+        filter?: string | null;
         editor?: EditorConfig;
     }[];
 }

--- a/modules/lib/lib-schema/src/test/java/com/enonic/xp/lib/schema/GetDynamicStylesHandlerTest.java
+++ b/modules/lib/lib-schema/src/test/java/com/enonic/xp/lib/schema/GetDynamicStylesHandlerTest.java
@@ -30,6 +30,12 @@ class GetDynamicStylesHandlerTest
 
                                       .name( "mystyle" )
                                       .labelI18nKey( "style.display" )
+                                      .aspectRatio( "16:9" )
+                                      .filter( "sharpen()" )
+                                      .build() )
+                .addStyleElement( ImageStyle.create()
+                                      .label( "Plain" )
+                                      .name( "plain" )
                                       .build() )
                 .modifiedTime( Instant.parse( "2021-02-25T10:44:33.170079900Z" ) )
                 .build();


### PR DESCRIPTION
## Summary

Expose `aspectRatio` and `filter` on `ImageStyle` through the
lib-schema JS API.

The original lib-schema audit landed in #12008 before this slice
could be pushed to that branch — opening as a follow-up PR rather
than reusing the merged branch (matches the pattern used by #12018).
Same audit scope (#11991), same authoring approach: the underlying
YAML parser (`YmlStyleDescriptorParser`) already binds both fields
onto `ImageStyle`, and `RichTextProcessor` / `DefaultImageLinkProcessor`
read them at render time. Only `StyleDescriptorMapper` was dropping
them on the way back out to JS.

### Changes

- `StyleDescriptorMapper`: pattern-match the `ImageStyle` branch and
  emit `aspectRatio` + `filter` alongside `type`. `MapGenerator.value`
  silently omits null, so the keys only appear when populated.
- `schema.ts`: add optional `aspectRatio?: string | null;` and
  `filter?: string | null;` to `StyleDescriptor.elements[]`.
- Examples: `createStyles.js` / `updateStyles.js` already declared
  the fields in their YAML — assertion shapes now expect them on
  the `editor-style-cinema` element. `getStyles.js` fixture extended
  with one element carrying both fields and a companion element with
  neither (covers the null-omission path).

Refs #11991

## Test plan

- [x] `./gradlew :lib:lib-schema:test` — all tests green locally
- [x] `npm run build` (TypeScript declaration build) — clean
- [ ] CI: build + selenium-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)