### PR TITLE
Track lib .ts as typescript task inputs #12087

### DIFF
--- a/modules/lib/build.gradle
+++ b/modules/lib/build.gradle
@@ -42,6 +42,10 @@ tasks.register( 'typescript', NpmTask ) {
     inputs.file coreDir.file( "index.d.ts" )
     inputs.file "tsconfig.build.json"
     inputs.file "tsconfig.json"
+    inputs.files( subprojects.collect {
+        it.layout.projectDirectory.dir( 'src/main/resources/lib/xp' )
+            .asFileTree.matching { include '**/*.ts', '**/*.js', '**/*.json' }
+    } )
     outputs.files( subprojects.collect {
         it.layout.buildDirectory.dir( 'typescript/lib/xp' ).map { d -> d.asFileTree.matching { include '**/*.js' }
         }


### PR DESCRIPTION
## Summary

The `:lib:typescript` NpmTask in `modules/lib/build.gradle` runs `npm run build` to compile each lib-*'s `src/main/resources/lib/xp/**/*.ts` into the generated `.js`/`.d.ts` under `lib-*/build/typescript/`. Those JS files are then copied by `processResources` into `build/resources/main` for the OSGi bundle and tests.

The task only declared `global.d.ts`, `core/index.d.ts`, `tsconfig.build.json` and `tsconfig.json` as inputs — the actual TS sources were missing. Editing a subproject `.ts` therefore left `:lib:typescript` `UP-TO-DATE`, `processResources` copied the stale generated JS, and tests ran against old code until a `clean`.

Fix: declare the subproject TS (+ `.js`/`.json` siblings) as inputs of `:lib:typescript`, mirroring exactly the pattern the sibling `lint` task in the same file already uses. Outputs and other inputs untouched.

## Test plan

Verified in `claude-dev` against `xp` at HEAD of this branch:

- [x] `./gradlew :lib:lib-portal:processResources` — seeds outputs (clean run).
- [x] `./gradlew :lib:typescript` — `UP-TO-DATE` immediately after (caching still works with the new inputs declaration).
- [x] Throwaway edit appended to `modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts`, re-ran `./gradlew :lib:typescript --console=plain` — task now **executed** (`> Task :lib:typescript` + `tsc --declaration --project tsconfig.build.json`), proving the subproject `.ts` is now a tracked input. Before this fix the same scenario reported `UP-TO-DATE`.
- [x] Reverted throwaway edit, ran `./gradlew :lib:lib-portal:test` — green.

Closes #12087

🤖 Generated with [Claude Code](https://claude.com/claude-code)