### PR TITLE
Add Felix-runtime test for system-app stop guard #12029

### DIFF
--- a/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/ApplicationServiceSystemAppGuardsTest.java
+++ b/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/ApplicationServiceSystemAppGuardsTest.java
@@ -1,0 +1,113 @@
+package com.enonic.xp.core.impl.app;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.ops4j.pax.tinybundles.TinyBundles;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+
+import com.google.common.io.ByteSource;
+import com.google.common.io.ByteStreams;
+
+import com.enonic.xp.app.Application;
+import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.app.ApplicationService;
+import com.enonic.xp.audit.AuditLogService;
+import com.enonic.xp.context.Context;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.event.EventPublisher;
+import com.enonic.xp.node.NodeService;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.SystemConstants;
+import com.enonic.xp.security.User;
+import com.enonic.xp.security.auth.AuthenticationInfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class ApplicationServiceSystemAppGuardsTest
+    extends BundleBasedTest
+{
+    private static final String SYSTEM_APP_NAME = "com.enonic.test.systemapp";
+
+    private ApplicationService applicationService;
+
+    @BeforeEach
+    void initService()
+    {
+        final BundleContext bundleContext = getBundleContext();
+
+        final AppConfig appConfig = mock( AppConfig.class, invocation -> invocation.getMethod().getDefaultValue() );
+        final NodeService nodeService = mock( NodeService.class );
+
+        final ApplicationFactoryServiceImpl applicationFactoryService =
+            new ApplicationFactoryServiceImpl( bundleContext, nodeService, appConfig );
+        applicationFactoryService.activate();
+
+        final ApplicationAuditLogSupportImpl auditLogSupport = new ApplicationAuditLogSupportImpl( mock( AuditLogService.class ) );
+        auditLogSupport.activate( appConfig );
+
+        this.applicationService = new ApplicationServiceImpl(
+            new ApplicationRegistryImpl( bundleContext, new ApplicationListenerHub(), applicationFactoryService ),
+            mock( ApplicationRepoService.class ), mock( EventPublisher.class ), new AppFilterServiceImpl( appConfig ),
+            new VirtualAppService( nodeService ), auditLogSupport );
+    }
+
+    @Test
+    void deploy_installed_system_app_cannot_be_stopped()
+    {
+        final ApplicationKey key = ApplicationKey.from( SYSTEM_APP_NAME );
+
+        final Application installed =
+            adminContext().callWith( () -> applicationService.installLocalApplication( createSystemBundleSource() ) );
+
+        assertThat( installed ).isNotNull();
+        assertThat( installed.isSystem() ).isTrue();
+
+        final Bundle bundle = getBundleContext().getBundle( SYSTEM_APP_NAME );
+        assertThat( bundle ).isNotNull();
+        assertThat( bundle.getState() ).isEqualTo( Bundle.ACTIVE );
+
+        adminContext().runWith( () -> {
+            assertThatThrownBy( () -> applicationService.stopApplication( key ) ).isInstanceOf( IllegalArgumentException.class )
+                .hasMessageContaining( "system application" );
+            assertThat( bundle.getState() ).isEqualTo( Bundle.ACTIVE );
+        } );
+
+        assertThat( applicationService.getInstalledApplication( key ) ).isNotNull();
+    }
+
+    private static ByteSource createSystemBundleSource()
+    {
+        try
+        {
+            return ByteSource.wrap( ByteStreams.toByteArray( TinyBundles.bundle()
+                                                                 .setHeader( Constants.BUNDLE_SYMBOLICNAME, SYSTEM_APP_NAME )
+                                                                 .setHeader( Constants.BUNDLE_VERSION, "1.0.0" )
+                                                                 .setHeader( "X-Bundle-Type", "system" )
+                                                                 .addResource( "application.yml", ByteSource.wrap(
+                                                                     "kind: \"Application\"\ndescription: \"Test system app\"\n".getBytes(
+                                                                         StandardCharsets.UTF_8 ) ).openStream() )
+                                                                 .build() ) );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    private static Context adminContext()
+    {
+        return ContextBuilder.create()
+            .branch( SystemConstants.BRANCH_SYSTEM )
+            .repositoryId( SystemConstants.SYSTEM_REPO_ID )
+            .authInfo( AuthenticationInfo.create().principals( RoleKeys.ADMIN ).user( User.anonymous() ).build() )
+            .build();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a unit test under `modules/core/core-app/src/test/` that exercises the system-application stop guard introduced by #12030 against an embedded `org.apache.felix.framework`, going through the real install pipeline rather than the `MockApplication` shortcut.

The test:

1. Builds a tiny `X-Bundle-Type: system` bundle (with `application.yml`) via `pax-tinybundles`.
2. Installs it through `ApplicationService.installLocalApplication(...)` — the same path `DeployDirectoryWatcher` takes when an operator drops a JAR into `$XP_HOME/deploy/` (the "extra system app" scenario described in #12029).
3. Verifies the install succeeds, `Application#isSystem()` is `true`, and the bundle is `ACTIVE`.
4. Calls `stopApplication`, asserting it throws `IllegalArgumentException` with `"system application"` in the message and that the bundle remains `ACTIVE`.

`startApplication`, `uninstallApplication`, and `uninstallLocalApplication` are NOT asserted to throw — those are intentionally unguarded (see #12029 / #12030).

## Why this is needed on top of the unit tests in #12030

The `ApplicationServiceImplTest` cases in #12030 use a `MockApplication` fixture and a manually `registerApplication`-ed `Bundle`, so they verify only the guard logic in isolation. They don't exercise the actual OSGi pipeline an operator-installed system bundle goes through (`installLocalApplication` → `ApplicationRegistry#install` → `BundleContext#installBundle` → `BundleTracker` → bundle reaching `ACTIVE`). This test closes that gap by running the full pipeline in an embedded Felix framework, then attacks it through the `ApplicationService` API the same way an in-process Java caller would.

Closes #12029 (combined with #12030).

## Test plan
- [x] `./gradlew :core:core-app:test --tests '*ApplicationServiceSystemAppGuardsTest*'` — passes
- [x] `./gradlew :core:core-app:test` — passes

## Notes for reviewer

- This PR is currently based on `12029-block-system-app-stop` (the branch behind #12030) since it depends on the guard implementation. Once #12030 merges to master I'll rebase onto master and re-target the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)