### PR TITLE
Block stop of system apps #12029

### DIFF
--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationServiceImpl.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationServiceImpl.java
@@ -122,7 +122,6 @@ public final class ApplicationServiceImpl
     @Override
     public void startApplication( final ApplicationKey key )
     {
-        requireNotSystemApp( key, "start" );
         final boolean global = !localApplicationSet.contains( key );
         ApplicationHelper.runWithContext( () -> {
             if ( global )
@@ -144,7 +143,11 @@ public final class ApplicationServiceImpl
     @Override
     public void stopApplication( final ApplicationKey key )
     {
-        requireNotSystemApp( key, "stop" );
+        final Application app = registry.get( key );
+        if ( app != null && app.isSystem() )
+        {
+            throw new IllegalArgumentException( "Cannot stop system application: " + key );
+        }
         final boolean global = !localApplicationSet.contains( key );
         ApplicationHelper.runWithContext( () -> {
             if ( global )
@@ -188,7 +191,6 @@ public final class ApplicationServiceImpl
     @Override
     public void uninstallApplication( final ApplicationKey key )
     {
-        requireNotSystemApp( key, "uninstall" );
         if ( localApplicationSet.contains( key ) )
         {
             throw new ApplicationBundleException(
@@ -209,7 +211,6 @@ public final class ApplicationServiceImpl
     @Override
     public void uninstallLocalApplication( final ApplicationKey key )
     {
-        requireNotSystemApp( key, "uninstall" );
         final boolean removed = localApplicationSet.remove( key );
         if ( !removed )
         {
@@ -217,15 +218,6 @@ public final class ApplicationServiceImpl
         }
         doUninstallApplication( key );
         ApplicationHelper.runWithContext( () -> doReinstallStoredApplication( key ) );
-    }
-
-    private void requireNotSystemApp( final ApplicationKey key, final String op )
-    {
-        final Application app = registry.get( key );
-        if ( app != null && app.isSystem() )
-        {
-            throw new IllegalArgumentException( "Cannot " + op + " system application: " + key );
-        }
     }
 
     @Override

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationServiceImpl.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationServiceImpl.java
@@ -122,6 +122,7 @@ public final class ApplicationServiceImpl
     @Override
     public void startApplication( final ApplicationKey key )
     {
+        requireNotSystemApp( key, "start" );
         final boolean global = !localApplicationSet.contains( key );
         ApplicationHelper.runWithContext( () -> {
             if ( global )
@@ -143,6 +144,7 @@ public final class ApplicationServiceImpl
     @Override
     public void stopApplication( final ApplicationKey key )
     {
+        requireNotSystemApp( key, "stop" );
         final boolean global = !localApplicationSet.contains( key );
         ApplicationHelper.runWithContext( () -> {
             if ( global )
@@ -186,6 +188,7 @@ public final class ApplicationServiceImpl
     @Override
     public void uninstallApplication( final ApplicationKey key )
     {
+        requireNotSystemApp( key, "uninstall" );
         if ( localApplicationSet.contains( key ) )
         {
             throw new ApplicationBundleException(
@@ -206,6 +209,7 @@ public final class ApplicationServiceImpl
     @Override
     public void uninstallLocalApplication( final ApplicationKey key )
     {
+        requireNotSystemApp( key, "uninstall" );
         final boolean removed = localApplicationSet.remove( key );
         if ( !removed )
         {
@@ -213,6 +217,15 @@ public final class ApplicationServiceImpl
         }
         doUninstallApplication( key );
         ApplicationHelper.runWithContext( () -> doReinstallStoredApplication( key ) );
+    }
+
+    private void requireNotSystemApp( final ApplicationKey key, final String op )
+    {
+        final Application app = registry.get( key );
+        if ( app != null && app.isSystem() )
+        {
+            throw new IllegalArgumentException( "Cannot " + op + " system application: " + key );
+        }
     }
 
     @Override

--- a/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/ApplicationServiceImplTest.java
+++ b/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/ApplicationServiceImplTest.java
@@ -273,7 +273,7 @@ class ApplicationServiceImplTest
     }
 
     @Test
-    void startApplication_systemApp_throws()
+    void start_system_application_ignored()
         throws Exception
     {
         final Bundle bundle = deploySystemAppBundle( "systemApp" );
@@ -284,10 +284,7 @@ class ApplicationServiceImplTest
 
         assertEquals( Bundle.ACTIVE, bundle.getState() );
         final ApplicationKey applicationKey = ApplicationKey.from( "systemApp" );
-
-        assertThatThrownBy( () -> this.service.startApplication( applicationKey ) ).isInstanceOf( IllegalArgumentException.class )
-            .hasMessageContaining( "system application" );
-
+        this.service.startApplication( applicationKey );
         assertEquals( Bundle.ACTIVE, bundle.getState() );
     }
 
@@ -378,38 +375,6 @@ class ApplicationServiceImplTest
         assertThatThrownBy( () -> this.service.stopApplication( applicationKey ) ).isInstanceOf( IllegalArgumentException.class )
             .hasMessageContaining( "system application" );
 
-        assertEquals( Bundle.ACTIVE, bundle.getState() );
-    }
-
-    @Test
-    void uninstallApplication_systemApp_throws()
-    {
-        final Bundle bundle = deploySystemAppBundle( "systemApp" );
-        applicationRegistry.registerApplication( bundle );
-
-        final ApplicationKey applicationKey = ApplicationKey.from( "systemApp" );
-
-        assertThatThrownBy( () -> this.service.uninstallApplication( applicationKey ) ).isInstanceOf( IllegalArgumentException.class )
-            .hasMessageContaining( "system application" );
-
-        assertNotNull( this.service.getInstalledApplication( applicationKey ) );
-        assertEquals( Bundle.INSTALLED, bundle.getState() );
-    }
-
-    @Test
-    void uninstallLocalApplication_systemApp_throws()
-        throws Exception
-    {
-        final Bundle bundle = deploySystemAppBundle( "systemApp" );
-        applicationRegistry.registerApplication( bundle );
-        bundle.start();
-
-        final ApplicationKey applicationKey = ApplicationKey.from( "systemApp" );
-
-        assertThatThrownBy( () -> this.service.uninstallLocalApplication( applicationKey ) ).isInstanceOf( IllegalArgumentException.class )
-            .hasMessageContaining( "system application" );
-
-        assertNotNull( this.service.getInstalledApplication( applicationKey ) );
         assertEquals( Bundle.ACTIVE, bundle.getState() );
     }
 

--- a/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/ApplicationServiceImplTest.java
+++ b/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/ApplicationServiceImplTest.java
@@ -50,6 +50,7 @@ import com.enonic.xp.node.NodeVersionId;
 import com.enonic.xp.node.Nodes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -272,7 +273,7 @@ class ApplicationServiceImplTest
     }
 
     @Test
-    void start_system_application_ignored()
+    void startApplication_systemApp_throws()
         throws Exception
     {
         final Bundle bundle = deploySystemAppBundle( "systemApp" );
@@ -283,7 +284,10 @@ class ApplicationServiceImplTest
 
         assertEquals( Bundle.ACTIVE, bundle.getState() );
         final ApplicationKey applicationKey = ApplicationKey.from( "systemApp" );
-        this.service.startApplication( applicationKey );
+
+        assertThatThrownBy( () -> this.service.startApplication( applicationKey ) ).isInstanceOf( IllegalArgumentException.class )
+            .hasMessageContaining( "system application" );
+
         assertEquals( Bundle.ACTIVE, bundle.getState() );
     }
 
@@ -359,7 +363,7 @@ class ApplicationServiceImplTest
     }
 
     @Test
-    void stop_system_application()
+    void stopApplication_systemApp_throws()
         throws Exception
     {
         final Bundle bundle = deploySystemAppBundle( "systemApp" );
@@ -370,8 +374,43 @@ class ApplicationServiceImplTest
 
         assertEquals( Bundle.ACTIVE, bundle.getState() );
         final ApplicationKey applicationKey = ApplicationKey.from( "systemApp" );
-        this.service.stopApplication( applicationKey );
-        assertEquals( Bundle.RESOLVED, bundle.getState() );
+
+        assertThatThrownBy( () -> this.service.stopApplication( applicationKey ) ).isInstanceOf( IllegalArgumentException.class )
+            .hasMessageContaining( "system application" );
+
+        assertEquals( Bundle.ACTIVE, bundle.getState() );
+    }
+
+    @Test
+    void uninstallApplication_systemApp_throws()
+    {
+        final Bundle bundle = deploySystemAppBundle( "systemApp" );
+        applicationRegistry.registerApplication( bundle );
+
+        final ApplicationKey applicationKey = ApplicationKey.from( "systemApp" );
+
+        assertThatThrownBy( () -> this.service.uninstallApplication( applicationKey ) ).isInstanceOf( IllegalArgumentException.class )
+            .hasMessageContaining( "system application" );
+
+        assertNotNull( this.service.getInstalledApplication( applicationKey ) );
+        assertEquals( Bundle.INSTALLED, bundle.getState() );
+    }
+
+    @Test
+    void uninstallLocalApplication_systemApp_throws()
+        throws Exception
+    {
+        final Bundle bundle = deploySystemAppBundle( "systemApp" );
+        applicationRegistry.registerApplication( bundle );
+        bundle.start();
+
+        final ApplicationKey applicationKey = ApplicationKey.from( "systemApp" );
+
+        assertThatThrownBy( () -> this.service.uninstallLocalApplication( applicationKey ) ).isInstanceOf( IllegalArgumentException.class )
+            .hasMessageContaining( "system application" );
+
+        assertNotNull( this.service.getInstalledApplication( applicationKey ) );
+        assertEquals( Bundle.ACTIVE, bundle.getState() );
     }
 
     @Test

--- a/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/ApplicationServiceSystemAppGuardsTest.java
+++ b/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/ApplicationServiceSystemAppGuardsTest.java
@@ -1,0 +1,113 @@
+package com.enonic.xp.core.impl.app;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.ops4j.pax.tinybundles.TinyBundles;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+
+import com.google.common.io.ByteSource;
+import com.google.common.io.ByteStreams;
+
+import com.enonic.xp.app.Application;
+import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.app.ApplicationService;
+import com.enonic.xp.audit.AuditLogService;
+import com.enonic.xp.context.Context;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.event.EventPublisher;
+import com.enonic.xp.node.NodeService;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.SystemConstants;
+import com.enonic.xp.security.User;
+import com.enonic.xp.security.auth.AuthenticationInfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class ApplicationServiceSystemAppGuardsTest
+    extends BundleBasedTest
+{
+    private static final String SYSTEM_APP_NAME = "com.enonic.test.systemapp";
+
+    private ApplicationService applicationService;
+
+    @BeforeEach
+    void initService()
+    {
+        final BundleContext bundleContext = getBundleContext();
+
+        final AppConfig appConfig = mock( AppConfig.class, invocation -> invocation.getMethod().getDefaultValue() );
+        final NodeService nodeService = mock( NodeService.class );
+
+        final ApplicationFactoryServiceImpl applicationFactoryService =
+            new ApplicationFactoryServiceImpl( bundleContext, nodeService, appConfig );
+        applicationFactoryService.activate();
+
+        final ApplicationAuditLogSupportImpl auditLogSupport = new ApplicationAuditLogSupportImpl( mock( AuditLogService.class ) );
+        auditLogSupport.activate( appConfig );
+
+        this.applicationService = new ApplicationServiceImpl(
+            new ApplicationRegistryImpl( bundleContext, new ApplicationListenerHub(), applicationFactoryService ),
+            mock( ApplicationRepoService.class ), mock( EventPublisher.class ), new AppFilterServiceImpl( appConfig ),
+            new VirtualAppService( nodeService ), auditLogSupport );
+    }
+
+    @Test
+    void deploy_installed_system_app_cannot_be_stopped()
+    {
+        final ApplicationKey key = ApplicationKey.from( SYSTEM_APP_NAME );
+
+        final Application installed =
+            adminContext().callWith( () -> applicationService.installLocalApplication( createSystemBundleSource() ) );
+
+        assertThat( installed ).isNotNull();
+        assertThat( installed.isSystem() ).isTrue();
+
+        final Bundle bundle = getBundleContext().getBundle( SYSTEM_APP_NAME );
+        assertThat( bundle ).isNotNull();
+        assertThat( bundle.getState() ).isEqualTo( Bundle.ACTIVE );
+
+        adminContext().runWith( () -> {
+            assertThatThrownBy( () -> applicationService.stopApplication( key ) ).isInstanceOf( IllegalArgumentException.class )
+                .hasMessageContaining( "system application" );
+            assertThat( bundle.getState() ).isEqualTo( Bundle.ACTIVE );
+        } );
+
+        assertThat( applicationService.getInstalledApplication( key ) ).isNotNull();
+    }
+
+    private static ByteSource createSystemBundleSource()
+    {
+        try
+        {
+            return ByteSource.wrap( ByteStreams.toByteArray( TinyBundles.bundle()
+                                                                 .setHeader( Constants.BUNDLE_SYMBOLICNAME, SYSTEM_APP_NAME )
+                                                                 .setHeader( Constants.BUNDLE_VERSION, "1.0.0" )
+                                                                 .setHeader( "X-Bundle-Type", "system" )
+                                                                 .addResource( "application.yml", ByteSource.wrap(
+                                                                     "kind: \"Application\"\ndescription: \"Test system app\"\n".getBytes(
+                                                                         StandardCharsets.UTF_8 ) ).openStream() )
+                                                                 .build() ) );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    private static Context adminContext()
+    {
+        return ContextBuilder.create()
+            .branch( SystemConstants.BRANCH_SYSTEM )
+            .repositoryId( SystemConstants.SYSTEM_REPO_ID )
+            .authInfo( AuthenticationInfo.create().principals( RoleKeys.ADMIN ).user( User.anonymous() ).build() )
+            .build();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a single guard at the top of `ApplicationServiceImpl#stopApplication`: if the application resolved through the registry is a system app (`X-Bundle-Type: system`), throw `IllegalArgumentException`. Stopping a system app at runtime leaves the platform in a broken state until JVM restart, so the call is rejected.

The scope is intentionally narrow: `startApplication`, `uninstallApplication`, and `uninstallLocalApplication` remain unguarded. Starting an already-`ACTIVE` system app is a no-op; uninstalling is a legitimate operator action — particularly via `DeployDirectoryWatcher` when an "extra system app" JAR is removed from `$XP_HOME/deploy/`. The existing `appInfo.system` rejection in `doInstallGlobalApplication` is unrelated and stays as-is.

`ApplicationServiceImplTest`: the previous `stop_system_application` test asserted the bug (bundle went `ACTIVE` → `RESOLVED`); it's replaced with `stopApplication_systemApp_throws`, which asserts `IllegalArgumentException` and that the bundle remains `ACTIVE`. The pre-existing `start_system_application_ignored` test is left intact.

Closes #12029

## Test plan
- [x] `./gradlew :core:core-app:test --tests '*ApplicationServiceImplTest*'` (passes)
- [x] `./gradlew :core:core-app:test` (passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)