### PR TITLE
#12134 Get rid of JNA warning

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,7 @@ elasticsearch = { module = "org.elasticsearch:elasticsearch", version = "2.4.6" 
 elasticsearch-icu = { module = "org.elasticsearch.plugin:analysis-icu", version = "2.4.6" }
 icu4j = { module = "com.ibm.icu:icu4j", version = "78.3" }
 
-jna = { module = "net.java.dev.jna:jna", version = "4.1.0" }
+jna = { module = "net.java.dev.jna:jna", version = "5.19.0" }
 
 jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
 

--- a/modules/launcher/launcher-impl/src/main/resources/META-INF/config/system.properties
+++ b/modules/launcher/launcher-impl/src/main/resources/META-INF/config/system.properties
@@ -53,9 +53,9 @@ internal.osgi.system.packages=\
   org.slf4j.helpers;version=2.0.17,\
   org.slf4j.spi;version=2.0.17,\
   org.slf4j.event;version=2.0.17,\
-  com.sun.jna;version=4.1.0,\
-  com.sun.jna.ptr;version=4.1.0,\
-  com.sun.jna.win32;version=4.1.0
+  com.sun.jna;version=5.19.0,\
+  com.sun.jna.ptr;version=5.19.0,\
+  com.sun.jna.win32;version=5.19.0
 #
 # Use for extra bootdelegation and export packages
 #


### PR DESCRIPTION
Closes #12134

Bumps JNA `4.1.0` → `5.19.0`.

### Why
JNA 4.1.0 (2014) bundles a darwin native dispatch library built only for `i386/x86_64/ppc7400` — **no arm64**. On Apple Silicon the native lib can't load, so Elasticsearch 2.4.6 logs `unable to load JNA native support library, native methods will be disabled` at startup, which is regularly mistaken for an error. JNA 5.19.0 ships a dedicated `darwin-aarch64/libjnidispatch.jnilib`.

### Compatibility
ES 2.4.6 only touches JNA from its `org.elasticsearch.bootstrap.*` classes. Every symbol it references — `Native.getLastError`, `Native.loadLibrary`, `Native.register`, `Native.SIZE_T_SIZE`, `IntegerType(int,long)`, `Pointer.getString(long)`, `nativeValue` — is unchanged in 5.19.0. The repacked ES bundle imports `com.sun.jna;resolution:=optional` with no version range, so OSGi resolution is unaffected; the `system.properties` export-version bump is just to keep the advertised version honest.

### Verification (Apple Silicon / arm64)
Built the distro with 5.19.0 **without** the local `rm jna` workaround and ran on a throwaway `XP_HOME`:
- No `unable to load JNA` warning at startup.
- Created a snapshot, then ran **3 consecutive restores** — each drives the in-process Elasticsearch node restart (`ClusterRestarter` lowers/raises the OSGi framework: `node.close()` → `new Node().start()`), the exact path that previously hung when the jar was present. All completed, indices recovered, server stayed responsive (HTTP 200), zero `UnsatisfiedLinkError`/exceptions in logs.

This makes the local "delete jna-4.1.0.jar" build workaround obsolete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)