### PR TITLE
Restore string arg for portal.assetUrl

### DIFF
--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -74,6 +74,9 @@ interface AssetUrlHandler {
  *
  * This function generates a URL pointing to a static file.
  *
+ * For backward compatibility, a `string` may be passed in place of `params`;
+ * it is treated as `params.path` with all other fields defaulted.
+ *
  * @example-ref examples/portal/assetUrl.js
  *
  * @param {object} params Input parameters as JSON.
@@ -84,15 +87,17 @@ interface AssetUrlHandler {
  *
  * @returns {string} The generated URL.
  */
-export function assetUrl(params: AssetUrlParams): string {
+export function assetUrl(params: AssetUrlParams | string): string {
+    const normalized: AssetUrlParams = typeof params === 'string' ? {path: params} : params;
+
     const bean: AssetUrlHandler = __.newBean<AssetUrlHandler>('com.enonic.xp.lib.portal.url.AssetUrlHandler');
 
-    const path = checkRequired(params, 'path');
+    const path = checkRequired(normalized, 'path');
 
     bean.setPath(path);
-    bean.setUrlType(__.nullOrValue(params.type));
-    bean.setApplication(__.nullOrValue(params.application));
-    bean.setQueryParams(__.toScriptValue(params.params));
+    bean.setUrlType(__.nullOrValue(normalized.type));
+    bean.setApplication(__.nullOrValue(normalized.application));
+    bean.setQueryParams(__.toScriptValue(normalized.params));
 
     return bean.createUrl();
 }

--- a/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/url/UrlServiceScriptTest.java
+++ b/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/url/UrlServiceScriptTest.java
@@ -264,6 +264,18 @@ class UrlServiceScriptTest
     }
 
     @Test
+    void assetUrlTest_stringArg()
+    {
+        assertTrue( execute( "assetUrlTest_stringArg" ) );
+    }
+
+    @Test
+    void assetUrlTest_stringArg_empty()
+    {
+        assertTrue( execute( "assetUrlTest_stringArg_empty" ) );
+    }
+
+    @Test
     void attachmentUrlTest()
     {
         assertTrue( execute( "attachmentUrlTest" ) );

--- a/modules/lib/lib-portal/src/test/resources/test/url-test.js
+++ b/modules/lib/lib-portal/src/test/resources/test/url-test.js
@@ -44,6 +44,22 @@ exports.assetUrlTest_invalidProperty = function () {
     return true;
 };
 
+exports.assetUrlTest_stringArg = function () {
+    var stringForm = portal.assetUrl('styles/my.css');
+    var objectForm = portal.assetUrl({path: 'styles/my.css'});
+
+    assert.assertEquals(objectForm, stringForm);
+    return true;
+};
+
+exports.assetUrlTest_stringArg_empty = function () {
+    var stringForm = portal.assetUrl('');
+    var objectForm = portal.assetUrl({path: ''});
+
+    assert.assertEquals(objectForm, stringForm);
+    return true;
+};
+
 exports.attachmentUrlTest = function () {
     var result = portal.attachmentUrl({
         name: 'myattachment.pdf',


### PR DESCRIPTION
## Summary

In XP 7, `portal.assetUrl` accepted either an `AssetUrlParams` object **or** a plain string (the path). The XP 8 rewrite tightened the TS signature so the function now requires `{path: ...}`. Both legacy call styles break:

| XP 7 | XP 8 (current) |
|---|---|
| `portal.assetUrl('foo/bar.png')` | throws `Parameter 'path' is required` |
| `portal.assetUrl({ path: 'foo/bar.png' })` | works |
| `portal.assetUrl('')` (legacy base-URL idiom: `{{assetUrl}}/foo.png`) | throws `Parameter 'path' is required` |

That's a breaking change inside a function whose own `@deprecated` tag says it will only be removed "in future versions" — the intent of marking it deprecated is "stop using it, but it still works", not "silently break on upgrade". Concrete impact: https://github.com/enonic/app-image-xpert/pull/47/files had to migrate five files from `portal.assetUrl('')` to `portal.assetUrl({path: ''})` purely to unbreak under XP 8.

## Change

`modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts` — widen the parameter type to `AssetUrlParams | string` and normalise at the top of the body: if `typeof params === 'string'`, treat it as `{ path: params }`. The `@deprecated` tag stays.

Scope is intentionally just `assetUrl`. The other url functions in `portal.ts` aren't deprecated and never had a documented string-form contract, so they're not touched.

## Test plan

- [x] New JS tests `assetUrlTest_stringArg` and `assetUrlTest_stringArg_empty` in `modules/lib/lib-portal/src/test/resources/test/url-test.js` assert that the string form returns the same URL as the equivalent `{path: ...}` form, both for a normal path and for the empty-string idiom.
- [x] Driven from `UrlServiceScriptTest` (Java) via the existing `execute(...)` harness.
- [x] `./gradlew :lib:lib-portal:test` green (77 → 79 tests, all pass).
- [x] `./gradlew test` green (the only failing test, `ZipExportWriterTest.testPathWithSpecialCharacters`, is a pre-existing POSIX-locale issue unrelated to this change — passes under `LANG=C.utf8 LC_ALL=C.utf8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)