### PR TITLE
#12118 Imported node timestamp is used as version's timestamp

### DIFF
--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CreateNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CreateNodeCommand.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.time.Instant;
 import java.util.List;
 
 import com.enonic.xp.context.ContextAccessor;
@@ -36,8 +35,6 @@ public final class CreateNodeCommand
 {
     private final CreateNodeParams params;
 
-    private final Instant timestamp;
-
     private final BinaryService binaryService;
 
     private final boolean skipVerification;
@@ -46,7 +43,6 @@ public final class CreateNodeCommand
     {
         super( builder );
         this.params = builder.params;
-        this.timestamp = builder.timestamp;
         this.binaryService = builder.binaryService;
         this.skipVerification = builder.skipVerification;
     }
@@ -88,7 +84,7 @@ public final class CreateNodeCommand
             .permissions( permissions )
             .nodeType( params.getNodeType() != null ? params.getNodeType() : NodeType.DEFAULT_NODE_COLLECTION )
             .attachedBinaries( attachedBinaries )
-            .timestamp( Millis.fromOrElseNow( this.timestamp ) );
+            .timestamp( Millis.now() );
 
         final Node builtNode = nodeBuilder.build();
         final Attributes resolvedAttributes =
@@ -198,8 +194,6 @@ public final class CreateNodeCommand
     {
         private CreateNodeParams params;
 
-        private Instant timestamp;
-
         private BinaryService binaryService;
 
         private boolean skipVerification;
@@ -223,12 +217,6 @@ public final class CreateNodeCommand
         public Builder binaryService( final BinaryService binaryService )
         {
             this.binaryService = binaryService;
-            return this;
-        }
-
-        public Builder timestamp( final Instant timestamp )
-        {
-            this.timestamp = timestamp;
             return this;
         }
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ImportNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ImportNodeCommand.java
@@ -116,7 +116,6 @@ public class ImportNodeCommand
 
             node = CreateNodeCommand.create( this )
                 .params( createNodeParams )
-                .timestamp( this.importNode.getTimestamp() )
                 .binaryService( binaryService )
                 .build()
                 .execute();

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/ImportNodeCommandTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/ImportNodeCommandTest.java
@@ -51,30 +51,46 @@ class ImportNodeCommandTest
     }
 
     @Test
-    void created_nodes_with_id_and_timestamp_should_be_equal()
+    void imported_timestamp_is_not_used_as_version_timestamp()
     {
-        ctxDefault().callWith( () -> importNode( Node.create()
-                                                     .id( NodeId.from( "abc" ) )
-                                                     .name( "myNode" )
-                                                     .parentPath( NodePath.ROOT )
-                                                     .data( new PropertyTree() )
-                                                     .timestamp( Instant.parse( "2014-01-01T10:00:00Z" ) )
-                                                     .build() ) );
+        final Instant nodeTimestamp = Instant.parse( "2014-01-01T10:00:00Z" );
+        final Instant beforeImport = Instant.now().minusSeconds( 60 );
 
-        ctxOther().callWith( () -> importNode( Node.create()
-                                                   .id( NodeId.from( "abc" ) )
-                                                   .name( "myNode" )
-                                                   .parentPath( NodePath.ROOT )
-                                                   .data( new PropertyTree() )
-                                                   .timestamp( Instant.parse( "2014-01-01T10:00:00Z" ) )
-                                                   .build() ) );
+        final ImportNodeResult importNodeResult = importNode( Node.create()
+                                                                  .name( "myNode" )
+                                                                  .parentPath( NodePath.ROOT )
+                                                                  .data( new PropertyTree() )
+                                                                  .timestamp( nodeTimestamp )
+                                                                  .build() );
 
-        final NodeComparison comparison = CompareNodeCommand.create()
-            .nodeId( NodeId.from( "abc" ) )
+        final Instant versionTimestamp = importNodeResult.getNode().getTimestamp();
+        assertNotEquals( nodeTimestamp, versionTimestamp );
+        assertTrue( versionTimestamp.isAfter( beforeImport ), "version timestamp should be the import time, not the imported value" );
+    }
+
+    @Test
+    void pushed_node_is_equal_in_both_branches()
+    {
+        final NodeId nodeId = NodeId.from( "abc" );
+
+        // Branches are kept in sync by sharing the same version (push), not by importing the same
+        // content separately into each branch - separate imports now get independent version timestamps.
+        ctxDefault().callWith( () -> {
+            importNode( Node.create()
+                            .id( nodeId )
+                            .name( "myNode" )
+                            .parentPath( NodePath.ROOT )
+                            .data( new PropertyTree() )
+                            .build() );
+            return pushNodes( WS_OTHER, nodeId );
+        } );
+
+        final NodeComparison comparison = ctxDefault().callWith( () -> CompareNodeCommand.create()
+            .nodeId( nodeId )
             .target( WS_OTHER )
             .storageService( this.storageService )
             .build()
-            .execute();
+            .execute() );
 
         assertEquals( NodeCompareStatus.EQUAL, comparison.getCompareStatus() );
     }


### PR DESCRIPTION
## Problem

The XML `<timestamp>` element of an imported node (e.g. [app-corporate-theme node.xml](https://github.com/enonic/app-corporate-theme/blob/master/src/main/resources/import/my-corporation/_/node.xml)) was used as the stored **version** timestamp on import, so the version timestamp could be set to an arbitrary value.

Flow: `XmlNodeParser` → `ImportNodeFactory` → `ImportNodeCommand` → `CreateNodeCommand`, after which `NodeStorageServiceImpl.store()` uses `node.getTimestamp()` as the version timestamp.

## Fix

`ImportNodeCommand` no longer passes the imported timestamp to `CreateNodeCommand`, so the created node and its first version use the actual import time (`now()`) — consistent with every other node-mutation command (`PatchNodeCommand`, `MoveNodeCommand`, `SortNodeCommand`, `PushNodesCommand`, `ApplyNodePermissionsCommand`).

In XP8, branches are kept in sync by sharing the same node version (push), not by importing identical content with a matching timestamp into each branch — so dropping the imported timestamp does not break cross-branch comparison.

## Cleanup

Removed the now-unused `timestamp` plumbing from `CreateNodeCommand` (field, builder method, `Instant` import); `Millis.fromOrElseNow(this.timestamp)` becomes `Millis.now()`.

## Tests

- New `ImportNodeCommandTest.imported_timestamp_is_not_used_as_version_timestamp` (regression; verified it failed before the fix).
- Reworked the obsolete `created_nodes_with_id_and_timestamp_should_be_equal` into `pushed_node_is_equal_in_both_branches`, documenting the push-based in-sync behavior.
- `:itest:itest-core:integrationTest --tests ImportNodeCommandTest`, `NodeImporterIntegrationTest`, and `:core:core-repo:test` / `:core:core-export:test` / `:lib:lib-export:test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)