### PR TITLE
docs(csp): CSP API doc wording cleanups

### DIFF
--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -1165,10 +1165,10 @@ export interface Csp {
 
     /**
      * Parses a serialized policy (a `Content-Security-Policy` header value) and unions each directive's
-     * source expressions onto this policy — the additive counterpart to {@link resetTo}. Existing
+     * source expressions onto this policy. Existing
      * directives are extended and absent ones added, so you can grant extra permissions on top of a
      * policy built elsewhere without restating it (a nonce-source already wired into
-     * `script-src`/`style-src` is kept). Lenient like {@link resetTo}: invalid tokens are skipped and
+     * `script-src`/`style-src` is kept). Lenient: invalid tokens are skipped and
      * nonce-sources dropped. `null`/`undefined` adds nothing. A comma-separated list of policies is
      * flattened into one additive directive set (no extra enforced policy is created). Additive.
      */

--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -1159,7 +1159,7 @@ export interface Csp {
      * Unions source expressions into the serialized-source-list for `directive`, de-duplicated. With
      * no source expressions, registers a valueless directive (e.g. `upgrade-insecure-requests`).
      *
-     * A nonce-source is rejected: only the `nonce*` methods mint the per-request nonce.
+     * A nonce-source is rejected: only the `nonce*` methods generate the per-request nonce.
      */
     add(directive: string, ...sources: string[]): Csp;
 

--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -1177,8 +1177,7 @@ export interface Csp {
     /**
      * The source expressions currently declared for `directive`, in serialized order (already
      * de-duplicated), or `null` if no contributor has declared it. A declared valueless directive
-     * (e.g. `upgrade-insecure-requests`) returns an empty array. Lets a contributor inspect before it
-     * `override`s or gap-fills (`if (csp.directive(name) === null) csp.add(name, ...)`). Reads this
+     * (e.g. `upgrade-insecure-requests`) returns an empty array. Reads this
      * policy only; the report-only policy is reached via {@link cspReportOnly}.
      */
     directive(directive: string): string[] | null;

--- a/modules/web/web-api/src/main/java/com/enonic/xp/web/csp/ContentSecurityPolicy.java
+++ b/modules/web/web-api/src/main/java/com/enonic/xp/web/csp/ContentSecurityPolicy.java
@@ -196,7 +196,7 @@ public final class ContentSecurityPolicy
      * Existing directives are extended and absent ones are added,
      * so a caller can grant extra permissions on top of a policy built elsewhere without
      * restating it (and without discarding a nonce already wired into {@code script-src}/{@code style-src}).
-     * Parsing is lenient, mirroring the browser and {@link #resetTo}: tokens that would not survive
+     * Parsing is lenient, mirroring the browser: tokens that would not survive
      * {@link #add} validation are skipped rather than thrown, and {@code 'nonce-…'} sources are dropped
      * (a nonce baked into a header value is static across requests). A {@code null} value adds nothing.
      * Several comma-separated policies are flattened into one additive set of directives — no additional

--- a/modules/web/web-api/src/main/java/com/enonic/xp/web/csp/ContentSecurityPolicy.java
+++ b/modules/web/web-api/src/main/java/com/enonic/xp/web/csp/ContentSecurityPolicy.java
@@ -234,10 +234,7 @@ public final class ContentSecurityPolicy
      * deduplicated, since contributions union into a set), or {@link Optional#empty()} if no
      * contributor has declared it. A present directive with no sources (a boolean directive such as
      * {@code upgrade-insecure-requests}) returns an empty list. The returned list is an immutable
-     * snapshot. Lets a baseline gap-fill what is missing without overriding what is set —
-     * {@code if ( policy.directive( name ).isEmpty() ) policy.add( name, … )} — and a contributor
-     * probe what another already set. Reads this rule set only; the report-only set is reached via
-     * {@link #reportOnly()}.
+     * snapshot. Reads this rule set only; the report-only set is reached via {@link #reportOnly()}.
      */
     public Optional<List<String>> directive( final String directive )
     {

--- a/modules/web/web-api/src/main/java/com/enonic/xp/web/csp/ContentSecurityPolicy.java
+++ b/modules/web/web-api/src/main/java/com/enonic/xp/web/csp/ContentSecurityPolicy.java
@@ -178,7 +178,7 @@ public final class ContentSecurityPolicy
      * @throws IllegalArgumentException when {@code directive} is not a valid directive name, or a
      * source contains whitespace, control characters, {@code ;} or {@code ,} — tokens that would
      * smuggle extra directives into the emitted header — or is a {@code 'nonce-…'} source, which
-     * only the {@code nonce*} methods may mint.
+     * only the {@code nonce*} methods may generate.
      */
     public ContentSecurityPolicy add( final String directive, final String... sources )
     {
@@ -672,7 +672,7 @@ public final class ContentSecurityPolicy
         if ( isExternalNonce( source ) )
         {
             throw new IllegalArgumentException(
-                "A 'nonce-' source cannot be supplied; only the nonce* methods mint the request nonce: " + source );
+                "A 'nonce-' source cannot be supplied; only the nonce* methods generate the request nonce: " + source );
         }
         if ( !isValidSource( source ) )
         {


### PR DESCRIPTION
## What

Behaviour-neutral wording cleanups on the CSP API docs, companion to enonic/doc-code#66:

1. **"generate" instead of "mint" for the request nonce** — "mint" is common for tokens and certificates but not the conventional verb for *nonces*. Covers the `@throws` javadoc on `add()`, the `IllegalArgumentException` message thrown on a caller-supplied `'nonce-'` source (no test asserts on it), and the matching `portal.ts` JSDoc.

2. **Drop the `resetTo` cross-reference from `merge()`** — described on its own terms rather than as "the additive counterpart to `resetTo()`".

3. **Drop usage guidance from `directive()`** — describe what it returns without explaining when or why to call it (no "gap-fill" / "inspect before `override`" prose).

All three apply to both `ContentSecurityPolicy.java` and `portal.ts`.

## Context

Split out from #12155 (already merged) — that PR landed before these wording changes were made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)