### PR TITLE
#12116 Close WebSockets when the HTTP session ends

### DIFF
--- a/modules/lib/core/index.d.ts
+++ b/modules/lib/core/index.d.ts
@@ -358,6 +358,7 @@ export interface MappedResponse {
 export interface ResponseInterface
     extends Partial<MappedResponse> {
     redirect?: string;
+    webSocket?: WebSocketResponse;
 }
 
 export interface DefaultResponse
@@ -383,6 +384,31 @@ export type HttpFilterNext<
     RequestToJava extends SerializableRequest = SerializableRequest<DefaultRequest>,
     ResponseToJava extends ResponseInterface = DefaultResponse
 > = (request: RequestToJava) => ResponseToJava;
+
+export interface WebSocketResponse {
+    data?: Record<string, string>;
+    subProtocols?: string | string[];
+    checkOrigin?: (origin: string) => boolean;
+
+    /**
+     * When `true` (default), the WebSocket is closed with code 1008 when its HTTP session ends — either
+     * through logout (invalidation) or idle-timeout expiry. Set to `false` to let the socket outlive the
+     * session.
+     */
+    terminateOnSessionExit?: boolean;
+
+    /**
+     * When `true`, inbound WebSocket messages refresh (access) the HTTP session, keeping it alive.
+     * Server-to-client messages never count. Defaults to `false`.
+     */
+    sessionAccess?: boolean;
+
+    /**
+     * Minimum interval, in milliseconds, between session refreshes when `sessionAccess` is enabled.
+     * Defaults to 60000.
+     */
+    sessionAccessThrottleMs?: number;
+}
 
 export interface WebSocketSession {
     id: string;

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/controller/PortalResponseSerializer.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/controller/PortalResponseSerializer.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.portal.impl.controller;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -307,8 +308,42 @@ public final class PortalResponseSerializer
         populateWebSocketData( config, value.getMember( "data" ) );
         populateWebSocketSubProtocols( config, value.getMember( "subProtocols" ) );
         populateWebSocketOriginValidator( config, value.getMember( "checkOrigin" ) );
+        populateWebSocketSessionBinding( config, value );
 
         builder.webSocket( config );
+    }
+
+    private void populateWebSocketSessionBinding( final WebSocketConfig config, final ScriptValue value )
+    {
+        final ScriptValue terminateOnSessionExit = value.getMember( "terminateOnSessionExit" );
+        if ( terminateOnSessionExit != null )
+        {
+            final Boolean terminate = terminateOnSessionExit.getValue( Boolean.class );
+            if ( terminate != null )
+            {
+                config.setTerminateOnSessionExit( terminate );
+            }
+        }
+
+        final ScriptValue sessionAccess = value.getMember( "sessionAccess" );
+        if ( sessionAccess != null )
+        {
+            final Boolean access = sessionAccess.getValue( Boolean.class );
+            if ( access != null )
+            {
+                config.setSessionAccess( access );
+            }
+        }
+
+        final ScriptValue sessionAccessThrottleMs = value.getMember( "sessionAccessThrottleMs" );
+        if ( sessionAccessThrottleMs != null )
+        {
+            final Double throttleMs = sessionAccessThrottleMs.getValue( Double.class );
+            if ( throttleMs != null )
+            {
+                config.setSessionAccessThrottle( Duration.ofMillis( throttleMs.longValue() ) );
+            }
+        }
     }
 
     private void populateWebSocketOriginValidator( final WebSocketConfig config, final ScriptValue value )

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/websocket/EndpointFactoryImpl.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/websocket/EndpointFactoryImpl.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.portal.impl.websocket;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -31,5 +32,23 @@ final class EndpointFactoryImpl
     public Predicate<String> getOriginValidator()
     {
         return this.endpoint.getConfig().getOriginValidator();
+    }
+
+    @Override
+    public boolean isTerminateOnSessionExit()
+    {
+        return this.endpoint.getConfig().isTerminateOnSessionExit();
+    }
+
+    @Override
+    public boolean isSessionAccess()
+    {
+        return this.endpoint.getConfig().isSessionAccess();
+    }
+
+    @Override
+    public Duration getSessionAccessThrottle()
+    {
+        return this.endpoint.getConfig().getSessionAccessThrottle();
     }
 }

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/controller/PortalResponseSerializerWebSocketTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/controller/PortalResponseSerializerWebSocketTest.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.portal.impl.controller;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import com.enonic.xp.portal.PortalResponse;
 import com.enonic.xp.script.ScriptValue;
+import com.enonic.xp.web.websocket.WebSocketConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -52,6 +54,71 @@ class PortalResponseSerializerWebSocketTest
         assertThat( response.getWebSocket().getSubProtocols() ).containsExactly( "text" );
         assertThat( response.getWebSocket().getData() ).containsEntry( "k", "v" );
         assertThat( response.getWebSocket().getOriginValidator() ).isNull();
+    }
+
+    @Test
+    void session_binding_defaults_when_absent()
+    {
+        final ScriptValue root = mock( ScriptValue.class );
+        when( root.isObject() ).thenReturn( true );
+
+        final ScriptValue webSocket = mock( ScriptValue.class );
+        when( root.getMember( "webSocket" ) ).thenReturn( webSocket );
+
+        final WebSocketConfig config = new PortalResponseSerializer( root ).serialize().getWebSocket();
+
+        assertThat( config.isTerminateOnSessionExit() ).isTrue();
+        assertThat( config.isSessionAccess() ).isFalse();
+        assertThat( config.getSessionAccessThrottle() ).isEqualTo( WebSocketConfig.DEFAULT_SESSION_ACCESS_THROTTLE );
+    }
+
+    @Test
+    void terminateOnSessionExit_false_is_mapped()
+    {
+        final WebSocketConfig config = serializeWebSocket( webSocket -> {
+            final ScriptValue terminate = mock( ScriptValue.class );
+            when( terminate.getValue( Boolean.class ) ).thenReturn( Boolean.FALSE );
+            when( webSocket.getMember( "terminateOnSessionExit" ) ).thenReturn( terminate );
+        } );
+
+        assertThat( config.isTerminateOnSessionExit() ).isFalse();
+    }
+
+    @Test
+    void sessionAccess_true_is_mapped()
+    {
+        final WebSocketConfig config = serializeWebSocket( webSocket -> {
+            final ScriptValue access = mock( ScriptValue.class );
+            when( access.getValue( Boolean.class ) ).thenReturn( Boolean.TRUE );
+            when( webSocket.getMember( "sessionAccess" ) ).thenReturn( access );
+        } );
+
+        assertThat( config.isSessionAccess() ).isTrue();
+    }
+
+    @Test
+    void sessionAccessThrottleMs_is_mapped_to_duration()
+    {
+        final WebSocketConfig config = serializeWebSocket( webSocket -> {
+            final ScriptValue throttle = mock( ScriptValue.class );
+            when( throttle.getValue( Double.class ) ).thenReturn( 30000.0 );
+            when( webSocket.getMember( "sessionAccessThrottleMs" ) ).thenReturn( throttle );
+        } );
+
+        assertThat( config.getSessionAccessThrottle() ).isEqualTo( Duration.ofMillis( 30000 ) );
+    }
+
+    private static WebSocketConfig serializeWebSocket( final java.util.function.Consumer<ScriptValue> webSocketSetup )
+    {
+        final ScriptValue root = mock( ScriptValue.class );
+        when( root.isObject() ).thenReturn( true );
+
+        final ScriptValue webSocket = mock( ScriptValue.class );
+        when( root.getMember( "webSocket" ) ).thenReturn( webSocket );
+
+        webSocketSetup.accept( webSocket );
+
+        return new PortalResponseSerializer( root ).serialize().getWebSocket();
     }
 
     @Test

--- a/modules/web/web-api/src/main/java/com/enonic/xp/web/websocket/EndpointFactory.java
+++ b/modules/web/web-api/src/main/java/com/enonic/xp/web/websocket/EndpointFactory.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.web.websocket;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
@@ -18,5 +19,20 @@ public interface EndpointFactory
     default Predicate<String> getOriginValidator()
     {
         return null;
+    }
+
+    default boolean isTerminateOnSessionExit()
+    {
+        return true;
+    }
+
+    default boolean isSessionAccess()
+    {
+        return false;
+    }
+
+    default Duration getSessionAccessThrottle()
+    {
+        return WebSocketConfig.DEFAULT_SESSION_ACCESS_THROTTLE;
     }
 }

--- a/modules/web/web-api/src/main/java/com/enonic/xp/web/websocket/WebSocketConfig.java
+++ b/modules/web/web-api/src/main/java/com/enonic/xp/web/websocket/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.web.websocket;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -7,11 +8,19 @@ import java.util.function.Predicate;
 
 public final class WebSocketConfig
 {
+    public static final Duration DEFAULT_SESSION_ACCESS_THROTTLE = Duration.ofSeconds( 60 );
+
     private List<String> subProtocols = List.of();
 
     private Map<String, String> data = new ConcurrentHashMap<>();
 
     private Predicate<String> originValidator;
+
+    private boolean terminateOnSessionExit = true;
+
+    private boolean sessionAccess = false;
+
+    private Duration sessionAccessThrottle = DEFAULT_SESSION_ACCESS_THROTTLE;
 
     public List<String> getSubProtocols()
     {
@@ -41,5 +50,35 @@ public final class WebSocketConfig
     public void setOriginValidator( final Predicate<String> originValidator )
     {
         this.originValidator = originValidator;
+    }
+
+    public boolean isTerminateOnSessionExit()
+    {
+        return this.terminateOnSessionExit;
+    }
+
+    public void setTerminateOnSessionExit( final boolean terminateOnSessionExit )
+    {
+        this.terminateOnSessionExit = terminateOnSessionExit;
+    }
+
+    public boolean isSessionAccess()
+    {
+        return this.sessionAccess;
+    }
+
+    public void setSessionAccess( final boolean sessionAccess )
+    {
+        this.sessionAccess = sessionAccess;
+    }
+
+    public Duration getSessionAccessThrottle()
+    {
+        return this.sessionAccessThrottle;
+    }
+
+    public void setSessionAccessThrottle( final Duration sessionAccessThrottle )
+    {
+        this.sessionAccessThrottle = sessionAccessThrottle == null ? DEFAULT_SESSION_ACCESS_THROTTLE : sessionAccessThrottle;
     }
 }

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/JettyActivator.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/JettyActivator.java
@@ -31,6 +31,7 @@ import com.enonic.xp.web.jetty.impl.configurator.MultipartConfigurator;
 import com.enonic.xp.web.jetty.impl.configurator.RequestLogConfigurator;
 import com.enonic.xp.web.jetty.impl.configurator.SessionConfigurator;
 import com.enonic.xp.web.jetty.impl.session.JettySessionStoreConfigurator;
+import com.enonic.xp.web.jetty.impl.websocket.WebSocketSessionTracker;
 
 @Component(immediate = true, configurationPid = "com.enonic.xp.web.jetty")
 public final class JettyActivator
@@ -43,6 +44,8 @@ public final class JettyActivator
 
     private final List<DispatchServlet> dispatchServlets;
 
+    private final WebSocketSessionTracker webSocketSessionTracker;
+
     private final JettyConfig config;
 
     private volatile Server server;
@@ -52,11 +55,13 @@ public final class JettyActivator
     @Activate
     public JettyActivator( final JettyConfig config, final BundleContext bundleContext,
                            @Reference final JettySessionStoreConfigurator jettySessionStoreConfigurator,
+                           @Reference final WebSocketSessionTracker webSocketSessionTracker,
                            @Reference final List<DispatchServlet> dispatchServlets )
     {
         this.config = config;
         this.bundleContext = bundleContext;
         this.jettySessionStoreConfigurator = jettySessionStoreConfigurator;
+        this.webSocketSessionTracker = webSocketSessionTracker;
         this.dispatchServlets = dispatchServlets;
     }
 
@@ -115,6 +120,9 @@ public final class JettyActivator
     {
         final ServletContextHandler context = new ServletContextHandler( "/", ServletContextHandler.SESSIONS );
         final SessionHandler sessionHandler = context.getSessionHandler();
+
+        // Close WebSocket sessions bound to an HTTP session when that session ends (logout or idle-timeout).
+        context.addEventListener( this.webSocketSessionTracker );
 
         final ServletHolder holder = new ServletHolder( servlet );
         holder.setAsyncSupported( true );

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/KeepAliveSession.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/KeepAliveSession.java
@@ -1,0 +1,317 @@
+package com.enonic.xp.web.jetty.impl.websocket;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.security.Principal;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.http.HttpSession;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.Extension;
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.Session;
+import jakarta.websocket.WebSocketContainer;
+
+/**
+ * Forwarding {@link Session} wrapper used when {@code sessionAccess} is enabled. It delegates every operation
+ * to the real session, but interposes on the message handlers the application registers so that
+ * <strong>inbound</strong> messages refresh the HTTP session through its {@link HttpSession.Accessor}.
+ * Server-to-client pushes never count as user activity.
+ * <p>
+ * The refresh is throttled to at most once per {@code sessionAccessThrottle}. If the session is already gone
+ * ({@link IllegalStateException} from {@code access}) the socket is closed with code 1008 as a lazy backstop
+ * to the {@link WebSocketSessionTracker} listener.
+ */
+final class KeepAliveSession
+    implements Session
+{
+    private static final Logger LOG = LoggerFactory.getLogger( KeepAliveSession.class );
+
+    private final Session delegate;
+
+    private final HttpSession.Accessor sessionAccessor;
+
+    private final long throttleNanos;
+
+    private final AtomicLong lastTouchNanos;
+
+    KeepAliveSession( final Session delegate, final HttpSession.Accessor sessionAccessor, final Duration sessionAccessThrottle )
+    {
+        this.delegate = delegate;
+        this.sessionAccessor = sessionAccessor;
+        this.throttleNanos = Math.max( 0, sessionAccessThrottle.toNanos() );
+        this.lastTouchNanos = new AtomicLong( System.nanoTime() - this.throttleNanos );
+    }
+
+    private void touch()
+    {
+        final long now = System.nanoTime();
+        final long last = this.lastTouchNanos.get();
+        if ( now - last < this.throttleNanos || !this.lastTouchNanos.compareAndSet( last, now ) )
+        {
+            return;
+        }
+
+        try
+        {
+            this.sessionAccessor.access( session -> {
+            } );
+        }
+        catch ( IllegalStateException e )
+        {
+            // The HTTP session is already gone; close the socket as a backstop (the listener normally wins).
+            try
+            {
+                this.delegate.close( new CloseReason( CloseReason.CloseCodes.VIOLATED_POLICY, "HTTP session ended" ) );
+            }
+            catch ( IOException ex )
+            {
+                LOG.debug( "Failed to close WebSocket session [{}] after HTTP session was gone", this.delegate.getId(), ex );
+            }
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void addMessageHandler( final MessageHandler handler )
+    {
+        if ( handler instanceof MessageHandler.Whole )
+        {
+            final Class<?> type = resolveMessageType( handler, MessageHandler.Whole.class );
+            if ( type != null )
+            {
+                this.delegate.addMessageHandler( (Class<Object>) type, touching( (MessageHandler.Whole<Object>) handler ) );
+                return;
+            }
+        }
+        else if ( handler instanceof MessageHandler.Partial )
+        {
+            final Class<?> type = resolveMessageType( handler, MessageHandler.Partial.class );
+            if ( type != null )
+            {
+                this.delegate.addMessageHandler( (Class<Object>) type, touching( (MessageHandler.Partial<Object>) handler ) );
+                return;
+            }
+        }
+        // Unable to determine the message type (e.g. a lambda handler); forward unwrapped so the socket still
+        // works, at the cost of keep-alive touches for this particular handler.
+        this.delegate.addMessageHandler( handler );
+    }
+
+    @Override
+    public <T> void addMessageHandler( final Class<T> clazz, final MessageHandler.Whole<T> handler )
+    {
+        this.delegate.addMessageHandler( clazz, touching( handler ) );
+    }
+
+    @Override
+    public <T> void addMessageHandler( final Class<T> clazz, final MessageHandler.Partial<T> handler )
+    {
+        this.delegate.addMessageHandler( clazz, touching( handler ) );
+    }
+
+    private <T> MessageHandler.Whole<T> touching( final MessageHandler.Whole<T> handler )
+    {
+        return message -> {
+            touch();
+            handler.onMessage( message );
+        };
+    }
+
+    private <T> MessageHandler.Partial<T> touching( final MessageHandler.Partial<T> handler )
+    {
+        return ( message, last ) -> {
+            touch();
+            handler.onMessage( message, last );
+        };
+    }
+
+    private static Class<?> resolveMessageType( final MessageHandler handler, final Class<?> handlerInterface )
+    {
+        for ( Class<?> type = handler.getClass(); type != null; type = type.getSuperclass() )
+        {
+            for ( final Type genericInterface : type.getGenericInterfaces() )
+            {
+                if ( genericInterface instanceof ParameterizedType parameterized && parameterized.getRawType() == handlerInterface )
+                {
+                    final Type argument = parameterized.getActualTypeArguments()[0];
+                    if ( argument instanceof Class<?> klass )
+                    {
+                        return klass;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    // --- pure delegation below ---
+
+    @Override
+    public WebSocketContainer getContainer()
+    {
+        return this.delegate.getContainer();
+    }
+
+    @Override
+    public Set<MessageHandler> getMessageHandlers()
+    {
+        return this.delegate.getMessageHandlers();
+    }
+
+    @Override
+    public void removeMessageHandler( final MessageHandler handler )
+    {
+        this.delegate.removeMessageHandler( handler );
+    }
+
+    @Override
+    public String getProtocolVersion()
+    {
+        return this.delegate.getProtocolVersion();
+    }
+
+    @Override
+    public String getNegotiatedSubprotocol()
+    {
+        return this.delegate.getNegotiatedSubprotocol();
+    }
+
+    @Override
+    public List<Extension> getNegotiatedExtensions()
+    {
+        return this.delegate.getNegotiatedExtensions();
+    }
+
+    @Override
+    public boolean isSecure()
+    {
+        return this.delegate.isSecure();
+    }
+
+    @Override
+    public boolean isOpen()
+    {
+        return this.delegate.isOpen();
+    }
+
+    @Override
+    public long getMaxIdleTimeout()
+    {
+        return this.delegate.getMaxIdleTimeout();
+    }
+
+    @Override
+    public void setMaxIdleTimeout( final long milliseconds )
+    {
+        this.delegate.setMaxIdleTimeout( milliseconds );
+    }
+
+    @Override
+    public void setMaxBinaryMessageBufferSize( final int length )
+    {
+        this.delegate.setMaxBinaryMessageBufferSize( length );
+    }
+
+    @Override
+    public int getMaxBinaryMessageBufferSize()
+    {
+        return this.delegate.getMaxBinaryMessageBufferSize();
+    }
+
+    @Override
+    public void setMaxTextMessageBufferSize( final int length )
+    {
+        this.delegate.setMaxTextMessageBufferSize( length );
+    }
+
+    @Override
+    public int getMaxTextMessageBufferSize()
+    {
+        return this.delegate.getMaxTextMessageBufferSize();
+    }
+
+    @Override
+    public RemoteEndpoint.Async getAsyncRemote()
+    {
+        return this.delegate.getAsyncRemote();
+    }
+
+    @Override
+    public RemoteEndpoint.Basic getBasicRemote()
+    {
+        return this.delegate.getBasicRemote();
+    }
+
+    @Override
+    public String getId()
+    {
+        return this.delegate.getId();
+    }
+
+    @Override
+    public void close()
+        throws IOException
+    {
+        this.delegate.close();
+    }
+
+    @Override
+    public void close( final CloseReason closeReason )
+        throws IOException
+    {
+        this.delegate.close( closeReason );
+    }
+
+    @Override
+    public URI getRequestURI()
+    {
+        return this.delegate.getRequestURI();
+    }
+
+    @Override
+    public Map<String, List<String>> getRequestParameterMap()
+    {
+        return this.delegate.getRequestParameterMap();
+    }
+
+    @Override
+    public String getQueryString()
+    {
+        return this.delegate.getQueryString();
+    }
+
+    @Override
+    public Map<String, String> getPathParameters()
+    {
+        return this.delegate.getPathParameters();
+    }
+
+    @Override
+    public Map<String, Object> getUserProperties()
+    {
+        return this.delegate.getUserProperties();
+    }
+
+    @Override
+    public Principal getUserPrincipal()
+    {
+        return this.delegate.getUserPrincipal();
+    }
+
+    @Override
+    public Set<Session> getOpenSessions()
+    {
+        return this.delegate.getOpenSessions();
+    }
+}

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/SessionBoundEndpoint.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/SessionBoundEndpoint.java
@@ -1,0 +1,89 @@
+package com.enonic.xp.web.jetty.impl.websocket;
+
+import java.time.Duration;
+
+import jakarta.servlet.http.HttpSession;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.Session;
+
+/**
+ * Wraps an application {@link Endpoint} to bind its WebSocket session to the HTTP session it was opened
+ * within. When {@code httpSessionId} is set, the socket is registered with the {@link WebSocketSessionTracker}
+ * on open (and unregistered on close) so it gets closed when the HTTP session ends. When
+ * {@code sessionAccessor} is set, the delegate endpoint is handed a {@link KeepAliveSession} wrapper so that
+ * inbound messages refresh the HTTP session.
+ */
+final class SessionBoundEndpoint
+    extends Endpoint
+{
+    private final Endpoint delegate;
+
+    private final WebSocketSessionTracker tracker;
+
+    private final String httpSessionId;
+
+    private final HttpSession.Accessor sessionAccessor;
+
+    private final Duration sessionAccessThrottle;
+
+    // A fresh endpoint instance is created per connection, so the effective session opened in onOpen can be
+    // remembered here and handed to the delegate again in onClose/onError. Without this the delegate would see
+    // the KeepAliveSession wrapper in onOpen but the raw container Session afterwards, breaking endpoints that
+    // compare session identity.
+    private volatile Session effectiveSession;
+
+    SessionBoundEndpoint( final Endpoint delegate, final WebSocketSessionTracker tracker, final String httpSessionId,
+                          final HttpSession.Accessor sessionAccessor, final Duration sessionAccessThrottle )
+    {
+        this.delegate = delegate;
+        this.tracker = tracker;
+        this.httpSessionId = httpSessionId;
+        this.sessionAccessor = sessionAccessor;
+        this.sessionAccessThrottle = sessionAccessThrottle;
+    }
+
+    @Override
+    public void onOpen( final Session session, final EndpointConfig config )
+    {
+        if ( this.httpSessionId != null )
+        {
+            this.tracker.register( this.httpSessionId, session );
+        }
+
+        this.effectiveSession =
+            this.sessionAccessor != null ? new KeepAliveSession( session, this.sessionAccessor, this.sessionAccessThrottle ) : session;
+
+        this.delegate.onOpen( this.effectiveSession, config );
+    }
+
+    @Override
+    public void onClose( final Session session, final CloseReason closeReason )
+    {
+        try
+        {
+            // Tracking is keyed on the raw container session, the same instance that was registered in onOpen.
+            if ( this.httpSessionId != null )
+            {
+                this.tracker.unregister( this.httpSessionId, session );
+            }
+        }
+        finally
+        {
+            this.delegate.onClose( effectiveSession( session ), closeReason );
+        }
+    }
+
+    @Override
+    public void onError( final Session session, final Throwable thr )
+    {
+        this.delegate.onError( effectiveSession( session ), thr );
+    }
+
+    private Session effectiveSession( final Session session )
+    {
+        final Session opened = this.effectiveSession;
+        return opened != null ? opened : session;
+    }
+}

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketServiceImpl.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketServiceImpl.java
@@ -1,6 +1,7 @@
 package com.enonic.xp.web.jetty.impl.websocket;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -12,11 +13,13 @@ import org.eclipse.jetty.ee11.websocket.jakarta.server.config.ContainerDefaultCo
 import org.eclipse.jetty.websocket.core.server.WebSocketMappings;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import jakarta.websocket.DeploymentException;
 import jakarta.websocket.Endpoint;
 import jakarta.websocket.Extension;
@@ -34,10 +37,13 @@ public final class WebSocketServiceImpl
 
     private final boolean defaultOriginCheckEnabled;
 
+    private final WebSocketSessionTracker sessionTracker;
+
     @Activate
-    public WebSocketServiceImpl( final JettyConfig config )
+    public WebSocketServiceImpl( final JettyConfig config, @Reference final WebSocketSessionTracker sessionTracker )
     {
         this.defaultOriginCheckEnabled = config.websocket_defaultOriginCheck();
+        this.sessionTracker = sessionTracker;
     }
 
     @Override
@@ -56,8 +62,30 @@ public final class WebSocketServiceImpl
         final String expectedHost = req.getServerName();
         final int expectedPort = req.getServerPort();
 
+        final boolean terminateOnSessionExit = factory.isTerminateOnSessionExit();
+        final boolean sessionAccess = factory.isSessionAccess();
+
+        // The HTTP session is only observable during the upgrade request, so capture what we need now: its id
+        // (to close the socket when the session ends) and/or an Accessor (to refresh it on inbound messages).
+        final String httpSessionId;
+        final HttpSession.Accessor sessionAccessor;
+        final HttpSession httpSession = terminateOnSessionExit || sessionAccess ? req.getSession( false ) : null;
+        if ( httpSession == null )
+        {
+            // No HTTP session at upgrade time (or nothing to bind): the socket is left detached.
+            httpSessionId = null;
+            sessionAccessor = null;
+        }
+        else
+        {
+            httpSessionId = terminateOnSessionExit ? httpSession.getId() : null;
+            sessionAccessor = sessionAccess ? httpSession.getAccessor() : null;
+        }
+
         final ServerEndpointConfig config = ServerEndpointConfig.Builder.create( Endpoint.class, "/" )
-            .configurator( newConfigurator( factory, expectedScheme, expectedHost, expectedPort, this.defaultOriginCheckEnabled ) )
+            .configurator(
+                newConfigurator( factory, expectedScheme, expectedHost, expectedPort, this.defaultOriginCheckEnabled, this.sessionTracker,
+                                 httpSessionId, sessionAccessor, factory.getSessionAccessThrottle() ) )
             .subprotocols( factory.getSubProtocols() )
             .build();
 
@@ -74,7 +102,11 @@ public final class WebSocketServiceImpl
 
     private static ServerEndpointConfig.Configurator newConfigurator( final EndpointFactory factory, final String expectedScheme,
                                                                       final String expectedHost, final int expectedPort,
-                                                                      final boolean defaultOriginCheckEnabled )
+                                                                      final boolean defaultOriginCheckEnabled,
+                                                                      final WebSocketSessionTracker sessionTracker,
+                                                                      final String httpSessionId,
+                                                                      final HttpSession.Accessor sessionAccessor,
+                                                                      final Duration sessionAccessThrottle )
     {
         final ContainerDefaultConfigurator defaultConfigurator = new ContainerDefaultConfigurator();
 
@@ -132,7 +164,13 @@ public final class WebSocketServiceImpl
             @Override
             public <T> T getEndpointInstance( final Class<T> endpointClass )
             {
-                return endpointClass.cast( factory.newEndpoint() );
+                final Endpoint endpoint = factory.newEndpoint();
+                if ( httpSessionId == null && sessionAccessor == null )
+                {
+                    return endpointClass.cast( endpoint );
+                }
+                return endpointClass.cast(
+                    new SessionBoundEndpoint( endpoint, sessionTracker, httpSessionId, sessionAccessor, sessionAccessThrottle ) );
             }
         };
     }

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketSessionTracker.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketSessionTracker.java
@@ -1,0 +1,69 @@
+package com.enonic.xp.web.jetty.impl.websocket;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.http.HttpSessionEvent;
+import jakarta.servlet.http.HttpSessionListener;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.Session;
+
+/**
+ * Tracks the WebSocket sessions opened within each HTTP session and closes them with code 1008
+ * ({@link CloseReason.CloseCodes#VIOLATED_POLICY}) when that HTTP session ends — either through explicit
+ * invalidation (logout) or idle-timeout expiry.
+ * <p>
+ * The Jakarta WebSocket spec (§7.2) suggests this behavior but Jetty deliberately leaves it to the
+ * application, so XP implements it here. Tracking is node-local, which matches the supported sticky
+ * load-balancing topology.
+ */
+@Component(service = WebSocketSessionTracker.class)
+public final class WebSocketSessionTracker
+    implements HttpSessionListener
+{
+    private static final Logger LOG = LoggerFactory.getLogger( WebSocketSessionTracker.class );
+
+    private final ConcurrentMap<String, Set<Session>> sessionsByHttpSessionId = new ConcurrentHashMap<>();
+
+    public void register( final String httpSessionId, final Session wsSession )
+    {
+        this.sessionsByHttpSessionId.computeIfAbsent( httpSessionId, key -> ConcurrentHashMap.newKeySet() ).add( wsSession );
+    }
+
+    public void unregister( final String httpSessionId, final Session wsSession )
+    {
+        this.sessionsByHttpSessionId.computeIfPresent( httpSessionId, ( key, tracked ) -> {
+            tracked.remove( wsSession );
+            return tracked.isEmpty() ? null : tracked;
+        } );
+    }
+
+    @Override
+    public void sessionDestroyed( final HttpSessionEvent se )
+    {
+        final Set<Session> tracked = this.sessionsByHttpSessionId.remove( se.getSession().getId() );
+        if ( tracked == null )
+        {
+            return;
+        }
+
+        final CloseReason reason = new CloseReason( CloseReason.CloseCodes.VIOLATED_POLICY, "HTTP session ended" );
+        for ( final Session wsSession : tracked )
+        {
+            try
+            {
+                wsSession.close( reason );
+            }
+            catch ( Exception e )
+            {
+                // Swallow per-socket failures so one failing socket cannot block closing the rest.
+                LOG.warn( "Failed to close WebSocket session [{}] after HTTP session ended", wsSession.getId(), e );
+            }
+        }
+    }
+}

--- a/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/JettyActivatorTest.java
+++ b/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/JettyActivatorTest.java
@@ -15,6 +15,7 @@ import org.osgi.framework.ServiceRegistration;
 import com.enonic.xp.web.dispatch.DispatchConstants;
 import com.enonic.xp.web.dispatch.DispatchServlet;
 import com.enonic.xp.web.jetty.impl.session.JettySessionStoreConfigurator;
+import com.enonic.xp.web.jetty.impl.websocket.WebSocketSessionTracker;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -52,8 +53,8 @@ class JettyActivatorTest
         final JettySessionStoreConfigurator jettySessionStoreConfigurator = Mockito.mock( JettySessionStoreConfigurator.class );
         final DispatchServlet xpDispatcherServlet = mock( DispatchServlet.class );
         when( xpDispatcherServlet.getConnector() ).thenReturn( DispatchConstants.XP_CONNECTOR );
-        JettyActivator activator =
-            new JettyActivator( config, bundleContext, jettySessionStoreConfigurator, Collections.singletonList( xpDispatcherServlet ) );
+        JettyActivator activator = new JettyActivator( config, bundleContext, jettySessionStoreConfigurator, new WebSocketSessionTracker(),
+                                                       Collections.singletonList( xpDispatcherServlet ) );
 
         activator.activate();
 

--- a/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/websocket/KeepAliveSessionTest.java
+++ b/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/websocket/KeepAliveSessionTest.java
@@ -1,0 +1,236 @@
+package com.enonic.xp.web.jetty.impl.websocket;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import jakarta.servlet.http.HttpSession;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.Session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class KeepAliveSessionTest
+{
+    private Session delegate;
+
+    private HttpSession.Accessor accessor;
+
+    private KeepAliveSession session;
+
+    @BeforeEach
+    void setUp()
+    {
+        this.delegate = mock( Session.class );
+        this.accessor = mock( HttpSession.Accessor.class );
+        this.session = new KeepAliveSession( this.delegate, this.accessor, Duration.ofSeconds( 60 ) );
+    }
+
+    private MessageHandler.Whole<String> registerWholeHandler( final List<String> received )
+    {
+        this.session.addMessageHandler( new StringHandler( received ) );
+
+        @SuppressWarnings("unchecked") final ArgumentCaptor<MessageHandler.Whole<String>> captor =
+            ArgumentCaptor.forClass( MessageHandler.Whole.class );
+        verify( this.delegate ).addMessageHandler( eq( String.class ), captor.capture() );
+        return captor.getValue();
+    }
+
+    @Test
+    void inbound_message_refreshes_session_and_is_forwarded()
+    {
+        final List<String> received = new ArrayList<>();
+        final MessageHandler.Whole<String> wrapped = registerWholeHandler( received );
+
+        wrapped.onMessage( "hello" );
+
+        verify( this.accessor ).access( any() );
+        assertThat( received ).containsExactly( "hello" );
+    }
+
+    @Test
+    void session_refresh_is_throttled()
+    {
+        final List<String> received = new ArrayList<>();
+        final MessageHandler.Whole<String> wrapped = registerWholeHandler( received );
+
+        wrapped.onMessage( "one" );
+        wrapped.onMessage( "two" );
+        wrapped.onMessage( "three" );
+
+        // All messages are forwarded, but the session is refreshed at most once within the throttle window.
+        verify( this.accessor, times( 1 ) ).access( any() );
+        assertThat( received ).containsExactly( "one", "two", "three" );
+    }
+
+    @Test
+    void closes_socket_with_1008_when_session_already_gone()
+        throws Exception
+    {
+        doThrow( new IllegalStateException( "session invalidated" ) ).when( this.accessor ).access( any() );
+
+        final List<String> received = new ArrayList<>();
+        final MessageHandler.Whole<String> wrapped = registerWholeHandler( received );
+
+        wrapped.onMessage( "hello" );
+
+        final ArgumentCaptor<CloseReason> reason = ArgumentCaptor.forClass( CloseReason.class );
+        verify( this.delegate ).close( reason.capture() );
+        assertThat( reason.getValue().getCloseCode().getCode() ).isEqualTo( CloseReason.CloseCodes.VIOLATED_POLICY.getCode() );
+        // The message is still forwarded to the application.
+        assertThat( received ).containsExactly( "hello" );
+    }
+
+    @Test
+    void lambda_handler_is_forwarded_unwrapped()
+    {
+        // The message type of a lambda handler cannot be resolved by reflection, so it is forwarded as-is.
+        final MessageHandler.Whole<String> lambda = message -> {
+        };
+        this.session.addMessageHandler( lambda );
+
+        verify( this.delegate ).addMessageHandler( lambda );
+        verify( this.delegate, never() ).addMessageHandler( any( Class.class ), any( MessageHandler.Whole.class ) );
+    }
+
+    @Test
+    void single_arg_partial_handler_refreshes_session_and_is_forwarded()
+    {
+        final List<String> received = new ArrayList<>();
+        this.session.addMessageHandler( new StringPartialHandler( received ) );
+
+        @SuppressWarnings("unchecked") final ArgumentCaptor<MessageHandler.Partial<String>> captor =
+            ArgumentCaptor.forClass( MessageHandler.Partial.class );
+        verify( this.delegate ).addMessageHandler( eq( String.class ), captor.capture() );
+
+        captor.getValue().onMessage( "part", true );
+
+        verify( this.accessor ).access( any() );
+        assertThat( received ).containsExactly( "part" );
+    }
+
+    @Test
+    void typed_whole_handler_refreshes_session_and_is_forwarded()
+    {
+        final List<String> received = new ArrayList<>();
+        this.session.addMessageHandler( String.class, (MessageHandler.Whole<String>) received::add );
+
+        @SuppressWarnings("unchecked") final ArgumentCaptor<MessageHandler.Whole<String>> captor =
+            ArgumentCaptor.forClass( MessageHandler.Whole.class );
+        verify( this.delegate ).addMessageHandler( eq( String.class ), captor.capture() );
+
+        captor.getValue().onMessage( "hi" );
+
+        verify( this.accessor ).access( any() );
+        assertThat( received ).containsExactly( "hi" );
+    }
+
+    @Test
+    void typed_partial_handler_refreshes_session_and_is_forwarded()
+    {
+        final List<String> received = new ArrayList<>();
+        this.session.addMessageHandler( String.class, (MessageHandler.Partial<String>) ( message, last ) -> received.add( message ) );
+
+        @SuppressWarnings("unchecked") final ArgumentCaptor<MessageHandler.Partial<String>> captor =
+            ArgumentCaptor.forClass( MessageHandler.Partial.class );
+        verify( this.delegate ).addMessageHandler( eq( String.class ), captor.capture() );
+
+        captor.getValue().onMessage( "part", false );
+
+        verify( this.accessor ).access( any() );
+        assertThat( received ).containsExactly( "part" );
+    }
+
+    @Test
+    void delegates_all_session_operations()
+        throws Exception
+    {
+        this.session.getContainer();
+        this.session.getMessageHandlers();
+        final MessageHandler handler = mock( MessageHandler.class );
+        this.session.removeMessageHandler( handler );
+        this.session.getProtocolVersion();
+        this.session.getNegotiatedSubprotocol();
+        this.session.getNegotiatedExtensions();
+        this.session.isSecure();
+        this.session.isOpen();
+        this.session.getMaxIdleTimeout();
+        this.session.setMaxIdleTimeout( 123L );
+        this.session.setMaxBinaryMessageBufferSize( 10 );
+        this.session.getMaxBinaryMessageBufferSize();
+        this.session.setMaxTextMessageBufferSize( 20 );
+        this.session.getMaxTextMessageBufferSize();
+        this.session.getAsyncRemote();
+        this.session.getBasicRemote();
+        this.session.getId();
+        this.session.close();
+        final CloseReason reason = new CloseReason( CloseReason.CloseCodes.NORMAL_CLOSURE, "x" );
+        this.session.close( reason );
+        this.session.getRequestURI();
+        this.session.getRequestParameterMap();
+        this.session.getQueryString();
+        this.session.getPathParameters();
+        this.session.getUserProperties();
+        this.session.getUserPrincipal();
+        this.session.getOpenSessions();
+
+        verify( this.delegate ).getContainer();
+        verify( this.delegate ).getMessageHandlers();
+        verify( this.delegate ).removeMessageHandler( handler );
+        verify( this.delegate ).setMaxIdleTimeout( 123L );
+        verify( this.delegate ).setMaxBinaryMessageBufferSize( 10 );
+        verify( this.delegate ).setMaxTextMessageBufferSize( 20 );
+        verify( this.delegate ).getAsyncRemote();
+        verify( this.delegate ).getBasicRemote();
+        verify( this.delegate ).getId();
+        verify( this.delegate ).close();
+        verify( this.delegate ).close( reason );
+        verify( this.delegate ).getOpenSessions();
+    }
+
+    private static final class StringHandler
+        implements MessageHandler.Whole<String>
+    {
+        private final List<String> received;
+
+        StringHandler( final List<String> received )
+        {
+            this.received = received;
+        }
+
+        @Override
+        public void onMessage( final String message )
+        {
+            this.received.add( message );
+        }
+    }
+
+    private static final class StringPartialHandler
+        implements MessageHandler.Partial<String>
+    {
+        private final List<String> received;
+
+        StringPartialHandler( final List<String> received )
+        {
+            this.received = received;
+        }
+
+        @Override
+        public void onMessage( final String partialMessage, final boolean last )
+        {
+            this.received.add( partialMessage );
+        }
+    }
+}

--- a/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/websocket/SessionBoundEndpointTest.java
+++ b/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/websocket/SessionBoundEndpointTest.java
@@ -1,0 +1,109 @@
+package com.enonic.xp.web.jetty.impl.websocket;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpSession;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.Session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class SessionBoundEndpointTest
+{
+    private static final Duration THROTTLE = Duration.ofSeconds( 60 );
+
+    private final RecordingEndpoint delegate = new RecordingEndpoint();
+
+    private final WebSocketSessionTracker tracker = mock( WebSocketSessionTracker.class );
+
+    private final EndpointConfig config = mock( EndpointConfig.class );
+
+    @Test
+    void registers_and_unregisters_raw_session_and_forwards_raw_session_when_not_accessing()
+    {
+        final Session session = mock( Session.class );
+        final SessionBoundEndpoint endpoint = new SessionBoundEndpoint( this.delegate, this.tracker, "s1", null, THROTTLE );
+
+        endpoint.onOpen( session, this.config );
+        endpoint.onClose( session, new CloseReason( CloseReason.CloseCodes.NORMAL_CLOSURE, "bye" ) );
+
+        verify( this.tracker ).register( "s1", session );
+        verify( this.tracker ).unregister( "s1", session );
+
+        // Without an accessor the delegate sees the raw session in every callback.
+        assertThat( this.delegate.opened ).containsExactly( session );
+        assertThat( this.delegate.closed ).containsExactly( session );
+    }
+
+    @Test
+    void delegate_sees_the_same_keepalive_session_in_open_and_close_when_accessing()
+    {
+        final Session session = mock( Session.class );
+        final HttpSession.Accessor accessor = mock( HttpSession.Accessor.class );
+        final SessionBoundEndpoint endpoint = new SessionBoundEndpoint( this.delegate, this.tracker, "s1", accessor, THROTTLE );
+
+        endpoint.onOpen( session, this.config );
+        endpoint.onError( session, new RuntimeException( "boom" ) );
+        endpoint.onClose( session, new CloseReason( CloseReason.CloseCodes.NORMAL_CLOSURE, "bye" ) );
+
+        final Session effective = this.delegate.opened.get( 0 );
+        assertThat( effective ).isInstanceOf( KeepAliveSession.class ).isNotSameAs( session );
+        assertThat( this.delegate.errored ).containsExactly( effective );
+        assertThat( this.delegate.closed ).containsExactly( effective );
+
+        // Tracking still uses the raw container session.
+        verify( this.tracker ).register( "s1", session );
+        verify( this.tracker ).unregister( "s1", session );
+    }
+
+    @Test
+    void does_not_touch_tracker_when_only_accessing()
+    {
+        final Session session = mock( Session.class );
+        final HttpSession.Accessor accessor = mock( HttpSession.Accessor.class );
+        final SessionBoundEndpoint endpoint = new SessionBoundEndpoint( this.delegate, this.tracker, null, accessor, THROTTLE );
+
+        endpoint.onOpen( session, this.config );
+        endpoint.onClose( session, new CloseReason( CloseReason.CloseCodes.NORMAL_CLOSURE, "bye" ) );
+
+        verifyNoInteractions( this.tracker );
+        assertThat( this.delegate.opened.get( 0 ) ).isInstanceOf( KeepAliveSession.class );
+    }
+
+    private static final class RecordingEndpoint
+        extends Endpoint
+    {
+        final List<Session> opened = new ArrayList<>();
+
+        final List<Session> closed = new ArrayList<>();
+
+        final List<Session> errored = new ArrayList<>();
+
+        @Override
+        public void onOpen( final Session session, final EndpointConfig config )
+        {
+            this.opened.add( session );
+        }
+
+        @Override
+        public void onClose( final Session session, final CloseReason closeReason )
+        {
+            this.closed.add( session );
+        }
+
+        @Override
+        public void onError( final Session session, final Throwable thr )
+        {
+            this.errored.add( session );
+        }
+    }
+}

--- a/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketServiceImplTest.java
+++ b/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketServiceImplTest.java
@@ -7,11 +7,16 @@ import java.net.Socket;
 import java.net.URI;
 import java.net.http.WebSocket;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import jakarta.websocket.CloseReason;
 
 import com.enonic.xp.web.jetty.impl.JettyConfig;
 import com.enonic.xp.web.jetty.impl.JettyTestSupport;
@@ -33,7 +38,8 @@ class WebSocketServiceImplTest
     {
         this.endpoint = new TestEndpoint();
 
-        this.service = new WebSocketServiceImpl( mock( JettyConfig.class, invocation -> invocation.getMethod().getDefaultValue() ) );
+        this.service = new WebSocketServiceImpl( mock( JettyConfig.class, invocation -> invocation.getMethod().getDefaultValue() ),
+                                                 this.server.getSessionTracker() );
 
         TestWebSocketServlet servlet = new TestWebSocketServlet();
         servlet.service = this.service;
@@ -45,7 +51,108 @@ class WebSocketServiceImplTest
     private WebSocket newWebSocketRequest( final WebSocket.Listener listener )
         throws ExecutionException, InterruptedException
     {
-        return client.newWebSocketBuilder().buildAsync( URI.create( "ws://localhost:" + this.server.getPort() + "/ws" ), listener ).get();
+        return newWebSocketRequest( listener, "/ws" );
+    }
+
+    private WebSocket newWebSocketRequest( final WebSocket.Listener listener, final String path )
+        throws ExecutionException, InterruptedException
+    {
+        return client.newWebSocketBuilder().buildAsync( URI.create( "ws://localhost:" + this.server.getPort() + path ), listener ).get();
+    }
+
+    private static void awaitSession( final TestEndpoint endpoint )
+        throws InterruptedException
+    {
+        awaitSessionCount( endpoint, 1 );
+    }
+
+    private static void awaitSessionCount( final TestEndpoint endpoint, final int expected )
+        throws InterruptedException
+    {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos( 10 );
+        while ( endpoint.sessions.size() != expected )
+        {
+            if ( System.nanoTime() > deadline )
+            {
+                throw new AssertionError( "WebSocket session count did not reach " + expected + " in time" );
+            }
+            Thread.sleep( 10 );
+        }
+    }
+
+    private TestEndpoint addSessionAwareServlet( final String path, final boolean createSession, final TestWebSocketServlet servlet )
+    {
+        final TestEndpoint endpoint = new TestEndpoint();
+        servlet.service = this.service;
+        servlet.endpoint = endpoint;
+        servlet.createSession = createSession;
+        addServlet( servlet, path );
+        return endpoint;
+    }
+
+    @Test
+    void terminating_socket_closes_with_1008_on_session_invalidation_while_sessionless_socket_survives()
+        throws Exception
+    {
+        // Default config: terminateOnSessionExit = true, sessionAccess = false.
+        final TestWebSocketServlet boundServlet = new TestWebSocketServlet();
+        final TestEndpoint boundEndpoint = addSessionAwareServlet( "/ws-bound", true, boundServlet );
+
+        final TestEndpoint freeEndpoint = addSessionAwareServlet( "/ws-free", false, new TestWebSocketServlet() );
+
+        final CloseListener boundListener = new CloseListener();
+        final CloseListener freeListener = new CloseListener();
+        newWebSocketRequest( boundListener, "/ws-bound" );
+        newWebSocketRequest( freeListener, "/ws-free" );
+
+        awaitSession( boundEndpoint );
+        awaitSession( freeEndpoint );
+
+        boundServlet.session.invalidate();
+
+        assertEquals( CloseReason.CloseCodes.VIOLATED_POLICY.getCode(), boundListener.awaitCloseCode() );
+        assertThat( freeListener.isClosed() ).isFalse();
+        assertThat( freeEndpoint.sessions ).hasSize( 1 );
+    }
+
+    @Test
+    void session_access_socket_closes_with_1008_and_endpoint_cleans_up_on_invalidation()
+        throws Exception
+    {
+        final TestWebSocketServlet servlet = new TestWebSocketServlet();
+        servlet.sessionAccess = true; // terminateOnSessionExit stays true (default)
+        final TestEndpoint endpoint = addSessionAwareServlet( "/ws-access", true, servlet );
+
+        final CloseListener listener = new CloseListener();
+        newWebSocketRequest( listener, "/ws-access" );
+        awaitSession( endpoint );
+
+        servlet.session.invalidate();
+
+        assertEquals( CloseReason.CloseCodes.VIOLATED_POLICY.getCode(), listener.awaitCloseCode() );
+        // onClose must receive the same (KeepAliveSession) instance opened in onOpen, so the endpoint's
+        // identity-based removal works and the session list drains.
+        awaitSessionCount( endpoint, 0 );
+    }
+
+    @Test
+    void non_terminating_socket_survives_session_invalidation()
+        throws Exception
+    {
+        final TestWebSocketServlet servlet = new TestWebSocketServlet();
+        servlet.terminateOnSessionExit = false;
+        final TestEndpoint endpoint = addSessionAwareServlet( "/ws-detached", true, servlet );
+
+        final CloseListener listener = new CloseListener();
+        newWebSocketRequest( listener, "/ws-detached" );
+        awaitSession( endpoint );
+
+        servlet.session.invalidate();
+
+        // Give a (would-be) close a chance to propagate before asserting the socket is still alive.
+        Thread.sleep( 500 );
+        assertThat( listener.isClosed() ).isFalse();
+        assertThat( endpoint.sessions ).hasSize( 1 );
     }
 
     private String rawHandshakeStatusLine( final String originHeader )
@@ -217,7 +324,7 @@ class WebSocketServiceImplTest
                 return false;
             }
             return invocation.getMethod().getDefaultValue();
-        } ) );
+        } ), this.server.getSessionTracker() );
         final TestWebSocketServlet servlet = new TestWebSocketServlet();
         servlet.service = permissiveService;
         servlet.endpoint = new TestEndpoint();
@@ -225,5 +332,29 @@ class WebSocketServiceImplTest
 
         final String status = rawHandshakeStatusLine( "/ws-permissive", "https://evil.example.org" );
         assertThat( status ).contains( "101" );
+    }
+
+    private static final class CloseListener
+        implements WebSocket.Listener
+    {
+        private final CompletableFuture<Integer> closeCode = new CompletableFuture<>();
+
+        @Override
+        public CompletionStage<?> onClose( final WebSocket webSocket, final int statusCode, final String reason )
+        {
+            this.closeCode.complete( statusCode );
+            return null;
+        }
+
+        int awaitCloseCode()
+            throws Exception
+        {
+            return this.closeCode.get( 30, TimeUnit.SECONDS );
+        }
+
+        boolean isClosed()
+        {
+            return this.closeCode.isDone();
+        }
     }
 }

--- a/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketSessionTrackerTest.java
+++ b/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketSessionTrackerTest.java
@@ -1,0 +1,104 @@
+package com.enonic.xp.web.jetty.impl.websocket;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpSessionEvent;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.Session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WebSocketSessionTrackerTest
+{
+    private final WebSocketSessionTracker tracker = new WebSocketSessionTracker();
+
+    private static HttpSessionEvent sessionEvent( final String id )
+    {
+        final HttpSession httpSession = mock( HttpSession.class );
+        when( httpSession.getId() ).thenReturn( id );
+        return new HttpSessionEvent( httpSession );
+    }
+
+    @Test
+    void sessionDestroyed_closes_all_tracked_sockets_with_1008()
+        throws Exception
+    {
+        final Session ws1 = mock( Session.class );
+        final Session ws2 = mock( Session.class );
+        tracker.register( "s1", ws1 );
+        tracker.register( "s1", ws2 );
+
+        tracker.sessionDestroyed( sessionEvent( "s1" ) );
+
+        final ArgumentCaptor<CloseReason> reason = ArgumentCaptor.forClass( CloseReason.class );
+        verify( ws1 ).close( reason.capture() );
+        verify( ws2 ).close( reason.capture() );
+        assertThat( reason.getAllValues() ).allSatisfy(
+            r -> assertThat( r.getCloseCode().getCode() ).isEqualTo( CloseReason.CloseCodes.VIOLATED_POLICY.getCode() ) );
+    }
+
+    @Test
+    void sessionDestroyed_for_unknown_id_is_noop()
+        throws Exception
+    {
+        final Session ws1 = mock( Session.class );
+        tracker.register( "s1", ws1 );
+
+        tracker.sessionDestroyed( sessionEvent( "other" ) );
+
+        verify( ws1, never() ).close( any() );
+    }
+
+    @Test
+    void unregistered_socket_is_not_closed()
+        throws Exception
+    {
+        final Session ws1 = mock( Session.class );
+        tracker.register( "s1", ws1 );
+        tracker.unregister( "s1", ws1 );
+
+        tracker.sessionDestroyed( sessionEvent( "s1" ) );
+
+        verify( ws1, never() ).close( any() );
+    }
+
+    @Test
+    void failure_to_close_one_socket_does_not_block_the_rest()
+        throws Exception
+    {
+        final Session failing = mock( Session.class );
+        final Session healthy = mock( Session.class );
+        doThrow( new IOException( "boom" ) ).when( failing ).close( any() );
+        tracker.register( "s1", failing );
+        tracker.register( "s1", healthy );
+
+        tracker.sessionDestroyed( sessionEvent( "s1" ) );
+
+        verify( failing ).close( any() );
+        verify( healthy ).close( any() );
+    }
+
+    @Test
+    void destroying_a_session_clears_tracking_so_a_second_destroy_is_noop()
+        throws Exception
+    {
+        final Session ws1 = mock( Session.class );
+        tracker.register( "s1", ws1 );
+
+        tracker.sessionDestroyed( sessionEvent( "s1" ) );
+        tracker.sessionDestroyed( sessionEvent( "s1" ) );
+
+        verify( ws1, times( 1 ) ).close( any() );
+    }
+}

--- a/modules/web/web-jetty/src/testFixtures/java/com/enonic/xp/web/jetty/impl/JettyTestServer.java
+++ b/modules/web/web-jetty/src/testFixtures/java/com/enonic/xp/web/jetty/impl/JettyTestServer.java
@@ -16,12 +16,15 @@ import jakarta.servlet.Filter;
 import jakarta.servlet.http.HttpServlet;
 
 import com.enonic.xp.web.dispatch.DispatchConstants;
+import com.enonic.xp.web.jetty.impl.websocket.WebSocketSessionTracker;
 
 public final class JettyTestServer
 {
     private final Server server;
 
     private final ServletContextHandler handler;
+
+    private final WebSocketSessionTracker sessionTracker = new WebSocketSessionTracker();
 
     public JettyTestServer()
     {
@@ -35,9 +38,15 @@ public final class JettyTestServer
         this.server.addConnector( connector );
 
         this.handler = new ServletContextHandler( "/", ServletContextHandler.SESSIONS );
+        this.handler.addEventListener( this.sessionTracker );
         JakartaWebSocketServletContainerInitializer.configure( this.handler, ( _, _ ) -> {
         } );
         this.server.setHandler( this.handler );
+    }
+
+    public WebSocketSessionTracker getSessionTracker()
+    {
+        return this.sessionTracker;
     }
 
     public void start()

--- a/modules/web/web-jetty/src/testFixtures/java/com/enonic/xp/web/jetty/impl/websocket/TestWebSocketServlet.java
+++ b/modules/web/web-jetty/src/testFixtures/java/com/enonic/xp/web/jetty/impl/websocket/TestWebSocketServlet.java
@@ -1,14 +1,17 @@
 package com.enonic.xp.web.jetty.impl.websocket;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.function.Predicate;
 
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import jakarta.websocket.Endpoint;
 
 import com.enonic.xp.web.websocket.EndpointFactory;
+import com.enonic.xp.web.websocket.WebSocketConfig;
 import com.enonic.xp.web.websocket.WebSocketService;
 
 public class TestWebSocketServlet
@@ -20,6 +23,16 @@ public class TestWebSocketServlet
 
     protected Predicate<String> originValidator;
 
+    protected boolean terminateOnSessionExit = true;
+
+    protected boolean sessionAccess = false;
+
+    protected Duration sessionAccessThrottle = WebSocketConfig.DEFAULT_SESSION_ACCESS_THROTTLE;
+
+    protected boolean createSession;
+
+    public volatile HttpSession session;
+
     @Override
     protected void doGet( final HttpServletRequest req, final HttpServletResponse res )
         throws IOException
@@ -28,6 +41,11 @@ public class TestWebSocketServlet
         {
             res.sendError( HttpServletResponse.SC_NOT_FOUND );
             return;
+        }
+
+        if ( this.createSession )
+        {
+            this.session = req.getSession( true );
         }
 
         this.service.acceptWebSocket( req, res, new EndpointFactory()
@@ -42,6 +60,24 @@ public class TestWebSocketServlet
             public Predicate<String> getOriginValidator()
             {
                 return originValidator;
+            }
+
+            @Override
+            public boolean isTerminateOnSessionExit()
+            {
+                return terminateOnSessionExit;
+            }
+
+            @Override
+            public boolean isSessionAccess()
+            {
+                return sessionAccess;
+            }
+
+            @Override
+            public Duration getSessionAccessThrottle()
+            {
+                return sessionAccessThrottle;
             }
         } );
     }


### PR DESCRIPTION
Fixes #12116.

WebSocket connections opened within an HTTP session previously survived that session's end: after logout or idle-timeout expiry the server kept pushing and accepting messages under the stale `Context` (including `AuthenticationInfo`) captured at upgrade. The Jakarta WebSocket spec (§7.2) suggests closing them, but Jetty deliberately leaves this to the application, so XP now implements it.

## Behavior

Session binding is controlled by two orthogonal, per-socket parameters plus a throttle, set from the controller's `webSocket` response:

| Parameter | Default | Effect |
|---|---|---|
| `terminateOnSessionExit` | `true` | Close the socket with code **1008** when the HTTP session ends — both on explicit invalidation (logout) and idle-timeout expiry. |
| `sessionAccess` | `false` | Inbound WebSocket messages refresh (access) the HTTP session, keeping it alive. Server→client pushes never count. |
| `sessionAccessThrottle` | `60` (s) | Minimum interval between those refreshes. |

```js
return {
    webSocket: {
        data: { /* ... */ },
        subProtocols: ['...'],
        sessionAccess: false,            // optional, default false
        terminateOnSessionExit: true,    // optional, default true
        sessionAccessThrottle: 60        // optional seconds, default 60
    }
};
```

**Behavior change:** session-bound sockets that previously outlived logout/expiry now close with 1008. `terminateOnSessionExit: false` is the escape hatch for apps that relied on the old behavior. Worth a release-note callout.

## Implementation (core logic in `web-jetty`)

- **`WebSocketSessionTracker`** — an `HttpSessionListener` that tracks the sockets opened under each HTTP session and closes them with 1008 on `sessionDestroyed`. Per-socket close failures are logged and swallowed so one failing socket can't block the rest.
- **`WebSocketServiceImpl`** captures the HTTP session **id** (only when terminating) and an `HttpSession.Accessor` (only when accessing) at upgrade — the `HttpSession` itself is never retained — and wraps the application endpoint in **`SessionBoundEndpoint`**, which registers/unregisters with the tracker and, when accessing, hands the delegate a **`KeepAliveSession`** that refreshes the session on inbound messages (throttled; 1008 backstop if the session is already gone).
- **`JettyActivator`** registers the tracker as a session listener on each context.
- **`PortalResponseSerializer`** / **`EndpointFactory`** / **`WebSocketConfig`** carry the new parameters; the WebSocket controller response config is now typed in `lib/core/index.d.ts` via a new `WebSocketResponse` interface (which also finally types the existing `data`/`subProtocols`/`checkOrigin`).

## Out of scope
Cluster-wide close propagation. Session events are node-local in Jetty; with sticky load balancing the socket and session live on the same node. Propagating session-destroyed over the XP event bus is a possible follow-up.

## Tests
- `WebSocketSessionTracker` unit tests (register/unregister, close-all with 1008, partial-failure isolation, unknown id no-op).
- `KeepAliveSession` unit tests (inbound refresh + forwarding, throttling, 1008 on `IllegalStateException`, lambda handler forwarded unwrapped).
- Real-Jetty integration tests: terminating socket closes with 1008 on `session.invalidate()`; sessionless and non-terminating sockets survive.
- `PortalResponseSerializer` mapping tests for the new fields.

All of `web-api`, `web-jetty`, `portal-impl` compile and tests pass; the TS declaration build is clean.

https://claude.ai/code/session_01W2wzGUpkSNqRa51nnfJzEw

---
_Generated by [Claude Code](https://claude.ai/code/session_01W2wzGUpkSNqRa51nnfJzEw)_