### PR TITLE
Add response processor SPI for admin extensions #12211

### DIFF
--- a/modules/admin/admin-api/build.gradle
+++ b/modules/admin/admin-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     api project( ':core:core-api' )
+    api project( ':portal:portal-api' )
 }
 
 jar {

--- a/modules/admin/admin-api/src/main/java/com/enonic/xp/admin/extension/AdminExtensionDescriptor.java
+++ b/modules/admin/admin-api/src/main/java/com/enonic/xp/admin/extension/AdminExtensionDescriptor.java
@@ -16,6 +16,8 @@ import com.enonic.xp.util.GenericValue;
 public final class AdminExtensionDescriptor
     extends Descriptor
 {
+    public static final String GENERIC_INTERFACE = "generic";
+
     private final String title;
 
     private final String titleI18nKey;

--- a/modules/admin/admin-api/src/main/java/com/enonic/xp/admin/extension/AdminExtensionResponseProcessor.java
+++ b/modules/admin/admin-api/src/main/java/com/enonic/xp/admin/extension/AdminExtensionResponseProcessor.java
@@ -2,15 +2,15 @@ package com.enonic.xp.admin.extension;
 
 import org.jspecify.annotations.NullMarked;
 
-import com.enonic.xp.descriptor.DescriptorKey;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalResponse;
 
 /**
  * Lets an admin extension process the response of admin tool pages the extension is mounted to.
  * <p>
- * Implementations are registered as OSGi services and run after the tool controller, for tools that share
- * an interface with the extension identified by {@link #getExtensionKey()} (or for all tools, if the extension
+ * Implementations are registered as OSGi services with a mandatory {@code key} service property holding
+ * the extension's descriptor key, e.g. {@code key=com.example.app:my-widget}. They run after the tool
+ * controller, for tools that share an interface with the extension (or for all tools, if the extension
  * declares the {@code generic} interface), and only when the current user is allowed to access the extension.
  * <p>
  * Typical uses: adjust the tool page's Content-Security-Policy via {@code request.getContentSecurityPolicy()}
@@ -20,7 +20,5 @@ import com.enonic.xp.portal.PortalResponse;
 @NullMarked
 public interface AdminExtensionResponseProcessor
 {
-    DescriptorKey getExtensionKey();
-
     PortalResponse process( PortalRequest request, PortalResponse response );
 }

--- a/modules/admin/admin-api/src/main/java/com/enonic/xp/admin/extension/AdminExtensionResponseProcessor.java
+++ b/modules/admin/admin-api/src/main/java/com/enonic/xp/admin/extension/AdminExtensionResponseProcessor.java
@@ -1,0 +1,26 @@
+package com.enonic.xp.admin.extension;
+
+import org.jspecify.annotations.NullMarked;
+
+import com.enonic.xp.descriptor.DescriptorKey;
+import com.enonic.xp.portal.PortalRequest;
+import com.enonic.xp.portal.PortalResponse;
+
+/**
+ * Lets an admin extension process the response of admin tool pages the extension is mounted to.
+ * <p>
+ * Implementations are registered as OSGi services and run after the tool controller, for tools that share
+ * an interface with the extension identified by {@link #getExtensionKey()} (or for all tools, if the extension
+ * declares the {@code generic} interface), and only when the current user is allowed to access the extension.
+ * <p>
+ * Typical uses: adjust the tool page's Content-Security-Policy via {@code request.getContentSecurityPolicy()}
+ * so the extension can call external APIs from the browser, or add page contributions that load
+ * the extension's scripts on the page.
+ */
+@NullMarked
+public interface AdminExtensionResponseProcessor
+{
+    DescriptorKey getExtensionKey();
+
+    PortalResponse process( PortalRequest request, PortalResponse response );
+}

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/AdminToolHandler.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/AdminToolHandler.java
@@ -3,11 +3,13 @@ package com.enonic.xp.admin.impl.portal;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import com.enonic.xp.admin.impl.portal.extension.AdminExtensionResponseProcessorExecutor;
 import com.enonic.xp.admin.tool.AdminToolDescriptorService;
 import com.enonic.xp.descriptor.DescriptorKey;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalResponse;
 import com.enonic.xp.portal.controller.ControllerScriptFactory;
+import com.enonic.xp.portal.postprocess.PostProcessor;
 import com.enonic.xp.portal.handler.WebHandlerHelper;
 import com.enonic.xp.trace.Traced;
 import com.enonic.xp.trace.Tracer;
@@ -25,6 +27,10 @@ public final class AdminToolHandler
     private AdminToolDescriptorService adminToolDescriptorService;
 
     private ControllerScriptFactory controllerScriptFactory;
+
+    private AdminExtensionResponseProcessorExecutor extensionResponseProcessorExecutor;
+
+    private PostProcessor postProcessor;
 
     public AdminToolHandler()
     {
@@ -63,6 +69,8 @@ public final class AdminToolHandler
         final AdminToolHandlerWorker worker = new AdminToolHandlerWorker( portalRequest );
         worker.controllerScriptFactory = this.controllerScriptFactory;
         worker.adminToolDescriptorService = adminToolDescriptorService;
+        worker.extensionResponseProcessorExecutor = this.extensionResponseProcessorExecutor;
+        worker.postProcessor = this.postProcessor;
         worker.descriptorKey = descriptorKey;
 
         final PortalResponse response = worker.execute();
@@ -80,5 +88,17 @@ public final class AdminToolHandler
     public void setControllerScriptFactory( final ControllerScriptFactory controllerScriptFactory )
     {
         this.controllerScriptFactory = controllerScriptFactory;
+    }
+
+    @Reference
+    public void setExtensionResponseProcessorExecutor( final AdminExtensionResponseProcessorExecutor extensionResponseProcessorExecutor )
+    {
+        this.extensionResponseProcessorExecutor = extensionResponseProcessorExecutor;
+    }
+
+    @Reference
+    public void setPostProcessor( final PostProcessor postProcessor )
+    {
+        this.postProcessor = postProcessor;
     }
 }

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/AdminToolHandlerWorker.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/AdminToolHandlerWorker.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.admin.impl.portal;
 
+import com.enonic.xp.admin.impl.portal.extension.AdminExtensionResponseProcessorExecutor;
 import com.enonic.xp.admin.tool.AdminToolDescriptor;
 import com.enonic.xp.admin.tool.AdminToolDescriptorService;
 import com.enonic.xp.context.ContextAccessor;
@@ -8,6 +9,7 @@ import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalResponse;
 import com.enonic.xp.portal.controller.ControllerScript;
 import com.enonic.xp.portal.controller.ControllerScriptFactory;
+import com.enonic.xp.portal.postprocess.PostProcessor;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.security.PrincipalKeys;
 import com.enonic.xp.web.WebException;
@@ -19,6 +21,10 @@ final class AdminToolHandlerWorker
     ControllerScriptFactory controllerScriptFactory;
 
     AdminToolDescriptorService adminToolDescriptorService;
+
+    AdminExtensionResponseProcessorExecutor extensionResponseProcessorExecutor;
+
+    PostProcessor postProcessor;
 
     DescriptorKey descriptorKey;
 
@@ -49,6 +55,15 @@ final class AdminToolHandlerWorker
         final ResourceKey script = ResourceKey.from( descriptorKey.getApplicationKey(),
                                                      "admin/tools/" + descriptorKey.getName() + "/" + descriptorKey.getName() + ".js" );
         final ControllerScript controllerScript = this.controllerScriptFactory.fromScript( script );
-        return controllerScript.execute( this.request );
+        PortalResponse response = controllerScript.execute( this.request );
+
+        //Lets extensions mounted to the admin tool process the response (adjust CSP, add page contributions)
+        response = extensionResponseProcessorExecutor.execute( adminToolDescriptor, this.request, response );
+
+        if ( response.hasContributions() )
+        {
+            response = postProcessor.processResponseContributions( this.request, response );
+        }
+        return response;
     }
 }

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionApiHandler.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionApiHandler.java
@@ -30,8 +30,6 @@ public class AdminExtensionApiHandler
 {
     private static final Pattern EXTENSION_API_PATTERN = Pattern.compile( "^/admin:extension/(?<descriptor>[^/]+:[^/]+)" );
 
-    private static final String GENERIC_EXTENSION_INTERFACE = "generic";
-
     private final AdminExtensionDescriptorService descriptorService;
 
     private final ControllerScriptFactory controllerScriptFactory;
@@ -86,7 +84,7 @@ public class AdminExtensionApiHandler
 
     private void verifyMounts( final AdminExtensionDescriptor descriptor, final WebRequest webRequest )
     {
-        if ( descriptor.hasInterface( GENERIC_EXTENSION_INTERFACE ) )
+        if ( descriptor.hasInterface( AdminExtensionDescriptor.GENERIC_INTERFACE ) )
         {
             return;
         }

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionResponseProcessorExecutor.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionResponseProcessorExecutor.java
@@ -2,6 +2,7 @@ package com.enonic.xp.admin.impl.portal.extension;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -16,6 +17,7 @@ import com.enonic.xp.admin.extension.AdminExtensionDescriptorService;
 import com.enonic.xp.admin.extension.AdminExtensionResponseProcessor;
 import com.enonic.xp.admin.tool.AdminToolDescriptor;
 import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.descriptor.DescriptorKey;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalResponse;
 import com.enonic.xp.security.PrincipalKeys;
@@ -23,7 +25,11 @@ import com.enonic.xp.security.PrincipalKeys;
 @Component(service = AdminExtensionResponseProcessorExecutor.class)
 public class AdminExtensionResponseProcessorExecutor
 {
-    private final List<AdminExtensionResponseProcessor> processors = new CopyOnWriteArrayList<>();
+    private record RegisteredProcessor(DescriptorKey extensionKey, AdminExtensionResponseProcessor processor)
+    {
+    }
+
+    private final List<RegisteredProcessor> processors = new CopyOnWriteArrayList<>();
 
     private final AdminExtensionDescriptorService descriptorService;
 
@@ -41,22 +47,22 @@ public class AdminExtensionResponseProcessorExecutor
         }
 
         // registration order is non-deterministic, sort to make the chain stable across restarts
-        final List<AdminExtensionResponseProcessor> chain = this.processors.stream()
-            .sorted( Comparator.comparing( processor -> processor.getExtensionKey().toString() ) )
+        final List<RegisteredProcessor> chain = this.processors.stream()
+            .sorted( Comparator.comparing( registered -> registered.extensionKey().toString() ) )
             .toList();
 
         final PrincipalKeys principals = ContextAccessor.current().getAuthInfo().getPrincipals();
 
         PortalResponse result = response;
-        for ( final AdminExtensionResponseProcessor processor : chain )
+        for ( final RegisteredProcessor registered : chain )
         {
-            final AdminExtensionDescriptor descriptor = descriptorService.getByKey( processor.getExtensionKey() );
+            final AdminExtensionDescriptor descriptor = descriptorService.getByKey( registered.extensionKey() );
             if ( descriptor == null || !isMounted( descriptor, tool ) || !descriptor.isAccessAllowed( principals ) )
             {
                 continue;
             }
-            result = Objects.requireNonNull( processor.process( request, result ), () -> String.format(
-                "Response processor for extension [%s] returned null", processor.getExtensionKey() ) );
+            result = Objects.requireNonNull( registered.processor().process( request, result ), () -> String.format(
+                "Response processor for extension [%s] returned null", registered.extensionKey() ) );
         }
         return result;
     }
@@ -68,13 +74,14 @@ public class AdminExtensionResponseProcessorExecutor
     }
 
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
-    public void addProcessor( final AdminExtensionResponseProcessor processor )
+    public void addProcessor( final AdminExtensionResponseProcessor processor, final Map<String, ?> properties )
     {
-        this.processors.add( processor );
+        final DescriptorKey extensionKey = DescriptorKey.from( (String) properties.get( "key" ) );
+        this.processors.add( new RegisteredProcessor( extensionKey, processor ) );
     }
 
     public void removeProcessor( final AdminExtensionResponseProcessor processor )
     {
-        this.processors.remove( processor );
+        this.processors.removeIf( registered -> registered.processor() == processor );
     }
 }

--- a/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionResponseProcessorExecutor.java
+++ b/modules/admin/admin-impl/src/main/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionResponseProcessorExecutor.java
@@ -1,0 +1,80 @@
+package com.enonic.xp.admin.impl.portal.extension;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+import com.enonic.xp.admin.extension.AdminExtensionDescriptor;
+import com.enonic.xp.admin.extension.AdminExtensionDescriptorService;
+import com.enonic.xp.admin.extension.AdminExtensionResponseProcessor;
+import com.enonic.xp.admin.tool.AdminToolDescriptor;
+import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.portal.PortalRequest;
+import com.enonic.xp.portal.PortalResponse;
+import com.enonic.xp.security.PrincipalKeys;
+
+@Component(service = AdminExtensionResponseProcessorExecutor.class)
+public class AdminExtensionResponseProcessorExecutor
+{
+    private final List<AdminExtensionResponseProcessor> processors = new CopyOnWriteArrayList<>();
+
+    private final AdminExtensionDescriptorService descriptorService;
+
+    @Activate
+    public AdminExtensionResponseProcessorExecutor( @Reference final AdminExtensionDescriptorService descriptorService )
+    {
+        this.descriptorService = descriptorService;
+    }
+
+    public PortalResponse execute( final AdminToolDescriptor tool, final PortalRequest request, final PortalResponse response )
+    {
+        if ( this.processors.isEmpty() )
+        {
+            return response;
+        }
+
+        // registration order is non-deterministic, sort to make the chain stable across restarts
+        final List<AdminExtensionResponseProcessor> chain = this.processors.stream()
+            .sorted( Comparator.comparing( processor -> processor.getExtensionKey().toString() ) )
+            .toList();
+
+        final PrincipalKeys principals = ContextAccessor.current().getAuthInfo().getPrincipals();
+
+        PortalResponse result = response;
+        for ( final AdminExtensionResponseProcessor processor : chain )
+        {
+            final AdminExtensionDescriptor descriptor = descriptorService.getByKey( processor.getExtensionKey() );
+            if ( descriptor == null || !isMounted( descriptor, tool ) || !descriptor.isAccessAllowed( principals ) )
+            {
+                continue;
+            }
+            result = Objects.requireNonNull( processor.process( request, result ), () -> String.format(
+                "Response processor for extension [%s] returned null", processor.getExtensionKey() ) );
+        }
+        return result;
+    }
+
+    private static boolean isMounted( final AdminExtensionDescriptor descriptor, final AdminToolDescriptor tool )
+    {
+        return descriptor.hasInterface( AdminExtensionDescriptor.GENERIC_INTERFACE ) ||
+            descriptor.getInterfaces().stream().anyMatch( tool::hasInterface );
+    }
+
+    @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
+    public void addProcessor( final AdminExtensionResponseProcessor processor )
+    {
+        this.processors.add( processor );
+    }
+
+    public void removeProcessor( final AdminExtensionResponseProcessor processor )
+    {
+        this.processors.remove( processor );
+    }
+}

--- a/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/portal/AdminToolHandlerTest.java
+++ b/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/portal/AdminToolHandlerTest.java
@@ -6,6 +6,7 @@ import org.mockito.Mockito;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import com.enonic.xp.admin.impl.portal.extension.AdminExtensionResponseProcessorExecutor;
 import com.enonic.xp.admin.tool.AdminToolDescriptor;
 import com.enonic.xp.admin.tool.AdminToolDescriptorService;
 import com.enonic.xp.descriptor.DescriptorKey;
@@ -13,6 +14,8 @@ import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalResponse;
 import com.enonic.xp.portal.controller.ControllerScript;
 import com.enonic.xp.portal.controller.ControllerScriptFactory;
+import com.enonic.xp.portal.postprocess.HtmlTag;
+import com.enonic.xp.portal.postprocess.PostProcessor;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.security.PrincipalKeys;
 import com.enonic.xp.trace.TestTrace;
@@ -50,22 +53,35 @@ class AdminToolHandlerTest
 
     private AdminToolDescriptorService adminToolDescriptorService;
 
+    private ControllerScript controllerScript;
+
+    private AdminExtensionResponseProcessorExecutor extensionResponseProcessorExecutor;
+
+    private PostProcessor postProcessor;
+
     @BeforeEach
     public final void setup()
     {
 
         this.adminToolDescriptorService = mock( AdminToolDescriptorService.class );
-        ControllerScript controllerScript = mock( ControllerScript.class );
+        this.controllerScript = mock( ControllerScript.class );
 
         this.portalResponse = PortalResponse.create().build();
-        when( controllerScript.execute( any( PortalRequest.class ) ) ).thenReturn( this.portalResponse );
+        when( this.controllerScript.execute( any( PortalRequest.class ) ) ).thenReturn( this.portalResponse );
 
         final ControllerScriptFactory controllerScriptFactory = mock( ControllerScriptFactory.class );
-        when( controllerScriptFactory.fromScript( any( ResourceKey.class ) ) ).thenReturn( controllerScript );
+        when( controllerScriptFactory.fromScript( any( ResourceKey.class ) ) ).thenReturn( this.controllerScript );
+
+        this.extensionResponseProcessorExecutor = mock( AdminExtensionResponseProcessorExecutor.class );
+        when( this.extensionResponseProcessorExecutor.execute( any(), any(), any() ) ).thenAnswer( inv -> inv.getArgument( 2 ) );
+
+        this.postProcessor = mock( PostProcessor.class );
 
         this.handler = new AdminToolHandler();
         this.handler.setAdminToolDescriptorService( this.adminToolDescriptorService );
         this.handler.setControllerScriptFactory( controllerScriptFactory );
+        this.handler.setExtensionResponseProcessorExecutor( this.extensionResponseProcessorExecutor );
+        this.handler.setPostProcessor( this.postProcessor );
 
         this.rawRequest = mock( HttpServletRequest.class );
         when( this.rawRequest.isUserInRole( Mockito.anyString() ) ).thenReturn( true );
@@ -157,6 +173,26 @@ class AdminToolHandlerTest
         assertEquals( 200L, trace.get( "status" ) );
         assertInstanceOf( String.class, trace.get( "type" ) );
         assertInstanceOf( Long.class, trace.get( "size" ) );
+    }
+
+    @Test
+    void testExtensionProcessorResponseWithContributionsIsPostProcessed()
+        throws Exception
+    {
+        this.mockDescriptor( DescriptorKey.from( "app:tool" ), true );
+        this.portalRequest.setBaseUri( "/admin/webapp/tool" );
+        this.portalRequest.setRawPath( "/admin/webapp/tool/1" );
+
+        final PortalResponse withContributions =
+            PortalResponse.create().contribution( HtmlTag.HEAD_END, "<script src=\"widget.js\"></script>" ).build();
+        when( this.extensionResponseProcessorExecutor.execute( any(), any(), any() ) ).thenReturn( withContributions );
+
+        final PortalResponse postProcessed = PortalResponse.create().body( "post-processed" ).build();
+        when( this.postProcessor.processResponseContributions( any( PortalRequest.class ), any( PortalResponse.class ) ) ).thenReturn(
+            postProcessed );
+
+        final WebResponse response = this.handler.doHandle( this.portalRequest, this.webResponse, this.chain );
+        assertEquals( postProcessed, response );
     }
 
     @Test

--- a/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionResponseProcessorExecutorTest.java
+++ b/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionResponseProcessorExecutorTest.java
@@ -50,7 +50,7 @@ class AdminExtensionResponseProcessorExecutorTest
     void executesProcessorOfMountedExtension()
     {
         final PortalResponse processed = PortalResponse.create().body( "processed" ).build();
-        this.executor.addProcessor( processor( "app:ext", ( req, res ) -> processed ) );
+        this.executor.addProcessor( processor( "app:ext", res -> processed ) );
         mockDescriptor( "app:ext", Set.of( "admin.dashboard" ), true );
 
         assertSame( processed, this.executor.execute( this.tool, this.request, this.response ) );
@@ -60,7 +60,7 @@ class AdminExtensionResponseProcessorExecutorTest
     void genericExtensionRunsForAnyTool()
     {
         final PortalResponse processed = PortalResponse.create().body( "processed" ).build();
-        this.executor.addProcessor( processor( "app:ext", ( req, res ) -> processed ) );
+        this.executor.addProcessor( processor( "app:ext", res -> processed ) );
         mockDescriptor( "app:ext", Set.of( AdminExtensionDescriptor.GENERIC_INTERFACE ), true );
 
         assertSame( processed, this.executor.execute( this.tool, this.request, this.response ) );
@@ -69,7 +69,7 @@ class AdminExtensionResponseProcessorExecutorTest
     @Test
     void skipsExtensionNotMountedToTool()
     {
-        this.executor.addProcessor( processor( "app:ext", ( req, res ) -> PortalResponse.create().build() ) );
+        this.executor.addProcessor( processor( "app:ext", res -> PortalResponse.create().build() ) );
         mockDescriptor( "app:ext", Set.of( "other.interface" ), true );
 
         assertSame( this.response, this.executor.execute( this.tool, this.request, this.response ) );
@@ -78,7 +78,7 @@ class AdminExtensionResponseProcessorExecutorTest
     @Test
     void skipsExtensionWithoutDescriptor()
     {
-        this.executor.addProcessor( processor( "app:ext", ( req, res ) -> PortalResponse.create().build() ) );
+        this.executor.addProcessor( processor( "app:ext", res -> PortalResponse.create().build() ) );
         when( this.descriptorService.getByKey( eq( DescriptorKey.from( "app:ext" ) ) ) ).thenReturn( null );
 
         assertSame( this.response, this.executor.execute( this.tool, this.request, this.response ) );
@@ -87,7 +87,7 @@ class AdminExtensionResponseProcessorExecutorTest
     @Test
     void skipsExtensionWhenAccessDenied()
     {
-        this.executor.addProcessor( processor( "app:ext", ( req, res ) -> PortalResponse.create().build() ) );
+        this.executor.addProcessor( processor( "app:ext", res -> PortalResponse.create().build() ) );
         mockDescriptor( "app:ext", Set.of( "admin.dashboard" ), false );
 
         assertSame( this.response, this.executor.execute( this.tool, this.request, this.response ) );
@@ -97,11 +97,11 @@ class AdminExtensionResponseProcessorExecutorTest
     void executesProcessorsOrderedByExtensionKey()
     {
         final List<String> invocations = new ArrayList<>();
-        this.executor.addProcessor( processor( "appb:ext", ( req, res ) -> {
+        this.executor.addProcessor( processor( "appb:ext", res -> {
             invocations.add( "appb:ext" );
             return res;
         } ) );
-        this.executor.addProcessor( processor( "appa:ext", ( req, res ) -> {
+        this.executor.addProcessor( processor( "appa:ext", res -> {
             invocations.add( "appa:ext" );
             return res;
         } ) );
@@ -115,7 +115,7 @@ class AdminExtensionResponseProcessorExecutorTest
     @Test
     void removedProcessorDoesNotRun()
     {
-        final AdminExtensionResponseProcessor processor = processor( "app:ext", ( req, res ) -> PortalResponse.create().build() );
+        final AdminExtensionResponseProcessor processor = processor( "app:ext", res -> PortalResponse.create().build() );
         this.executor.addProcessor( processor );
         this.executor.removeProcessor( processor );
         mockDescriptor( "app:ext", Set.of( "admin.dashboard" ), true );
@@ -126,7 +126,7 @@ class AdminExtensionResponseProcessorExecutorTest
     @Test
     void failsWhenProcessorReturnsNull()
     {
-        this.executor.addProcessor( processor( "app:ext", ( req, res ) -> null ) );
+        this.executor.addProcessor( processor( "app:ext", res -> null ) );
         mockDescriptor( "app:ext", Set.of( "admin.dashboard" ), true );
 
         assertThrows( NullPointerException.class, () -> this.executor.execute( this.tool, this.request, this.response ) );
@@ -155,13 +155,13 @@ class AdminExtensionResponseProcessorExecutorTest
             @Override
             public PortalResponse process( final PortalRequest request, final PortalResponse response )
             {
-                return process.apply( request, response );
+                return process.apply( response );
             }
         };
     }
 
     private interface ProcessFunction
     {
-        PortalResponse apply( PortalRequest request, PortalResponse response );
+        PortalResponse apply( PortalResponse response );
     }
 }

--- a/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionResponseProcessorExecutorTest.java
+++ b/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionResponseProcessorExecutorTest.java
@@ -1,0 +1,167 @@
+package com.enonic.xp.admin.impl.portal.extension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.enonic.xp.admin.extension.AdminExtensionDescriptor;
+import com.enonic.xp.admin.extension.AdminExtensionDescriptorService;
+import com.enonic.xp.admin.extension.AdminExtensionResponseProcessor;
+import com.enonic.xp.admin.tool.AdminToolDescriptor;
+import com.enonic.xp.descriptor.DescriptorKey;
+import com.enonic.xp.portal.PortalRequest;
+import com.enonic.xp.portal.PortalResponse;
+import com.enonic.xp.security.PrincipalKeys;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AdminExtensionResponseProcessorExecutorTest
+{
+    private AdminExtensionDescriptorService descriptorService;
+
+    private AdminExtensionResponseProcessorExecutor executor;
+
+    private AdminToolDescriptor tool;
+
+    private PortalRequest request;
+
+    private PortalResponse response;
+
+    @BeforeEach
+    void setUp()
+    {
+        this.descriptorService = mock( AdminExtensionDescriptorService.class );
+        this.executor = new AdminExtensionResponseProcessorExecutor( this.descriptorService );
+        this.tool = AdminToolDescriptor.create().key( DescriptorKey.from( "toolapp:tool" ) ).interfaces( "admin.dashboard" ).build();
+        this.request = new PortalRequest();
+        this.response = PortalResponse.create().build();
+    }
+
+    @Test
+    void executesProcessorOfMountedExtension()
+    {
+        final PortalResponse processed = PortalResponse.create().body( "processed" ).build();
+        this.executor.addProcessor( processor( "app:ext", ( req, res ) -> processed ) );
+        mockDescriptor( "app:ext", Set.of( "admin.dashboard" ), true );
+
+        assertSame( processed, this.executor.execute( this.tool, this.request, this.response ) );
+    }
+
+    @Test
+    void genericExtensionRunsForAnyTool()
+    {
+        final PortalResponse processed = PortalResponse.create().body( "processed" ).build();
+        this.executor.addProcessor( processor( "app:ext", ( req, res ) -> processed ) );
+        mockDescriptor( "app:ext", Set.of( AdminExtensionDescriptor.GENERIC_INTERFACE ), true );
+
+        assertSame( processed, this.executor.execute( this.tool, this.request, this.response ) );
+    }
+
+    @Test
+    void skipsExtensionNotMountedToTool()
+    {
+        this.executor.addProcessor( processor( "app:ext", ( req, res ) -> PortalResponse.create().build() ) );
+        mockDescriptor( "app:ext", Set.of( "other.interface" ), true );
+
+        assertSame( this.response, this.executor.execute( this.tool, this.request, this.response ) );
+    }
+
+    @Test
+    void skipsExtensionWithoutDescriptor()
+    {
+        this.executor.addProcessor( processor( "app:ext", ( req, res ) -> PortalResponse.create().build() ) );
+        when( this.descriptorService.getByKey( eq( DescriptorKey.from( "app:ext" ) ) ) ).thenReturn( null );
+
+        assertSame( this.response, this.executor.execute( this.tool, this.request, this.response ) );
+    }
+
+    @Test
+    void skipsExtensionWhenAccessDenied()
+    {
+        this.executor.addProcessor( processor( "app:ext", ( req, res ) -> PortalResponse.create().build() ) );
+        mockDescriptor( "app:ext", Set.of( "admin.dashboard" ), false );
+
+        assertSame( this.response, this.executor.execute( this.tool, this.request, this.response ) );
+    }
+
+    @Test
+    void executesProcessorsOrderedByExtensionKey()
+    {
+        final List<String> invocations = new ArrayList<>();
+        this.executor.addProcessor( processor( "appb:ext", ( req, res ) -> {
+            invocations.add( "appb:ext" );
+            return res;
+        } ) );
+        this.executor.addProcessor( processor( "appa:ext", ( req, res ) -> {
+            invocations.add( "appa:ext" );
+            return res;
+        } ) );
+        mockDescriptor( "appa:ext", Set.of( "admin.dashboard" ), true );
+        mockDescriptor( "appb:ext", Set.of( "admin.dashboard" ), true );
+
+        assertSame( this.response, this.executor.execute( this.tool, this.request, this.response ) );
+        assertEquals( List.of( "appa:ext", "appb:ext" ), invocations );
+    }
+
+    @Test
+    void removedProcessorDoesNotRun()
+    {
+        final AdminExtensionResponseProcessor processor = processor( "app:ext", ( req, res ) -> PortalResponse.create().build() );
+        this.executor.addProcessor( processor );
+        this.executor.removeProcessor( processor );
+        mockDescriptor( "app:ext", Set.of( "admin.dashboard" ), true );
+
+        assertSame( this.response, this.executor.execute( this.tool, this.request, this.response ) );
+    }
+
+    @Test
+    void failsWhenProcessorReturnsNull()
+    {
+        this.executor.addProcessor( processor( "app:ext", ( req, res ) -> null ) );
+        mockDescriptor( "app:ext", Set.of( "admin.dashboard" ), true );
+
+        assertThrows( NullPointerException.class, () -> this.executor.execute( this.tool, this.request, this.response ) );
+    }
+
+    private void mockDescriptor( final String key, final Set<String> interfaces, final boolean accessAllowed )
+    {
+        final AdminExtensionDescriptor descriptor = mock( AdminExtensionDescriptor.class );
+        when( descriptor.getInterfaces() ).thenReturn( interfaces );
+        when( descriptor.hasInterface( any( String.class ) ) ).thenAnswer( inv -> interfaces.contains( inv.<String>getArgument( 0 ) ) );
+        when( descriptor.isAccessAllowed( any( PrincipalKeys.class ) ) ).thenReturn( accessAllowed );
+        when( this.descriptorService.getByKey( eq( DescriptorKey.from( key ) ) ) ).thenReturn( descriptor );
+    }
+
+    private static AdminExtensionResponseProcessor processor( final String extensionKey, final ProcessFunction process )
+    {
+        final DescriptorKey key = DescriptorKey.from( extensionKey );
+        return new AdminExtensionResponseProcessor()
+        {
+            @Override
+            public DescriptorKey getExtensionKey()
+            {
+                return key;
+            }
+
+            @Override
+            public PortalResponse process( final PortalRequest request, final PortalResponse response )
+            {
+                return process.apply( request, response );
+            }
+        };
+    }
+
+    private interface ProcessFunction
+    {
+        PortalResponse apply( PortalRequest request, PortalResponse response );
+    }
+}

--- a/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionResponseProcessorExecutorTest.java
+++ b/modules/admin/admin-impl/src/test/java/com/enonic/xp/admin/impl/portal/extension/AdminExtensionResponseProcessorExecutorTest.java
@@ -2,6 +2,7 @@ package com.enonic.xp.admin.impl.portal.extension;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -16,9 +17,9 @@ import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalResponse;
 import com.enonic.xp.security.PrincipalKeys;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -50,7 +51,7 @@ class AdminExtensionResponseProcessorExecutorTest
     void executesProcessorOfMountedExtension()
     {
         final PortalResponse processed = PortalResponse.create().body( "processed" ).build();
-        this.executor.addProcessor( processor( "app:ext", res -> processed ) );
+        addProcessor( "app:ext", ( req, res ) -> processed );
         mockDescriptor( "app:ext", Set.of( "admin.dashboard" ), true );
 
         assertSame( processed, this.executor.execute( this.tool, this.request, this.response ) );
@@ -60,7 +61,7 @@ class AdminExtensionResponseProcessorExecutorTest
     void genericExtensionRunsForAnyTool()
     {
         final PortalResponse processed = PortalResponse.create().body( "processed" ).build();
-        this.executor.addProcessor( processor( "app:ext", res -> processed ) );
+        addProcessor( "app:ext", ( req, res ) -> processed );
         mockDescriptor( "app:ext", Set.of( AdminExtensionDescriptor.GENERIC_INTERFACE ), true );
 
         assertSame( processed, this.executor.execute( this.tool, this.request, this.response ) );
@@ -69,7 +70,7 @@ class AdminExtensionResponseProcessorExecutorTest
     @Test
     void skipsExtensionNotMountedToTool()
     {
-        this.executor.addProcessor( processor( "app:ext", res -> PortalResponse.create().build() ) );
+        addProcessor( "app:ext", ( req, res ) -> PortalResponse.create().build() );
         mockDescriptor( "app:ext", Set.of( "other.interface" ), true );
 
         assertSame( this.response, this.executor.execute( this.tool, this.request, this.response ) );
@@ -78,7 +79,7 @@ class AdminExtensionResponseProcessorExecutorTest
     @Test
     void skipsExtensionWithoutDescriptor()
     {
-        this.executor.addProcessor( processor( "app:ext", res -> PortalResponse.create().build() ) );
+        addProcessor( "app:ext", ( req, res ) -> PortalResponse.create().build() );
         when( this.descriptorService.getByKey( eq( DescriptorKey.from( "app:ext" ) ) ) ).thenReturn( null );
 
         assertSame( this.response, this.executor.execute( this.tool, this.request, this.response ) );
@@ -87,7 +88,7 @@ class AdminExtensionResponseProcessorExecutorTest
     @Test
     void skipsExtensionWhenAccessDenied()
     {
-        this.executor.addProcessor( processor( "app:ext", res -> PortalResponse.create().build() ) );
+        addProcessor( "app:ext", ( req, res ) -> PortalResponse.create().build() );
         mockDescriptor( "app:ext", Set.of( "admin.dashboard" ), false );
 
         assertSame( this.response, this.executor.execute( this.tool, this.request, this.response ) );
@@ -97,14 +98,14 @@ class AdminExtensionResponseProcessorExecutorTest
     void executesProcessorsOrderedByExtensionKey()
     {
         final List<String> invocations = new ArrayList<>();
-        this.executor.addProcessor( processor( "appb:ext", res -> {
+        addProcessor( "appb:ext", ( req, res ) -> {
             invocations.add( "appb:ext" );
             return res;
-        } ) );
-        this.executor.addProcessor( processor( "appa:ext", res -> {
+        } );
+        addProcessor( "appa:ext", ( req, res ) -> {
             invocations.add( "appa:ext" );
             return res;
-        } ) );
+        } );
         mockDescriptor( "appa:ext", Set.of( "admin.dashboard" ), true );
         mockDescriptor( "appb:ext", Set.of( "admin.dashboard" ), true );
 
@@ -115,8 +116,8 @@ class AdminExtensionResponseProcessorExecutorTest
     @Test
     void removedProcessorDoesNotRun()
     {
-        final AdminExtensionResponseProcessor processor = processor( "app:ext", res -> PortalResponse.create().build() );
-        this.executor.addProcessor( processor );
+        final AdminExtensionResponseProcessor processor = ( req, res ) -> PortalResponse.create().build();
+        addProcessor( "app:ext", processor );
         this.executor.removeProcessor( processor );
         mockDescriptor( "app:ext", Set.of( "admin.dashboard" ), true );
 
@@ -126,10 +127,23 @@ class AdminExtensionResponseProcessorExecutorTest
     @Test
     void failsWhenProcessorReturnsNull()
     {
-        this.executor.addProcessor( processor( "app:ext", res -> null ) );
+        addProcessor( "app:ext", ( req, res ) -> null );
         mockDescriptor( "app:ext", Set.of( "admin.dashboard" ), true );
 
-        assertThrows( NullPointerException.class, () -> this.executor.execute( this.tool, this.request, this.response ) );
+        assertThatThrownBy( () -> this.executor.execute( this.tool, this.request, this.response ) ).isInstanceOf(
+            NullPointerException.class ).hasMessage( "Response processor for extension [app:ext] returned null" );
+    }
+
+    @Test
+    void failsToRegisterProcessorWithoutKeyProperty()
+    {
+        assertThatThrownBy( () -> this.executor.addProcessor( ( req, res ) -> res, Map.of() ) ).isInstanceOf(
+            NullPointerException.class ).hasMessage( "DescriptorKey cannot be null" );
+    }
+
+    private void addProcessor( final String extensionKey, final AdminExtensionResponseProcessor processor )
+    {
+        this.executor.addProcessor( processor, Map.of( "key", extensionKey ) );
     }
 
     private void mockDescriptor( final String key, final Set<String> interfaces, final boolean accessAllowed )
@@ -139,29 +153,5 @@ class AdminExtensionResponseProcessorExecutorTest
         when( descriptor.hasInterface( any( String.class ) ) ).thenAnswer( inv -> interfaces.contains( inv.<String>getArgument( 0 ) ) );
         when( descriptor.isAccessAllowed( any( PrincipalKeys.class ) ) ).thenReturn( accessAllowed );
         when( this.descriptorService.getByKey( eq( DescriptorKey.from( key ) ) ) ).thenReturn( descriptor );
-    }
-
-    private static AdminExtensionResponseProcessor processor( final String extensionKey, final ProcessFunction process )
-    {
-        final DescriptorKey key = DescriptorKey.from( extensionKey );
-        return new AdminExtensionResponseProcessor()
-        {
-            @Override
-            public DescriptorKey getExtensionKey()
-            {
-                return key;
-            }
-
-            @Override
-            public PortalResponse process( final PortalRequest request, final PortalResponse response )
-            {
-                return process.apply( response );
-            }
-        };
-    }
-
-    private interface ProcessFunction
-    {
-        PortalResponse apply( PortalResponse response );
     }
 }


### PR DESCRIPTION
Adds a pure Java SPI letting admin extensions process the response of admin tool pages they are mounted to — the admin counterpart of site response processors.

`AdminExtensionResponseProcessor` (new in `admin-api`) is a pure functional interface registered as an OSGi service with a mandatory `key` service property holding the extension's descriptor key (the same convention as dynamic universal API handler registration). `AdminExtensionResponseProcessorExecutor` collects the services and, after the admin tool controller has rendered, runs the processors of every extension that shares an interface with the tool (or declares the `generic` interface) and passes the extension access check for the current user, in deterministic extension-key order. A processor can adjust the request-scoped `ContentSecurityPolicy` (additively, on top of the host tool's own baseline — needed by widgets that call external APIs or load external resources from the browser) and add page contributions, which are now injected into admin tool pages via `PostProcessor.processResponseContributions` (previously dropped on the admin rendering path).

Also promotes the `generic` interface name to `AdminExtensionDescriptor.GENERIC_INTERFACE` and adds a `portal-api` dependency to `admin-api` (acyclic; `portal-api` has no admin references).

First consumer: enonic/app-google-analytics#163 — the analytics-report widget loads Google Charts in the browser and is currently blocked by Content Studio's CSP.

Closes #12211

<sub>*Drafted with AI assistance*</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2nsz1N2UqLJQhuA7ddzqJ