### PR TITLE
Allow ${app} in Pattern mappings #10369

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/site/mapping/ControllerMappingDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/site/mapping/ControllerMappingDescriptor.java
@@ -158,6 +158,8 @@ public final class ControllerMappingDescriptor
 
     public static final class Builder
     {
+        private static final String APP_TOKEN = "${app}";
+
         private String service;
 
         private ResourceKey controller;
@@ -166,11 +168,15 @@ public final class ControllerMappingDescriptor
 
         private Pattern pattern;
 
+        private String patternStr;
+
         private boolean invertPattern = false;
 
         private ContentMappingConstraint contentConstraint;
 
         private int order = DEFAULT_ORDER;
+
+        private ApplicationKey applicationKey;
 
         private Builder( final ControllerMappingDescriptor mappingDescriptor )
         {
@@ -181,6 +187,7 @@ public final class ControllerMappingDescriptor
             this.invertPattern = mappingDescriptor.invertPattern();
             this.contentConstraint = mappingDescriptor.getContentConstraint();
             this.order = mappingDescriptor.getOrder();
+            this.applicationKey = mappingDescriptor.getApplication();
         }
 
         private Builder()
@@ -208,12 +215,14 @@ public final class ControllerMappingDescriptor
         public Builder pattern( final Pattern pattern )
         {
             this.pattern = pattern;
+            this.patternStr = null;
             return this;
         }
 
         public Builder pattern( final String pattern )
         {
-            this.pattern = pattern != null ? Pattern.compile( pattern ) : null;
+            this.patternStr = pattern;
+            this.pattern = null;
             return this;
         }
 
@@ -241,8 +250,26 @@ public final class ControllerMappingDescriptor
             return this;
         }
 
+        public Builder applicationKey( final ApplicationKey applicationKey )
+        {
+            this.applicationKey = applicationKey;
+            return this;
+        }
+
         public ControllerMappingDescriptor build()
         {
+            if ( this.patternStr != null )
+            {
+                final ApplicationKey resolvedApp = this.applicationKey != null
+                    ? this.applicationKey
+                    : this.controller != null ? this.controller.getApplicationKey()
+                        : this.filter != null ? this.filter.getApplicationKey() : null;
+                final String resolved = resolvedApp != null
+                    ? this.patternStr.replace( APP_TOKEN, Pattern.quote( resolvedApp.getName() ) )
+                    : this.patternStr;
+                this.pattern = Pattern.compile( resolved );
+                this.patternStr = null;
+            }
             return new ControllerMappingDescriptor( this );
         }
     }

--- a/modules/core/core-api/src/test/java/com/enonic/xp/site/mapping/ControllerMappingDescriptorTest.java
+++ b/modules/core/core-api/src/test/java/com/enonic/xp/site/mapping/ControllerMappingDescriptorTest.java
@@ -120,6 +120,70 @@ class ControllerMappingDescriptorTest
     }
 
     @Test
+    void testAppTokenSubstitutedInPattern()
+    {
+        final ApplicationKey applicationKey = ApplicationKey.from( "com.foo.bar" );
+
+        final ControllerMappingDescriptor descriptor = ControllerMappingDescriptor.create().
+            controller( ResourceKey.from( applicationKey, "/site/controllers/mycontroller.js" ) ).
+            pattern( "/_/static/${app}/.+" ).
+            build();
+
+        final String expected = "/_/static/" + Pattern.quote( "com.foo.bar" ) + "/.+";
+        assertEquals( expected, descriptor.getPattern().pattern() );
+        assertTrue( descriptor.getPattern().matcher( "/_/static/com.foo.bar/main.js" ).matches() );
+        assertFalse( descriptor.getPattern().matcher( "/_/static/com.other.app/main.js" ).matches() );
+    }
+
+    @Test
+    void testAppTokenAbsentIsNoOp()
+    {
+        final ControllerMappingDescriptor descriptor = ControllerMappingDescriptor.create().
+            controller( ResourceKey.from( ApplicationKey.from( "com.foo.bar" ), "/site/controllers/mycontroller.js" ) ).
+            pattern( "/people/.*" ).
+            build();
+
+        assertEquals( "/people/.*", descriptor.getPattern().pattern() );
+    }
+
+    @Test
+    void testAppTokenExpansionIsRegexQuoted()
+    {
+        final ControllerMappingDescriptor descriptor = ControllerMappingDescriptor.create().
+            controller( ResourceKey.from( ApplicationKey.from( "com.foo.bar" ), "/site/controllers/mycontroller.js" ) ).
+            pattern( "/_/static/${app}/.+" ).
+            build();
+
+        assertFalse( descriptor.getPattern().matcher( "/_/static/comXfooYbar/main.js" ).matches() );
+    }
+
+    @Test
+    void testAppTokenSubstitutedForFilter()
+    {
+        final ApplicationKey applicationKey = ApplicationKey.from( "com.foo.bar" );
+
+        final ControllerMappingDescriptor descriptor = ControllerMappingDescriptor.create().
+            filter( ResourceKey.from( applicationKey, "/site/filters/myfilter.js" ) ).
+            pattern( "/_/static/${app}/.+" ).
+            build();
+
+        assertTrue( descriptor.getPattern().matcher( "/_/static/com.foo.bar/main.js" ).matches() );
+    }
+
+    @Test
+    void testExplicitApplicationKeyTakesPrecedence()
+    {
+        final ControllerMappingDescriptor descriptor = ControllerMappingDescriptor.create().
+            controller( ResourceKey.from( ApplicationKey.from( "com.foo.bar" ), "/site/controllers/mycontroller.js" ) ).
+            applicationKey( ApplicationKey.from( "com.override.app" ) ).
+            pattern( "/_/static/${app}/.+" ).
+            build();
+
+        assertTrue( descriptor.getPattern().matcher( "/_/static/com.override.app/main.js" ).matches() );
+        assertFalse( descriptor.getPattern().matcher( "/_/static/com.foo.bar/main.js" ).matches() );
+    }
+
+    @Test
     void testCompare()
     {
         final ControllerMappingDescriptor descriptor = ControllerMappingDescriptor.create().

--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/parser/YmlSiteDescriptorParser.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/parser/YmlSiteDescriptorParser.java
@@ -129,6 +129,9 @@ public final class YmlSiteDescriptorParser
 
                 @JsonProperty("match")
                 abstract ControllerMappingDescriptor.Builder contentConstraint( String contentConstraint );
+
+                @JacksonInject("currentApplication")
+                abstract ControllerMappingDescriptor.Builder applicationKey( ApplicationKey applicationKey );
             }
         }
 

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/parser/YmlSiteDescriptorParserTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/parser/YmlSiteDescriptorParserTest.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Iterator;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
@@ -86,6 +87,12 @@ public class YmlSiteDescriptorParserTest
         assertEquals( "/my-filter", mapping_3.getPattern().pattern() );
         assertTrue( mapping_3.invertPattern() );
         assertEquals( "type:'portal:fragment'", mapping_3.getContentConstraint().toString() );
+
+        final ControllerMappingDescriptor mapping_4 = mappingsIterator.next();
+        assertEquals( ResourceKey.from( currentApplication, "/site/mappings/static-controller.js" ), mapping_4.getController() );
+        assertEquals( "/_/static/" + Pattern.quote( "myapp" ) + "/.+", mapping_4.getPattern().pattern() );
+        assertTrue( mapping_4.getPattern().matcher( "/_/static/myapp/main.js" ).matches() );
+        assertFalse( mapping_4.getPattern().matcher( "/_/static/other.app/main.js" ).matches() );
 
         // verify mounted APIs
         final DescriptorKeys mountedApis = siteDescriptor.getApiMounts();

--- a/modules/core/core-content/src/test/resources/descriptors/site-descriptor.yml
+++ b/modules/core/core-content/src/test/resources/descriptors/site-descriptor.yml
@@ -23,6 +23,9 @@ mappings:
     invertPattern: true
     match: "type:'portal:fragment'"
     order: 10
+  - pattern: "/_/static/${app}/.+"
+    controller: "/site/mappings/static-controller.js"
+    order: 10
 
 apis:
   - "admin:extension"


### PR DESCRIPTION
## Summary

Site descriptor `<pattern>` entries (in `cms/site.yml` / `site.yaml`) now expand the `${app}` placeholder to the owning application's key at parse time, so authors can write app-relative URL patterns without hardcoding the bundle symbolic name.

Example:

```yaml
mappings:
  - pattern: "/_/static/${app}/.+"
    controller: "/site/mappings/static-controller.js"
```

For an application `com.foo.bar`, the compiled regex becomes `/_/static/\Qcom.foo.bar\E/.+`.

## Details

- `${app}` is the same token the existing `ApplicationWildcardMatcher` (core-api) recognises for content-type wildcards; we reuse the convention.
- Expansion value is `applicationKey.getName()`.
- The expansion is wrapped in `Pattern.quote(...)` so regex metacharacters inside app keys (most contain dots) are treated literally — `${app}` with key `com.foo.bar` does **not** match `comXfooYbar`.
- Substitution happens once, in `ControllerMappingDescriptor.Builder.build()`, before `Pattern.compile`. The Pattern is cached per descriptor by `ResourceService.processResource`. No per-request cost.
- `ControllerMappingsResolver` / `MappingHandler*` are untouched.
- Scope: only `${app}`, only the `<pattern>` element of mappings. No general templating engine, no other variables.

## Where

- `ControllerMappingDescriptor.Builder` keeps the raw string pattern + applicationKey and resolves+compiles in `build()`. Programmatic callers benefit too: the application key is derived from `controller`/`filter` if not set explicitly.
- `YmlSiteDescriptorParser` Jackson mixin gains a `@JacksonInject("currentApplication")` setter on the builder, mirroring `ResponseProcessorDescriptor.Builder.application(...)`.

## Test plan

- [x] `:core:core-api:test` — new `ControllerMappingDescriptorTest` cases for ${app} substitution, no-op when token absent, `Pattern.quote` guard against regex-metachar app keys, filter-derived key, explicit-key override.
- [x] `:core:core-content:test` — `YmlSiteDescriptorParserTest` parses a mapping with `${app}` and asserts the compiled pattern resolves against the injected currentApplication.
- [x] `:portal:portal-impl:test` (mapping handler tests still green).
- [x] `./gradlew test` — green except a pre-existing unrelated `ZipExportWriterTest.testPathWithSpecialCharacters` filesystem-charset failure on this runner (reproduced on `master`).

Closes #10369