### PR TITLE
#12137 WebSocket wrongly closed when session not cached

### DIFF
--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/KeepAliveSession.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/KeepAliveSession.java
@@ -70,9 +70,10 @@ final class KeepAliveSession
         catch ( IllegalStateException e )
         {
             // The HTTP session is already gone; close the socket as a backstop (the listener normally wins).
+            LOG.debug( "HTTP session gone on inbound message for WebSocket [{}]", this.delegate.getId(), e );
             try
             {
-                this.delegate.close( new CloseReason( CloseReason.CloseCodes.VIOLATED_POLICY, "HTTP session ended" ) );
+                this.delegate.close( new CloseReason( CloseReason.CloseCodes.VIOLATED_POLICY, "HTTP session ended (keep-alive)" ) );
             }
             catch ( IOException ex )
             {

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/SessionBoundEndpoint.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/SessionBoundEndpoint.java
@@ -1,6 +1,7 @@
 package com.enonic.xp.web.jetty.impl.websocket;
 
 import java.time.Duration;
+import java.util.function.BooleanSupplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,9 +30,8 @@ final class SessionBoundEndpoint
 
     private final String httpSessionId;
 
-    // Held only until the validity probe in onOpen, then dropped - the HttpSession must not be retained for
-    // the socket's lifetime.
-    private HttpSession httpSession;
+    // Held only until the validity probe in onOpen, then dropped.
+    private BooleanSupplier httpSessionAlive;
 
     private final HttpSession.Accessor sessionAccessor;
 
@@ -43,12 +43,12 @@ final class SessionBoundEndpoint
     // compare session identity.
     private volatile Session effectiveSession;
 
-    SessionBoundEndpoint( final Endpoint delegate, final WebSocketSessionTracker tracker, final HttpSession httpSession,
+    SessionBoundEndpoint( final Endpoint delegate, final WebSocketSessionTracker tracker, final BooleanSupplier httpSessionAlive,
                           final String httpSessionId, final HttpSession.Accessor sessionAccessor, final Duration sessionAccessThrottle )
     {
         this.delegate = delegate;
         this.tracker = tracker;
-        this.httpSession = httpSession;
+        this.httpSessionAlive = httpSessionAlive;
         this.httpSessionId = httpSessionId;
         this.sessionAccessor = sessionAccessor;
         this.sessionAccessThrottle = sessionAccessThrottle;
@@ -79,26 +79,20 @@ final class SessionBoundEndpoint
      */
     private void closeIfHttpSessionAlreadyEnded( final Session session )
     {
-        final HttpSession probed = this.httpSession;
-        this.httpSession = null;
-        if ( probed == null )
+        final BooleanSupplier probe = this.httpSessionAlive;
+        this.httpSessionAlive = null;
+        if ( probe == null || probe.getAsBoolean() )
         {
             return;
         }
+        LOG.debug( "HTTP session ended before WebSocket [{}] open", session.getId() );
         try
         {
-            probed.getCreationTime(); // throws IllegalStateException once the session is invalidated
+            session.close( new CloseReason( CloseReason.CloseCodes.VIOLATED_POLICY, "HTTP session ended during upgrade" ) );
         }
-        catch ( IllegalStateException sessionEnded )
+        catch ( Exception e )
         {
-            try
-            {
-                session.close( new CloseReason( CloseReason.CloseCodes.VIOLATED_POLICY, "HTTP session ended" ) );
-            }
-            catch ( Exception e )
-            {
-                LOG.warn( "Failed to close WebSocket session [{}] opened under an already-ended HTTP session", session.getId(), e );
-            }
+            LOG.warn( "Failed to close WebSocket session [{}] opened under an already-ended HTTP session", session.getId(), e );
         }
     }
 

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketServiceImpl.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketServiceImpl.java
@@ -4,10 +4,12 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
 import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee11.servlet.ServletContextRequest;
+import org.eclipse.jetty.session.SessionManager;
 import org.eclipse.jetty.ee11.websocket.jakarta.server.JakartaWebSocketServerContainer;
 import org.eclipse.jetty.ee11.websocket.jakarta.server.config.ContainerDefaultConfigurator;
 import org.eclipse.jetty.websocket.core.server.WebSocketMappings;
@@ -82,11 +84,18 @@ public final class WebSocketServiceImpl
             sessionAccessor = sessionAccess ? httpSession.getAccessor() : null;
         }
 
+        // The session must never be probed through the captured HttpSession object: with a NullSessionCache
+        // (cluster session store) it goes non-resident as soon as the upgrade request completes, while the
+        // session itself lives on. Liveness is checked by id through the SessionManager instead.
+        final BooleanSupplier httpSessionAlive = httpSessionId == null
+            ? null
+            : newHttpSessionProbe( ServletContextHandler.getServletContextHandler( req.getServletContext() ).getSessionHandler(),
+                                   httpSessionId );
+
         final ServerEndpointConfig config = ServerEndpointConfig.Builder.create( Endpoint.class, "/" )
             .configurator(
                 newConfigurator( factory, expectedScheme, expectedHost, expectedPort, this.defaultOriginCheckEnabled, this.sessionTracker,
-                                 httpSessionId != null ? httpSession : null, httpSessionId, sessionAccessor,
-                                 factory.getSessionAccessThrottle() ) )
+                                 httpSessionAlive, httpSessionId, sessionAccessor, factory.getSessionAccessThrottle() ) )
             .subprotocols( factory.getSubProtocols() )
             .build();
 
@@ -101,11 +110,28 @@ public final class WebSocketServiceImpl
         }
     }
 
+    private static BooleanSupplier newHttpSessionProbe( final SessionManager sessionManager, final String httpSessionId )
+    {
+        return () -> {
+            try
+            {
+                // exists() consults the cache and store without entering the session, so the probe neither
+                // marks the session as in-use nor resets its inactivity timer.
+                return sessionManager.getSessionCache().exists( httpSessionId );
+            }
+            catch ( Exception e )
+            {
+                LOG.debug( "Could not determine HTTP session [{}] state; treating it as alive", httpSessionId, e );
+                return true;
+            }
+        };
+    }
+
     private static ServerEndpointConfig.Configurator newConfigurator( final EndpointFactory factory, final String expectedScheme,
                                                                       final String expectedHost, final int expectedPort,
                                                                       final boolean defaultOriginCheckEnabled,
                                                                       final WebSocketSessionTracker sessionTracker,
-                                                                      final HttpSession httpSession, final String httpSessionId,
+                                                                      final BooleanSupplier httpSessionAlive, final String httpSessionId,
                                                                       final HttpSession.Accessor sessionAccessor,
                                                                       final Duration sessionAccessThrottle )
     {
@@ -171,7 +197,7 @@ public final class WebSocketServiceImpl
                     return endpointClass.cast( endpoint );
                 }
                 return endpointClass.cast(
-                    new SessionBoundEndpoint( endpoint, sessionTracker, httpSession, httpSessionId, sessionAccessor,
+                    new SessionBoundEndpoint( endpoint, sessionTracker, httpSessionAlive, httpSessionId, sessionAccessor,
                                               sessionAccessThrottle ) );
             }
         };

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketSessionTracker.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketSessionTracker.java
@@ -52,6 +52,8 @@ public final class WebSocketSessionTracker
             return;
         }
 
+        LOG.debug( "Closing {} WebSocket session(s) after HTTP session [{}] ended", tracked.size(), se.getSession().getId() );
+
         final CloseReason reason = new CloseReason( CloseReason.CloseCodes.VIOLATED_POLICY, "HTTP session ended" );
         for ( final Session wsSession : tracked )
         {

--- a/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/websocket/SessionBoundEndpointTest.java
+++ b/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/websocket/SessionBoundEndpointTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 class SessionBoundEndpointTest
 {
@@ -38,8 +37,7 @@ class SessionBoundEndpointTest
     void registers_and_unregisters_raw_session_and_forwards_raw_session_when_not_accessing()
     {
         final Session session = mock( Session.class );
-        final SessionBoundEndpoint endpoint =
-            new SessionBoundEndpoint( this.delegate, this.tracker, mock( HttpSession.class ), "s1", null, THROTTLE );
+        final SessionBoundEndpoint endpoint = new SessionBoundEndpoint( this.delegate, this.tracker, () -> true, "s1", null, THROTTLE );
 
         endpoint.onOpen( session, this.config );
         endpoint.onClose( session, new CloseReason( CloseReason.CloseCodes.NORMAL_CLOSURE, "bye" ) );
@@ -58,7 +56,7 @@ class SessionBoundEndpointTest
         final Session session = mock( Session.class );
         final HttpSession.Accessor accessor = mock( HttpSession.Accessor.class );
         final SessionBoundEndpoint endpoint =
-            new SessionBoundEndpoint( this.delegate, this.tracker, mock( HttpSession.class ), "s1", accessor, THROTTLE );
+            new SessionBoundEndpoint( this.delegate, this.tracker, () -> true, "s1", accessor, THROTTLE );
 
         endpoint.onOpen( session, this.config );
         endpoint.onError( session, new RuntimeException( "boom" ) );
@@ -93,9 +91,7 @@ class SessionBoundEndpointTest
         throws Exception
     {
         final Session session = mock( Session.class );
-        final HttpSession httpSession = mock( HttpSession.class );
-        when( httpSession.getCreationTime() ).thenThrow( new IllegalStateException( "invalidated" ) );
-        final SessionBoundEndpoint endpoint = new SessionBoundEndpoint( this.delegate, this.tracker, httpSession, "s1", null, THROTTLE );
+        final SessionBoundEndpoint endpoint = new SessionBoundEndpoint( this.delegate, this.tracker, () -> false, "s1", null, THROTTLE );
 
         endpoint.onOpen( session, this.config );
 
@@ -117,8 +113,7 @@ class SessionBoundEndpointTest
         throws Exception
     {
         final Session session = mock( Session.class );
-        final SessionBoundEndpoint endpoint =
-            new SessionBoundEndpoint( this.delegate, this.tracker, mock( HttpSession.class ), "s1", null, THROTTLE );
+        final SessionBoundEndpoint endpoint = new SessionBoundEndpoint( this.delegate, this.tracker, () -> true, "s1", null, THROTTLE );
 
         endpoint.onOpen( session, this.config );
 

--- a/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketNullSessionCacheTest.java
+++ b/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/websocket/WebSocketNullSessionCacheTest.java
@@ -1,0 +1,138 @@
+package com.enonic.xp.web.jetty.impl.websocket;
+
+import java.net.URI;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.websocket.CloseReason;
+
+import com.enonic.xp.web.jetty.impl.JettyConfig;
+import com.enonic.xp.web.jetty.impl.JettyTestServer;
+import com.enonic.xp.web.jetty.impl.JettyTestSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * WebSocket session binding in the cluster session topology (NullSessionCache + shared data store, as wired
+ * by HazelcastSessionStoreFactoryActivator). There the HttpSession object captured during the upgrade request
+ * goes non-resident as soon as that request completes, while the session itself stays alive in the store - so
+ * session liveness must never be judged from the captured object.
+ */
+class WebSocketNullSessionCacheTest
+    extends JettyTestSupport
+{
+    private TestWebSocketServlet servlet;
+
+    @Override
+    protected JettyTestServer createServer()
+    {
+        return new JettyTestServer( true );
+    }
+
+    @Override
+    protected void configure()
+    {
+        final WebSocketServiceImpl service =
+            new WebSocketServiceImpl( mock( JettyConfig.class, invocation -> invocation.getMethod().getDefaultValue() ),
+                                      this.server.getSessionTracker() );
+        this.servlet = new TestWebSocketServlet();
+        this.servlet.service = service;
+        this.servlet.endpoint = new TestEndpoint();
+        this.servlet.createSession = true;
+        addServlet( this.servlet, "/ws-bound" );
+    }
+
+    @Test
+    void bound_socket_survives_open_when_sessions_are_not_cached()
+        throws Exception
+    {
+        final CloseListener listener = new CloseListener();
+        connect( listener );
+
+        // The HTTP session is alive in the data store; only the object captured at upgrade is non-resident.
+        Thread.sleep( 500 );
+        assertThat( listener.closedInfo() ).isNull();
+    }
+
+    @Test
+    void bound_socket_closes_with_1008_when_session_invalidated_by_another_request()
+        throws Exception
+    {
+        addServlet( new InvalidatingServlet(), "/logout" );
+
+        final CloseListener listener = new CloseListener();
+        connect( listener );
+
+        Thread.sleep( 500 );
+        assertThat( listener.closedInfo() ).isNull();
+
+        // Invalidate through a second request: with no session cache it operates on a different
+        // ManagedSession object than the one captured at upgrade, like a logout on another node would.
+        final HttpResponse<String> response =
+            callRequest( newRequest( "/logout" ).header( "Cookie", "JSESSIONID=" + this.servlet.session.getId() ).GET().build() );
+        assertEquals( 200, response.statusCode() );
+
+        assertEquals( CloseReason.CloseCodes.VIOLATED_POLICY.getCode(), listener.awaitCloseCode() );
+    }
+
+    private void connect( final CloseListener listener )
+        throws Exception
+    {
+        this.client.newWebSocketBuilder()
+            .buildAsync( URI.create( "ws://localhost:" + this.server.getPort() + "/ws-bound" ), listener )
+            .get();
+    }
+
+    private static final class InvalidatingServlet
+        extends HttpServlet
+    {
+        @Override
+        protected void doGet( final HttpServletRequest req, final HttpServletResponse res )
+        {
+            final HttpSession session = req.getSession( false );
+            if ( session != null )
+            {
+                session.invalidate();
+            }
+            res.setStatus( HttpServletResponse.SC_OK );
+        }
+    }
+
+    private static final class CloseListener
+        implements WebSocket.Listener
+    {
+        private final CompletableFuture<Integer> closeCode = new CompletableFuture<>();
+
+        private volatile String closedInfo;
+
+        @Override
+        public CompletionStage<?> onClose( final WebSocket webSocket, final int statusCode, final String reason )
+        {
+            this.closedInfo = statusCode + ": " + reason;
+            this.closeCode.complete( statusCode );
+            return null;
+        }
+
+        int awaitCloseCode()
+            throws Exception
+        {
+            return this.closeCode.get( 30, TimeUnit.SECONDS );
+        }
+
+        String closedInfo()
+        {
+            return this.closedInfo;
+        }
+    }
+}

--- a/modules/web/web-jetty/src/testFixtures/java/com/enonic/xp/web/jetty/impl/InMemorySessionDataStore.java
+++ b/modules/web/web-jetty/src/testFixtures/java/com/enonic/xp/web/jetty/impl/InMemorySessionDataStore.java
@@ -1,0 +1,74 @@
+package com.enonic.xp.web.jetty.impl;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.eclipse.jetty.session.AbstractSessionDataStore;
+import org.eclipse.jetty.session.SessionData;
+
+/**
+ * Minimal in-memory {@link org.eclipse.jetty.session.SessionDataStore} standing in for a distributed store
+ * (e.g. Hazelcast) in tests: passivating, and - when paired with a
+ * {@link org.eclipse.jetty.session.NullSessionCache} - the only place sessions survive between requests.
+ */
+public final class InMemorySessionDataStore
+    extends AbstractSessionDataStore
+{
+    private final Map<String, SessionData> sessions = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean isPassivating()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean doExists( final String id )
+    {
+        return this.sessions.containsKey( id );
+    }
+
+    @Override
+    public void doStore( final String id, final SessionData data, final long lastSaveTime )
+    {
+        this.sessions.put( id, data );
+    }
+
+    @Override
+    public SessionData doLoad( final String id )
+    {
+        return this.sessions.get( id );
+    }
+
+    @Override
+    public boolean delete( final String id )
+    {
+        return this.sessions.remove( id ) != null;
+    }
+
+    @Override
+    public Set<String> doCheckExpired( final Set<String> candidates, final long time )
+    {
+        return candidates.stream().filter( id -> {
+            final SessionData data = this.sessions.get( id );
+            return data == null || data.isExpiredAt( time );
+        } ).collect( Collectors.toSet() );
+    }
+
+    @Override
+    public Set<String> doGetExpired( final long before )
+    {
+        return this.sessions.entrySet()
+            .stream()
+            .filter( entry -> entry.getValue().isExpiredAt( before ) )
+            .map( Map.Entry::getKey )
+            .collect( Collectors.toSet() );
+    }
+
+    @Override
+    public void doCleanOrphans( final long time )
+    {
+    }
+}

--- a/modules/web/web-jetty/src/testFixtures/java/com/enonic/xp/web/jetty/impl/JettyTestServer.java
+++ b/modules/web/web-jetty/src/testFixtures/java/com/enonic/xp/web/jetty/impl/JettyTestServer.java
@@ -12,6 +12,8 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.session.DefaultSessionIdManager;
 import org.eclipse.jetty.session.HouseKeeper;
+import org.eclipse.jetty.session.NullSessionCacheFactory;
+import org.eclipse.jetty.session.SessionCache;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
@@ -29,6 +31,11 @@ public final class JettyTestServer
     private final WebSocketSessionTracker sessionTracker = new WebSocketSessionTracker();
 
     public JettyTestServer()
+    {
+        this( false );
+    }
+
+    public JettyTestServer( final boolean clusterStyleSessions )
     {
         this.server = new Server();
 
@@ -55,6 +62,15 @@ public final class JettyTestServer
         this.server.addBean( sessionIdManager, true );
 
         this.handler = new ServletContextHandler( "/", ServletContextHandler.SESSIONS );
+        if ( clusterStyleSessions )
+        {
+            // Mirror the Hazelcast wiring (HazelcastSessionStoreFactoryActivator): no session cache, so each
+            // request works on its own ManagedSession object that goes non-resident at request completion,
+            // and sessions survive only in the shared data store.
+            final SessionCache sessionCache = new NullSessionCacheFactory().getSessionCache( this.handler.getSessionHandler() );
+            sessionCache.setSessionDataStore( new InMemorySessionDataStore() );
+            this.handler.getSessionHandler().setSessionCache( sessionCache );
+        }
         this.handler.addEventListener( this.sessionTracker );
         JakartaWebSocketServletContainerInitializer.configure( this.handler, ( _, _ ) -> {
         } );

--- a/modules/web/web-jetty/src/testFixtures/java/com/enonic/xp/web/jetty/impl/JettyTestSupport.java
+++ b/modules/web/web-jetty/src/testFixtures/java/com/enonic/xp/web/jetty/impl/JettyTestSupport.java
@@ -28,12 +28,17 @@ public abstract class JettyTestSupport
         throws Exception
     {
         this.config = mock( JettyConfig.class, invocation -> invocation.getMethod().getDefaultValue() );
-        this.server = new JettyTestServer();
+        this.server = createServer();
         this.server.start();
         configure();
 
         this.client = HttpClient.newHttpClient();
         this.baseUrl = "http://localhost:" + this.server.getPort();
+    }
+
+    protected JettyTestServer createServer()
+    {
+        return new JettyTestServer();
     }
 
     protected abstract void configure()


### PR DESCRIPTION
Closes #12137

WebSockets bound to an HTTP session were closed with 1008 "HTTP session ended" right at open when sessions are stored in Hazelcast (`NullSessionCache`), although the session was alive. The post-open probe read `HttpSession.getCreationTime()` on the object captured during the upgrade request, and Jetty throws `IllegalStateException` for non-resident objects too - the steady state after request completion when no session cache is used.

## Changes
- `WebSocketServiceImpl` probes session liveness **by id** via `SessionManager.getSessionCache().exists(id)` - side-effect free (no session enter, no inactivity-timer reset) and correct in both cache topologies; `SessionBoundEndpoint` now takes a `BooleanSupplier` probe instead of the `HttpSession` object.
- Distinct 1008 reason phrases per close site ("HTTP session ended", "... during upgrade", "... (keep-alive)") and debug logging, so the close frame identifies which path terminated the socket.
- New `WebSocketNullSessionCacheTest` reproduces the cluster topology end-to-end (`NullSessionCache` + new `InMemorySessionDataStore` fixture): a bound socket must survive open, and must still close 1008 when the session is invalidated through a different request.

## Testing
- New regression test failed with `1008: HTTP session ended during upgrade` before the fix, passes after.
- The existing idle-expiry test caught (and now guards against) an alternative by-id probe that pinned sessions as in-use.
- `:web:web-jetty:test` green; fixture consumers `:web:web-impl`, `:jaxrs:jaxrs-impl`, `:admin:admin-event` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)