### PR TITLE
Enforce documented multipart upload size limit #12120

### DIFF
--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/JettyConfig.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/JettyConfig.java
@@ -110,19 +110,19 @@ public @interface JettyConfig
     String multipart_store();
 
     /**
-     * Max file size for multipart (-1 if unlimited).
+     * Max file size for multipart, in bytes (-1 if unlimited). Default: 15 GiB.
      */
-    long multipart_maxFileSize() default -1;
+    long multipart_maxFileSize() default 16106127360L;
 
     /**
-     * Max request size for multipart (-1 if unlimited).
+     * Max request size for multipart, in bytes (-1 if unlimited). Default: 15 GiB.
      */
-    long multipart_maxRequestSize() default -1;
+    long multipart_maxRequestSize() default 16106127360L;
 
     /**
      * File size treshold for when to store to disk. 0 means always. Specified in bytes.
      */
-    int multipart_fileSizeThreshold() default 1000;
+    int multipart_fileSizeThreshold() default 10240;
 
     /**
      * True if GZip should be enabled.

--- a/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/configurator/MultipartConfiguratorTest.java
+++ b/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/configurator/MultipartConfiguratorTest.java
@@ -40,9 +40,9 @@ class MultipartConfiguratorTest
 
         final MultipartConfigElement multipartConfig = getMultipartConfig();
         assertEquals( StandardSystemProperty.JAVA_IO_TMPDIR.value(), multipartConfig.getLocation() );
-        assertEquals( -1, multipartConfig.getMaxFileSize() );
-        assertEquals( -1, multipartConfig.getMaxRequestSize() );
-        assertEquals( 1000, multipartConfig.getFileSizeThreshold() );
+        assertEquals( 16106127360L, multipartConfig.getMaxFileSize() );
+        assertEquals( 16106127360L, multipartConfig.getMaxRequestSize() );
+        assertEquals( 10240, multipartConfig.getFileSizeThreshold() );
     }
 
     @Test


### PR DESCRIPTION
The 15 GiB multipart upload cap has been documented in `com.enonic.xp.web.jetty.cfg` since #8864 (2021), but `JettyConfig` kept the defaults at `-1` (unlimited) — so the limit never took effect. This sets the defaults to the documented values so multipart uploads are actually capped out of the box.

- `multipart.maxFileSize`: `-1` → `16106127360` (15 GiB)
- `multipart.maxRequestSize`: `-1` → `16106127360` (15 GiB)
- `multipart.fileSizeThreshold`: `1000` → `10240`

**Behavior change:** portal multipart uploads larger than 15 GiB without an explicit `multipart.maxFileSize` / `maxRequestSize` override now fail. Worth a release-note callout.

Closes #12120

<sub>*Drafted with AI assistance*</sub>