### PR TITLE
#11987 Doh page logout is wrong

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/exception/ExceptionRendererImpl.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/exception/ExceptionRendererImpl.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.content.ContentConstants;
 import com.enonic.xp.context.ContextAccessor;
@@ -28,6 +30,7 @@ import com.enonic.xp.portal.impl.error.PortalError;
 import com.enonic.xp.portal.postprocess.PostProcessor;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceService;
+import com.enonic.xp.security.IdProviderKey;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.server.RunMode;
 import com.enonic.xp.site.SiteConfig;
@@ -39,6 +42,8 @@ import com.enonic.xp.web.WebResponse;
 import com.enonic.xp.web.exception.ExceptionMapper;
 import com.enonic.xp.web.exception.ExceptionRenderer;
 import com.enonic.xp.web.servlet.ServletRequestUrlHelper;
+import com.enonic.xp.web.vhost.VirtualHost;
+import com.enonic.xp.web.vhost.VirtualHostHelper;
 
 import static com.enonic.xp.portal.RenderMode.EDIT;
 import static com.google.common.base.Strings.nullToEmpty;
@@ -295,13 +300,24 @@ public final class ExceptionRendererImpl
                 new ErrorPageSimpleBuilder().status( info.status.value() ).tip( info.tip ).title( info.status.getReasonPhrase() );
             if ( info.status == HttpStatus.FORBIDDEN && ContextAccessor.current().getAuthInfo().isAuthenticated() )
             {
-                errorBuilder.logoutUrl( ServletRequestUrlHelper.createUri( req.getRawRequest(), "/_/idprovider/" +
-                    ContextAccessor.current().getAuthInfo().getUser().getKey().getIdProviderKey() + "/logout" ) );
+                errorBuilder.logoutUrl( createLogoutUrl( req.getRawRequest() ) );
             }
             builder = errorBuilder;
         }
 
         final String html = builder.build();
         return PortalResponse.create().status( info.status ).body( html ).contentType( MediaType.HTML_UTF_8 ).build();
+    }
+
+    private static String createLogoutUrl( final HttpServletRequest rawRequest )
+    {
+        final IdProviderKey idProviderKey = ContextAccessor.current().getAuthInfo().getUser().getKey().getIdProviderKey();
+
+        // Prepend the virtual host target so createUri can rewrite it back to the source path (vhost rewrite).
+        final VirtualHost virtualHost = VirtualHostHelper.getVirtualHost( rawRequest );
+        final String target = virtualHost != null ? virtualHost.getTarget() : "/";
+        final String base = target.endsWith( "/" ) ? target : target + "/";
+
+        return ServletRequestUrlHelper.createUri( rawRequest, base + "_/idprovider/" + idProviderKey + "/logout" );
     }
 }

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/exception/ExceptionRendererImplTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/exception/ExceptionRendererImplTest.java
@@ -345,9 +345,9 @@ class ExceptionRendererImplTest
         this.request.getHeaders().put( HttpHeaders.ACCEPT, "text/html,text/*" );
 
         final VirtualHost virtualHost = mock( VirtualHost.class );
-        when( virtualHost.getSource() ).thenReturn( "/" );
-        when( virtualHost.getTarget() ).thenReturn( "/admin/site/intranet/master" );
-        VirtualHostHelper.setVirtualHost( request.getRawRequest(), virtualHost );
+        when( virtualHost.getSource() ).thenReturn( "/intranet" );
+        when( virtualHost.getTarget() ).thenReturn( "/site/intra/master" );
+        when( request.getRawRequest().getAttribute( VirtualHost.class.getName() ) ).thenReturn( virtualHost );
 
         final RuntimeException cause = new RuntimeException( "Custom message" );
 
@@ -358,7 +358,7 @@ class ExceptionRendererImplTest
             context.callWith( () -> this.renderer.render( this.request, new WebException( HttpStatus.FORBIDDEN, cause ) ) );
 
         final String responseBody = response.getBody().toString();
-        assertThat( responseBody ).contains( "class=\"logout\"" ).contains( "href=\"/_/idprovider/system/logout\"" );
+        assertThat( responseBody ).contains( "class=\"logout\"" ).contains( "href=\"/intranet/_/idprovider/system/logout\"" );
     }
 
     private Site newSite()

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/exception/ExceptionRendererImplTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/exception/ExceptionRendererImplTest.java
@@ -331,7 +331,34 @@ class ExceptionRendererImplTest
 
         final String responseBody = response.getBody().toString();
         assertThat( responseBody ).contains( "<h3>403 - Forbidden</h3>" );
-        assertThat( responseBody ).contains( "class=\"logout\"" ).contains( "/_/idprovider/system/logout" );
+        assertThat( responseBody ).contains( "class=\"logout\"" ).contains( "/admin/_/idprovider/system/logout" );
+    }
+
+    @Test
+    void testRenderForbiddenLogoutUrlConsidersVhostRewrite()
+        throws IOException
+    {
+        RunModeSupport.set( RunMode.PROD );
+        this.renderer = new ExceptionRendererImpl( resourceService, errorHandlerScriptFactory, idProviderControllerService, postProcessor,
+                                                   new ExceptionMapperImpl() );
+
+        this.request.getHeaders().put( HttpHeaders.ACCEPT, "text/html,text/*" );
+
+        final VirtualHost virtualHost = mock( VirtualHost.class );
+        when( virtualHost.getSource() ).thenReturn( "/" );
+        when( virtualHost.getTarget() ).thenReturn( "/admin/site/intranet/master" );
+        VirtualHostHelper.setVirtualHost( request.getRawRequest(), virtualHost );
+
+        final RuntimeException cause = new RuntimeException( "Custom message" );
+
+        final AuthenticationInfo authenticationInfo = AuthenticationInfo.create().user( User.anonymous() ).build();
+        final Context context = ContextBuilder.from( ContextAccessor.current() ).authInfo( authenticationInfo ).build();
+
+        final PortalResponse response =
+            context.callWith( () -> this.renderer.render( this.request, new WebException( HttpStatus.FORBIDDEN, cause ) ) );
+
+        final String responseBody = response.getBody().toString();
+        assertThat( responseBody ).contains( "class=\"logout\"" ).contains( "href=\"/_/idprovider/system/logout\"" );
     }
 
     private Site newSite()


### PR DESCRIPTION
Fixes #11987

## Problem
The default error ("D'oh!") page rendered by `ExceptionRendererImpl` shows a **Logout** link on a `403 Forbidden` for authenticated users. It built that link from a bare `/_/idprovider/<key>/logout` path passed to `ServletRequestUrlHelper.createUri`.

`createUri` performs a virtual-host **target → source** rewrite, but only on a URI that *starts with the vhost target*. A bare path does not, so when the vhost target is not `/`, the rewrite is skipped and `createUri` returns the path unchanged — the source prefix is never applied and the logout URL is wrong. It only happened to work when the vhost source was `/`.

## Fix
Prepend `virtualHost.getTarget()` before calling `createUri`, mirroring the canonical `IdentityBaseUrlSupplier`, so the vhost rewrite applies correctly.

No new dependency is introduced — `VirtualHostHelper` is already used within `portal-impl` (e.g. `IdentityHandler`). In particular this avoids pulling `PortalUrlService` (and its `PortalRequestAccessor` binding) into the error renderer.

## Tests
- Updated `testRenderForbidden` (source=`/admin`, target=`/admin`): the link is now the working `/admin/_/idprovider/system/logout` instead of the previously-asserted buggy `/_/idprovider/system/logout`.
- Added `testRenderForbiddenLogoutUrlConsidersVhostRewrite` (source=`/`, target=`/admin/site/intranet/master`) asserting the link rewrites back to `/_/idprovider/system/logout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)