### PR TITLE
Expose sha512 and textContent on attachments

### DIFF
--- a/modules/lib/core/index.d.ts
+++ b/modules/lib/core/index.d.ts
@@ -563,6 +563,8 @@ export interface Attachment {
     label?: string;
     size: number;
     mimeType: string;
+    sha512?: string | null;
+    textContent?: string | null;
 }
 
 export interface DataValidationError

--- a/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/mapper/AttachmentsMapper.java
+++ b/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/mapper/AttachmentsMapper.java
@@ -33,5 +33,7 @@ public final class AttachmentsMapper
         gen.value( "label", attachment.getLabel() );
         gen.value( "size", attachment.getSize() );
         gen.value( "mimeType", attachment.getMimeType() );
+        gen.value( "sha512", attachment.getSha512() );
+        gen.value( "textContent", attachment.getTextContent() );
     }
 }

--- a/modules/lib/lib-content/src/test/java/com/enonic/xp/lib/content/mapper/AttachmentsMapperTest.java
+++ b/modules/lib/lib-content/src/test/java/com/enonic/xp/lib/content/mapper/AttachmentsMapperTest.java
@@ -1,0 +1,60 @@
+package com.enonic.xp.lib.content.mapper;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import com.enonic.xp.attachment.Attachment;
+import com.enonic.xp.attachment.Attachments;
+import com.enonic.xp.testing.serializer.JsonMapGenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AttachmentsMapperTest
+{
+    @Test
+    void allFieldsPopulated()
+    {
+        final Attachment attachment = Attachment.create()
+            .name( "report.pdf" )
+            .label( "Report" )
+            .mimeType( "application/pdf" )
+            .size( 1234L )
+            .sha512( "deadbeef" )
+            .textContent( "Quarterly report contents" )
+            .build();
+
+        final JsonNode node = serialize( Attachments.from( attachment ) ).get( "report.pdf" );
+
+        assertThat( node.get( "name" ).asText() ).isEqualTo( "report.pdf" );
+        assertThat( node.get( "label" ).asText() ).isEqualTo( "Report" );
+        assertThat( node.get( "size" ).asLong() ).isEqualTo( 1234L );
+        assertThat( node.get( "mimeType" ).asText() ).isEqualTo( "application/pdf" );
+        assertThat( node.get( "sha512" ).asText() ).isEqualTo( "deadbeef" );
+        assertThat( node.get( "textContent" ).asText() ).isEqualTo( "Quarterly report contents" );
+    }
+
+    @Test
+    void sha512AndTextContentNullEmittedAsNull()
+    {
+        final Attachment attachment = Attachment.create()
+            .name( "image.png" )
+            .mimeType( "image/png" )
+            .size( 42L )
+            .build();
+
+        final JsonNode node = serialize( Attachments.from( attachment ) ).get( "image.png" );
+
+        assertThat( node.has( "sha512" ) ).isTrue();
+        assertThat( node.get( "sha512" ).isNull() ).isTrue();
+        assertThat( node.has( "textContent" ) ).isTrue();
+        assertThat( node.get( "textContent" ).isNull() ).isTrue();
+    }
+
+    private JsonNode serialize( final Attachments attachments )
+    {
+        final JsonMapGenerator generator = new JsonMapGenerator();
+        new AttachmentsMapper( attachments ).serialize( generator );
+        return (JsonNode) generator.getRoot();
+    }
+}


### PR DESCRIPTION
## Summary

The lib-content [`AttachmentsMapper`](https://github.com/enonic/xp/blob/master/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/mapper/AttachmentsMapper.java) only emitted `name`, `label`, `size`, `mimeType` — even though the underlying `Attachment` model has carried `sha512` and `textContent` for some time. As a result, those two fields were invisible to anything reading attachments via `/lib/xp/content` (e.g. `contentLib.get(...)` / `contentLib.getAttachments(...)`), including Content Studio's JSON preview, which renders the lib-content view rather than the app-contentstudio-side `AttachmentJson`.

This PR surfaces both fields:

- `AttachmentsMapper#serializeAttachment` now emits `sha512` and `textContent` (`MapGenerator.value` handles `null` fine; on the script side the existing `ScriptMapGenerator` filters nulls out, so existing JS callers that don't expect these keys are unaffected).
- The `Attachment` interface in `@enonic-types/core` (`modules/lib/core/index.d.ts`) gains optional `sha512?: string | null` and `textContent?: string | null`.
- New `AttachmentsMapperTest` covers both the all-fields and null cases against `JsonMapGenerator`.

## Context

Follow-up to [app-contentstudio#10388 (comment by @arod1ique)](https://github.com/enonic/app-contentstudio/pull/10388#issuecomment-4371089923):

> To see the result in JSON preview we need to update modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/mapper/AttachmentsMapper.java

PR #10388 in app-contentstudio already plumbed `sha512` / `textContent` through the REST response and the TS model. The JSON preview path is independent and lives here in xp's lib-content.

## Test plan

- [x] `./gradlew :lib:lib-content:test` is green locally (new `AttachmentsMapperTest` runs 2 cases; existing `GetAttachmentsHandlerTest` JS spec still passes since null-valued fields are dropped by `ScriptMapGenerator`).
- [ ] CI green.
- [ ] Spot-check on a local XP: read an attachment via `contentLib.get(...)` / `contentLib.getAttachments(...)` and verify `sha512` / `textContent` are present when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)