### PR TITLE
Move attachment textContent to media data

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/attachment/Attachment.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/attachment/Attachment.java
@@ -22,8 +22,6 @@ public final class Attachment
 
     private final String sha512;
 
-    private final String textContent;
-
     public Attachment( final Builder builder )
     {
         this.mimeType = requireNonNull( builder.mimeType, "mimeType is mandatory for an Attachment" );
@@ -31,7 +29,6 @@ public final class Attachment
         this.sha512 = builder.sha512;
         this.size = builder.size;
         this.label = builder.label;
-        this.textContent = builder.textContent;
     }
 
     public String getMimeType()
@@ -74,11 +71,6 @@ public final class Attachment
         return sha512;
     }
 
-    public String getTextContent()
-    {
-        return textContent;
-    }
-
     @Override
     public boolean equals( final Object o )
     {
@@ -92,14 +84,13 @@ public final class Attachment
         }
         final Attachment that = (Attachment) o;
         return Objects.equals( this.name, that.name ) && Objects.equals( this.mimeType, that.mimeType ) &&
-            Objects.equals( this.label, that.label ) && this.size == that.size && Objects.equals( this.sha512, that.sha512 ) &&
-            Objects.equals( this.textContent, that.textContent );
+            Objects.equals( this.label, that.label ) && this.size == that.size && Objects.equals( this.sha512, that.sha512 );
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( name, mimeType, label, size, sha512, textContent );
+        return Objects.hash( name, mimeType, label, size, sha512 );
     }
 
     @Override
@@ -111,7 +102,6 @@ public final class Attachment
         s.add( "label", label );
         s.add( "size", size );
         s.add( "sha512", sha512 );
-        s.add( "textContent", textContent );
         return s.toString();
     }
 
@@ -137,8 +127,6 @@ public final class Attachment
 
         private long size;
 
-        private String textContent;
-
         private Builder()
         {
 
@@ -150,7 +138,6 @@ public final class Attachment
             this.name = attachment.name;
             this.label = attachment.label;
             this.size = attachment.size;
-            this.textContent = attachment.textContent;
             this.sha512 = attachment.sha512;
         }
 
@@ -181,12 +168,6 @@ public final class Attachment
         public Builder size( final long size )
         {
             this.size = size;
-            return this;
-        }
-
-        public Builder textContent( final String textContent )
-        {
-            this.textContent = textContent;
             return this;
         }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/attachment/AttachmentSerializer.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/attachment/AttachmentSerializer.java
@@ -33,7 +33,6 @@ public final class AttachmentSerializer
             attachmentSet.addString( ContentPropertyNames.ATTACHMENT_LABEL, createAttachment.getLabel() );
             attachmentSet.addBinaryReference( ContentPropertyNames.ATTACHMENT_BINARY_REF, createAttachment.getBinaryReference() );
             attachmentSet.addString( ContentPropertyNames.ATTACHMENT_MIMETYPE, createAttachment.getMimeType() );
-            attachmentSet.addString( ContentPropertyNames.ATTACHMENT_TEXT, createAttachment.getTextContent() );
             populateByteSourceProperties( createAttachment.getByteSource(), attachmentSet );
         }
     }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/attachment/CreateAttachment.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/attachment/CreateAttachment.java
@@ -18,15 +18,12 @@ public final class CreateAttachment
 
     private final ByteSource byteSource;
 
-    private final String textContent;
-
     private CreateAttachment( final Builder builder )
     {
         this.mimeType = builder.mimeType;
         this.name = builder.name;
         this.label = builder.label;
         this.byteSource = builder.byteSource;
-        this.textContent = builder.text;
     }
 
     public String getName()
@@ -64,11 +61,6 @@ public final class CreateAttachment
         return BinaryReference.from( name );
     }
 
-    public String getTextContent()
-    {
-        return textContent;
-    }
-
     public static Builder create()
     {
         return new Builder();
@@ -89,8 +81,6 @@ public final class CreateAttachment
 
         private String label;
 
-        private String text;
-
         private Builder()
         {
         }
@@ -101,7 +91,6 @@ public final class CreateAttachment
             this.mimeType = source.mimeType;
             this.label = source.label;
             this.byteSource = source.byteSource;
-            this.text = source.textContent;
         }
 
         public Builder mimeType( final String value )
@@ -125,12 +114,6 @@ public final class CreateAttachment
         public Builder byteSource( final ByteSource value )
         {
             byteSource = value;
-            return this;
-        }
-
-        public Builder text( final String value )
-        {
-            this.text = value;
             return this;
         }
 

--- a/modules/core/core-api/src/main/java/com/enonic/xp/content/ContentPropertyNames.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/content/ContentPropertyNames.java
@@ -8,8 +8,6 @@ public final class ContentPropertyNames
 
     public static final String APPLICATION_KEY = "applicationkey";
 
-    public static final String ATTACHMENT_TEXT_COMPONENT = "attachment.text";
-
     public static final String FORM = "form";
 
     public static final String SITE = "site";
@@ -54,6 +52,10 @@ public final class ContentPropertyNames
 
     public static final String MEDIA_IMAGE_HEIGHT = "imageHeight";
 
+    public static final String MEDIA_TEXT = "text";
+
+    public static final String MEDIA_TEXT_COMPONENT = "media.text";
+
     public static final String ATTACHMENT = "attachment";
 
     public static final String ATTACHMENT_LABEL = "label";
@@ -77,8 +79,6 @@ public final class ContentPropertyNames
     public static final String ATTACHMENT_SIZE = "size";
 
     public static final String ATTACHMENT_SHA512 = "sha512";
-
-    public static final String ATTACHMENT_TEXT = "text";
 
     public static final String OWNER = "owner";
 

--- a/modules/core/core-api/src/test/java/com/enonic/xp/attachment/AttachmentTest.java
+++ b/modules/core/core-api/src/test/java/com/enonic/xp/attachment/AttachmentTest.java
@@ -78,7 +78,7 @@ class AttachmentTest
             name( "MyImage.jpg" ).
             build();
 
-        assertEquals( "Attachment{name=MyImage.jpg, mimeType=image/jpeg, label=My Image 1, size=1024, sha512=null, textContent=null}", a1.toString() );
+        assertEquals( "Attachment{name=MyImage.jpg, mimeType=image/jpeg, label=My Image 1, size=1024, sha512=null}", a1.toString() );
 
     }
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentAuditLogSupportImpl.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/ContentAuditLogSupportImpl.java
@@ -3,7 +3,6 @@ package com.enonic.xp.core.impl.content;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
@@ -608,9 +607,6 @@ public class ContentAuditLogSupportImpl
         targetSet.addString( "mimeType", attachment.getMimeType() );
         targetSet.addString( "label", attachment.getLabel() );
         attachment.getByteSource().sizeIfKnown().toJavaUtil().ifPresent( ( size -> targetSet.addLong( "byteSize", size ) ) );
-        targetSet.addLong( "textSize", Optional.ofNullable( attachment.getTextContent() )
-            .map( textContent -> (long) textContent.length() )
-            .orElse( null ) );
     }
 
 

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateMediaCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreateMediaCommand.java
@@ -55,6 +55,7 @@ final class CreateMediaCommand
             .artist( params.getArtistList() )
             .copyright( params.getCopyright() )
             .tags( params.getTagList() )
+            .text( mediaInfo.getTextContent() )
             .build( data );
 
         final CreateAttachment mediaAttachment = CreateAttachment.create()
@@ -62,7 +63,6 @@ final class CreateMediaCommand
             .mimeType( mimeType )
             .label( "source" )
             .byteSource( params.getByteSource() )
-            .text( type.isTextualMedia() ? mediaInfo.getTextContent() : null )
             .build();
 
         final CreateContentParams createContentParams = CreateContentParams.create()

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreatedEventSyncCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/CreatedEventSyncCommand.java
@@ -80,7 +80,6 @@ final class CreatedEventSyncCommand
                                  .name( attachment.getName() )
                                  .label( attachment.getLabel() )
                                  .mimeType( attachment.getMimeType() )
-                                 .text( attachment.getTextContent() )
                                  .byteSource( binary )
                                  .build() );
         }

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/MediaFormDataBuilder.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/MediaFormDataBuilder.java
@@ -31,6 +31,8 @@ final class MediaFormDataBuilder
 
     private FocalPoint focalPoint;
 
+    private String text;
+
     public MediaFormDataBuilder type( final ContentTypeName type )
     {
         this.type = type;
@@ -79,6 +81,12 @@ final class MediaFormDataBuilder
         return this;
     }
 
+    MediaFormDataBuilder text( final String text )
+    {
+        this.text = text;
+        return this;
+    }
+
     void build( PropertyTree data )
     {
         requireNonNull( type, "type is required" );
@@ -95,6 +103,11 @@ final class MediaFormDataBuilder
                 set.setDouble( PropertyPath.from( ContentPropertyNames.MEDIA_FOCAL_POINT, ContentPropertyNames.MEDIA_FOCAL_POINT_Y ),
                                focalPoint.yOffset() );
             }
+        }
+
+        if ( type.isTextualMedia() && text != null )
+        {
+            set.setString( ContentPropertyNames.MEDIA_TEXT, text );
         }
 
         data.removeProperties( ContentPropertyNames.MEDIA );

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/PatchContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/PatchContentCommand.java
@@ -138,8 +138,7 @@ public class PatchContentCommand
         final Attachment.Builder builder = Attachment.create()
             .name( createAttachment.getName() )
             .label( createAttachment.getLabel() )
-            .mimeType( createAttachment.getMimeType() )
-            .textContent( createAttachment.getTextContent() );
+            .mimeType( createAttachment.getMimeType() );
 
         populateByteSourceProperties( createAttachment.getByteSource(), builder );
         return builder.build();

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateContentCommand.java
@@ -175,8 +175,7 @@ final class UpdateContentCommand
             final Attachment.Builder builder = Attachment.create()
                 .name( createAttachment.getName() )
                 .label( createAttachment.getLabel() )
-                .mimeType( createAttachment.getMimeType() )
-                .textContent( createAttachment.getTextContent() );
+                .mimeType( createAttachment.getMimeType() );
             populateByteSourceProperties( createAttachment.getByteSource(), builder );
 
             final Attachment attachment = builder.build();

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdateMediaCommand.java
@@ -59,7 +59,6 @@ final class UpdateMediaCommand
             .mimeType( mediaType )
             .label( "source" )
             .byteSource( params.getByteSource() )
-            .text( type.isTextualMedia() ? mediaInfo.getTextContent() : null )
             .build();
 
         final MediaFormDataBuilder mediaFormBuilder = new MediaFormDataBuilder().type( type )
@@ -69,7 +68,8 @@ final class UpdateMediaCommand
             .altText( params.getAltText() )
             .artist( params.getArtistList() )
             .copyright( params.getCopyright() )
-            .tags( params.getTagList() );
+            .tags( params.getTagList() )
+            .text( mediaInfo.getTextContent() );
 
         final UpdateContentParams updateParams = new UpdateContentParams().contentId( params.getContent() )
             .clearAttachments( true )

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdatedEventSyncCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UpdatedEventSyncCommand.java
@@ -73,7 +73,6 @@ final class UpdatedEventSyncCommand
                                         .name( sourceAttachment.getName() )
                                         .mimeType( sourceAttachment.getMimeType() )
                                         .byteSource( sourceBinary )
-                                        .text( sourceAttachment.getTextContent() )
                                         .label( sourceAttachment.getLabel() )
                                         .build() );
         } );

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/index/processor/AttachmentConfigProcessor.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/index/processor/AttachmentConfigProcessor.java
@@ -4,7 +4,7 @@ import com.enonic.xp.index.IndexConfig;
 import com.enonic.xp.index.PatternIndexConfigDocument;
 import com.enonic.xp.schema.content.ContentTypeName;
 
-import static com.enonic.xp.content.ContentPropertyNames.ATTACHMENT_TEXT_COMPONENT;
+import static com.enonic.xp.content.ContentPropertyNames.MEDIA_TEXT_COMPONENT;
 
 public class AttachmentConfigProcessor
     implements ContentIndexConfigProcessor
@@ -22,20 +22,10 @@ public class AttachmentConfigProcessor
 
         if ( contentTypeName.isTextualMedia() )
         {
-            configBuilder.add( ATTACHMENT_TEXT_COMPONENT, IndexConfig.create().
+            configBuilder.add( MEDIA_TEXT_COMPONENT, IndexConfig.create().
                 enabled( true ).
                 fulltext( true ).
                 includeInAllText( true ).
-                nGram( true ).
-                decideByType( false ).
-                build() );
-        }
-        else
-        {
-            configBuilder.add( ATTACHMENT_TEXT_COMPONENT, IndexConfig.create().
-                enabled( true ).
-                fulltext( true ).
-                includeInAllText( false ).
                 nGram( true ).
                 decideByType( false ).
                 build() );

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/ContentDataSerializer.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/serializer/ContentDataSerializer.java
@@ -420,7 +420,6 @@ public final class ContentDataSerializer
                                  .mimeType( attachmentAsSet.getString( ContentPropertyNames.ATTACHMENT_MIMETYPE ) )
                                  .size( attachmentAsSet.getLong( ContentPropertyNames.ATTACHMENT_SIZE ) )
                                  .sha512( attachmentAsSet.getString( ContentPropertyNames.ATTACHMENT_SHA512 ) )
-                                 .textContent( attachmentAsSet.getString( ContentPropertyNames.ATTACHMENT_TEXT ) )
                                  .build() );
         }
         return attachments.build();
@@ -437,7 +436,6 @@ public final class ContentDataSerializer
             attachmentSet.addString( ContentPropertyNames.ATTACHMENT_MIMETYPE, attachment.getMimeType() );
             attachmentSet.addLong( ContentPropertyNames.ATTACHMENT_SIZE, attachment.getSize() );
             attachmentSet.addString( ContentPropertyNames.ATTACHMENT_SHA512, attachment.getSha512() );
-            attachmentSet.addString( ContentPropertyNames.ATTACHMENT_TEXT, attachment.getTextContent() );
         }
     }
 }

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/ContentAuditLogSupportImplTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/ContentAuditLogSupportImplTest.java
@@ -186,7 +186,6 @@ class ContentAuditLogSupportImplTest
                                                             .label( "My Text 1" )
                                                             .name( "MyText.txp" )
                                                             .byteSource( ByteSource.wrap( "text data".getBytes( StandardCharsets.UTF_8 ) ) )
-                                                            .text( "text data" )
                                                             .build() ) )
             .patcher( edit -> edit.displayName.setValue( "New Display Name" ) )
             .build();
@@ -223,8 +222,6 @@ class ContentAuditLogSupportImplTest
         assertEquals( "My Image 1",
                       argumentCaptor.getValue().getData().getSet( "params" ).getSet( "createAttachments" ).getString( "label" ) );
         assertEquals( 4L, argumentCaptor.getValue().getData().getSet( "params" ).getSet( "createAttachments" ).getLong( "byteSize" ) );
-
-        assertEquals( 9L, argumentCaptor.getValue().getData().getSet( "params" ).getSet( "createAttachments", 1 ).getLong( "textSize" ) );
 
         assertEquals( "/contentName1", argumentCaptor.getValue().getData().getSet( "result" ).getSet( "draft" ).getString( "path" ) );
         assertEquals( "/contentName2", argumentCaptor.getValue().getData().getSet( "result" ).getSet( "master" ).getString( "path" ) );

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/index/processor/AttachmentConfigProcessorTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/index/processor/AttachmentConfigProcessorTest.java
@@ -7,20 +7,16 @@ import com.enonic.xp.index.IndexPath;
 import com.enonic.xp.index.PatternIndexConfigDocument;
 import com.enonic.xp.schema.content.ContentTypeName;
 
-import static com.enonic.xp.content.ContentPropertyNames.ATTACHMENT_TEXT_COMPONENT;
+import static com.enonic.xp.content.ContentPropertyNames.MEDIA_TEXT_COMPONENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AttachmentConfigProcessorTest
 {
-    private ContentTypeName contentTypeName;
-
-    private AttachmentConfigProcessor configProcessor;
-
     @Test
     void test_textual_media()
     {
-        this.contentTypeName = ContentTypeName.textMedia();
-        this.configProcessor = new AttachmentConfigProcessor( contentTypeName );
+        final ContentTypeName contentTypeName = ContentTypeName.textMedia();
+        final AttachmentConfigProcessor configProcessor = new AttachmentConfigProcessor( contentTypeName );
 
         final PatternIndexConfigDocument config = configProcessor.processDocument( PatternIndexConfigDocument.empty() );
 
@@ -30,25 +26,18 @@ class AttachmentConfigProcessorTest
             fulltext( true ).
             includeInAllText( true ).
             nGram( true ).
-            decideByType( false ).build(), config.getConfigForPath( IndexPath.from( ATTACHMENT_TEXT_COMPONENT ) ) );
+            decideByType( false ).build(), config.getConfigForPath( IndexPath.from( MEDIA_TEXT_COMPONENT ) ) );
 
     }
 
     @Test
     void test_non_textual_media()
     {
-        this.contentTypeName = ContentTypeName.folder();
-        this.configProcessor = new AttachmentConfigProcessor( contentTypeName );
+        final ContentTypeName contentTypeName = ContentTypeName.folder();
+        final AttachmentConfigProcessor configProcessor = new AttachmentConfigProcessor( contentTypeName );
 
         final PatternIndexConfigDocument config = configProcessor.processDocument( PatternIndexConfigDocument.empty() );
 
-        assertEquals( 1, config.getPathIndexConfigs().size() );
-        assertEquals( IndexConfig.create().
-            enabled( true ).
-            fulltext( true ).
-            includeInAllText( false ).
-            nGram( true ).
-            decideByType( false ).build(), config.getConfigForPath( IndexPath.from( ATTACHMENT_TEXT_COMPONENT ) ) );
-
+        assertEquals( 0, config.getPathIndexConfigs().size() );
     }
 }

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/processor/ImageContentProcessorTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/processor/ImageContentProcessorTest.java
@@ -270,7 +270,6 @@ class ImageContentProcessorTest
             .add( CreateAttachment.create()
                       .name( "imageAttach" )
                       .byteSource( ByteSource.wrap( "this is image".getBytes() ) )
-                      .text( "This is the image" )
                       .build() )
             .build();
     }

--- a/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/ProjectServiceImpl.java
+++ b/modules/core/core-project/src/main/java/com/enonic/xp/core/impl/project/ProjectServiceImpl.java
@@ -172,7 +172,6 @@ public class ProjectServiceImpl
                               .mimeType( iconData.getString( ContentPropertyNames.ATTACHMENT_MIMETYPE ) )
                               .size( iconData.getLong( ContentPropertyNames.ATTACHMENT_SIZE ) )
                               .sha512( iconData.getString( ContentPropertyNames.ATTACHMENT_SHA512 ) )
-                              .textContent( iconData.getString( ContentPropertyNames.ATTACHMENT_TEXT ) )
                               .build() );
         }
     }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/upgrade/model8to9/AttachmentTextToMediaUpgrader.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/upgrade/model8to9/AttachmentTextToMediaUpgrader.java
@@ -1,0 +1,80 @@
+package com.enonic.xp.repo.impl.dump.upgrade.model8to9;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.enonic.xp.content.ContentConstants;
+import com.enonic.xp.content.ContentPropertyNames;
+import com.enonic.xp.data.PropertySet;
+import com.enonic.xp.data.PropertyTree;
+import com.enonic.xp.project.ProjectConstants;
+import com.enonic.xp.repo.impl.NodeStoreVersion;
+import com.enonic.xp.repo.impl.dump.upgrade.NodeVersionUpgrader;
+import com.enonic.xp.repository.RepositoryId;
+import com.enonic.xp.schema.content.ContentTypeName;
+
+public class AttachmentTextToMediaUpgrader
+    implements NodeVersionUpgrader
+{
+    private static final Logger LOG = LoggerFactory.getLogger( AttachmentTextToMediaUpgrader.class );
+
+    private static final String LEGACY_ATTACHMENT_TEXT = "text";
+
+    @Override
+    public NodeStoreVersion upgradeNodeVersion( final RepositoryId repositoryId, final NodeStoreVersion nodeVersion )
+    {
+        if ( !repositoryId.toString().startsWith( ProjectConstants.PROJECT_REPO_ID_PREFIX ) ||
+            !ContentConstants.CONTENT_NODE_COLLECTION.equals( nodeVersion.nodeType() ) )
+        {
+            return null;
+        }
+
+        final PropertyTree data = nodeVersion.data();
+
+        final String typeString = data.getString( ContentPropertyNames.TYPE );
+        if ( typeString == null || !ContentTypeName.from( typeString ).isTextualMedia() )
+        {
+            return null;
+        }
+
+        final Iterable<PropertySet> attachments = data.getSets( ContentPropertyNames.ATTACHMENT );
+        if ( attachments == null )
+        {
+            return null;
+        }
+
+        boolean modified = false;
+        String text = null;
+
+        for ( PropertySet attachmentSet : attachments )
+        {
+            final String value = attachmentSet.getString( LEGACY_ATTACHMENT_TEXT );
+            if ( value != null )
+            {
+                if ( text == null )
+                {
+                    text = value;
+                }
+                attachmentSet.removeProperties( LEGACY_ATTACHMENT_TEXT );
+                modified = true;
+            }
+        }
+
+        if ( !modified )
+        {
+            return null;
+        }
+
+        if ( text != null )
+        {
+            final PropertySet mediaSet = data.getSet( ContentPropertyNames.MEDIA );
+            if ( mediaSet != null && mediaSet.getString( ContentPropertyNames.MEDIA_TEXT ) == null )
+            {
+                mediaSet.addString( ContentPropertyNames.MEDIA_TEXT, text );
+            }
+        }
+
+        LOG.info( "Moved attachment text to media for node [{}] in repository [{}]", nodeVersion.id(), repositoryId );
+        return nodeVersion;
+    }
+}

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/upgrade/model8to9/DumpUpgrader8to9.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/upgrade/model8to9/DumpUpgrader8to9.java
@@ -425,7 +425,7 @@ public class DumpUpgrader8to9
         for ( NodeVersionUpgrader upgrader : List.of( new ContentUpgrader(), new AuditLogMillisUpgrader(), new SchedulerUpgrader(),
                                                       new ReferenceLowercaseUpgrader(), new DefaultProjectPermissionsUpgrader(),
                                                       new LanguageTagUpgrader(), new IndexConfigLanguageUpgrader(),
-                                                      new AttachmentSha512Upgrader( dumpReader ),
+                                                      new AttachmentSha512Upgrader( dumpReader ), new AttachmentTextToMediaUpgrader(),
                                                       new ImageUpgrader( dumpReader ), new RepositoryBranchesRemovalUpgrader(),
                                                       new RepositoryModelVersionUpgrader() ) )
         {

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/dump/upgrade/model8to9/AttachmentTextToMediaUpgraderTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/dump/upgrade/model8to9/AttachmentTextToMediaUpgraderTest.java
@@ -1,0 +1,176 @@
+package com.enonic.xp.repo.impl.dump.upgrade.model8to9;
+
+import org.junit.jupiter.api.Test;
+
+import com.enonic.xp.content.ContentConstants;
+import com.enonic.xp.content.ContentPropertyNames;
+import com.enonic.xp.data.PropertySet;
+import com.enonic.xp.data.PropertyTree;
+import com.enonic.xp.node.NodeId;
+import com.enonic.xp.node.NodeType;
+import com.enonic.xp.project.ProjectConstants;
+import com.enonic.xp.repo.impl.NodeStoreVersion;
+import com.enonic.xp.repository.RepositoryId;
+import com.enonic.xp.schema.content.ContentTypeName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AttachmentTextToMediaUpgraderTest
+{
+    private static final RepositoryId PROJECT_REPO = RepositoryId.from( ProjectConstants.PROJECT_REPO_ID_PREFIX + "default" );
+
+    private final AttachmentTextToMediaUpgrader upgrader = new AttachmentTextToMediaUpgrader();
+
+    @Test
+    void textual_media_with_attachment_text_is_migrated()
+    {
+        final NodeStoreVersion nodeVersion =
+            textualMediaNode( ContentTypeName.documentMedia().toString(), "extracted text content", null );
+
+        final NodeStoreVersion result = upgrader.upgradeNodeVersion( PROJECT_REPO, nodeVersion );
+
+        assertThat( result ).isNotNull();
+        final PropertySet mediaSet = result.data().getSet( ContentPropertyNames.MEDIA );
+        assertThat( mediaSet.getString( ContentPropertyNames.MEDIA_TEXT ) ).isEqualTo( "extracted text content" );
+        final PropertySet attachmentSet = result.data().getSet( ContentPropertyNames.ATTACHMENT );
+        assertThat( attachmentSet.getString( "text" ) ).isNull();
+    }
+
+    @Test
+    void non_media_node_with_text_on_attachment_is_skipped()
+    {
+        final NodeStoreVersion nodeVersion = nonMediaNodeWithAttachmentText( "some unrelated text" );
+
+        final NodeStoreVersion result = upgrader.upgradeNodeVersion( PROJECT_REPO, nodeVersion );
+
+        assertThat( result ).isNull();
+        final PropertySet attachmentSet = nodeVersion.data().getSet( ContentPropertyNames.ATTACHMENT );
+        assertThat( attachmentSet.getString( "text" ) ).isEqualTo( "some unrelated text" );
+    }
+
+    @Test
+    void already_migrated_textual_media_returns_null()
+    {
+        final NodeStoreVersion nodeVersion =
+            textualMediaNode( ContentTypeName.documentMedia().toString(), null, "already migrated text" );
+
+        final NodeStoreVersion result = upgrader.upgradeNodeVersion( PROJECT_REPO, nodeVersion );
+
+        assertThat( result ).isNull();
+        final PropertySet mediaSet = nodeVersion.data().getSet( ContentPropertyNames.MEDIA );
+        assertThat( mediaSet.getString( ContentPropertyNames.MEDIA_TEXT ) ).isEqualTo( "already migrated text" );
+    }
+
+    @Test
+    void node_outside_project_repo_is_skipped()
+    {
+        final RepositoryId systemRepo = RepositoryId.from( "system-repo" );
+        final NodeStoreVersion nodeVersion =
+            textualMediaNode( ContentTypeName.documentMedia().toString(), "extracted text content", null );
+
+        final NodeStoreVersion result = upgrader.upgradeNodeVersion( systemRepo, nodeVersion );
+
+        assertThat( result ).isNull();
+        final PropertySet attachmentSet = nodeVersion.data().getSet( ContentPropertyNames.ATTACHMENT );
+        assertThat( attachmentSet.getString( "text" ) ).isEqualTo( "extracted text content" );
+    }
+
+    @Test
+    void non_content_node_is_skipped()
+    {
+        final PropertyTree data = new PropertyTree();
+        data.setString( ContentPropertyNames.TYPE, ContentTypeName.documentMedia().toString() );
+        final PropertySet mediaSet = data.addSet( ContentPropertyNames.MEDIA );
+        mediaSet.addString( ContentPropertyNames.MEDIA_ATTACHMENT, "doc.pdf" );
+        final PropertySet attachmentSet = data.addSet( ContentPropertyNames.ATTACHMENT );
+        attachmentSet.addString( ContentPropertyNames.ATTACHMENT_NAME, "doc.pdf" );
+        attachmentSet.addString( "text", "extracted text content" );
+
+        final NodeStoreVersion nodeVersion =
+            NodeStoreVersion.create().id( NodeId.from( "non-content-node" ) ).nodeType( NodeType.from( "other" ) ).data( data ).build();
+
+        final NodeStoreVersion result = upgrader.upgradeNodeVersion( PROJECT_REPO, nodeVersion );
+
+        assertThat( result ).isNull();
+    }
+
+    @Test
+    void non_textual_media_node_is_skipped()
+    {
+        final NodeStoreVersion nodeVersion =
+            textualMediaNode( ContentTypeName.imageMedia().toString(), "extracted text content", null );
+
+        final NodeStoreVersion result = upgrader.upgradeNodeVersion( PROJECT_REPO, nodeVersion );
+
+        assertThat( result ).isNull();
+        final PropertySet attachmentSet = nodeVersion.data().getSet( ContentPropertyNames.ATTACHMENT );
+        assertThat( attachmentSet.getString( "text" ) ).isEqualTo( "extracted text content" );
+    }
+
+    @Test
+    void textual_media_without_attachment_text_returns_null()
+    {
+        final NodeStoreVersion nodeVersion = textualMediaNode( ContentTypeName.documentMedia().toString(), null, null );
+
+        final NodeStoreVersion result = upgrader.upgradeNodeVersion( PROJECT_REPO, nodeVersion );
+
+        assertThat( result ).isNull();
+    }
+
+    @Test
+    void existing_media_text_is_not_overwritten_but_attachment_text_is_cleared()
+    {
+        final NodeStoreVersion nodeVersion =
+            textualMediaNode( ContentTypeName.documentMedia().toString(), "stale attachment text", "newer media text" );
+
+        final NodeStoreVersion result = upgrader.upgradeNodeVersion( PROJECT_REPO, nodeVersion );
+
+        assertThat( result ).isNotNull();
+        final PropertySet mediaSet = result.data().getSet( ContentPropertyNames.MEDIA );
+        assertThat( mediaSet.getString( ContentPropertyNames.MEDIA_TEXT ) ).isEqualTo( "newer media text" );
+        final PropertySet attachmentSet = result.data().getSet( ContentPropertyNames.ATTACHMENT );
+        assertThat( attachmentSet.getString( "text" ) ).isNull();
+    }
+
+    private static NodeStoreVersion textualMediaNode( final String type, final String attachmentText, final String mediaText )
+    {
+        final PropertyTree data = new PropertyTree();
+        data.setString( ContentPropertyNames.TYPE, type );
+
+        final PropertySet mediaSet = data.addSet( ContentPropertyNames.MEDIA );
+        mediaSet.addString( ContentPropertyNames.MEDIA_ATTACHMENT, "doc.txt" );
+        if ( mediaText != null )
+        {
+            mediaSet.addString( ContentPropertyNames.MEDIA_TEXT, mediaText );
+        }
+
+        final PropertySet attachmentSet = data.addSet( ContentPropertyNames.ATTACHMENT );
+        attachmentSet.addString( ContentPropertyNames.ATTACHMENT_NAME, "doc.txt" );
+        if ( attachmentText != null )
+        {
+            attachmentSet.addString( "text", attachmentText );
+        }
+
+        return NodeStoreVersion.create()
+            .id( NodeId.from( "textual-media-1" ) )
+            .nodeType( ContentConstants.CONTENT_NODE_COLLECTION )
+            .data( data )
+            .build();
+    }
+
+    private static NodeStoreVersion nonMediaNodeWithAttachmentText( final String attachmentText )
+    {
+        final PropertyTree data = new PropertyTree();
+        data.setString( ContentPropertyNames.TYPE, "myapp:custom" );
+
+        final PropertySet attachmentSet = data.addSet( ContentPropertyNames.ATTACHMENT );
+        attachmentSet.addString( ContentPropertyNames.ATTACHMENT_NAME, "file.bin" );
+        attachmentSet.addString( "text", attachmentText );
+
+        return NodeStoreVersion.create()
+            .id( NodeId.from( "non-media-1" ) )
+            .nodeType( ContentConstants.CONTENT_NODE_COLLECTION )
+            .data( data )
+            .build();
+    }
+}

--- a/modules/itest/itest-core-content/src/test/java/com/enonic/xp/core/content/ContentServiceImplTest_patch.java
+++ b/modules/itest/itest-core-content/src/test/java/com/enonic/xp/core/content/ContentServiceImplTest_patch.java
@@ -103,21 +103,18 @@ class ContentServiceImplTest_patch
                                               .name( "test-attachment1" )
                                               .label( "test-label1" )
                                               .mimeType( "image/jpeg" )
-                                              .text( "text content 1" )
                                               .byteSource( ByteSource.wrap( "ABC".getBytes() ) )
                                               .build() )
                                     .add( CreateAttachment.create()
                                               .name( "test-attachment2" )
                                               .label( "test-label2" )
                                               .mimeType( "image/jpeg" )
-                                              .text( "text content 2" )
                                               .byteSource( ByteSource.wrap( "ABCD".getBytes() ) )
                                               .build() )
                                     .add( CreateAttachment.create()
                                               .name( "test-attachment3" )
                                               .label( "test-label3" )
                                               .mimeType( "image/jpeg" )
-                                              .text( "text content 3" )
                                               .byteSource( ByteSource.wrap( "ABCDE".getBytes() ) )
                                               .build() )
                                     .build() )
@@ -136,7 +133,6 @@ class ContentServiceImplTest_patch
                                                          .mimeType( "image/gif" )
                                                          .size( 666 )
                                                          .sha512( "sha512" )
-                                                         .textContent( "text content edited" )
                                                          .build() )
                                                .build() );
             } )
@@ -145,7 +141,6 @@ class ContentServiceImplTest_patch
                                               .name( "test-attachment-added" )
                                               .label( "test-label-edited" )
                                               .mimeType( "image/jpeg" )
-                                              .text( "text content added" )
                                               .byteSource( ByteSource.wrap( "ABC".getBytes() ) )
                                               .build() )
                                     .build() )
@@ -165,14 +160,11 @@ class ContentServiceImplTest_patch
         assertEquals( "image/gif", attachment.getMimeType() );
         assertEquals( 666, attachment.getSize() );
         assertEquals( "sha512", attachment.getSha512() );
-        assertEquals( "text content edited", attachment.getTextContent() );
-        assertEquals( "sha512", attachment.getSha512() );
 
         final Attachment attachment2 = iterator.next();
         assertEquals( "test-attachment-added", attachment2.getName() );
         assertEquals( "test-label-edited", attachment2.getLabel() );
         assertEquals( "image/jpeg", attachment2.getMimeType() );
-        assertEquals( "text content added", attachment2.getTextContent() );
         assertEquals( 3, attachment2.getSize() );
         assertEquals( 128, attachment2.getSha512().length() );
     }
@@ -197,7 +189,6 @@ class ContentServiceImplTest_patch
                                               .name( AttachmentNames.THUMBNAIL )
                                               .label( "test-label-edited" )
                                               .mimeType( "image/jpeg" )
-                                              .text( "text content added" )
                                               .byteSource( ByteSource.wrap( "ABC".getBytes() ) )
                                               .build() )
                                     .build() )

--- a/modules/itest/itest-core-content/src/test/java/com/enonic/xp/core/content/ParentContentSynchronizerTest.java
+++ b/modules/itest/itest-core-content/src/test/java/com/enonic/xp/core/content/ParentContentSynchronizerTest.java
@@ -516,7 +516,6 @@ class ParentContentSynchronizerTest
                                                                          .name( AttachmentNames.THUMBNAIL )
                                                                          .byteSource( ByteSource.wrap( "this is image".getBytes() ) )
                                                                          .mimeType( "image/png" )
-                                                                         .text( "This is the image" )
                                                                          .build() )
                                                                .build() )
                                        .editor( _ -> {

--- a/modules/lib/core/index.d.ts
+++ b/modules/lib/core/index.d.ts
@@ -564,7 +564,6 @@ export interface Attachment {
     size: number;
     mimeType: string;
     sha512?: string | null;
-    textContent?: string | null;
 }
 
 export interface DataValidationError

--- a/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/deserializer/AttachmentsDeserializer.java
+++ b/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/deserializer/AttachmentsDeserializer.java
@@ -118,9 +118,6 @@ public class AttachmentsDeserializer
                 case "mimeType":
                     builder.mimeType( (String) value );
                     break;
-                case "textContent":
-                    builder.textContent( (String) value );
-                    break;
                 case "sha512":
                     builder.sha512( (String) value );
                     break;
@@ -162,9 +159,6 @@ public class AttachmentsDeserializer
                     break;
                 case "mimeType":
                     builder.mimeType( (String) value );
-                    break;
-                case "textContent":
-                    builder.text( (String) value );
                     break;
                 case "data":
                     if ( value instanceof ByteSource )

--- a/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/mapper/AttachmentsMapper.java
+++ b/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/mapper/AttachmentsMapper.java
@@ -34,6 +34,5 @@ public final class AttachmentsMapper
         gen.value( "size", attachment.getSize() );
         gen.value( "mimeType", attachment.getMimeType() );
         gen.value( "sha512", attachment.getSha512() );
-        gen.value( "textContent", attachment.getTextContent() );
     }
 }

--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -773,7 +773,6 @@ export interface ModifyAttachmentParam {
     name: string;
     label?: string;
     mimeType?: string;
-    textContent?: string;
     sha512?: string;
     size?: number;
 }
@@ -782,7 +781,6 @@ export interface CreateAttachmentParam {
     name: string;
     label?: string;
     mimeType?: string;
-    textContent?: string;
     data?: ByteSource | string;
 }
 

--- a/modules/lib/lib-content/src/test/java/com/enonic/xp/lib/content/PatchContentHandlerTest.java
+++ b/modules/lib/lib-content/src/test/java/com/enonic/xp/lib/content/PatchContentHandlerTest.java
@@ -319,7 +319,6 @@ public class PatchContentHandlerTest
                                         .name( "file.txt" )
                                         .label( "initial label" )
                                         .mimeType( "image/jpeg" )
-                                        .textContent( "initial content" )
                                         .sha512( "ABC" )
                                         .size( 123 )
                                         .build() )
@@ -346,7 +345,6 @@ public class PatchContentHandlerTest
         assertEquals( "file4.txt", createAttachment.getName() );
         assertEquals( "File 4", createAttachment.getLabel() );
         assertEquals( "text/plain", createAttachment.getMimeType() );
-        assertEquals( "data 4", createAttachment.getTextContent() );
         assertEquals( "data 2", new String( createAttachment.getByteSource().read() ) );
 
         final PatchableContent patchable = new PatchableContent( content );
@@ -359,7 +357,6 @@ public class PatchContentHandlerTest
         assertEquals( "text/plain", patchedAttachment.getMimeType() );
         assertEquals( "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae", patchedAttachment.getSha512() );
         assertEquals( 14, patchedAttachment.getSize() );
-        assertEquals( "data 1", patchedAttachment.getTextContent() );
     }
 
     @Test

--- a/modules/lib/lib-content/src/test/java/com/enonic/xp/lib/content/mapper/AttachmentsMapperTest.java
+++ b/modules/lib/lib-content/src/test/java/com/enonic/xp/lib/content/mapper/AttachmentsMapperTest.java
@@ -21,7 +21,6 @@ class AttachmentsMapperTest
             .mimeType( "application/pdf" )
             .size( 1234L )
             .sha512( "deadbeef" )
-            .textContent( "Quarterly report contents" )
             .build();
 
         final JsonNode node = serialize( Attachments.from( attachment ) ).get( "report.pdf" );
@@ -31,11 +30,11 @@ class AttachmentsMapperTest
         assertThat( node.get( "size" ).asLong() ).isEqualTo( 1234L );
         assertThat( node.get( "mimeType" ).asText() ).isEqualTo( "application/pdf" );
         assertThat( node.get( "sha512" ).asText() ).isEqualTo( "deadbeef" );
-        assertThat( node.get( "textContent" ).asText() ).isEqualTo( "Quarterly report contents" );
+        assertThat( node.has( "textContent" ) ).isFalse();
     }
 
     @Test
-    void sha512AndTextContentNullEmittedAsNull()
+    void sha512NullEmittedAsNull()
     {
         final Attachment attachment = Attachment.create()
             .name( "image.png" )
@@ -47,8 +46,6 @@ class AttachmentsMapperTest
 
         assertThat( node.has( "sha512" ) ).isTrue();
         assertThat( node.get( "sha512" ).isNull() ).isTrue();
-        assertThat( node.has( "textContent" ) ).isTrue();
-        assertThat( node.get( "textContent" ).isNull() ).isTrue();
     }
 
     private JsonNode serialize( final Attachments attachments )

--- a/modules/lib/lib-content/src/test/resources/test/PatchContentHandlerTest.js
+++ b/modules/lib/lib-content/src/test/resources/test/PatchContentHandlerTest.js
@@ -530,7 +530,6 @@ exports.patchAttachments = function () {
                 name: 'file.txt',
                 mimeType: 'text/plain',
                 label: 'File 1',
-                textContent: 'data 1',
                 sha512: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
                 size: 14
             }],
@@ -539,7 +538,6 @@ exports.patchAttachments = function () {
                 mimeType: 'text/plain',
                 name: 'file4.txt',
                 label: 'File 4',
-                textContent: 'data 4',
                 data: dataStream2
             }]
         }


### PR DESCRIPTION
## Summary

Follow-up to PR #12020. PR #12020 exposed `sha512` and `textContent` on the `Attachment` JS/TS surface (and added `textContent` storage to `Attachment` itself). The `sha512` half is correct — it's a binary-level concern. The `textContent` half is misplaced: it's the Tika-extracted text from a media binary, so it's meaningful **only for media content types** (PDFs, docs, …), not for every attachment.

Non-media attachments (page banners, article source attachments, project icons, …) always carried a null `textContent`, which was misleading both in the JS API and in Content Studio's JSON preview. Conceptually it belongs on the media content's own data, not on every attachment.

## Changes

- `sha512` stays on `Attachment` (no change to the #12020 fix).
- `textContent` is removed from:
  - `Attachment` (in-memory model, equals/hashCode/toString)
  - `CreateAttachment` (input DTO; `text(...)` builder method dropped)
  - `AttachmentsMapper` (lib-content JS serializer)
  - `AttachmentsDeserializer` (lib-content JS deserializer)
  - `Attachment` interface in `modules/lib/core/index.d.ts`
  - `ModifyAttachmentParam` and `CreateAttachmentParam` in `lib-content/src/main/resources/lib/xp/content.ts`
  - All upstream code that piped `getTextContent()` through (`UpdateContentCommand`, `PatchContentCommand`, `Created/UpdatedEventSyncCommand`, `ProjectServiceImpl`, `ContentAuditLogSupportImpl`)
- `textContent` is now written to the media content's `data.media.text` path:
  - New `MEDIA_TEXT = "text"` and `MEDIA_TEXT_COMPONENT = "media.text"` constants in `ContentPropertyNames` (replacing the removed `ATTACHMENT_TEXT` and `ATTACHMENT_TEXT_COMPONENT`).
  - `MediaFormDataBuilder` accepts `text(...)` and writes `media.text` only when `type.isTextualMedia()` and the value is non-null.
  - `CreateMediaCommand` and `UpdateMediaCommand` route `mediaInfo.getTextContent()` into the form-data builder instead of the attachment.
- `AttachmentConfigProcessor` now configures fulltext indexing for `media.text` instead of `attachment.text`, and only emits the rule for textual-media types (the prior else-branch added a no-op rule on a path nothing wrote to).

## Migration

Migration is handled by `AttachmentTextToMediaUpgrader` (registered in the `model8to9` dump-upgrade bundle, right after `AttachmentSha512Upgrader`). On dump import the upgrader copies the legacy attachment-level `text` value onto `data.media.text` for textual-media content types (`ContentTypeName.isTextualMedia()`) and clears the legacy `attachment[].text` field. The upgrader is gated by project repo prefix and content node type, and is a no-op when there is no legacy `text` to move or when `data.media.text` is already populated.

For in-place upgrades (no dump round-trip), new media saves write to the new path; the legacy `data.attachment[].text` becomes harmless dead data on un-resaved nodes and stops being read.

**Breaking change** (small window): code reading `attachment.textContent` from `/lib/xp/content` since #12020 will now see it absent. Downstream Content Studio gets the same correction in https://github.com/enonic/app-contentstudio (PR follow-up).

## Test plan

- [x] `./gradlew test` green (excluding the pre-existing, unrelated `core-export:ZipExportWriterTest.testPathWithSpecialCharacters` failure on the runner's filesystem)
- [x] `./gradlew :itest:itest-core-content:integrationTest` green for `*ContentServiceImplTest_media*`, `*ContentServiceImplTest_patch*`, and `*ParentContentSynchronizer*`
- [x] `AttachmentsMapperTest` updated: `textContent` no longer in JSON output
- [x] `AttachmentTest` toString assertion updated
- [x] `AttachmentConfigProcessorTest` updated for the new path and the dropped non-textual-media branch
- [x] `PatchContentHandlerTest` (Java + JS fixture) updated
- [x] `ContentServiceImplTest_patch` and `ParentContentSynchronizerTest` updated
- [x] `AttachmentTextToMediaUpgraderTest` covers: textual-media migration, non-media skip, already-migrated no-op, non-project-repo skip, non-content-node skip, non-textual-media skip, no-attachment-text no-op, and the existing-`media.text` preservation case
- [x] `:itest:itest-core:integrationTest --tests *DumpUpgradeIntegrationTest*` green (existing fixture has no legacy `text` so the new upgrader is a no-op there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
