### PR TITLE
#12150 lib-node RepoConnection type missing patch()

### DIFF
--- a/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
@@ -659,6 +659,8 @@ export interface RepoConnection {
 
     update<NodeData = Record<string, unknown>>(params: UpdateNodeParams<NodeData>): Node<NodeData>;
 
+    patch(params: PatchNodeParams): PatchNodeResult;
+
     get<NodeData = Record<string, unknown>>(key: string | GetNodeParams): Node<NodeData> | null;
 
     get<NodeData = Record<string, unknown>>(keys: (string | GetNodeParams)[]): Node<NodeData> | Node<NodeData>[] | null;


### PR DESCRIPTION
Closes #12150

## Problem

The public `RepoConnection` interface in `node.ts` did not declare the `patch()` method, even though:

- `RepoConnectionImpl.patch()` is fully implemented — `node.ts:769`
- `PatchNodeParams` / `PatchNodeResult` are defined — `node.ts:336` / `node.ts:342`
- the internal `NodeHandler.patch()` is declared — `node.ts:238`

Since `@enonic-types/lib-node` is generated from this interface, the published package (v8.0.0) shipped `PatchNodeParams` and `PatchNodeResult` as exported-but-unreferenced types, while `repoConnection.patch({ ... })` failed to type-check (`Property 'patch' does not exist on type 'RepoConnection'`) despite working at runtime.

## Fix

Add the missing signature to the `RepoConnection` interface, next to `update()`:

```ts
patch(params: PatchNodeParams): PatchNodeResult;
```

## Verification

`./gradlew :lib:typescript` succeeds and the regenerated `node.d.ts` now declares `patch(params: PatchNodeParams): PatchNodeResult;` on the `RepoConnection` interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)