### PR TITLE
#12166 Add allText to node API TypeScript types

### DIFF
--- a/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
@@ -567,6 +567,7 @@ export interface NodeIndexConfig {
         path: string;
         config: NodeConfigEntry;
     }[];
+    allText: NodeAllTextConfig;
 }
 
 export type NodeIndexConfigTemplates =
@@ -583,6 +584,7 @@ export interface NodeIndexConfigParams {
         path: string;
         config: Partial<NodeConfigEntry> | NodeIndexConfigTemplates;
     }[];
+    allText?: Partial<NodeAllTextConfig>;
 }
 
 export interface NodeConfigEntry {
@@ -593,6 +595,13 @@ export interface NodeConfigEntry {
     includeInAllText: boolean;
     path: boolean;
     indexValueProcessors: string[];
+    languages: string[];
+}
+
+export interface NodeAllTextConfig {
+    enabled: boolean;
+    nGram: boolean;
+    fulltext: boolean;
     languages: string[];
 }
 

--- a/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
+++ b/modules/lib/lib-node/src/main/resources/lib/xp/node.ts
@@ -567,6 +567,10 @@ export interface NodeIndexConfig {
         path: string;
         config: NodeConfigEntry;
     }[];
+
+    /**
+     * Indexing config for the generated `_allText` property. See {@link NodeAllTextConfig}.
+     */
     allText: NodeAllTextConfig;
 }
 
@@ -584,6 +588,11 @@ export interface NodeIndexConfigParams {
         path: string;
         config: Partial<NodeConfigEntry> | NodeIndexConfigTemplates;
     }[];
+
+    /**
+     * Indexing config for the generated `_allText` property. Any omitted fields keep their defaults.
+     * See {@link NodeAllTextConfig}.
+     */
     allText?: Partial<NodeAllTextConfig>;
 }
 
@@ -598,10 +607,30 @@ export interface NodeConfigEntry {
     languages: string[];
 }
 
+/**
+ * Customizes the indexing of the generated `_allText` system property, which aggregates the text
+ * content of all indexed `String` properties on a node and is commonly used in "search everything" queries.
+ */
 export interface NodeAllTextConfig {
+    /**
+     * If `false`, indexing of the `_allText` property is disabled. Defaults to `true`.
+     */
     enabled: boolean;
+
+    /**
+     * If `true`, values are indexed as `ngram`, enabling the nGram-function in queries. Defaults to `true`.
+     */
     nGram: boolean;
+
+    /**
+     * If `true`, values are indexed as `analyzed`, enabling the fulltext query expression. Defaults to `true`.
+     */
     fulltext: boolean;
+
+    /**
+     * Generates a stemming index (where supported) and a collation index for each specified language.
+     * Language codes use the `la[-co]` format (ISO-639 language code, optional ISO-3166 country code).
+     */
     languages: string[];
 }
 


### PR DESCRIPTION
Fixes #12166

## What

The Node API fully supports the `allText` index config at runtime (set via `node.create`/`modify`, read via `node.get`), but `lib/xp/node.ts` — the source of `@enonic-types/lib-node` — never declared it. So TypeScript consumers could neither set it (excess-property error) nor read it (`result._indexConfig.allText` typed as `undefined`).

## Change

Pure type addition to `node.ts`:

```ts
export interface NodeAllTextConfig {
    enabled: boolean;
    nGram: boolean;
    fulltext: boolean;
    languages: string[];
}
```

- `NodeIndexConfig.allText: NodeAllTextConfig` — read shape; always serialized by `IndexConfigDocMapper`, so non-optional.
- `NodeIndexConfigParams.allText?: Partial<NodeAllTextConfig>` — write shape; optional, all fields optional.

Runtime behaviour is unchanged; this only aligns the typed contract with what the runtime already does (covered by `IndexConfigFactoryTest.allText_*` and `IndexConfigDocMapperTest.allText_custom`).

## Test

- `./gradlew :lib:typescript` → BUILD SUCCESSFUL (declarations regenerate cleanly).
- `./gradlew :lib:lib-node:test` → BUILD SUCCESSFUL.

## Related

The 7.16 runtime backport is #12164 / PR #12165 (languages-only, matching 7.16's model). Its types are adjusted in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
