### PR TITLE
Stopped app prevents move operation #12077

### DIFF
--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/MoveContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/MoveContentCommand.java
@@ -29,6 +29,7 @@ import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.page.Page;
 import com.enonic.xp.schema.content.ContentTypeName;
+import com.enonic.xp.schema.content.GetContentTypeParams;
 
 import static com.enonic.xp.core.impl.content.ContentNodeHelper.translateNodePathToContentPath;
 import static java.util.Objects.requireNonNull;
@@ -141,6 +142,12 @@ final class MoveContentCommand
             final PropertyTree contentData = data.getProperty( ContentPropertyNames.DATA ).getSet().toTree();
             final String displayName = data.getProperty( ContentPropertyNames.DISPLAY_NAME ).getString();
             final ContentTypeName type = ContentTypeName.from( data.getProperty( ContentPropertyNames.TYPE ).getString() );
+
+            if ( contentTypeService.getByName( new GetContentTypeParams().contentTypeName( type ) ) == null )
+            {
+                return data;
+            }
+
             final Mixins mixins = data.hasProperty( ContentPropertyNames.MIXINS ) ? contentDataSerializer.fromMixinData(
                 data.getProperty( ContentPropertyNames.MIXINS ).getSet() ) : null;
             final Page page = data.hasProperty( ContentPropertyNames.PAGE ) ? contentDataSerializer.fromPageData(

--- a/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/MoveContentCommandTest.java
+++ b/modules/core/core-content/src/test/java/com/enonic/xp/core/impl/content/MoveContentCommandTest.java
@@ -10,6 +10,7 @@ import com.enonic.xp.content.ContentConstants;
 import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentNotFoundException;
 import com.enonic.xp.content.ContentPath;
+import com.enonic.xp.content.ContentPropertyNames;
 import com.enonic.xp.content.MoveContentParams;
 import com.enonic.xp.context.ContextAccessorSupport;
 import com.enonic.xp.context.ContextBuilder;
@@ -28,6 +29,8 @@ import com.enonic.xp.schema.content.GetContentTypeParams;
 import com.enonic.xp.schema.mixin.MixinService;
 import com.enonic.xp.site.Site;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -78,6 +81,75 @@ class MoveContentCommandTest
 
         // exercise
         assertThrows( ContentNotFoundException.class, () -> command.execute() );
+    }
+
+    @Test
+    void move_content_with_missing_content_type()
+    {
+        final Site parentSite = ContentFixture.mockSite();
+        final Content existingContent = Content.create( ContentFixture.mockContent( parentSite.getPath(), "my-content" ) )
+            .type( ContentTypeName.from( "myapp:content-type" ) )
+            .build();
+        final Content existingFolder = ContentFixture.mockContent( parentSite.getPath(), "my-folder" );
+
+        MoveContentParams params =
+            MoveContentParams.create().contentId( existingContent.getId() ).parentContentPath( existingFolder.getPath() ).build();
+
+        final MoveContentCommand command = MoveContentCommand.create( params )
+            .contentTypeService( this.contentTypeService )
+            .nodeService( this.nodeService )
+            .mixinService( this.mixinService )
+            .eventPublisher( this.eventPublisher )
+            .build();
+
+        final Node mockNode = ContentFixture.mockContentNode( existingContent );
+        mockNode.data().setString( ContentPropertyNames.DISPLAY_NAME, existingContent.getDisplayName() );
+        mockNode.data().setBoolean( ContentPropertyNames.VALID, false );
+
+        final PropertyTree[] processedData = new PropertyTree[1];
+
+        when( nodeService.getById( NodeId.from( existingContent.getId() ) ) ).thenReturn( mockNode );
+
+        when( nodeService.move( Mockito.any( MoveNodeParams.class ) ) ).thenAnswer( invocation -> {
+            final MoveNodeParams moveParams = invocation.getArgument( 0 );
+            processedData[0] = moveParams.getProcessor().process( mockNode.data(), mockNode.path() );
+
+            return MoveNodeResult.create()
+                .addMovedNode( MoveNodeResult.MovedNode.create()
+                                   .previousPath( mockNode.path() )
+                                   .node( Node.create( mockNode )
+                                              .data( processedData[0] )
+                                              .parentPath( moveParams.getNewParentPath() )
+                                              .build() )
+                                   .build() )
+                .build();
+        } );
+
+        final Node mockFolderNode = ContentFixture.mockContentNode( existingFolder );
+
+        when( nodeService.getByPath( ContentNodeHelper.translateContentPathToNodePath( existingFolder.getPath() ) ) ).thenReturn(
+            mockFolderNode );
+
+        final ContentType contentType = ContentType.create()
+            .name( ContentTypeName.folder() )
+            .title( "folder" )
+            .setBuiltIn()
+            .setFinal( false )
+            .setAbstract( false )
+            .build();
+
+        when( contentTypeService.getByName( Mockito.isA( GetContentTypeParams.class ) ) ).thenAnswer( invocation -> {
+            final GetContentTypeParams getContentTypeParams = invocation.getArgument( 0 );
+            return existingFolder.getType().equals( getContentTypeParams.getContentTypeName() ) ? contentType : null;
+        } );
+
+        // exercise
+        command.execute();
+        assertEquals( false, processedData[0].getBoolean( ContentPropertyNames.VALID ) );
+        assertFalse( processedData[0].hasProperty( ContentPropertyNames.VALIDATION_ERRORS ) );
+        Mockito.verify( contentTypeService )
+            .getByName( Mockito.argThat( getContentTypeParams -> existingContent.getType()
+                .equals( getContentTypeParams.getContentTypeName() ) ) );
     }
 
     @Test


### PR DESCRIPTION
- Guarded `MoveContentCommand.updateValid()` against null content type, so the move proceeds when the app is stopped.
- Preserved the existing `VALID` flag and serialized validation errors when the content type cannot be resolved.

Closes #12077

See the issue for full root-cause analysis and stack trace.

<sub>*Drafted with AI assistance*</sub>
