### PR TITLE
Add portal.getRegions() helper

### DIFF
--- a/modules/lib/lib-portal/src/main/resources/lib/xp/examples/portal/getRegions.js
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/examples/portal/getRegions.js
@@ -1,0 +1,28 @@
+var portalLib = require('/lib/xp/portal');
+var assert = require('/lib/xp/testing');
+
+// BEGIN
+var regions = portalLib.getRegions();
+log.info('Number of regions = %s', regions.length);
+// END
+
+// BEGIN
+// Array of regions returned, in declaration order.
+var expected = [
+    {
+        'components': [
+            {
+                'path': '/main/0/bottom/0',
+                'type': 'part',
+                'descriptor': 'myapplication:mypart',
+                'config': {
+                    'a': '1'
+                }
+            }
+        ],
+        'name': 'bottom'
+    }
+];
+// END
+
+assert.assertJsonEquals(expected, regions);

--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -708,6 +708,29 @@ export function getComponent<
     return __.toNativeObject(bean.execute());
 }
 
+/**
+ * This function returns the regions of the current page or layout component as an array, in the order
+ * they are declared on the descriptor.
+ *
+ * Convenience wrapper around `getComponent().regions`. Returns an empty array when there is no current
+ * component (e.g. called outside a page/layout) or the current component has no regions.
+ *
+ * @example-ref examples/portal/getRegions.js
+ *
+ * @returns {object[]} Array of regions on the current component, or an empty array if there are none.
+ */
+export function getRegions(): Region[] {
+    const component = getComponent();
+    if (component == null || (component.type !== 'layout' && component.type !== 'page')) {
+        return [];
+    }
+    const regions = component.regions;
+    if (regions == null) {
+        return [];
+    }
+    return Object.keys(regions).map((key) => regions[key]);
+}
+
 interface GetCurrentIdProviderKeyHandler {
     execute(): string | null;
 }

--- a/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/current/GetCurrentComponentScriptTest.java
+++ b/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/current/GetCurrentComponentScriptTest.java
@@ -33,4 +33,29 @@ class GetCurrentComponentScriptTest
 
         runScript( "/lib/xp/examples/portal/getComponent.js" );
     }
+
+    @Test
+    void currentRegions()
+    {
+        final Component component = TestDataFixtures.newLayoutComponent();
+        this.portalRequest.setComponent( component );
+
+        runFunction( "/test/getCurrentComponent-test.js", "currentRegions" );
+    }
+
+    @Test
+    void noCurrentComponentRegions()
+    {
+        this.portalRequest.setComponent( null );
+        runFunction( "/test/getCurrentComponent-test.js", "noCurrentComponentRegions" );
+    }
+
+    @Test
+    void testGetRegionsExample()
+    {
+        final Component component = TestDataFixtures.newLayoutComponent();
+        this.portalRequest.setComponent( component );
+
+        runScript( "/lib/xp/examples/portal/getRegions.js" );
+    }
 }

--- a/modules/lib/lib-portal/src/test/resources/test/getCurrentComponent-test.js
+++ b/modules/lib/lib-portal/src/test/resources/test/getCurrentComponent-test.js
@@ -34,3 +34,29 @@ exports.noCurrentComponent = function () {
     var result = portal.getComponent();
     assert.assertNull(result);
 };
+
+var expectedRegionsJson = [
+    {
+        'components': [
+            {
+                'path': '/main/0/bottom/0',
+                'type': 'part',
+                'descriptor': 'myapplication:mypart',
+                'config': {
+                    'a': '1'
+                }
+            }
+        ],
+        'name': 'bottom'
+    }
+];
+
+exports.currentRegions = function () {
+    var result = portal.getRegions();
+    assert.assertJsonEquals(expectedRegionsJson, result);
+};
+
+exports.noCurrentComponentRegions = function () {
+    var result = portal.getRegions();
+    assert.assertJsonEquals([], result);
+};


### PR DESCRIPTION
## Summary

Adds a small convenience helper to `lib/xp/portal`:

```ts
portal.getRegions(): Region[]
```

Returns the regions of the current page or layout component as an **array**, in declaration order. Convenience wrapper around `Object.values(getComponent().regions)` that also handles the edge cases (no current component, no regions) by returning `[]` instead of throwing.

### Why

`portal.getComponent().regions` returns a *map keyed by region name*, but practically every caller wants an *array* — to render regions in declaration order, count them, iterate them. Apps work around this with the same 4-line snippet pasted everywhere:

```js
var component = portalLib.getComponent();
var regions = component.regions;
var keys = Object.keys(regions);
var result = [];
for (var i = 0; i < keys.length; i++) { result.push(regions[keys[i]]); }
```

`lib-util` exposed exactly this as `util.region.get()`. With `lib-util` being phased out across the IdeaProjects tree, the platform should provide it directly. Real-world case: [enonic/app-wireframe#578](https://github.com/enonic/app-wireframe/pull/578) had to inline the snippet in four layout files just to drop the `lib-util` dependency.

### Behavior

- On a page/layout with regions: returns each region in declaration order (`Object.keys` order from the descriptor).
- No current component (e.g. called outside a layout/part controller): returns `[]`.
- Current component is fragment/part/text (no regions): returns `[]`.

`getComponent().regions` keeps working — both paths are supported.

## Test plan

- [x] `./gradlew :lib:lib-portal:test` — all green (78 tests, including 3 new for `getRegions`)
- [x] `./gradlew :lib:lint` — clean
- [x] `./gradlew :lib:jsdoc` — `getRegions` appears in generated `module-portal.html` with the example
- [x] New WDIO/E2E coverage: N/A — this is a server-side lib helper, exercised by the Nashorn `GetCurrentComponentScriptTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)