### PR TITLE
Sync Jetty config template with JettyConfig defaults

### DIFF
--- a/modules/runtime/src/home/config/com.enonic.xp.web.jetty.cfg
+++ b/modules/runtime/src/home/config/com.enonic.xp.web.jetty.cfg
@@ -9,8 +9,8 @@
 # http.management.host =
 # http.statistics.port = 2609
 # http.statistics.host =
-# http.requestHeaderSize = 32000
-# http.responseHeaderSize = 32000
+# http.requestHeaderSize = 32768
+# http.responseHeaderSize = 32768
 
 # session.timeout = 60
 # session.cookieName = JSESSIONID
@@ -37,3 +37,4 @@
 # threadPool.idleTimeout = 60000
 
 # websocket.idleTimeout = 300000
+# websocket.defaultOriginCheck = true


### PR DESCRIPTION
The shipped `com.enonic.xp.web.jetty.cfg` template drifted from the actual `JettyConfig` defaults. This syncs the documentation-only values:

- `http.requestHeaderSize` / `http.responseHeaderSize`: `32000` → `32768` (the real `32 * 1024` default)
- added the missing `websocket.defaultOriginCheck = true` option (introduced in #12102)

No behavior change — the template only documents defaults.

The stale multipart values in the template are handled separately in #12120 (enforcing the documented cap in code), so they are intentionally left untouched here.

doc-xp is updated in enonic/doc-xp#592.

<sub>*Drafted with AI assistance*</sub>