### PR TITLE
#12082 Image service fail to crop

### DIFF
--- a/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/ImageServiceImpl.java
+++ b/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/ImageServiceImpl.java
@@ -312,11 +312,15 @@ public class ImageServiceImpl
 
     private static BufferedImage applyCropping( final BufferedImage bufferedImage, final Cropping cropping )
     {
-        final double width = bufferedImage.getWidth();
-        final double height = bufferedImage.getHeight();
-        return bufferedImage.getSubimage( (int) ( width * cropping.left() ), (int) ( height * cropping.top() ),
-                                          (int) ( width * cropping.width() ), (int) ( height * cropping.height() ) );
+        final int imageWidth = bufferedImage.getWidth();
+        final int imageHeight = bufferedImage.getHeight();
 
+        final int x = Math.clamp( (long) ( imageWidth * cropping.left() ), 0, imageWidth - 1 );
+        final int y = Math.clamp( (long) ( imageHeight * cropping.top() ), 0, imageHeight - 1 );
+        final int width = Math.clamp( (long) ( imageWidth * cropping.width() ), 1, imageWidth - x );
+        final int height = Math.clamp( (long) ( imageHeight * cropping.height() ), 1, imageHeight - y );
+
+        return bufferedImage.getSubimage( x, y, width, height );
     }
 
     private static BufferedImage applyRotation( final BufferedImage bufferedImage, final ImageOrientation orientation )

--- a/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/ImageServiceImplTest.java
+++ b/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/ImageServiceImplTest.java
@@ -179,6 +179,25 @@ class ImageServiceImplTest
     }
 
     @Test
+    void readImage_cropping_out_of_bounds_does_not_throw()
+    {
+        mockOriginalImage( "effect/transparent.png" );
+
+        // Legacy zoomed cropPosition that escaped the offline migration: edges exceed [0,1].
+        // Before the fix this threw java.awt.image.RasterFormatException from BufferedImage.getSubimage.
+        final Cropping cropping = Cropping.create().top( 0.367 ).left( 0.285 ).bottom( 1.367 ).right( 1.285 ).build();
+
+        final ReadImageParams readImageParams = ReadImageParams.newImageParams()
+            .contentId( contentId )
+            .binaryReference( binaryReference )
+            .cropping( cropping )
+            .mimeType( "image/png" )
+            .build();
+
+        assertDoesNotThrow( () -> imageService.readImage( readImageParams ) );
+    }
+
+    @Test
     void readImage_filter_on_jpeg()
     {
         mockOriginalImage( "effect/source.jpg" );

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/dump/upgrade/model8to9/ImageUpgraderTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/dump/upgrade/model8to9/ImageUpgraderTest.java
@@ -29,6 +29,7 @@ import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.util.BinaryReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -308,6 +309,31 @@ class ImageUpgraderTest
         assertThat( upgraded.getDouble( ContentPropertyNames.MEDIA_CROPPING_LEFT ) ).isEqualTo( 0.05 );
         assertThat( upgraded.getDouble( ContentPropertyNames.MEDIA_CROPPING_BOTTOM ) ).isEqualTo( 0.40 );
         assertThat( upgraded.getDouble( ContentPropertyNames.MEDIA_CROPPING_RIGHT ) ).isEqualTo( 0.45 );
+        assertThat( upgraded.getDouble( "zoom" ) ).isNull();
+    }
+
+    @Test
+    void normalizes_crop_position_from_issue_12082()
+    {
+        // Real data from issue #12082: zoomed cropPosition whose right/bottom edges exceed 1.0,
+        // which made the runtime image service throw RasterFormatException. The migration must
+        // bring every edge back into [0,1] by dividing through the zoom factor.
+        final NodeStoreVersion nodeVersion = imageNode();
+        final PropertySet cropping = nodeVersion.data().getSet( ContentPropertyNames.MEDIA ).addSet( ContentPropertyNames.MEDIA_CROPPING );
+        cropping.addDouble( ContentPropertyNames.MEDIA_CROPPING_TOP, 0.36745983558369705 );
+        cropping.addDouble( ContentPropertyNames.MEDIA_CROPPING_LEFT, 0.28542309670781896 );
+        cropping.addDouble( ContentPropertyNames.MEDIA_CROPPING_BOTTOM, 1.367459835583697 );
+        cropping.addDouble( ContentPropertyNames.MEDIA_CROPPING_RIGHT, 1.2854230967078188 );
+        cropping.addDouble( "zoom", 1.7489711934156378 );
+
+        final NodeStoreVersion result = upgrader.upgradeNodeVersion( PROJECT_REPO, nodeVersion );
+
+        assertThat( result ).isNotNull();
+        final PropertySet upgraded = result.data().getSet( ContentPropertyNames.MEDIA ).getSet( ContentPropertyNames.MEDIA_CROPPING );
+        assertThat( upgraded.getDouble( ContentPropertyNames.MEDIA_CROPPING_TOP ) ).isCloseTo( 0.21010, within( 1e-4 ) );
+        assertThat( upgraded.getDouble( ContentPropertyNames.MEDIA_CROPPING_LEFT ) ).isCloseTo( 0.16319, within( 1e-4 ) );
+        assertThat( upgraded.getDouble( ContentPropertyNames.MEDIA_CROPPING_BOTTOM ) ).isCloseTo( 0.78187, within( 1e-4 ) );
+        assertThat( upgraded.getDouble( ContentPropertyNames.MEDIA_CROPPING_RIGHT ) ).isCloseTo( 0.73496, within( 1e-4 ) );
         assertThat( upgraded.getDouble( "zoom" ) ).isNull();
     }
 


### PR DESCRIPTION
Fixes #12082.

## Problem
`ImageServiceImpl.applyCropping` multiplies the stored `cropPosition` edges by the image dimensions and calls `BufferedImage.getSubimage`. Legacy "zoomed" `cropPosition` data has `right`/`bottom` edges exceeding `1.0`, so the subimage rectangle runs off the raster:

```
java.awt.image.RasterFormatException: (x + width) is outside of Raster
    at java.awt.image.BufferedImage.getSubimage
    at com.enonic.xp.core.impl.image.ImageServiceImpl.applyCropping
```

`ImageUpgrader#normalizeCropPositionZoom` already normalizes this data, but only on the offline **model 8→9** dump upgrade. Repos already at model 9 still carry the bad values and can't be reached by that migration, so the image service itself has to tolerate them. (Content Studio is still producing such data — tracked in enonic/app-contentstudio#10616.)

## Fix
- **`ImageServiceImpl.applyCropping`** — clamp the crop rectangle to the raster bounds so `getSubimage` can never throw, regardless of how out-of-range the stored values are. Covers cases the migration deliberately leaves alone (`zoom < 1`, out-of-range edges with no `zoom`, degenerate crops).
- **`ImageUpgraderTest.normalizes_crop_position_from_issue_12082`** — regression test pinning the exact `cropPosition` + `zoom` from the issue, asserting the migration brings every edge back into `[0,1]` and drops `zoom`.

## Tests
`./gradlew :core:core-image:test` and the `ImageUpgraderTest` class pass. New `readImage_cropping_out_of_bounds_does_not_throw` reproduces the original `RasterFormatException` (fails before the fix, passes after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)