### PR TITLE
Enforce admin tool access list for APIs mounted on the tool

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiHandler.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiHandler.java
@@ -210,22 +210,27 @@ public class SlashApiHandler
 
     private boolean verifyPathMountedOnAdminTool( final DescriptorKey descriptorKey, final PortalRequest portalRequest )
     {
-        final MatchResult matcher = PathMatchers.adminTool( portalRequest );
-        if ( !matcher.hasMatch() )
-        {
-            return false;
-        }
-
-        final ApplicationKey applicationKey = HandlerHelper.resolveApplicationKey( matcher.group( "app" ) );
-        final String tool = matcher.group( "tool" );
-
-        final AdminToolDescriptor adminToolDescriptor = adminToolDescriptorService.getByKey( DescriptorKey.from( applicationKey, tool ) );
+        final AdminToolDescriptor adminToolDescriptor = resolveAdminTool( portalRequest );
         if ( adminToolDescriptor == null )
         {
             return false;
         }
 
         return adminToolDescriptor.getApiMounts().contains( descriptorKey );
+    }
+
+    private AdminToolDescriptor resolveAdminTool( final PortalRequest portalRequest )
+    {
+        final MatchResult matcher = PathMatchers.adminTool( portalRequest );
+        if ( !matcher.hasMatch() )
+        {
+            return null;
+        }
+
+        final ApplicationKey applicationKey = HandlerHelper.resolveApplicationKey( matcher.group( "app" ) );
+        final String tool = matcher.group( "tool" );
+
+        return adminToolDescriptorService.getByKey( DescriptorKey.from( applicationKey, tool ) );
     }
 
     private boolean verifyPathMountedOnWebapps( final DescriptorKey descriptorKey, final PortalRequest portalRequest )
@@ -291,12 +296,27 @@ public class SlashApiHandler
 
     private void verifyAccessToApi( final ApiDescriptor apiDescriptor, final PortalRequest portalRequest )
     {
+        final PrincipalKeys principals = ContextAccessor.current().getAuthInfo().getPrincipals();
+
         if ( portalRequest.getBasePath().startsWith( PathMatchers.ADMIN_TOOL_PREFIX ) )
         {
             WebHandlerHelper.checkAdminLoginRole( portalRequest );
+
+            // An API mounted on an admin tool inherits the tool's access list: reaching it through the
+            // tool requires being allowed to access the tool itself. Site-embedded admin paths (e.g.
+            // Content Studio's "site" pseudo-tool) are governed by the content/project layer instead.
+            if ( !PortalRequestHelper.isSiteBase( portalRequest ) )
+            {
+                final AdminToolDescriptor adminToolDescriptor = resolveAdminTool( portalRequest );
+                if ( adminToolDescriptor != null && !adminToolDescriptor.isAccessAllowed( principals ) )
+                {
+                    throw WebException.forbidden(
+                        String.format( "You don't have permission to access \"%s\" API for \"%s\"", apiDescriptor.getKey().getName(),
+                                       apiDescriptor.getKey().getApplicationKey() ) );
+                }
+            }
         }
 
-        final PrincipalKeys principals = ContextAccessor.current().getAuthInfo().getPrincipals();
         if ( !apiDescriptor.isAccessAllowed( principals ) )
         {
             throw WebException.forbidden(

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiHandler.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiHandler.java
@@ -160,11 +160,6 @@ public class SlashApiHandler
         } );
     }
 
-    /**
-     * Classifies the request into the single mount context it is served through. Both the access check and
-     * the mount check are driven from this, so the site-vs-tool-vs-webapp-vs-connector decision lives in one
-     * place rather than being re-derived per check.
-     */
     private MountContext resolveMountContext( final PortalRequest portalRequest )
     {
         if ( portalRequest.getEndpointPath() == null )
@@ -297,23 +292,17 @@ public class SlashApiHandler
     {
         final PrincipalKeys principals = ContextAccessor.current().getAuthInfo().getPrincipals();
 
-        // Perimeter: only authenticated admin users may reach anything served under the admin area.
         if ( portalRequest.getBasePath().startsWith( PathMatchers.ADMIN_TOOL_PREFIX ) )
         {
             WebHandlerHelper.checkAdminLoginRole( portalRequest );
         }
 
-        // Capability: an API mounted on an admin tool inherits the tool's access list - reaching it through
-        // the tool requires being allowed to access the tool itself. Site mounts (e.g. Content Studio
-        // rendering a site under /admin) are governed by the content/project layer instead, so they are not
-        // classified as ADMIN_TOOL here.
         if ( mountContext.type() == MountContext.Type.ADMIN_TOOL && mountContext.adminTool() != null &&
             !mountContext.adminTool().isAccessAllowed( principals ) )
         {
             throw forbidden( apiDescriptor );
         }
 
-        // Resource: the API's own access list.
         if ( !apiDescriptor.isAccessAllowed( principals ) )
         {
             throw forbidden( apiDescriptor );

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiHandler.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiHandler.java
@@ -129,8 +129,9 @@ public class SlashApiHandler
             throw WebException.notFound( String.format( "API [%s] not found", descriptorKey ) );
         }
 
-        verifyAccessToApi( apiDescriptor, portalRequest );
-        verifyRequestMounted( apiDescriptor, portalRequest );
+        final MountContext mountContext = resolveMountContext( portalRequest );
+        verifyAccessToApi( apiDescriptor, portalRequest, mountContext );
+        verifyRequestMounted( apiDescriptor, portalRequest, mountContext );
 
         final Supplier<WebResponse> handler = dynamicApiHandler != null
             ? () -> executeDynamicApiHandler( portalRequest, dynamicApiHandler )
@@ -159,64 +160,62 @@ public class SlashApiHandler
         } );
     }
 
-    private void verifyRequestMounted( final ApiDescriptor apiDescriptor, final PortalRequest portalRequest )
+    /**
+     * Classifies the request into the single mount context it is served through. Both the access check and
+     * the mount check are driven from this, so the site-vs-tool-vs-webapp-vs-connector decision lives in one
+     * place rather than being re-derived per check.
+     */
+    private MountContext resolveMountContext( final PortalRequest portalRequest )
     {
-        final String basePath = portalRequest.getBasePath();
-
-        final DescriptorKey descriptorKey = apiDescriptor.getKey();
-
-        final boolean result;
         if ( portalRequest.getEndpointPath() == null )
         {
             final String connector = portalRequest.getRawRequest() != null
-                ? (String) portalRequest.getRawRequest()
-                           .getAttribute( DispatchConstants.CONNECTOR_ATTRIBUTE )
+                ? (String) portalRequest.getRawRequest().getAttribute( DispatchConstants.CONNECTOR_ATTRIBUTE )
                 : null;
 
             if ( DispatchConstants.API_CONNECTOR.equals( connector ) )
             {
-                result = apiDescriptor.getMount().contains( "management" );
+                return MountContext.connector( "management" );
             }
             else if ( DispatchConstants.XP_CONNECTOR.equals( connector ) )
             {
-                result = apiDescriptor.getMount().contains( "web" );
+                return MountContext.connector( "web" );
             }
-            else
-            {
-                result = false;
-            }
+            return MountContext.none();
         }
         else if ( PortalRequestHelper.isSiteBase( portalRequest ) )
         {
-            result = verifyRequestMountedOnSites( descriptorKey, portalRequest );
+            return MountContext.site();
         }
-        else if ( basePath.startsWith( PathMatchers.WEBAPP_PREFIX ) )
+        else if ( portalRequest.getBasePath().startsWith( PathMatchers.WEBAPP_PREFIX ) )
         {
-            result = verifyPathMountedOnWebapps( descriptorKey, portalRequest );
+            return MountContext.webapp();
         }
-        else if ( basePath.startsWith( PathMatchers.ADMIN_TOOL_PREFIX ) )
+        else if ( portalRequest.getBasePath().startsWith( PathMatchers.ADMIN_TOOL_PREFIX ) )
         {
-            result = verifyPathMountedOnAdminTool( descriptorKey, portalRequest );
+            return MountContext.adminTool( resolveAdminTool( portalRequest ) );
         }
-        else
+        return MountContext.none();
+    }
+
+    private void verifyRequestMounted( final ApiDescriptor apiDescriptor, final PortalRequest portalRequest, final MountContext mountContext )
+    {
+        final DescriptorKey descriptorKey = apiDescriptor.getKey();
+
+        final boolean result = switch ( mountContext.type() )
         {
-            result = false;
-        }
+            case CONNECTOR -> apiDescriptor.getMount().contains( mountContext.requiredMount() );
+            case SITE -> verifyRequestMountedOnSites( descriptorKey, portalRequest );
+            case WEBAPP -> verifyPathMountedOnWebapps( descriptorKey, portalRequest );
+            case ADMIN_TOOL ->
+                mountContext.adminTool() != null && mountContext.adminTool().getApiMounts().contains( descriptorKey );
+            case NONE -> false;
+        };
+
         if ( !result )
         {
             throw WebException.notFound( String.format( "API [%s] is not mounted", descriptorKey ) );
         }
-    }
-
-    private boolean verifyPathMountedOnAdminTool( final DescriptorKey descriptorKey, final PortalRequest portalRequest )
-    {
-        final AdminToolDescriptor adminToolDescriptor = resolveAdminTool( portalRequest );
-        if ( adminToolDescriptor == null )
-        {
-            return false;
-        }
-
-        return adminToolDescriptor.getApiMounts().contains( descriptorKey );
     }
 
     private AdminToolDescriptor resolveAdminTool( final PortalRequest portalRequest )
@@ -294,34 +293,70 @@ public class SlashApiHandler
         }
     }
 
-    private void verifyAccessToApi( final ApiDescriptor apiDescriptor, final PortalRequest portalRequest )
+    private void verifyAccessToApi( final ApiDescriptor apiDescriptor, final PortalRequest portalRequest, final MountContext mountContext )
     {
         final PrincipalKeys principals = ContextAccessor.current().getAuthInfo().getPrincipals();
 
+        // Perimeter: only authenticated admin users may reach anything served under the admin area.
         if ( portalRequest.getBasePath().startsWith( PathMatchers.ADMIN_TOOL_PREFIX ) )
         {
             WebHandlerHelper.checkAdminLoginRole( portalRequest );
-
-            // An API mounted on an admin tool inherits the tool's access list: reaching it through the
-            // tool requires being allowed to access the tool itself. Site-embedded admin paths (e.g.
-            // Content Studio's "site" pseudo-tool) are governed by the content/project layer instead.
-            if ( !PortalRequestHelper.isSiteBase( portalRequest ) )
-            {
-                final AdminToolDescriptor adminToolDescriptor = resolveAdminTool( portalRequest );
-                if ( adminToolDescriptor != null && !adminToolDescriptor.isAccessAllowed( principals ) )
-                {
-                    throw WebException.forbidden(
-                        String.format( "You don't have permission to access \"%s\" API for \"%s\"", apiDescriptor.getKey().getName(),
-                                       apiDescriptor.getKey().getApplicationKey() ) );
-                }
-            }
         }
 
+        // Capability: an API mounted on an admin tool inherits the tool's access list - reaching it through
+        // the tool requires being allowed to access the tool itself. Site mounts (e.g. Content Studio
+        // rendering a site under /admin) are governed by the content/project layer instead, so they are not
+        // classified as ADMIN_TOOL here.
+        if ( mountContext.type() == MountContext.Type.ADMIN_TOOL && mountContext.adminTool() != null &&
+            !mountContext.adminTool().isAccessAllowed( principals ) )
+        {
+            throw forbidden( apiDescriptor );
+        }
+
+        // Resource: the API's own access list.
         if ( !apiDescriptor.isAccessAllowed( principals ) )
         {
-            throw WebException.forbidden(
-                String.format( "You don't have permission to access \"%s\" API for \"%s\"", apiDescriptor.getKey().getName(),
-                               apiDescriptor.getKey().getApplicationKey() ) );
+            throw forbidden( apiDescriptor );
+        }
+    }
+
+    private static WebException forbidden( final ApiDescriptor apiDescriptor )
+    {
+        return WebException.forbidden(
+            String.format( "You don't have permission to access \"%s\" API for \"%s\"", apiDescriptor.getKey().getName(),
+                           apiDescriptor.getKey().getApplicationKey() ) );
+    }
+
+    private record MountContext(Type type, String requiredMount, AdminToolDescriptor adminTool)
+    {
+        private enum Type
+        {
+            CONNECTOR, SITE, WEBAPP, ADMIN_TOOL, NONE
+        }
+
+        private static MountContext connector( final String requiredMount )
+        {
+            return new MountContext( Type.CONNECTOR, requiredMount, null );
+        }
+
+        private static MountContext site()
+        {
+            return new MountContext( Type.SITE, null, null );
+        }
+
+        private static MountContext webapp()
+        {
+            return new MountContext( Type.WEBAPP, null, null );
+        }
+
+        private static MountContext adminTool( final AdminToolDescriptor adminTool )
+        {
+            return new MountContext( Type.ADMIN_TOOL, null, adminTool );
+        }
+
+        private static MountContext none()
+        {
+            return new MountContext( Type.NONE, null, null );
         }
     }
 

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiHandlerTest.java
@@ -16,6 +16,8 @@ import com.enonic.xp.api.ApiDescriptor;
 import com.enonic.xp.api.ApiDescriptorService;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.branch.Branch;
+import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.context.ContextBuilder;
 import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.content.ContentPropertyNames;
 import com.enonic.xp.data.PropertySet;
@@ -33,10 +35,13 @@ import com.enonic.xp.portal.universalapi.UniversalApiHandler;
 import com.enonic.xp.project.Project;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.resource.ResourceKey;
+import com.enonic.xp.security.IdProviderKey;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.security.PrincipalKeys;
 import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.User;
 import com.enonic.xp.security.acl.AccessControlEntry;
+import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.site.Site;
 import com.enonic.xp.site.SiteConfig;
@@ -567,6 +572,7 @@ class SlashApiHandlerTest
         final AdminToolDescriptor toolDescriptor = AdminToolDescriptor.create()
             .title( "My Tool" )
             .key( descriptorKey )
+            .addAllowedPrincipals( PrincipalKeys.from( RoleKeys.EVERYONE ) )
             .apiMounts( DescriptorKeys.from( DescriptorKey.from( apiApplicationKey, "myapi" ) ) )
             .build();
 
@@ -577,6 +583,46 @@ class SlashApiHandlerTest
 
         WebResponse response = this.handler.handle( request );
         assertEquals( HttpStatus.OK, response.getStatus() );
+    }
+
+    @Test
+    void testAdminMountToolAccessDenied()
+    {
+        final ApplicationKey apiApplicationKey = ApplicationKey.from( "com.enonic.app.external.app" );
+        final DescriptorKey apiDescriptorKey = DescriptorKey.from( apiApplicationKey, "myapi" );
+        final ApiDescriptor apiDescriptor =
+            ApiDescriptor.create().key( apiDescriptorKey ).allowedPrincipals( PrincipalKeys.from( RoleKeys.EVERYONE ) ).build();
+
+        when( apiDescriptorService.getByKey( eq( apiDescriptorKey ) ) ).thenReturn( apiDescriptor );
+
+        final ApplicationKey applicationKey = ApplicationKey.from( "com.enonic.app.myapp" );
+        final DescriptorKey descriptorKey = DescriptorKey.from( applicationKey, "mytool" );
+
+        // The API allows everyone and is mounted on the tool, but the tool restricts access to a role the
+        // caller does not hold - reaching the API through the tool must require access to the tool itself.
+        final AdminToolDescriptor toolDescriptor = AdminToolDescriptor.create()
+            .title( "My Tool" )
+            .key( descriptorKey )
+            .addAllowedPrincipals( PrincipalKeys.from( PrincipalKey.ofRole( "system.somerole" ) ) )
+            .apiMounts( DescriptorKeys.from( DescriptorKey.from( apiApplicationKey, "myapi" ) ) )
+            .build();
+
+        when( adminToolDescriptorService.getByKey( eq( descriptorKey ) ) ).thenReturn( toolDescriptor );
+
+        request.setRawPath( "/admin/com.enonic.app.myapp/mytool/_/com.enonic.app.external.app:myapi" );
+        when( servletRequestMock.isUserInRole( any() ) ).thenReturn( true );
+
+        // A logged-in user who is not on the tool's allow list: forbidden resolves to 403 for an
+        // authenticated caller (it would be 401 if unauthenticated).
+        final AuthenticationInfo authInfo = AuthenticationInfo.create()
+            .user( User.create().key( PrincipalKey.ofUser( IdProviderKey.system(), "tester" ) ).login( "tester" ).build() )
+            .principals( RoleKeys.AUTHENTICATED )
+            .build();
+
+        final WebException ex =
+            ContextBuilder.copyOf( ContextAccessor.current() ).authInfo( authInfo ).build().callWith( () -> assertThrows(
+                WebException.class, () -> this.handler.handle( request ) ) );
+        assertEquals( HttpStatus.FORBIDDEN, ex.getStatus() );
     }
 
     @Test
@@ -591,8 +637,12 @@ class SlashApiHandlerTest
 
         final ApplicationKey applicationKey = ApplicationKey.from( "com.enonic.app.myapp" );
         final DescriptorKey descriptorKey = DescriptorKey.from( applicationKey, "mytool" );
-        final AdminToolDescriptor toolDescriptor =
-            AdminToolDescriptor.create().title( "My Tool" ).key( descriptorKey ).apiMounts( DescriptorKeys.empty() ).build();
+        final AdminToolDescriptor toolDescriptor = AdminToolDescriptor.create()
+            .title( "My Tool" )
+            .key( descriptorKey )
+            .addAllowedPrincipals( PrincipalKeys.from( RoleKeys.EVERYONE ) )
+            .apiMounts( DescriptorKeys.empty() )
+            .build();
 
         when( adminToolDescriptorService.getByKey( eq( descriptorKey ) ) ).thenReturn( toolDescriptor );
 
@@ -658,6 +708,50 @@ class SlashApiHandlerTest
     }
 
     @Test
+    void testAdminSiteEmbeddedSkipsToolAccessCheck()
+        throws Exception
+    {
+        // Content Studio renders a site inside /admin. The "site" segment is a pseudo-tool - no real
+        // AdminToolDescriptor governs it - so the admin-tool access check must be skipped for site-based
+        // requests; access is governed by the content/project layer instead. Even a tool descriptor that
+        // would deny access must not block it here.
+        request.setBaseUri( "/admin/com.enonic.app.contentstudio/site" );
+        request.setMode( RenderMode.ADMIN );
+        request.setContentPath( ContentPath.from( "/mysite" ) );
+        request.setRawPath(
+            "/admin/com.enonic.app.contentstudio/site/project/draft/mysite/_/com.enonic.app.myapp:api-key-1" );
+        request.setRepositoryId( RepositoryId.from( "com.enonic.cms.project" ) );
+        request.setBranch( Branch.from( "draft" ) );
+        when( servletRequestMock.isUserInRole( any() ) ).thenReturn( true );
+
+        final ApplicationKey applicationKey = ApplicationKey.from( "com.enonic.app.myapp" );
+        final DescriptorKey descriptorKey = DescriptorKey.from( applicationKey, "api-key-1" );
+        final ApiDescriptor apiDescriptor =
+            ApiDescriptor.create().key( descriptorKey ).allowedPrincipals( PrincipalKeys.from( RoleKeys.EVERYONE ) ).build();
+        when( apiDescriptorService.getByKey( eq( descriptorKey ) ) ).thenReturn( apiDescriptor );
+
+        final Site site = mock( Site.class );
+        when( site.getPath() ).thenReturn( ContentPath.from( "/mysite" ) );
+        mockDataWithSiteConfig( applicationKey, site );
+        request.setSite( site );
+
+        final SiteDescriptor siteDescriptor =
+            SiteDescriptor.create().applicationKey( applicationKey ).apiMounts( DescriptorKeys.from( descriptorKey ) ).build();
+        when( siteService.getDescriptor( eq( applicationKey ) ) ).thenReturn( siteDescriptor );
+
+        // A tool descriptor that would deny access - it must be ignored for site-based requests.
+        final AdminToolDescriptor denyingTool = AdminToolDescriptor.create()
+            .title( "site" )
+            .key( DescriptorKey.from( ApplicationKey.from( "com.enonic.app.contentstudio" ), "site" ) )
+            .addAllowedPrincipals( PrincipalKeys.from( PrincipalKey.ofRole( "system.somerole" ) ) )
+            .build();
+        when( adminToolDescriptorService.getByKey( any() ) ).thenReturn( denyingTool );
+
+        final WebResponse response = this.handler.handle( request );
+        assertEquals( HttpStatus.OK, response.getStatus() );
+    }
+
+    @Test
     void testAddAndRemoveDynamicApiHandler()
         throws Exception
     {
@@ -673,6 +767,7 @@ class SlashApiHandlerTest
         final AdminToolDescriptor toolDescriptor = AdminToolDescriptor.create()
             .title( "My Tool" )
             .key( descriptorKey )
+            .addAllowedPrincipals( PrincipalKeys.from( RoleKeys.EVERYONE ) )
             .apiMounts( DescriptorKeys.from( DescriptorKey.from( apiApplicationKey, "myapi" ) ) )
             .build();
 
@@ -697,8 +792,12 @@ class SlashApiHandlerTest
 
         final ApplicationKey applicationKey = ApplicationKey.from( "com.enonic.app.myapp" );
         final DescriptorKey descriptorKey = DescriptorKey.from( applicationKey, "mytool" );
-        final AdminToolDescriptor toolDescriptor =
-            AdminToolDescriptor.create().title( "My Tool" ).key( descriptorKey ).apiMounts( DescriptorKeys.empty() ).build();
+        final AdminToolDescriptor toolDescriptor = AdminToolDescriptor.create()
+            .title( "My Tool" )
+            .key( descriptorKey )
+            .addAllowedPrincipals( PrincipalKeys.from( RoleKeys.EVERYONE ) )
+            .apiMounts( DescriptorKeys.empty() )
+            .build();
 
         when( adminToolDescriptorService.getByKey( eq( descriptorKey ) ) ).thenReturn( toolDescriptor );
         when( servletRequestMock.isUserInRole( any() ) ).thenReturn( true );


### PR DESCRIPTION
Closes #12170

## Problem
An API (or admin extension) reached through an admin tool was gated only by the `admin.login` perimeter and its own descriptor `allow:` list — the mounting tool's own access list was never consulted. A user who could not open a tool could still call the APIs it hosts.

## Change
In `SlashApiHandler.verifyAccessToApi`, the access check now reads **perimeter → capability → resource**: when a Universal API is reached through a real admin tool, the caller must also pass `AdminToolDescriptor.isAccessAllowed` (the tool's `allow:`), in addition to the admin-login role and the API's own `allow:`.

- Site-embedded admin paths (Content Studio's `site` pseudo-tool, where the request is `isSiteBase`) are intentionally skipped here — those are governed by the content/project layer instead.
- Because `admin:extension` is itself a Universal API mounted on admin tools, admin extensions inherit the hosting tool's access list through the same path — no extension-handler changes needed.
- Mount verification stays pure routing (404 "not mounted"); access denials remain 403 (401 if unauthenticated), consistent with the existing API-allow ordering.

## Tests
`SlashApiHandlerTest`: updated the existing admin-mount cases (which built tools with no `allow:`) and added:
- tool denies a logged-in caller → 403;
- site-embedded (pseudo-tool) request is not blocked even by a denying tool descriptor.

Full `:portal:portal-impl:test` suite passes.

## Compatibility
Behavior change: requests that previously returned 200 ("API mounted on a tool, callable by any backend user regardless of the tool's `allow:`") now return 403 unless the caller is allowed on the tool. This is the intended fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0118HR3meUyog8m5gR2iWk2X)_