### PR TITLE
#12142 Reject path traversal in imported binary references

### DIFF
--- a/modules/core/core-export/src/main/java/com/enonic/xp/core/impl/export/NodeImporter.java
+++ b/modules/core/core-export/src/main/java/com/enonic/xp/core/impl/export/NodeImporter.java
@@ -16,6 +16,7 @@ import com.enonic.xp.core.impl.export.validator.ImportValidator;
 import com.enonic.xp.core.impl.export.xml.XmlException;
 import com.enonic.xp.core.impl.export.xml.XmlNodeParser;
 import com.enonic.xp.core.impl.export.xml.XsltTransformer;
+import com.enonic.xp.core.internal.FileNames;
 import com.enonic.xp.data.Property;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.data.ValueTypes;
@@ -361,6 +362,12 @@ public final class NodeImporter
     private VirtualFile tryFindBinaryFile( final VirtualFile nodeFile, final BinaryReference binaryReference )
     {
         final String binaryReferenceAsString = binaryReference.toString();
+
+        if ( !FileNames.isSafeFileName( Normalizer.normalize( binaryReferenceAsString, Normalizer.Form.NFC ) ) )
+        {
+            throw new ImportNodeException( "Invalid binary reference: " + binaryReferenceAsString );
+        }
+
         final VirtualFile binaryOriginal =
             nodeFile.resolve( nodeFile.getPath().join( SYSTEM_FOLDER_NAME, BINARY_FOLDER, binaryReferenceAsString ) );
 

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/export/NodeImporterIntegrationTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/export/NodeImporterIntegrationTest.java
@@ -390,6 +390,27 @@ class NodeImporterIntegrationTest
     }
 
     @Test
+    void import_with_binary_path_traversal_rejected()
+        throws Exception
+    {
+        final Path file = Files.createDirectories(
+            resolveInTemporaryFolder( "myExport", "mynode" ).resolve( NodeExportPathResolver.SYSTEM_FOLDER_NAME ) ).resolve(
+            NodeExportPathResolver.NODE_XML_EXPORT_NAME );
+        copyFormResource( "node_with_traversal_binary.xml", file );
+
+        final NodeImportResult result = NodeImporter.create().
+            nodeService( this.nodeService ).
+            targetNodePath( NodePath.ROOT ).
+            sourceDirectory( VirtualFiles.from( temporaryFolder.resolve( "myExport" ) ) ).
+            build().
+            execute();
+
+        assertNull( nodeService.getByPath( new NodePath( "/mynode" ) ) );
+        assertTrue( result.getImportErrors().stream()
+                        .anyMatch( error -> error.getException().contains( "Invalid binary reference" ) ) );
+    }
+
+    @Test
     void import_special_characters()
         throws Exception
     {

--- a/modules/itest/itest-core/src/test/resources/com/enonic/xp/core/export/node_with_traversal_binary.xml
+++ b/modules/itest/itest-core/src/test/resources/com/enonic/xp/core/export/node_with_traversal_binary.xml
@@ -1,0 +1,19 @@
+<node>
+  <childOrder>_name DESC</childOrder>
+  <nodeType>content</nodeType>
+  <permissions/>
+  <data>
+    <string name="myString">myStringValue</string>
+    <binaryReference name="myImage">../../../../../../../../etc/passwd</binaryReference>
+  </data>
+  <indexConfigs>
+    <defaultConfig>
+      <decideByType>false</decideByType>
+      <enabled>true</enabled>
+      <nGram>true</nGram>
+      <fulltext>true</fulltext>
+      <includeInAllText>true</includeInAllText>
+    </defaultConfig>
+    <pathIndexConfigs/>
+  </indexConfigs>
+</node>


### PR DESCRIPTION
## Problem

When importing nodes, a node's binary reference is read verbatim from the export's `node.xml` and joined into a `VirtualFilePath` that `NodeImporter` resolves against the export location to locate the binary attachment. `BinaryReference.from` performs no validation, so a crafted reference such as `../../../../etc/passwd` can steer a filesystem-backed `VirtualFile` outside the export root and read an arbitrary file into the imported node's binary attachment.

## Fix

`NodeImporter#tryFindBinaryFile` now validates the reference as a safe, single file name before resolving it, reusing the existing `FileNames.isSafeFileName` guard already applied to content attachment names (`validateCreateAttachments`) and to other import file names. The value is normalized to NFC first so the existing UTF-8-MAC/NFD fallback still works. Invalid references are refused and recorded as an import error.

## Tests

Added `NodeImporterIntegrationTest#import_with_binary_path_traversal_rejected` (filesystem-backed source, the `LocalFile` case) plus a `node_with_traversal_binary.xml` fixture. It verifies the traversal payload is refused — no node imported and an "Invalid binary reference" import error recorded. Full `core-export` and `NodeImporterIntegrationTest` suites pass.

Closes #12142

https://claude.ai/code/session_01SXsdbfkv8m1bmVZxw14M8K