### PR TITLE
lib-auth: restore idProviderConfig #12041

### DIFF
--- a/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/CreateIdProviderHandler.java
+++ b/modules/lib/lib-auth/src/main/java/com/enonic/xp/lib/auth/CreateIdProviderHandler.java
@@ -5,12 +5,15 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.lib.common.IdProviderMapper;
 import com.enonic.xp.script.ScriptValue;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
 import com.enonic.xp.security.CreateIdProviderParams;
 import com.enonic.xp.security.IdProvider;
+import com.enonic.xp.security.IdProviderConfig;
 import com.enonic.xp.security.IdProviderKey;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.SecurityService;
@@ -29,6 +32,8 @@ public final class CreateIdProviderHandler
 
     private String description;
 
+    private ScriptValue idProviderConfig;
+
     private ScriptValue permissions;
 
     public void setKey( final String key )
@@ -46,6 +51,11 @@ public final class CreateIdProviderHandler
         this.description = description;
     }
 
+    public void setIdProviderConfig( final ScriptValue idProviderConfig )
+    {
+        this.idProviderConfig = idProviderConfig;
+    }
+
     public void setPermissions( final ScriptValue permissions )
     {
         this.permissions = permissions;
@@ -57,11 +67,26 @@ public final class CreateIdProviderHandler
             .key( IdProviderKey.from( this.key ) )
             .displayName( this.displayName )
             .description( this.description )
+            .idProviderConfig( buildIdProviderConfig() )
             .permissions( buildPermissions() )
             .build();
 
         final IdProvider idProvider = this.securityService.get().createIdProvider( params );
         return new IdProviderMapper( idProvider );
+    }
+
+    private IdProviderConfig buildIdProviderConfig()
+    {
+        if ( this.idProviderConfig == null )
+        {
+            return null;
+        }
+        final ScriptValue applicationKey = this.idProviderConfig.getMember( "applicationKey" );
+        final ScriptValue config = this.idProviderConfig.getMember( "config" );
+        return IdProviderConfig.create()
+            .applicationKey( applicationKey == null ? null : ApplicationKey.from( applicationKey.getValue( String.class ) ) )
+            .config( config == null || !config.isObject() ? null : PropertyTree.fromMap( config.getMap() ) )
+            .build();
     }
 
     private IdProviderAccessControlList buildPermissions()

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
@@ -881,14 +881,14 @@ export interface IdProviderAccessControlEntry {
  * providers — each with its own `config` tree (e.g. a `staff` and a
  * `customers` provider both implemented by the same id-provider app).
  *
- * When an id provider has no `idProviderConfig`, it exists in the security
- * repository but is inert: requests to `/_/idprovider/<key>` are not
- * dispatched to any app.
+ * An id provider without `idProviderConfig` is incomplete: admin UIs
+ * reject it as invalid, and most flows that rely on it won't work until
+ * a binding is added.
  */
 export interface IdProviderConfig {
     /**
-     * Key of the application whose `idprovider/*.js` handlers serve
-     * requests for this provider.
+     * Key of the application whose handlers serve requests for this
+     * provider.
      */
     applicationKey: string;
     /**
@@ -898,9 +898,9 @@ export interface IdProviderConfig {
 }
 
 /**
- * An id provider in the security repository. Has 0 or 1 bound application
- * via `idProviderConfig`; the binding determines which app handles login,
- * logout, registration, and similar flows for this provider.
+ * An id provider. Has 0 or 1 bound application via `idProviderConfig`;
+ * the binding determines which app handles login, logout, registration,
+ * and similar flows for this provider.
  */
 export interface IdProvider {
     /** Unique key identifying this provider (e.g. `system`, `simpleid`). */
@@ -910,16 +910,16 @@ export interface IdProvider {
     /** Optional free-text description. */
     description?: string;
     /**
-     * Application binding. Absent ⇒ passive provider (exists in the
-     * security repository but routes no auth requests).
+     * Application binding. Absent ⇒ the provider is incomplete; admin
+     * UIs treat it as invalid and dependent flows generally won't work.
      */
     idProviderConfig?: IdProviderConfig;
 }
 
 /**
  * Parameters for {@link createIdProvider}. See {@link IdProvider} for the
- * meaning of each field; `idProviderConfig` is optional and creates a
- * passive provider when omitted.
+ * meaning of each field; without `idProviderConfig` the provider is
+ * incomplete.
  */
 export interface CreateIdProviderParams {
     key: string;
@@ -944,12 +944,12 @@ interface CreateIdProviderHandler {
 }
 
 /**
- * Creates an id provider in the security repository.
+ * Creates an id provider.
  *
  * An id provider can be bound to at most one application via
- * `params.idProviderConfig`. Omit it to create a passive provider: the
- * record exists but cannot service `/_/idprovider/<key>` requests until a
- * binding is added.
+ * `params.idProviderConfig`. Without it the provider is incomplete —
+ * admin UIs reject it as invalid and most flows that rely on it won't
+ * work until a binding is added.
  *
  * @example-ref examples/auth/createIdProvider.js
  *
@@ -957,7 +957,7 @@ interface CreateIdProviderHandler {
  * @param {string} params.key Id provider key.
  * @param {string} params.displayName Id provider display name.
  * @param {string} [params.description] Id provider description.
- * @param {object} [params.idProviderConfig] Binds this provider to one application. Omit for a passive provider.
+ * @param {object} [params.idProviderConfig] Binds this provider to one application. Without it the provider is incomplete.
  * @param {string} params.idProviderConfig.applicationKey Application that handles requests for this provider. Required when `idProviderConfig` is set.
  * @param {object} [params.idProviderConfig.config] Per-instance configuration tree passed to the bound application.
  * @param {Array<object>} [params.permissions] Id provider permissions.
@@ -985,9 +985,9 @@ interface GetIdProvidersHandler {
 }
 
 /**
- * Returns all id providers known to the security repository. Each entry's
- * `idProviderConfig` is present only when the provider is bound to an
- * application; passive providers come back without it.
+ * Returns all id providers. Each entry's `idProviderConfig` is present
+ * only when the provider is bound to an application; incomplete
+ * providers come back without it.
  *
  * @example-ref examples/auth/getIdProviders.js
  *

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
@@ -872,18 +872,55 @@ export interface IdProviderAccessControlEntry {
     access: IdProviderAccess;
 }
 
+/**
+ * Configuration that binds an id provider to the application implementing
+ * its authentication flow.
+ *
+ * An id provider can be bound to at most **one** application via
+ * `applicationKey`. The same application may, in turn, back several id
+ * providers — each with its own `config` tree (e.g. a `staff` and a
+ * `customers` provider both implemented by the same id-provider app).
+ *
+ * When an id provider has no `idProviderConfig`, it exists in the security
+ * repository but is inert: requests to `/_/idprovider/<key>` are not
+ * dispatched to any app.
+ */
 export interface IdProviderConfig {
+    /**
+     * Key of the application whose `idprovider/*.js` handlers serve
+     * requests for this provider.
+     */
     applicationKey: string;
+    /**
+     * Per-instance configuration tree, exposed to the bound application.
+     */
     config?: Record<string, unknown>;
 }
 
+/**
+ * An id provider in the security repository. Has 0 or 1 bound application
+ * via `idProviderConfig`; the binding determines which app handles login,
+ * logout, registration, and similar flows for this provider.
+ */
 export interface IdProvider {
+    /** Unique key identifying this provider (e.g. `system`, `simpleid`). */
     key: string;
+    /** Human-readable label shown in admin UIs. */
     displayName: string;
+    /** Optional free-text description. */
     description?: string;
+    /**
+     * Application binding. Absent ⇒ passive provider (exists in the
+     * security repository but routes no auth requests).
+     */
     idProviderConfig?: IdProviderConfig;
 }
 
+/**
+ * Parameters for {@link createIdProvider}. See {@link IdProvider} for the
+ * meaning of each field; `idProviderConfig` is optional and creates a
+ * passive provider when omitted.
+ */
 export interface CreateIdProviderParams {
     key: string;
     displayName: string;
@@ -907,7 +944,12 @@ interface CreateIdProviderHandler {
 }
 
 /**
- * Creates an id provider.
+ * Creates an id provider in the security repository.
+ *
+ * An id provider can be bound to at most one application via
+ * `params.idProviderConfig`. Omit it to create a passive provider: the
+ * record exists but cannot service `/_/idprovider/<key>` requests until a
+ * binding is added.
  *
  * @example-ref examples/auth/createIdProvider.js
  *
@@ -915,9 +957,9 @@ interface CreateIdProviderHandler {
  * @param {string} params.key Id provider key.
  * @param {string} params.displayName Id provider display name.
  * @param {string} [params.description] Id provider description.
- * @param {object} [params.idProviderConfig] Id provider configuration binding it to an application.
- * @param {string} params.idProviderConfig.applicationKey Application key that handles the id provider requests.
- * @param {object} [params.idProviderConfig.config] Application-specific configuration tree.
+ * @param {object} [params.idProviderConfig] Binds this provider to one application. Omit for a passive provider.
+ * @param {string} params.idProviderConfig.applicationKey Application that handles requests for this provider. Required when `idProviderConfig` is set.
+ * @param {object} [params.idProviderConfig.config] Per-instance configuration tree passed to the bound application.
  * @param {Array<object>} [params.permissions] Id provider permissions.
  * @returns {IdProvider} The created id provider.
  */
@@ -943,7 +985,9 @@ interface GetIdProvidersHandler {
 }
 
 /**
- * Returns all id providers.
+ * Returns all id providers known to the security repository. Each entry's
+ * `idProviderConfig` is present only when the provider is bound to an
+ * application; passive providers come back without it.
  *
  * @example-ref examples/auth/getIdProviders.js
  *

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
@@ -872,16 +872,23 @@ export interface IdProviderAccessControlEntry {
     access: IdProviderAccess;
 }
 
+export interface IdProviderConfig {
+    applicationKey: string;
+    config?: Record<string, unknown>;
+}
+
 export interface IdProvider {
     key: string;
     displayName: string;
     description?: string;
+    idProviderConfig?: IdProviderConfig;
 }
 
 export interface CreateIdProviderParams {
     key: string;
     displayName: string;
     description?: string;
+    idProviderConfig?: IdProviderConfig;
     permissions?: IdProviderAccessControlEntry[];
 }
 
@@ -891,6 +898,8 @@ interface CreateIdProviderHandler {
     setDisplayName(value: string): void;
 
     setDescription(value: string | null): void;
+
+    setIdProviderConfig(value: ScriptValue | null): void;
 
     setPermissions(value: ScriptValue | null): void;
 
@@ -906,6 +915,9 @@ interface CreateIdProviderHandler {
  * @param {string} params.key Id provider key.
  * @param {string} params.displayName Id provider display name.
  * @param {string} [params.description] Id provider description.
+ * @param {object} [params.idProviderConfig] Id provider configuration binding it to an application.
+ * @param {string} params.idProviderConfig.applicationKey Application key that handles the id provider requests.
+ * @param {object} [params.idProviderConfig.config] Application-specific configuration tree.
  * @param {Array<object>} [params.permissions] Id provider permissions.
  * @returns {IdProvider} The created id provider.
  */
@@ -920,6 +932,7 @@ export function createIdProvider(
     bean.setKey(key);
     bean.setDisplayName(displayName);
     bean.setDescription(__.nullOrValue(params.description));
+    bean.setIdProviderConfig(params.idProviderConfig == null ? null : __.toScriptValue(params.idProviderConfig));
     bean.setPermissions(params.permissions == null ? null : __.toScriptValue(params.permissions));
 
     return __.toNativeObject(bean.createIdProvider()) as IdProvider;

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
@@ -639,8 +639,8 @@ export function deletePrincipal(principalKey: PrincipalKey): boolean {
     return __.toNativeObject(bean.deletePrincipal());
 }
 
-interface GetIdProviderConfigHandler<IdProviderConfig extends Record<string, unknown>> {
-    execute(): IdProviderConfig | null;
+interface GetIdProviderConfigHandler<Config extends Record<string, unknown>> {
+    execute(): Config | null;
 }
 
 /**
@@ -651,8 +651,8 @@ interface GetIdProviderConfigHandler<IdProviderConfig extends Record<string, unk
  *
  * @returns {object} The ID provider configuration as JSON.
  */
-export function getIdProviderConfig<IdProviderConfig extends Record<string, unknown>>(): IdProviderConfig | null {
-    const bean: GetIdProviderConfigHandler<IdProviderConfig> = __.newBean<GetIdProviderConfigHandler<IdProviderConfig>>(
+export function getIdProviderConfig<Config extends Record<string, unknown>>(): Config | null {
+    const bean: GetIdProviderConfigHandler<Config> = __.newBean<GetIdProviderConfigHandler<Config>>(
         'com.enonic.xp.lib.auth.GetIdProviderConfigHandler');
     return __.toNativeObject(bean.execute());
 }

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/auth.ts
@@ -881,9 +881,8 @@ export interface IdProviderAccessControlEntry {
  * providers — each with its own `config` tree (e.g. a `staff` and a
  * `customers` provider both implemented by the same id-provider app).
  *
- * An id provider without `idProviderConfig` is incomplete: admin UIs
- * reject it as invalid, and most flows that rely on it won't work until
- * a binding is added.
+ * An id provider without `idProviderConfig` is incomplete and most
+ * flows that rely on it won't work until a binding is added.
  */
 export interface IdProviderConfig {
     /**
@@ -910,8 +909,8 @@ export interface IdProvider {
     /** Optional free-text description. */
     description?: string;
     /**
-     * Application binding. Absent ⇒ the provider is incomplete; admin
-     * UIs treat it as invalid and dependent flows generally won't work.
+     * Application binding. Absent ⇒ the provider is incomplete and
+     * dependent flows generally won't work.
      */
     idProviderConfig?: IdProviderConfig;
 }
@@ -947,9 +946,8 @@ interface CreateIdProviderHandler {
  * Creates an id provider.
  *
  * An id provider can be bound to at most one application via
- * `params.idProviderConfig`. Without it the provider is incomplete —
- * admin UIs reject it as invalid and most flows that rely on it won't
- * work until a binding is added.
+ * `params.idProviderConfig`. Without it the provider is incomplete and
+ * most flows that rely on it won't work until a binding is added.
  *
  * @example-ref examples/auth/createIdProvider.js
  *

--- a/modules/lib/lib-auth/src/main/resources/lib/xp/examples/auth/createIdProvider.js
+++ b/modules/lib/lib-auth/src/main/resources/lib/xp/examples/auth/createIdProvider.js
@@ -4,6 +4,12 @@ var createIdProviderResult = authLib.createIdProvider({
     key: 'myIdProvider',
     displayName: 'My id provider',
     description: 'My id provider description',
+    idProviderConfig: {
+        applicationKey: 'com.enonic.app.myidprovider',
+        config: {
+            loginUrl: 'https://example.com/login'
+        }
+    },
     permissions: [
         {
             principal: 'role:system.admin',

--- a/modules/lib/lib-auth/src/test/java/com/enonic/xp/lib/auth/CreateIdProviderHandlerTest.java
+++ b/modules/lib/lib-auth/src/test/java/com/enonic/xp/lib/auth/CreateIdProviderHandlerTest.java
@@ -4,8 +4,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.security.CreateIdProviderParams;
 import com.enonic.xp.security.IdProviderAlreadyExistsException;
+import com.enonic.xp.security.IdProviderConfig;
 import com.enonic.xp.security.IdProviderKey;
 import com.enonic.xp.security.SecurityService;
 import com.enonic.xp.testing.ScriptTestSupport;
@@ -48,7 +50,15 @@ class CreateIdProviderHandlerTest
         assertThat( params.getKey() ).isEqualTo( IdProviderKey.from( "idProviderTestKey" ) );
         assertThat( params.getDisplayName() ).isEqualTo( "Id Provider test" );
         assertThat( params.getDescription() ).isEqualTo( "Id Provider used for testing" );
-        assertThat( params.getIdProviderConfig() ).isNull();
+
+        final IdProviderConfig idProviderConfig = params.getIdProviderConfig();
+        assertThat( idProviderConfig ).isNotNull();
+        assertThat( idProviderConfig.getApplicationKey() ).isEqualTo( ApplicationKey.from( "com.enonic.app.test" ) );
+        assertThat( idProviderConfig.getConfig() ).isNotNull();
+        assertThat( idProviderConfig.getConfig().getString( "loginUrl" ) ).isEqualTo( "https://example.com/login" );
+        assertThat( idProviderConfig.getConfig().getBoolean( "nested.flag" ) ).isTrue();
+        assertThat( idProviderConfig.getConfig().getLong( "nested.count" ) ).isEqualTo( 7L );
+
         assertThat( params.getIdProviderPermissions() ).isNotNull();
         assertThat( params.getIdProviderPermissions().isEmpty() ).isFalse();
     }
@@ -69,6 +79,31 @@ class CreateIdProviderHandlerTest
         assertThat( params.getDescription() ).isNull();
         assertThat( params.getIdProviderConfig() ).isNull();
         assertThat( params.getIdProviderPermissions().isEmpty() ).isTrue();
+    }
+
+    @Test
+    void testCreateIdProviderConfigWithoutConfig()
+    {
+        Mockito.when( securityService.createIdProvider( Mockito.any() ) ).thenReturn( TestDataFixtures.getTestIdProvider() );
+
+        runFunction( "/test/createIdProvider-test.js", "createIdProviderConfigWithoutConfig" );
+
+        final ArgumentCaptor<CreateIdProviderParams> captor = ArgumentCaptor.forClass( CreateIdProviderParams.class );
+        Mockito.verify( securityService ).createIdProvider( captor.capture() );
+
+        final IdProviderConfig idProviderConfig = captor.getValue().getIdProviderConfig();
+        assertThat( idProviderConfig ).isNotNull();
+        assertThat( idProviderConfig.getApplicationKey() ).isEqualTo( ApplicationKey.from( "com.enonic.app.test" ) );
+        assertThat( idProviderConfig.getConfig() ).isNotNull();
+        assertThat( idProviderConfig.getConfig().getRoot().getPropertySize() ).isZero();
+    }
+
+    @Test
+    void testCreateIdProviderMissingApplicationKey()
+    {
+        assertThatThrownBy(
+            () -> runFunction( "/test/createIdProvider-test.js", "createIdProviderMissingApplicationKey" ) ).hasMessageContaining(
+            "applicationKey" );
     }
 
     @Test

--- a/modules/lib/lib-auth/src/test/resources/test/createIdProvider-test.js
+++ b/modules/lib/lib-auth/src/test/resources/test/createIdProvider-test.js
@@ -1,12 +1,38 @@
 var t = require('/lib/xp/testing.js');
 var auth = require('/lib/xp/auth.js');
 
+var expectedFixtureResult = {
+    'key': 'idProviderTestKey',
+    'displayName': 'Id Provider test',
+    'description': 'Id Provider used for testing',
+    'idProviderConfig': {
+        'applicationKey': 'com.enonic.app.test',
+        'config': {
+            'set': {
+                'subString': 'subStringValue',
+                'subLong': 123
+            },
+            'string': 'stringValue'
+        }
+    }
+};
+
 exports.createIdProvider = function () {
 
     var result = auth.createIdProvider({
         key: 'idProviderTestKey',
         displayName: 'Id Provider test',
         description: 'Id Provider used for testing',
+        idProviderConfig: {
+            applicationKey: 'com.enonic.app.test',
+            config: {
+                loginUrl: 'https://example.com/login',
+                nested: {
+                    flag: true,
+                    count: 7
+                }
+            }
+        },
         permissions: [
             {
                 principal: 'role:system.admin',
@@ -15,13 +41,7 @@ exports.createIdProvider = function () {
         ]
     });
 
-    var expectedJson = {
-        'key': 'idProviderTestKey',
-        'displayName': 'Id Provider test',
-        'description': 'Id Provider used for testing'
-    };
-
-    t.assertJsonEquals(expectedJson, result, 'createIdProvider result not equals');
+    t.assertJsonEquals(expectedFixtureResult, result, 'createIdProvider result not equals');
 };
 
 exports.createIdProviderMinimal = function () {
@@ -31,13 +51,31 @@ exports.createIdProviderMinimal = function () {
         displayName: 'Id Provider test'
     });
 
-    var expectedJson = {
-        'key': 'idProviderTestKey',
-        'displayName': 'Id Provider test',
-        'description': 'Id Provider used for testing'
-    };
+    t.assertJsonEquals(expectedFixtureResult, result, 'createIdProvider result not equals');
+};
 
-    t.assertJsonEquals(expectedJson, result, 'createIdProvider result not equals');
+exports.createIdProviderConfigWithoutConfig = function () {
+
+    auth.createIdProvider({
+        key: 'idProviderTestKey',
+        displayName: 'Id Provider test',
+        idProviderConfig: {
+            applicationKey: 'com.enonic.app.test'
+        }
+    });
+};
+
+exports.createIdProviderMissingApplicationKey = function () {
+
+    auth.createIdProvider({
+        key: 'idProviderTestKey',
+        displayName: 'Id Provider test',
+        idProviderConfig: {
+            config: {
+                anything: 'goes'
+            }
+        }
+    });
 };
 
 exports.createIdProviderMissingKey = function () {

--- a/modules/lib/lib-auth/src/test/resources/test/getIdProviders-test.js
+++ b/modules/lib/lib-auth/src/test/resources/test/getIdProviders-test.js
@@ -9,7 +9,17 @@ exports.getIdProviders = function () {
         {
             'key': 'idProviderTestKey',
             'displayName': 'Id Provider test',
-            'description': 'Id Provider used for testing'
+            'description': 'Id Provider used for testing',
+            'idProviderConfig': {
+                'applicationKey': 'com.enonic.app.test',
+                'config': {
+                    'set': {
+                        'subString': 'subStringValue',
+                        'subLong': 123
+                    },
+                    'string': 'stringValue'
+                }
+            }
         }
     ];
 

--- a/modules/lib/lib-common/src/main/java/com/enonic/xp/lib/common/IdProviderMapper.java
+++ b/modules/lib/lib-common/src/main/java/com/enonic/xp/lib/common/IdProviderMapper.java
@@ -3,6 +3,7 @@ package com.enonic.xp.lib.common;
 import com.enonic.xp.script.serializer.MapGenerator;
 import com.enonic.xp.script.serializer.MapSerializable;
 import com.enonic.xp.security.IdProvider;
+import com.enonic.xp.security.IdProviderConfig;
 
 public final class IdProviderMapper
     implements MapSerializable
@@ -20,5 +21,20 @@ public final class IdProviderMapper
         gen.value( "key", idProvider.getKey() );
         gen.value( "displayName", idProvider.getDisplayName() );
         gen.value( "description", idProvider.getDescription() );
+        serializeIdProviderConfig( gen, idProvider.getIdProviderConfig() );
+    }
+
+    private void serializeIdProviderConfig( final MapGenerator gen, final IdProviderConfig idProviderConfig )
+    {
+        if ( idProviderConfig == null )
+        {
+            return;
+        }
+        gen.map( "idProviderConfig" );
+        gen.value( "applicationKey", idProviderConfig.getApplicationKey() );
+        gen.map( "config" );
+        new PropertyTreeMapper( idProviderConfig.getConfig() ).serialize( gen );
+        gen.end();
+        gen.end();
     }
 }

--- a/modules/lib/lib-common/src/test/java/com/enonic/xp/lib/common/IdProviderMapperTest.java
+++ b/modules/lib/lib-common/src/test/java/com/enonic/xp/lib/common/IdProviderMapperTest.java
@@ -1,0 +1,49 @@
+package com.enonic.xp.lib.common;
+
+import org.junit.jupiter.api.Test;
+
+import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.data.PropertySet;
+import com.enonic.xp.data.PropertyTree;
+import com.enonic.xp.security.IdProvider;
+import com.enonic.xp.security.IdProviderConfig;
+import com.enonic.xp.security.IdProviderKey;
+import com.enonic.xp.testing.helper.JsonAssert;
+
+class IdProviderMapperTest
+{
+    @Test
+    void testIdProviderSerialized()
+        throws Exception
+    {
+        final IdProvider idProvider = IdProvider.create()
+            .key( IdProviderKey.from( "idProviderTestKey" ) )
+            .displayName( "Id Provider test" )
+            .description( "Id Provider used for testing" )
+            .build();
+
+        JsonAssert.assertJson( getClass(), "minimal", new IdProviderMapper( idProvider ) );
+    }
+
+    @Test
+    void testIdProviderWithConfigSerialized()
+        throws Exception
+    {
+        final PropertyTree config = new PropertyTree();
+        final PropertySet nested = config.newSet();
+        nested.setString( "subString", "subStringValue" );
+        nested.setLong( "subLong", 123L );
+        config.setSet( "set", nested );
+        config.setString( "string", "stringValue" );
+
+        final IdProvider idProvider = IdProvider.create()
+            .key( IdProviderKey.from( "idProviderTestKey" ) )
+            .displayName( "Id Provider test" )
+            .description( "Id Provider used for testing" )
+            .idProviderConfig(
+                IdProviderConfig.create().applicationKey( ApplicationKey.from( "com.enonic.app.test" ) ).config( config ).build() )
+            .build();
+
+        JsonAssert.assertJson( getClass(), "with-config", new IdProviderMapper( idProvider ) );
+    }
+}

--- a/modules/lib/lib-common/src/test/resources/com/enonic/xp/lib/common/IdProviderMapperTest-minimal.json
+++ b/modules/lib/lib-common/src/test/resources/com/enonic/xp/lib/common/IdProviderMapperTest-minimal.json
@@ -1,0 +1,5 @@
+{
+  "key": "idProviderTestKey",
+  "displayName": "Id Provider test",
+  "description": "Id Provider used for testing"
+}

--- a/modules/lib/lib-common/src/test/resources/com/enonic/xp/lib/common/IdProviderMapperTest-with-config.json
+++ b/modules/lib/lib-common/src/test/resources/com/enonic/xp/lib/common/IdProviderMapperTest-with-config.json
@@ -1,0 +1,15 @@
+{
+  "key": "idProviderTestKey",
+  "displayName": "Id Provider test",
+  "description": "Id Provider used for testing",
+  "idProviderConfig": {
+    "applicationKey": "com.enonic.app.test",
+    "config": {
+      "set": {
+        "subString": "subStringValue",
+        "subLong": 123
+      },
+      "string": "stringValue"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Restores `idProviderConfig` on the lib-auth JS API, dropped during the squash that delivered #11990 (commit `5eb82cab93`). The Java domain (`com.enonic.xp.security.IdProviderConfig`, `CreateIdProviderParams.Builder.idProviderConfig(...)`) was already complete — only the JS surface was missing.

- `auth.ts`: add `IdProviderConfig` TS interface; expose `idProviderConfig` on `IdProvider` and `CreateIdProviderParams`; wire `params.idProviderConfig` via `__.toScriptValue(...)` to a new `setIdProviderConfig(ScriptValue)` on the bean.
- `CreateIdProviderHandler`: read `applicationKey` / `config` through `ScriptValue.getMember(...)` (mirrors `SubmitTaskHandler` for the `config` → `PropertyTree.fromMap` step), build a `com.enonic.xp.security.IdProviderConfig`, and pass it to `CreateIdProviderParams.create().idProviderConfig(...)`. The `null` path stays unchanged. `applicationKey` validation is delegated to the existing `requireNonNull` in `IdProviderConfig.Builder`.
- `IdProviderMapper`: when `IdProvider.getIdProviderConfig()` is non-null, emit `{ applicationKey, config }` — `config` is serialized through `PropertyTreeMapper` (same pattern `PrincipalMapper` uses for `user.profile`).

## File list

```
 .../xp/lib/auth/CreateIdProviderHandler.java       | 25 +++++++++
 .../lib/lib-auth/src/main/resources/lib/xp/auth.ts | 13 +++++
 .../lib/xp/examples/auth/createIdProvider.js       |  6 ++
 .../xp/lib/auth/CreateIdProviderHandlerTest.java   | 37 ++++++++++++-
 .../test/resources/test/createIdProvider-test.js   | 64 +++++++++++++++++-----
 .../src/test/resources/test/getIdProviders-test.js | 12 +++-
 .../com/enonic/xp/lib/common/IdProviderMapper.java | 16 ++++++
 .../enonic/xp/lib/common/IdProviderMapperTest.java | 49 +++++++++++++++++
 .../lib/common/IdProviderMapperTest-minimal.json   |  5 ++
 .../common/IdProviderMapperTest-with-config.json   | 15 +++++
 10 files changed, 227 insertions(+), 15 deletions(-)
```

## Approach for `ScriptValue` → `IdProviderConfig`

Two existing patterns informed the choice:

1. `SubmitTaskHandler.submitTask()` uses `PropertyTree.fromMap( config.getMap() )` to turn a script object into a `PropertyTree`. The new `buildIdProviderConfig()` does the same for `idProviderConfig.config`, but accessed via `getMember("config")` so the cast is implicit and the warning is avoided.
2. `CreateIdProviderHandler.buildPermissions()` already pulls structured fields out of a `ScriptValue` map; the new `applicationKey` field is read the same way via `getMember("applicationKey").getValue(String.class)`. `applicationKey == null` is forwarded to the builder unchanged so `IdProviderConfig.Builder`'s `requireNonNull` produces the same error message users would get from the Java API.

## Test plan

- `CreateIdProviderHandlerTest` (8 tests):
  - `testCreateIdProvider` — passes `idProviderConfig: { applicationKey, config: { ... nested } }` and captures the built params; asserts `ApplicationKey.from("com.enonic.app.test")` and `PropertyTree.getString/getBoolean/getLong` round-trip.
  - `testCreateIdProviderMinimal` — keeps the existing "no `idProviderConfig`" assertion: `params.getIdProviderConfig()` is `null`.
  - `testCreateIdProviderConfigWithoutConfig` — `{ applicationKey }` only; asserts an empty `PropertyTree` is built.
  - `testCreateIdProviderMissingApplicationKey` — `idProviderConfig` without `applicationKey` triggers `requireNonNull("applicationKey ...")` from `IdProviderConfig.Builder` (AssertJ `assertThatThrownBy`).
  - Pre-existing tests (`testExamples`, `testCreateIdProviderMissingKey`, `testCreateIdProviderMissingDisplayName`, `testCreateIdProviderDuplicate`) updated to match the new shape and still pass.
- `IdProviderMapperTest` (lib-common, 2 tests, new): minimal id provider and id provider with `idProviderConfig` both round-trip through `JsonAssert.assertJson` against fixture files.
- `getIdProviders-test.js` updated to assert the new `idProviderConfig` field in the response payload (the existing `TestDataFixtures.getTestIdProvider()` already carried one — the mapper just wasn't emitting it).

Local run:

```
$ ./gradlew :lib:lib-auth:test :lib:lib-common:test
...
> Task :lib:lib-common:test
> Task :lib:lib-auth:test
BUILD SUCCESSFUL in 37s
```

JUnit reports:

```
CreateIdProviderHandlerTest  tests=8 failures=0 errors=0
GetIdProvidersHandlerTest    tests=3 failures=0 errors=0
IdProviderMapperTest         tests=2 failures=0 errors=0
```

Out of scope (per the issue): `updateIdProvider` / `deleteIdProvider` JS exposure. `app-simple-idprovider` cleanup (enonic/app-simple-idprovider#78) is unblocked by this change but is not touched here.

Closes #12041

🤖 Generated with [Claude Code](https://claude.com/claude-code)