### PR TITLE
#12164 Node API ignores allText index config

### DIFF
--- a/modules/lib/lib-node/src/main/java/com/enonic/xp/lib/node/IndexConfigFactory.java
+++ b/modules/lib/lib-node/src/main/java/com/enonic/xp/lib/node/IndexConfigFactory.java
@@ -9,10 +9,12 @@ import com.enonic.xp.index.IndexValueProcessor;
 import com.enonic.xp.index.IndexValueProcessors;
 import com.enonic.xp.index.PatternIndexConfigDocument;
 
+import static com.enonic.xp.lib.node.NodePropertyConstants.ALL_TEXT;
 import static com.enonic.xp.lib.node.NodePropertyConstants.ANALYZER;
 import static com.enonic.xp.lib.node.NodePropertyConstants.CONFIG_ARRAY;
 import static com.enonic.xp.lib.node.NodePropertyConstants.CONFIG_PATH;
 import static com.enonic.xp.lib.node.NodePropertyConstants.CONFIG_SETTINGS;
+import static com.enonic.xp.lib.node.NodePropertyConstants.LANGUAGES;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 public class IndexConfigFactory
@@ -48,7 +50,24 @@ public class IndexConfigFactory
 
         createPathConfigs( builder );
 
+        createAllTextConfig( builder );
+
         return builder.build();
+    }
+
+    private void createAllTextConfig( final PatternIndexConfigDocument.Builder builder )
+    {
+        final PropertySet allTextConfig = this.propertySet.getSet( ALL_TEXT );
+
+        if ( allTextConfig == null )
+        {
+            return;
+        }
+
+        for ( final String language : allTextConfig.getStrings( LANGUAGES ) )
+        {
+            builder.addAllTextConfigLanguage( language );
+        }
     }
 
     private void createDefaultSettings( final PatternIndexConfigDocument.Builder builder )

--- a/modules/lib/lib-node/src/main/java/com/enonic/xp/lib/node/NodePropertyConstants.java
+++ b/modules/lib/lib-node/src/main/java/com/enonic/xp/lib/node/NodePropertyConstants.java
@@ -40,5 +40,8 @@ public class NodePropertyConstants
 
     public static final String CONFIG_PATH = "path";
 
+    public static final String ALL_TEXT = "allText";
+
+    public static final String LANGUAGES = "languages";
 
 }

--- a/modules/lib/lib-node/src/main/java/com/enonic/xp/lib/node/mapper/IndexConfigDocMapper.java
+++ b/modules/lib/lib-node/src/main/java/com/enonic/xp/lib/node/mapper/IndexConfigDocMapper.java
@@ -14,11 +14,13 @@ import com.enonic.xp.index.PatternIndexConfigDocument;
 import com.enonic.xp.script.serializer.MapGenerator;
 import com.enonic.xp.script.serializer.MapSerializable;
 
+import static com.enonic.xp.lib.node.NodePropertyConstants.ALL_TEXT;
 import static com.enonic.xp.lib.node.NodePropertyConstants.ANALYZER;
 import static com.enonic.xp.lib.node.NodePropertyConstants.CONFIG_ARRAY;
 import static com.enonic.xp.lib.node.NodePropertyConstants.CONFIG_PATH;
 import static com.enonic.xp.lib.node.NodePropertyConstants.CONFIG_SETTINGS;
 import static com.enonic.xp.lib.node.NodePropertyConstants.DEFAULT_CONFIG;
+import static com.enonic.xp.lib.node.NodePropertyConstants.LANGUAGES;
 
 class IndexConfigDocMapper
     implements MapSerializable
@@ -66,6 +68,10 @@ class IndexConfigDocMapper
             gen.end();
         }
 
+        gen.end();
+
+        gen.map( ALL_TEXT );
+        serializeArray( gen, LANGUAGES, document.getAllTextConfig().getLanguages() );
         gen.end();
     }
 

--- a/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/create-1.js
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/create-1.js
@@ -38,7 +38,10 @@ var expected = {
             'indexValueProcessors': [],
             'languages': []
         },
-        'configs': []
+        'configs': [],
+        'allText': {
+            'languages': []
+        }
     },
     '_inheritsPermissions': false,
     '_permissions': [

--- a/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/create-2.js
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/create-2.js
@@ -103,7 +103,10 @@ var expected = {
                         'languages': []
                     }
                 }
-            ]
+            ],
+        'allText': {
+            'languages': []
+        }
         },
     '_inheritsPermissions': false,
     '_permissions': [

--- a/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/create-3.js
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/create-3.js
@@ -37,7 +37,10 @@ var expected = {
             'indexValueProcessors': [],
             'languages': []
             },
-        'configs': []
+        'configs': [],
+        'allText': {
+            'languages': []
+        }
         },
     '_inheritsPermissions': true,
     '_permissions': [

--- a/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/duplicate.js
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/duplicate.js
@@ -21,7 +21,10 @@ var expectedJson = {
             "path": false,
             "indexValueProcessors": [],
             "languages": []
-        }, "configs": []
+        }, "configs": [],
+        "allText": {
+            "languages": []
+        }
     },
     "_inheritsPermissions": false,
     "_permissions": [{

--- a/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/get-1.js
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/get-1.js
@@ -57,7 +57,10 @@ var expected = {
                     'languages': []
                 }
             }
-        ]
+        ],
+        'allText': {
+            'languages': []
+        }
     },
     '_inheritsPermissions': false,
     '_permissions': [

--- a/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/get-3.js
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/get-3.js
@@ -60,7 +60,10 @@ var expected = {
                     'languages': []
                 }
             }
-        ]
+        ],
+        'allText': {
+            'languages': []
+        }
     },
     '_inheritsPermissions': false,
     '_permissions': [

--- a/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/modify-keep-types.js
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/modify-keep-types.js
@@ -50,7 +50,10 @@ var expected = {
             'indexValueProcessors': [],
             'languages': []
         },
-        'configs': []
+        'configs': [],
+        'allText': {
+            'languages': []
+        }
     },
     '_inheritsPermissions': false,
     '_state': 'DEFAULT',

--- a/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/modify.js
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/examples/node/modify.js
@@ -96,7 +96,10 @@ var expected = {
                     'languages': []
                 }
             }
-        ]
+        ],
+        'allText': {
+            'languages': []
+        }
     },
     '_inheritsPermissions': false,
     '_permissions': [

--- a/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
@@ -519,6 +519,7 @@ export interface NodeIndexConfig {
         path: string;
         config: NodeConfigEntry;
     }[];
+    allText: NodeAllTextConfig;
 }
 
 export type NodeIndexConfigTemplates =
@@ -535,6 +536,7 @@ export interface NodeIndexConfigParams {
         path: string;
         config: Partial<NodeConfigEntry> | NodeIndexConfigTemplates;
     }[];
+    allText?: Partial<NodeAllTextConfig>;
 }
 
 export interface NodeConfigEntry {
@@ -545,6 +547,10 @@ export interface NodeConfigEntry {
     includeInAllText: boolean;
     path: boolean;
     indexValueProcessors: string[];
+    languages: string[];
+}
+
+export interface NodeAllTextConfig {
     languages: string[];
 }
 

--- a/modules/lib/lib-node/src/test/java/com/enonic/xp/lib/node/IndexConfigFactoryTest.java
+++ b/modules/lib/lib-node/src/test/java/com/enonic/xp/lib/node/IndexConfigFactoryTest.java
@@ -91,6 +91,17 @@ public class IndexConfigFactoryTest
     }
 
     @Test
+    public void allText_languages()
+        throws Exception
+    {
+        final IndexConfigDocument config = create( "{ \"allText\": { \"languages\": [ \"no\", \"en\" ] } }" );
+
+        assertTrue( config instanceof PatternIndexConfigDocument );
+        final List<String> languages = ( (PatternIndexConfigDocument) config ).getAllTextConfig().getLanguages();
+        assertEquals( List.of( "no", "en" ), languages );
+    }
+
+    @Test
     public void empty()
         throws Exception
     {

--- a/modules/lib/lib-node/src/test/java/com/enonic/xp/lib/node/mapper/IndexConfigDocMapperTest.java
+++ b/modules/lib/lib-node/src/test/java/com/enonic/xp/lib/node/mapper/IndexConfigDocMapperTest.java
@@ -33,4 +33,20 @@ public class IndexConfigDocMapperTest
 
         assertJson( "index_config_full.json", jsonGenerator );
     }
+
+    @Test
+    public void allText_languages()
+        throws Exception
+    {
+        final IndexConfigDocument doc = PatternIndexConfigDocument.create().
+            defaultConfig( IndexConfig.BY_TYPE ).
+            addAllTextConfigLanguage( "no" ).
+            addAllTextConfigLanguage( "en" ).
+            build();
+
+        final JsonMapGenerator jsonGenerator = new JsonMapGenerator();
+        new IndexConfigDocMapper( doc ).serialize( jsonGenerator );
+
+        assertJson( "index_config_alltext.json", jsonGenerator );
+    }
 }

--- a/modules/lib/lib-node/src/test/resources/com/enonic/xp/lib/node/mapper/index_config_alltext.json
+++ b/modules/lib/lib-node/src/test/resources/com/enonic/xp/lib/node/mapper/index_config_alltext.json
@@ -1,0 +1,20 @@
+{
+  "analyzer": null,
+  "default": {
+    "decideByType": true,
+    "enabled": true,
+    "nGram": false,
+    "fulltext": false,
+    "includeInAllText": false,
+    "path": false,
+    "indexValueProcessors": [],
+    "languages": []
+  },
+  "configs": [],
+  "allText": {
+    "languages": [
+      "no",
+      "en"
+    ]
+  }
+}

--- a/modules/lib/lib-node/src/test/resources/com/enonic/xp/lib/node/mapper/index_config_full.json
+++ b/modules/lib/lib-node/src/test/resources/com/enonic/xp/lib/node/mapper/index_config_full.json
@@ -143,5 +143,8 @@
         "languages": []
       }
     }
-  ]
+  ],
+  "allText": {
+    "languages": []
+  }
 }


### PR DESCRIPTION
Fixes #12164

## What

Setting the `allText` index config via the JS Node API was silently dropped in 7.16 (all 7.x). Example:

```js
nodeConnection.create({
    _name: 'my-node',
    _indexConfig: {
        allText: { languages: ['no'] }
    }
});
```

…produced no `_allText._stemmed_no` field, did not show up under `_indexConfig` on read, and `stemmed('_allText', '...', 'no')` matched nothing.

## Why

The engine already supports stemmed `_allText` (`AllTextTypeFactory` consumes `AllTextIndexConfig.getLanguages()`; covered by `FindNodesByQueryCommandTest_func_stemmed`). The gap was only in the `lib-node` JS↔Java bridge:

- `IndexConfigFactory` (JS → Java) read only `analyzer`, `default` and the per-path `configs` array — never the top-level `allText` object.
- `IndexConfigDocMapper` (Java → JS) never serialized the `allText` config.

## Changes

- `IndexConfigFactory` — parse `allText.languages`.
- `IndexConfigDocMapper` — serialize the `allText` config.
- `NodePropertyConstants` — `ALL_TEXT` / `LANGUAGES` keys.
- `node.ts` — declare `allText` (read + write) so `@enonic-types` consumers can set/read it type-safely.
- Tests: `IndexConfigFactoryTest.allText_languages`, `IndexConfigDocMapperTest.allText_languages` (+ golden `index_config_alltext.json`); updated node examples and `index_config_full.json`.

## Scope

`languages` only — 7.16's `AllTextIndexConfig` does not model the `enabled`/`nGram`/`fulltext` allText toggles (added in 8.0.0). Backport of #11568 / #11571.

## Test

- `./gradlew :lib:typescript` → BUILD SUCCESSFUL.
- `./gradlew :lib:lib-node:test` → 76 tests, 0 failed.

## Related

The full (`enabled`/`nGram`/`fulltext`/`languages`) TypeScript types for master are added in #12166 / PR #12167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
