### PR TITLE
#12109 Dump load does not verify model version

### DIFF
--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/DumpServiceImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/dump/DumpServiceImpl.java
@@ -68,6 +68,7 @@ import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.repository.RepositoryIds;
 import com.enonic.xp.security.SystemConstants;
 import com.enonic.xp.server.VersionInfo;
+import com.enonic.xp.util.Version;
 
 import static com.google.common.base.Strings.nullToEmpty;
 
@@ -343,6 +344,8 @@ public class DumpServiceImpl
 
         try (DumpReader dumpReader = ZipDumpReaderModel9.create( params.getListener(), basePath, dumpName ))
         {
+            verifyModelVersion( dumpReader.getDumpMeta().getModelVersion() );
+
             final RepositoryIds dumpRepositories = dumpReader.getRepositories();
 
             if ( !dumpRepositories.contains( SystemConstants.SYSTEM_REPO_ID ) )
@@ -371,6 +374,16 @@ public class DumpServiceImpl
             throw new UncheckedIOException( e );
         }
         return results.build();
+    }
+
+    static void verifyModelVersion( final Version modelVersion )
+    {
+        if ( !Model.MODEL_VERSION.equals( modelVersion ) )
+        {
+            throw new RepoLoadException(
+                "Cannot load dump; model version [" + modelVersion + "] is not supported, expected [" + Model.MODEL_VERSION +
+                    "]. Load with upgrade enabled to migrate it first." );
+        }
     }
 
     private void doFullLoad( final SystemLoadParams params, final DumpReader dumpReader, final RepositoryIds dumpRepositories,

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/dump/DumpServiceImplModelVersionTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/dump/DumpServiceImplModelVersionTest.java
@@ -1,0 +1,32 @@
+package com.enonic.xp.repo.impl.dump;
+
+import org.junit.jupiter.api.Test;
+
+import com.enonic.xp.repo.impl.Model;
+import com.enonic.xp.util.Version;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class DumpServiceImplModelVersionTest
+{
+    @Test
+    void accepts_current_model_version()
+    {
+        assertDoesNotThrow( () -> DumpServiceImpl.verifyModelVersion( Model.MODEL_VERSION ) );
+    }
+
+    @Test
+    void rejects_older_model_version()
+    {
+        assertThatThrownBy( () -> DumpServiceImpl.verifyModelVersion( new Version( 8, 0, 0 ) ) )
+            .isInstanceOf( RepoLoadException.class )
+            .hasMessageContaining( "model version [8.0.0] is not supported" );
+    }
+
+    @Test
+    void rejects_missing_model_version()
+    {
+        assertThatThrownBy( () -> DumpServiceImpl.verifyModelVersion( null ) ).isInstanceOf( RepoLoadException.class );
+    }
+}

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/dump/serializer/json/DumpMetaJsonSerializerTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/dump/serializer/json/DumpMetaJsonSerializerTest.java
@@ -1,0 +1,36 @@
+package com.enonic.xp.repo.impl.dump.serializer.json;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import com.enonic.xp.repo.impl.dump.model.DumpMeta;
+import com.enonic.xp.util.Version;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DumpMetaJsonSerializerTest
+{
+    @Test
+    void missing_model_version_deserializes_to_null()
+    {
+        final String json = "{\"xpVersion\":\"7.16.4\",\"timestamp\":\"2022-06-07T11:53:40.088Z\"}";
+
+        final DumpMeta dumpMeta =
+            new DumpMetaJsonSerializer().toDumpMeta( new ByteArrayInputStream( json.getBytes( StandardCharsets.UTF_8 ) ) );
+
+        assertThat( dumpMeta.getModelVersion() ).isNull();
+    }
+
+    @Test
+    void present_model_version_is_read()
+    {
+        final String json = "{\"xpVersion\":\"7.16.4\",\"timestamp\":\"2022-06-07T11:53:40.088Z\",\"modelVersion\":\"8\"}";
+
+        final DumpMeta dumpMeta =
+            new DumpMetaJsonSerializer().toDumpMeta( new ByteArrayInputStream( json.getBytes( StandardCharsets.UTF_8 ) ) );
+
+        assertThat( dumpMeta.getModelVersion() ).isEqualTo( new Version( 8, 0, 0 ) );
+    }
+}


### PR DESCRIPTION
Fixes #12109.

## Problem
`DumpServiceImpl.load()` opens a dump with `ZipDumpReaderModel9` but never checks the dump's `modelVersion`. `ZipDumpReaderModel9.create(...)` only verifies that `dump.json` exists; it doesn't compare the dump's model version to the current `Model.MODEL_VERSION` (9). The only model-version check is in the upgrade path (`DumpUpgraderRunner` requires `8.0.0`), reached only when `isUpgrade()` is true.

So loading a non-v9 dump without the upgrade flag isn't rejected cleanly — the v9 reader tries to read an older layout and fails downstream with a confusing error instead of failing fast.

## Change
`load()` now verifies the dump's model version against `Model.MODEL_VERSION` right after opening the reader and throws a clear `RepoLoadException` on mismatch. When `isUpgrade()` is true the dump has already been migrated to the current version, so the check passes.

## Missing modelVersion
A dump-meta with **no** `modelVersion` field deserializes to a `null` model version (`DumpMetaJson.fromJson` skips the field, `DumpMeta.Builder` has no default), so the check rejects it too — a missing model version is a load failure, not silently treated as current.

## Verification
- `DumpServiceImplModelVersionTest`: current version accepted; older (`8.0.0`) and `null` rejected with `RepoLoadException`.
- `DumpMetaJsonSerializerTest`: a meta without `modelVersion` deserializes to `null`; a present one is read correctly.
- `:core:core-repo:test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)