### PR TITLE
Application-scoped cache invalidation and task executors #7966

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/MultiResourceProcessor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/MultiResourceProcessor.java
@@ -10,13 +10,13 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * Unlike {@link ResourceProcessor}, the produced value depends on several resources at once
  * (for example, a chain of {@code .properties} files merged into one message bundle).
- * {@link ResourceService#processResources(ResourcesProcessor)} caches the value and recomputes it
+ * {@link ResourceService#processResources(MultiResourceProcessor)} caches the value and recomputes it
  * when the owning application bundle changes or any of the resources appears, disappears or is modified.
  *
  * @param <K> type of the cache key
  * @param <V> type of the processed value
  */
-public final class ResourcesProcessor<K, V>
+public final class MultiResourceProcessor<K, V>
 {
     private final K key;
 
@@ -27,7 +27,7 @@ public final class ResourcesProcessor<K, V>
     private final Function<List<Resource>, V> processor;
 
     @SuppressWarnings("unchecked")
-    private ResourcesProcessor( final Builder builder )
+    private MultiResourceProcessor( final Builder builder )
     {
         this.key = (K) builder.key;
         this.segment = builder.segment;
@@ -102,14 +102,14 @@ public final class ResourcesProcessor<K, V>
             return this;
         }
 
-        public ResourcesProcessor<K, V> build()
+        public MultiResourceProcessor<K, V> build()
         {
             requireNonNull( this.key, "key is required" );
             requireNonNull( this.segment, "segment is required" );
             requireNonNull( this.keysTranslator, "keysTranslator is required" );
             requireNonNull( this.processor, "processor is required" );
 
-            return new ResourcesProcessor<>( this );
+            return new MultiResourceProcessor<>( this );
         }
     }
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/ResourceService.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/ResourceService.java
@@ -19,7 +19,7 @@ public interface ResourceService
      * @param processor multi-resource processor
      * @return processed value, or null if the processor returned null
      */
-    <K, V> V processResources( ResourcesProcessor<K, V> processor );
+    <K, V> V processResources( MultiResourceProcessor<K, V> processor );
 
     VirtualFile getVirtualFile( ResourceKey resourceKey );
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/ResourceService.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/ResourceService.java
@@ -11,5 +11,15 @@ public interface ResourceService
 
     <K, V> V processResource( ResourceProcessor<K, V> processor );
 
+    /**
+     * Processes several resources of an application ("file bundle") into a single cached value.
+     * The value is recomputed when the application bundle changes or any of the resources
+     * appears, disappears or is modified.
+     *
+     * @param processor multi-resource processor
+     * @return processed value, or null if the processor returned null
+     */
+    <K, V> V processResources( ResourcesProcessor<K, V> processor );
+
     VirtualFile getVirtualFile( ResourceKey resourceKey );
 }

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/ResourcesProcessor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/ResourcesProcessor.java
@@ -1,0 +1,115 @@
+package com.enonic.xp.resource;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Processes a fixed set of resources ("file bundle") into a single cached value.
+ * <p>
+ * Unlike {@link ResourceProcessor}, the produced value depends on several resources at once
+ * (for example, a chain of {@code .properties} files merged into one message bundle).
+ * {@link ResourceService#processResources(ResourcesProcessor)} caches the value and recomputes it
+ * when the owning application bundle changes or any of the resources appears, disappears or is modified.
+ *
+ * @param <K> type of the cache key
+ * @param <V> type of the processed value
+ */
+public final class ResourcesProcessor<K, V>
+{
+    private final K key;
+
+    private final String segment;
+
+    private final Function<K, List<ResourceKey>> keysTranslator;
+
+    private final Function<List<Resource>, V> processor;
+
+    @SuppressWarnings("unchecked")
+    private ResourcesProcessor( final Builder builder )
+    {
+        this.key = (K) builder.key;
+        this.segment = builder.segment;
+        this.keysTranslator = builder.keysTranslator;
+        this.processor = builder.processor;
+    }
+
+    public K getKey()
+    {
+        return this.key;
+    }
+
+    public String getSegment()
+    {
+        return this.segment;
+    }
+
+    /**
+     * Resolves the keys of all resources the value is built from, in processing order.
+     * Must be deterministic for a given {@link #getKey() key}.
+     *
+     * @return resource keys in processing order
+     */
+    public List<ResourceKey> toResourceKeys()
+    {
+        return List.copyOf( this.keysTranslator.apply( this.key ) );
+    }
+
+    /**
+     * Computes the value from the resolved resources. Resources are passed in {@link #toResourceKeys()} order
+     * and may not exist - the processor decides how to treat missing ones.
+     *
+     * @param resources resolved resources, existing or not, in {@link #toResourceKeys()} order
+     * @return processed value, or null to skip caching
+     */
+    public V process( final List<Resource> resources )
+    {
+        return this.processor.apply( resources );
+    }
+
+    public static final class Builder<K, V>
+    {
+        private K key;
+
+        private String segment;
+
+        private Function<K, List<ResourceKey>> keysTranslator;
+
+        private Function<List<Resource>, V> processor;
+
+        public Builder<K, V> key( final K key )
+        {
+            this.key = key;
+            return this;
+        }
+
+        public Builder<K, V> segment( final String segment )
+        {
+            this.segment = segment;
+            return this;
+        }
+
+        public Builder<K, V> keysTranslator( final Function<K, List<ResourceKey>> keysTranslator )
+        {
+            this.keysTranslator = keysTranslator;
+            return this;
+        }
+
+        public Builder<K, V> processor( final Function<List<Resource>, V> processor )
+        {
+            this.processor = processor;
+            return this;
+        }
+
+        public ResourcesProcessor<K, V> build()
+        {
+            requireNonNull( this.key, "key is required" );
+            requireNonNull( this.segment, "segment is required" );
+            requireNonNull( this.keysTranslator, "keysTranslator is required" );
+            requireNonNull( this.processor, "processor is required" );
+
+            return new ResourcesProcessor<>( this );
+        }
+    }
+}

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationFactoryService.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationFactoryService.java
@@ -13,5 +13,7 @@ public interface ApplicationFactoryService
 
     Optional<ApplicationAdaptor> findActiveApplication( ApplicationKey applicationKey );
 
+    Optional<Bundle> findActiveBundle( ApplicationKey applicationKey );
+
     Optional<ApplicationUrlResolver> findResolver( ApplicationKey applicationKey, String resolverSource );
 }

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationFactoryServiceImpl.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/ApplicationFactoryServiceImpl.java
@@ -82,6 +82,17 @@ public class ApplicationFactoryServiceImpl
     }
 
     @Override
+    public Optional<Bundle> findActiveBundle( final ApplicationKey applicationKey )
+    {
+        return bundleTracker.getTracked()
+            .keySet()
+            .stream()
+            .filter( bundle -> applicationKey.equals( ApplicationHelper.getApplicationKey( bundle ) ) )
+            .filter( bundle -> bundle.getState() == Bundle.ACTIVE )
+            .findAny();
+    }
+
+    @Override
     public Optional<ApplicationUrlResolver> findResolver( final ApplicationKey applicationKey, final String source )
     {
         final Optional<Map.Entry<Bundle, ApplicationAdaptor>> adaptorEntry = bundleTracker.getTracked()

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/BundleStamp.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/BundleStamp.java
@@ -1,0 +1,16 @@
+package com.enonic.xp.core.impl.app.resource;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * Identity of an application bundle incarnation. A reinstalled or updated application gets a new stamp,
+ * while stop/start of the same bundle keeps it - so cached values keyed by the stamp survive an
+ * application restart but never outlive the bundle they were computed from.
+ */
+record BundleStamp(long bundleId, long lastModified)
+{
+    static BundleStamp from( final Bundle bundle )
+    {
+        return new BundleStamp( bundle.getBundleId(), bundle.getLastModified() );
+    }
+}

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/MultiProcessingEntry.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/MultiProcessingEntry.java
@@ -10,10 +10,13 @@ final class MultiProcessingEntry
 
     final List<BundleStamp> stamps;
 
-    MultiProcessingEntry( final Object value, final long[] timestamps, final List<BundleStamp> stamps )
+    final boolean stable;
+
+    MultiProcessingEntry( final Object value, final long[] timestamps, final List<BundleStamp> stamps, final boolean stable )
     {
         this.value = value;
         this.timestamps = timestamps;
         this.stamps = stamps;
+        this.stable = stable;
     }
 }

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/MultiProcessingEntry.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/MultiProcessingEntry.java
@@ -1,0 +1,19 @@
+package com.enonic.xp.core.impl.app.resource;
+
+import java.util.List;
+
+final class MultiProcessingEntry
+{
+    final Object value;
+
+    final long[] timestamps;
+
+    final List<BundleStamp> stamps;
+
+    MultiProcessingEntry( final Object value, final long[] timestamps, final List<BundleStamp> stamps )
+    {
+        this.value = value;
+        this.timestamps = timestamps;
+        this.stamps = stamps;
+    }
+}

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/ProcessingEntry.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/ProcessingEntry.java
@@ -8,10 +8,13 @@ final class ProcessingEntry
 
     final BundleStamp stamp;
 
-    ProcessingEntry( final Object value, final long timestamp, final BundleStamp stamp )
+    final boolean stable;
+
+    ProcessingEntry( final Object value, final long timestamp, final BundleStamp stamp, final boolean stable )
     {
         this.value = value;
         this.timestamp = timestamp;
         this.stamp = stamp;
+        this.stable = stable;
     }
 }

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/ProcessingEntry.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/ProcessingEntry.java
@@ -1,19 +1,17 @@
 package com.enonic.xp.core.impl.app.resource;
 
-import com.enonic.xp.resource.ResourceKey;
-
 final class ProcessingEntry
 {
-    final ResourceKey key;
-
     final Object value;
 
     final long timestamp;
 
-    ProcessingEntry( final ResourceKey key, final Object value, final long timestamp )
+    final BundleStamp stamp;
+
+    ProcessingEntry( final Object value, final long timestamp, final BundleStamp stamp )
     {
-        this.key = key;
         this.value = value;
         this.timestamp = timestamp;
+        this.stamp = stamp;
     }
 }

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImpl.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImpl.java
@@ -22,12 +22,12 @@ import com.enonic.xp.core.impl.app.ApplicationAdaptor;
 import com.enonic.xp.core.impl.app.ApplicationFactoryService;
 import com.enonic.xp.core.impl.app.resolver.ApplicationUrlResolver;
 import com.enonic.xp.core.impl.app.resolver.BundleApplicationUrlResolver;
+import com.enonic.xp.resource.MultiResourceProcessor;
 import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceKeys;
 import com.enonic.xp.resource.ResourceProcessor;
 import com.enonic.xp.resource.ResourceService;
-import com.enonic.xp.resource.ResourcesProcessor;
 import com.enonic.xp.resource.UrlResource;
 import com.enonic.xp.vfs.VirtualFile;
 
@@ -132,7 +132,7 @@ public final class ResourceServiceImpl
     }
 
     @Override
-    public <K, V> V processResources( final ResourcesProcessor<K, V> processor )
+    public <K, V> V processResources( final MultiResourceProcessor<K, V> processor )
     {
         final List<ResourceKey> resourceKeys = processor.toResourceKeys();
         final MultiProcessingEntry entry =

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImpl.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImpl.java
@@ -2,14 +2,15 @@ package com.enonic.xp.core.impl.app.resource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -20,6 +21,7 @@ import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.core.impl.app.ApplicationAdaptor;
 import com.enonic.xp.core.impl.app.ApplicationFactoryService;
 import com.enonic.xp.core.impl.app.resolver.ApplicationUrlResolver;
+import com.enonic.xp.core.impl.app.resolver.BundleApplicationUrlResolver;
 import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceKeys;
@@ -52,8 +54,17 @@ public final class ResourceServiceImpl
     @Override
     public Resource getResource( final ResourceKey key )
     {
-        return findApplicationUrlResolver( key.getApplicationKey() ).map( urlResolver -> urlResolver.findResource( key.getPath() ) )
-            .orElse( new UrlResource( key, null ) );
+        return findResource( findApplicationUrlResolver( key.getApplicationKey() ), key );
+    }
+
+    private static Resource findResource( final Optional<ApplicationUrlResolver> urlResolver, final ResourceKey key )
+    {
+        return urlResolver.map( resolver -> resolver.findResource( key.getPath() ) ).orElse( new UrlResource( key, null ) );
+    }
+
+    private static boolean isStable( final Optional<ApplicationUrlResolver> urlResolver )
+    {
+        return urlResolver.filter( resolver -> resolver instanceof BundleApplicationUrlResolver ).isPresent();
     }
 
     @Override
@@ -92,21 +103,29 @@ public final class ResourceServiceImpl
         final ProcessingEntry entry = this.cache.compute( new ProcessingKey( processor.getSegment(), processor.getKey() ), ( k, v ) -> {
             // stamp is read before the resource: a redeploy racing in-between costs a recompute, never staleness
             final BundleStamp stamp = bundleStamp( resourceKey.getApplicationKey() );
-            final Resource resource = this.getResource( resourceKey );
-            if ( v == null || !Objects.equals( v.stamp, stamp ) || !resource.exists() || resource.getTimestamp() != v.timestamp )
-            {
-                final V value = processor.process( resource );
-                if ( value == null )
-                {
-                    return null;
-                }
+            final Optional<ApplicationUrlResolver> urlResolver = findApplicationUrlResolver( resourceKey.getApplicationKey() );
+            final boolean stable = isStable( urlResolver );
 
-                return new ProcessingEntry( value, resource.getTimestamp(), stamp );
+            final boolean sameStamp = v != null && Objects.equals( v.stamp, stamp );
+            if ( sameStamp && stable && v.stable )
+            {
+                // resources come straight from the immutable bundle: a new bundle is the only signal that
+                // files may be new - their timestamps prove nothing (constant with reproducible builds)
+                return v;
             }
-            else
+
+            final Resource resource = findResource( urlResolver, resourceKey );
+            if ( sameStamp && resource.exists() && resource.getTimestamp() == v.timestamp )
             {
                 return v;
             }
+
+            final V value = processor.process( resource );
+            if ( value == null )
+            {
+                return null;
+            }
+            return new ProcessingEntry( value, resource.getTimestamp(), stamp, stable );
         } );
 
         return entry != null ? (V) entry.value : null;
@@ -119,33 +138,49 @@ public final class ResourceServiceImpl
         final MultiProcessingEntry entry =
             this.multiCache.compute( new ProcessingKey( processor.getSegment(), processor.getKey() ), ( k, v ) -> {
                 // stamps are read before the resources: a redeploy racing in-between costs a recompute, never staleness
-                final List<BundleStamp> stamps =
-                    resourceKeys.stream().map( ResourceKey::getApplicationKey ).distinct().map( this::bundleStamp ).collect(
-                        Collectors.toList() );
+                final List<ApplicationKey> applicationKeys =
+                    resourceKeys.stream().map( ResourceKey::getApplicationKey ).distinct().toList();
+
+                final List<BundleStamp> stamps = new ArrayList<>( applicationKeys.size() );
+                final Map<ApplicationKey, Optional<ApplicationUrlResolver>> urlResolvers = new HashMap<>();
+                boolean stable = true;
+                for ( final ApplicationKey applicationKey : applicationKeys )
+                {
+                    stamps.add( bundleStamp( applicationKey ) );
+                    final Optional<ApplicationUrlResolver> urlResolver = findApplicationUrlResolver( applicationKey );
+                    urlResolvers.put( applicationKey, urlResolver );
+                    stable = stable && isStable( urlResolver );
+                }
+
+                final boolean sameStamps = v != null && v.stamps.equals( stamps );
+                if ( sameStamps && stable && v.stable )
+                {
+                    // resources come straight from the immutable bundles: a new bundle is the only signal that
+                    // files may be new - their timestamps prove nothing (constant with reproducible builds)
+                    return v;
+                }
 
                 final List<Resource> resources = new ArrayList<>( resourceKeys.size() );
                 final long[] timestamps = new long[resourceKeys.size()];
                 for ( int i = 0; i < resourceKeys.size(); i++ )
                 {
-                    final Resource resource = this.getResource( resourceKeys.get( i ) );
+                    final ResourceKey resourceKey = resourceKeys.get( i );
+                    final Resource resource = findResource( urlResolvers.get( resourceKey.getApplicationKey() ), resourceKey );
                     resources.add( resource );
                     timestamps[i] = resource.getTimestamp();
                 }
 
-                if ( v == null || !v.stamps.equals( stamps ) || !Arrays.equals( v.timestamps, timestamps ) )
-                {
-                    final V value = processor.process( resources );
-                    if ( value == null )
-                    {
-                        return null;
-                    }
-
-                    return new MultiProcessingEntry( value, timestamps, stamps );
-                }
-                else
+                if ( sameStamps && Arrays.equals( v.timestamps, timestamps ) )
                 {
                     return v;
                 }
+
+                final V value = processor.process( resources );
+                if ( value == null )
+                {
+                    return null;
+                }
+                return new MultiProcessingEntry( value, timestamps, stamps, stable );
             } );
 
         return entry != null ? (V) entry.value : null;

--- a/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImpl.java
+++ b/modules/core/core-app/src/main/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImpl.java
@@ -1,19 +1,20 @@
 package com.enonic.xp.core.impl.app.resource;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.enonic.xp.app.ApplicationInvalidationLevel;
-import com.enonic.xp.app.ApplicationInvalidator;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.core.impl.app.ApplicationAdaptor;
@@ -24,18 +25,19 @@ import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceKeys;
 import com.enonic.xp.resource.ResourceProcessor;
 import com.enonic.xp.resource.ResourceService;
+import com.enonic.xp.resource.ResourcesProcessor;
 import com.enonic.xp.resource.UrlResource;
 import com.enonic.xp.vfs.VirtualFile;
 
 @Component(immediate = true)
 public final class ResourceServiceImpl
-    implements ResourceService, ApplicationInvalidator
+    implements ResourceService
 {
-    private static final Logger LOG = LoggerFactory.getLogger( ResourceServiceImpl.class );
-
     private static final ApplicationKey SYSTEM_APPLICATION_KEY = ApplicationKey.from( "com.enonic.xp.app.system" );
 
     private final ConcurrentMap<ProcessingKey, ProcessingEntry> cache;
+
+    private final ConcurrentMap<ProcessingKey, MultiProcessingEntry> multiCache;
 
     private final ApplicationFactoryService applicationFactoryService;
 
@@ -43,6 +45,7 @@ public final class ResourceServiceImpl
     public ResourceServiceImpl( @Reference final ApplicationFactoryService applicationFactoryService )
     {
         this.cache = new ConcurrentHashMap<>();
+        this.multiCache = new ConcurrentHashMap<>();
         this.applicationFactoryService = applicationFactoryService;
     }
 
@@ -69,20 +72,28 @@ public final class ResourceServiceImpl
     private Optional<ApplicationUrlResolver> findApplicationUrlResolver( final ApplicationKey key )
     {
         final String resolverSource = (String) ContextAccessor.current().getAttribute( ResourceConstants.RESOURCE_SOURCE_ATTRIBUTE );
-        return applicationFactoryService.findResolver( isSystemApp( key ) ? SYSTEM_APPLICATION_KEY : key, resolverSource );
+        return applicationFactoryService.findResolver( effectiveKey( key ), resolverSource );
     }
 
-    private boolean isSystemApp( final ApplicationKey key )
+    private static ApplicationKey effectiveKey( final ApplicationKey key )
     {
-        return ApplicationKey.SYSTEM_RESERVED_APPLICATION_KEYS.contains( key );
+        return ApplicationKey.SYSTEM_RESERVED_APPLICATION_KEYS.contains( key ) ? SYSTEM_APPLICATION_KEY : key;
+    }
+
+    private BundleStamp bundleStamp( final ApplicationKey key )
+    {
+        return applicationFactoryService.findActiveBundle( effectiveKey( key ) ).map( BundleStamp::from ).orElse( null );
     }
 
     @Override
     public <K, V> V processResource( final ResourceProcessor<K, V> processor )
     {
+        final ResourceKey resourceKey = processor.toResourceKey();
         final ProcessingEntry entry = this.cache.compute( new ProcessingKey( processor.getSegment(), processor.getKey() ), ( k, v ) -> {
-            final Resource resource = this.getResource( processor.toResourceKey() );
-            if ( v == null || !resource.exists() || resource.getTimestamp() > v.timestamp )
+            // stamp is read before the resource: a redeploy racing in-between costs a recompute, never staleness
+            final BundleStamp stamp = bundleStamp( resourceKey.getApplicationKey() );
+            final Resource resource = this.getResource( resourceKey );
+            if ( v == null || !Objects.equals( v.stamp, stamp ) || !resource.exists() || resource.getTimestamp() != v.timestamp )
             {
                 final V value = processor.process( resource );
                 if ( value == null )
@@ -90,7 +101,7 @@ public final class ResourceServiceImpl
                     return null;
                 }
 
-                return new ProcessingEntry( processor.toResourceKey(), value, resource.getTimestamp() );
+                return new ProcessingEntry( value, resource.getTimestamp(), stamp );
             }
             else
             {
@@ -102,18 +113,50 @@ public final class ResourceServiceImpl
     }
 
     @Override
+    public <K, V> V processResources( final ResourcesProcessor<K, V> processor )
+    {
+        final List<ResourceKey> resourceKeys = processor.toResourceKeys();
+        final MultiProcessingEntry entry =
+            this.multiCache.compute( new ProcessingKey( processor.getSegment(), processor.getKey() ), ( k, v ) -> {
+                // stamps are read before the resources: a redeploy racing in-between costs a recompute, never staleness
+                final List<BundleStamp> stamps =
+                    resourceKeys.stream().map( ResourceKey::getApplicationKey ).distinct().map( this::bundleStamp ).collect(
+                        Collectors.toList() );
+
+                final List<Resource> resources = new ArrayList<>( resourceKeys.size() );
+                final long[] timestamps = new long[resourceKeys.size()];
+                for ( int i = 0; i < resourceKeys.size(); i++ )
+                {
+                    final Resource resource = this.getResource( resourceKeys.get( i ) );
+                    resources.add( resource );
+                    timestamps[i] = resource.getTimestamp();
+                }
+
+                if ( v == null || !v.stamps.equals( stamps ) || !Arrays.equals( v.timestamps, timestamps ) )
+                {
+                    final V value = processor.process( resources );
+                    if ( value == null )
+                    {
+                        return null;
+                    }
+
+                    return new MultiProcessingEntry( value, timestamps, stamps );
+                }
+                else
+                {
+                    return v;
+                }
+            } );
+
+        return entry != null ? (V) entry.value : null;
+    }
+
+    @Override
     public VirtualFile getVirtualFile( final ResourceKey resourceKey )
     {
         return this.applicationFactoryService.findActiveApplication( resourceKey.getApplicationKey() )
             .map( ApplicationAdaptor::getBundle )
             .map( b -> (VirtualFile) new BundleResource( b, resourceKey.getPath() ) )
             .orElseGet( () -> new NullResource( resourceKey.getPath() ) );
-    }
-
-    @Override
-    public void invalidate( final ApplicationKey key, final ApplicationInvalidationLevel level )
-    {
-        LOG.debug( "Cleanup Resource cache for {}", key );
-        this.cache.entrySet().removeIf( entry -> entry.getValue().key.getApplicationKey().equals( key ) );
     }
 }

--- a/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/ApplicationFactoryServiceMock.java
+++ b/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/ApplicationFactoryServiceMock.java
@@ -43,6 +43,12 @@ public class ApplicationFactoryServiceMock
     }
 
     @Override
+    public Optional<Bundle> findActiveBundle( final ApplicationKey applicationKey )
+    {
+        return map.keySet().stream().filter( bundle -> ApplicationHelper.getApplicationKey( bundle ).equals( applicationKey ) ).findAny();
+    }
+
+    @Override
     public Optional<ApplicationUrlResolver> findResolver( final ApplicationKey applicationKey, final String resolverName )
     {
         return map.entrySet()

--- a/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImplTest.java
+++ b/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImplTest.java
@@ -304,6 +304,22 @@ class ResourceServiceImplTest
     }
 
     @Test
+    void testProcessResources_nullValueNotCached()
+        throws Exception
+    {
+        newFile( "a.txt" );
+
+        final ResourcesProcessor<String, String> processor = new ResourcesProcessor.Builder<String, String>().key( "bundle" )
+            .segment( "segment1" )
+            .keysTranslator( k -> List.of( ResourceKey.from( "myapp:/a.txt" ) ) )
+            .processor( resources -> null )
+            .build();
+
+        assertNull( this.resourceService.processResources( processor ) );
+        assertNull( this.resourceService.processResources( processor ) );
+    }
+
+    @Test
     void testProcessResources_allMissingCachedUntilResourceAppears()
         throws Exception
     {

--- a/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImplTest.java
+++ b/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImplTest.java
@@ -24,6 +24,7 @@ import com.enonic.xp.core.impl.app.ApplicationFactoryService;
 import com.enonic.xp.core.impl.app.MockApplication;
 import com.enonic.xp.core.impl.app.VirtualAppConstants;
 import com.enonic.xp.core.impl.app.resolver.ApplicationUrlResolver;
+import com.enonic.xp.core.impl.app.resolver.BundleApplicationUrlResolver;
 import com.enonic.xp.core.impl.app.resolver.NodeResourceApplicationUrlResolver;
 import com.enonic.xp.core.internal.Dictionaries;
 import com.enonic.xp.data.PropertyTree;
@@ -156,6 +157,59 @@ class ResourceServiceImplTest
 
         final String value5 = processResource( "segment2", "a.txt", "5" );
         assertEquals( "myapp:/a.txt->5", value5 );
+    }
+
+    @Test
+    void testProcessResource_bundleResolverIgnoresTimestamps()
+        throws Exception
+    {
+        newFile( "a.txt" );
+        when( bundle.getResource( "/a.txt" ) ).thenReturn( appDir.resolve( "a.txt" ).toUri().toURL() );
+        doReturn( Optional.of( new BundleApplicationUrlResolver( bundle ) ) ).when( applicationFactoryService )
+            .findResolver( appKey, null );
+
+        final String value1 = processResource( "segment1", "a.txt", "1" );
+        assertEquals( "myapp:/a.txt->1", value1 );
+
+        // timestamps of bundle-backed resources are unreliable (constant with reproducible builds):
+        // under the same bundle they are not even probed
+        Files.setLastModifiedTime( appDir.resolve( "a.txt" ), FileTime.fromMillis( System.currentTimeMillis() + 10_000 ) );
+
+        final String value2 = processResource( "segment1", "a.txt", "2" );
+        assertEquals( value1, value2 );
+
+        // a new bundle is the only signal that files may be new
+        final Bundle newBundle = newBundle( 42 );
+        when( applicationFactoryService.findActiveBundle( appKey ) ).thenReturn( Optional.of( newBundle ) );
+
+        final String value3 = processResource( "segment1", "a.txt", "3" );
+        assertEquals( "myapp:/a.txt->3", value3 );
+    }
+
+    @Test
+    void testProcessResources_bundleResolverIgnoresTimestamps()
+        throws Exception
+    {
+        newFile( "a.txt" );
+        when( bundle.getResource( "/a.txt" ) ).thenReturn( appDir.resolve( "a.txt" ).toUri().toURL() );
+        doReturn( Optional.of( new BundleApplicationUrlResolver( bundle ) ) ).when( applicationFactoryService )
+            .findResolver( appKey, null );
+
+        final List<String> names = List.of( "a.txt", "b.txt" );
+
+        final String value1 = processResources( "segment1", "bundle", names, "1" );
+        assertEquals( "myapp:/a.txt->1", value1 );
+
+        Files.setLastModifiedTime( appDir.resolve( "a.txt" ), FileTime.fromMillis( System.currentTimeMillis() + 10_000 ) );
+
+        final String value2 = processResources( "segment1", "bundle", names, "2" );
+        assertEquals( value1, value2 );
+
+        final Bundle newBundle = newBundle( 42 );
+        when( applicationFactoryService.findActiveBundle( appKey ) ).thenReturn( Optional.of( newBundle ) );
+
+        final String value3 = processResources( "segment1", "bundle", names, "3" );
+        assertEquals( "myapp:/a.txt->3", value3 );
     }
 
     @Test

--- a/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImplTest.java
+++ b/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImplTest.java
@@ -3,16 +3,18 @@ package com.enonic.xp.core.impl.app.resource;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.osgi.framework.Bundle;
 
-import com.enonic.xp.app.ApplicationInvalidationLevel;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.branch.Branches;
@@ -37,6 +39,7 @@ import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceKeys;
 import com.enonic.xp.resource.ResourceProcessor;
+import com.enonic.xp.resource.ResourcesProcessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -80,8 +83,16 @@ class ResourceServiceImplTest
 
         when( applicationFactoryService.findActiveApplication( appKey ) ).thenReturn( Optional.of( app ) );
         when( applicationFactoryService.findResolver( appKey, null ) ).thenReturn( Optional.of( app.getUrlResolver() ) );
+        when( applicationFactoryService.findActiveBundle( appKey ) ).thenReturn( Optional.of( bundle ) );
 
         resourceService = new ResourceServiceImpl( applicationFactoryService );
+    }
+
+    private Bundle newBundle( final long bundleId )
+    {
+        final Bundle newBundle = mock( Bundle.class );
+        when( newBundle.getBundleId() ).thenReturn( bundleId );
+        return newBundle;
     }
 
     private void newFile( final String name )
@@ -133,7 +144,9 @@ class ResourceServiceImplTest
         final String value2 = processResource( "segment1", "a.txt", "2" );
         assertEquals( value1, value2 );
 
-        this.resourceService.invalidate( ApplicationKey.from( "myapp" ), ApplicationInvalidationLevel.FULL );
+        // a new bundle incarnation of the application invalidates cached entries
+        final Bundle newBundle = newBundle( 42 );
+        when( applicationFactoryService.findActiveBundle( appKey ) ).thenReturn( Optional.of( newBundle ) );
 
         final String value3 = processResource( "segment1", "a.txt", "3" );
         assertEquals( "myapp:/a.txt->3", value3 );
@@ -237,6 +250,75 @@ class ResourceServiceImplTest
     {
         final String value = processResource( "segment1", "a.txt", "1" );
         assertNull( value );
+    }
+
+    private String processResources( final String segment, final String key, final List<String> names, final String suffix )
+    {
+        final ResourcesProcessor<String, String> processor = new ResourcesProcessor.Builder<String, String>().key( key )
+            .segment( segment )
+            .keysTranslator( k -> names.stream().map( name -> ResourceKey.from( "myapp:/" + name ) ).toList() )
+            .processor( resources -> resources.stream()
+                .filter( Resource::exists )
+                .map( res -> res.getKey().toString() )
+                .collect( Collectors.joining( ",", "", "->" + suffix ) ) )
+            .build();
+
+        return this.resourceService.processResources( processor );
+    }
+
+    @Test
+    void testProcessResources()
+        throws Exception
+    {
+        newFile( "a.txt" );
+
+        final List<String> names = List.of( "a.txt", "b.txt" );
+
+        final String value1 = processResources( "segment1", "bundle", names, "1" );
+        assertEquals( "myapp:/a.txt->1", value1 );
+
+        final String value2 = processResources( "segment1", "bundle", names, "2" );
+        assertEquals( value1, value2 );
+
+        // a resource appearing invalidates the cached value
+        newFile( "b.txt" );
+
+        final String value3 = processResources( "segment1", "bundle", names, "3" );
+        assertEquals( "myapp:/a.txt,myapp:/b.txt->3", value3 );
+
+        final String value4 = processResources( "segment1", "bundle", names, "4" );
+        assertEquals( value3, value4 );
+
+        // a resource modification invalidates the cached value
+        Files.setLastModifiedTime( appDir.resolve( "b.txt" ), FileTime.fromMillis( System.currentTimeMillis() + 10_000 ) );
+
+        final String value5 = processResources( "segment1", "bundle", names, "5" );
+        assertEquals( "myapp:/a.txt,myapp:/b.txt->5", value5 );
+
+        // a new bundle incarnation of the application invalidates the cached value
+        final Bundle newBundle = newBundle( 42 );
+        when( applicationFactoryService.findActiveBundle( appKey ) ).thenReturn( Optional.of( newBundle ) );
+
+        final String value6 = processResources( "segment1", "bundle", names, "6" );
+        assertEquals( "myapp:/a.txt,myapp:/b.txt->6", value6 );
+    }
+
+    @Test
+    void testProcessResources_allMissingCachedUntilResourceAppears()
+        throws Exception
+    {
+        final List<String> names = List.of( "a.txt" );
+
+        final String value1 = processResources( "segment1", "bundle", names, "1" );
+        assertEquals( "->1", value1 );
+
+        final String value2 = processResources( "segment1", "bundle", names, "2" );
+        assertEquals( value1, value2 );
+
+        newFile( "a.txt" );
+
+        final String value3 = processResources( "segment1", "bundle", names, "3" );
+        assertEquals( "myapp:/a.txt->3", value3 );
     }
 
     private Node createNode( final String name, final NodePath root, final Instant timestamp, final PropertyTree data )

--- a/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImplTest.java
+++ b/modules/core/core-app/src/test/java/com/enonic/xp/core/impl/app/resource/ResourceServiceImplTest.java
@@ -36,11 +36,11 @@ import com.enonic.xp.project.ProjectName;
 import com.enonic.xp.repository.Repository;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.repository.RepositoryService;
+import com.enonic.xp.resource.MultiResourceProcessor;
 import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceKeys;
 import com.enonic.xp.resource.ResourceProcessor;
-import com.enonic.xp.resource.ResourcesProcessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -308,7 +308,7 @@ class ResourceServiceImplTest
 
     private String processResources( final String segment, final String key, final List<String> names, final String suffix )
     {
-        final ResourcesProcessor<String, String> processor = new ResourcesProcessor.Builder<String, String>().key( key )
+        final MultiResourceProcessor<String, String> processor = new MultiResourceProcessor.Builder<String, String>().key( key )
             .segment( segment )
             .keysTranslator( k -> names.stream().map( name -> ResourceKey.from( "myapp:/" + name ) ).toList() )
             .processor( resources -> resources.stream()
@@ -363,7 +363,7 @@ class ResourceServiceImplTest
     {
         newFile( "a.txt" );
 
-        final ResourcesProcessor<String, String> processor = new ResourcesProcessor.Builder<String, String>().key( "bundle" )
+        final MultiResourceProcessor<String, String> processor = new MultiResourceProcessor.Builder<String, String>().key( "bundle" )
             .segment( "segment1" )
             .keysTranslator( k -> List.of( ResourceKey.from( "myapp:/a.txt" ) ) )
             .processor( resources -> null )

--- a/modules/core/core-app/src/testFixtures/java/com/enonic/xp/core/impl/app/ApplicationTestSupport.java
+++ b/modules/core/core-app/src/testFixtures/java/com/enonic/xp/core/impl/app/ApplicationTestSupport.java
@@ -42,6 +42,9 @@ public abstract class ApplicationTestSupport
         ApplicationFactoryService applicationFactoryService = mock( ApplicationFactoryService.class );
         when( applicationFactoryService.findActiveApplication( any() ) ).then(
             invocationOnMock -> Optional.ofNullable( apps.get( invocationOnMock.getArgument( 0 ) ) ) );
+        when( applicationFactoryService.findActiveBundle( any() ) ).then(
+            invocationOnMock -> Optional.ofNullable( apps.get( invocationOnMock.getArgument( 0 ) ) )
+                .map( MockApplication::getBundle ) );
         when( applicationFactoryService.findResolver( any(), any() ) ).then( invocationOnMock -> {
             final Object argument = invocationOnMock.getArgument( 0 );
             return Optional.ofNullable( apps.get( argument ) ).map( MockApplication::getUrlResolver );

--- a/modules/core/core-i18n/src/main/java/com/enonic/xp/core/impl/i18n/LocaleServiceImpl.java
+++ b/modules/core/core-i18n/src/main/java/com/enonic/xp/core/impl/i18n/LocaleServiceImpl.java
@@ -2,6 +2,7 @@ package com.enonic.xp.core.impl.i18n;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -10,8 +11,6 @@ import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
 
 import org.jspecify.annotations.NullMarked;
@@ -24,22 +23,21 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.io.Files;
 
-import com.enonic.xp.app.Application;
 import com.enonic.xp.app.ApplicationKey;
-import com.enonic.xp.app.ApplicationListener;
 import com.enonic.xp.i18n.LocaleService;
 import com.enonic.xp.i18n.MessageBundle;
 import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceKeys;
 import com.enonic.xp.resource.ResourceService;
+import com.enonic.xp.resource.ResourcesProcessor;
 
 import static java.util.Objects.requireNonNullElse;
 
 @Component(immediate = true)
 @NullMarked
 public final class LocaleServiceImpl
-    implements LocaleService, ApplicationListener
+    implements LocaleService
 {
     private static final Logger LOG = LoggerFactory.getLogger( LocaleServiceImpl.class );
 
@@ -55,10 +53,6 @@ public final class LocaleServiceImpl
 
     private final ResourceService resourceService;
 
-    private final ConcurrentMap<String, MessageBundle> bundleCache = new ConcurrentHashMap<>();
-
-    private final ConcurrentMap<String, Set<Locale>> appLocalesCache = new ConcurrentHashMap<>();
-
     @Activate
     public LocaleServiceImpl( @Reference final ResourceService resourceService )
     {
@@ -71,17 +65,22 @@ public final class LocaleServiceImpl
         final String[] baseNames = bundleNames.length == 0 ? DEFAULT_BASE_NAMES : bundleNames;
         final Locale nonNullLocale = requireNonNullElse( locale, Locale.ROOT );
 
-        final String key = bundleCacheKey( applicationKey, nonNullLocale, baseNames );
-        return this.bundleCache.computeIfAbsent( key, k -> createMessageBundle( applicationKey, nonNullLocale, baseNames ) );
+        final ResourcesProcessor<String, MessageBundle> processor =
+            new ResourcesProcessor.Builder<String, MessageBundle>().key( bundleCacheKey( applicationKey, nonNullLocale, baseNames ) )
+                .segment( "i18n" )
+                .keysTranslator( k -> candidateKeys( applicationKey, nonNullLocale, baseNames ) )
+                .processor( resources -> createMessageBundle( resources, nonNullLocale ) )
+                .build();
+
+        final MessageBundle bundle = resourceService.processResources( processor );
+        return bundle != null ? bundle : new MessageBundleImpl( new Properties(), nonNullLocale );
     }
 
     @Override
     public Set<Locale> getLocales( final ApplicationKey applicationKey, final String... bundleNames )
     {
         final String[] baseNames = bundleNames.length == 0 ? DEFAULT_BASE_NAMES : bundleNames;
-
-        final String key = appBundlesCacheKey( applicationKey, baseNames );
-        return this.appLocalesCache.computeIfAbsent( key, k -> getAppLocales( applicationKey, baseNames ) );
+        return getAppLocales( applicationKey, baseNames );
     }
 
     @Override
@@ -162,84 +161,49 @@ public final class LocaleServiceImpl
         return key.toString();
     }
 
-    private String appBundlesCacheKey( final ApplicationKey applicationKey, final String... baseNames )
+    private List<ResourceKey> candidateKeys( final ApplicationKey applicationKey, final Locale locale, final String... bundleNames )
     {
-        StringJoiner key = new StringJoiner( KEY_SEPARATOR ).add( applicationKey.toString() );
-        for ( String bundleName : baseNames )
-        {
-            key.add( bundleName );
-        }
-        return key.toString();
-    }
+        final ResourceBundle.Control control = ResourceBundle.Control.getControl( ResourceBundle.Control.FORMAT_PROPERTIES );
 
-    private MessageBundle createMessageBundle( final ApplicationKey applicationKey, final Locale locale, final String... bundleNames )
-    {
-        LOG.debug( "Create message bundle for {} {}", applicationKey, locale );
-        final Properties props = new Properties();
+        final List<ResourceKey> keys = new ArrayList<>();
         for ( final String baseName : bundleNames )
         {
-            props.putAll( loadBundles( applicationKey, locale, baseName ) );
-        }
+            final List<Locale> candidateLocales = control.getCandidateLocales( baseName, locale );
+            Collections.reverse( candidateLocales );
 
+            for ( final Locale candidateLocale : candidateLocales )
+            {
+                keys.add( ResourceKey.from( applicationKey, control.toBundleName( baseName, candidateLocale ) + ".properties" ) );
+            }
+        }
+        return keys;
+    }
+
+    private MessageBundle createMessageBundle( final List<Resource> resources, final Locale locale )
+    {
+        LOG.debug( "Create message bundle for {}", locale );
+        final Properties props = new Properties();
+        for ( final Resource resource : resources )
+        {
+            if ( resource.exists() )
+            {
+                props.putAll( loadProperties( resource ) );
+            }
+        }
         return new MessageBundleImpl( props, locale );
     }
 
-    private Properties loadBundles( final ApplicationKey applicationKey, final Locale locale, final String baseName )
+    private Properties loadProperties( final Resource resource )
     {
-        final Properties props = new Properties();
-
-        final ResourceBundle.Control control = ResourceBundle.Control.getControl( ResourceBundle.Control.FORMAT_PROPERTIES );
-        final List<Locale> candidateLocales = control.getCandidateLocales( baseName, locale );
-        Collections.reverse( candidateLocales );
-
-        for ( Locale candidateLocale : candidateLocales )
-        {
-            props.putAll( loadBundle( applicationKey, control.toBundleName( baseName, candidateLocale ) ) );
-        }
-
-        return props;
-    }
-
-    private Properties loadBundle( final ApplicationKey applicationKey, final String bundleName )
-    {
-        final ResourceKey resourceKey = ResourceKey.from( applicationKey, bundleName + ".properties" );
-        final Resource resource = resourceService.getResource( resourceKey );
-
         final Properties properties = new Properties();
-        if ( resource.exists() )
+        try (Reader in = resource.openReader())
         {
-            try (Reader in = resource.openReader())
-            {
-                properties.load( in );
-            }
-            catch ( final IOException e )
-            {
-                throw new LocalizationException( "Not able to load resource for: " + applicationKey, e );
-            }
+            properties.load( in );
         }
-
+        catch ( final IOException e )
+        {
+            throw new LocalizationException( "Not able to load resource for: " + resource.getKey(), e );
+        }
         return properties;
-    }
-
-    @Override
-    public void activated( final Application app )
-    {
-        // Locale and message bundle cache can get populated even when application was uninstalled.
-        // We clear it as soon as application is started, so it can be repopulated.
-        clearCache( app.getKey() );
-    }
-
-    @Override
-    public void deactivated( final Application app )
-    {
-        clearCache( app.getKey() );
-    }
-
-    private void clearCache( ApplicationKey appKey )
-    {
-        LOG.debug( "Cleanup i18n caches for {}", appKey );
-        final String cacheKeyPrefix = appKey + KEY_SEPARATOR;
-        bundleCache.keySet().removeIf( ( k ) -> k.startsWith( cacheKeyPrefix ) );
-        appLocalesCache.keySet().removeIf( ( k ) -> k.startsWith( cacheKeyPrefix ) );
     }
 }

--- a/modules/core/core-i18n/src/main/java/com/enonic/xp/core/impl/i18n/LocaleServiceImpl.java
+++ b/modules/core/core-i18n/src/main/java/com/enonic/xp/core/impl/i18n/LocaleServiceImpl.java
@@ -26,11 +26,11 @@ import com.google.common.io.Files;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.i18n.LocaleService;
 import com.enonic.xp.i18n.MessageBundle;
+import com.enonic.xp.resource.MultiResourceProcessor;
 import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceKeys;
 import com.enonic.xp.resource.ResourceService;
-import com.enonic.xp.resource.ResourcesProcessor;
 
 import static java.util.Objects.requireNonNullElse;
 
@@ -65,8 +65,8 @@ public final class LocaleServiceImpl
         final String[] baseNames = bundleNames.length == 0 ? DEFAULT_BASE_NAMES : bundleNames;
         final Locale nonNullLocale = requireNonNullElse( locale, Locale.ROOT );
 
-        final ResourcesProcessor<String, MessageBundle> processor =
-            new ResourcesProcessor.Builder<String, MessageBundle>().key( bundleCacheKey( applicationKey, nonNullLocale, baseNames ) )
+        final MultiResourceProcessor<String, MessageBundle> processor =
+            new MultiResourceProcessor.Builder<String, MessageBundle>().key( bundleCacheKey( applicationKey, nonNullLocale, baseNames ) )
                 .segment( "i18n" )
                 .keysTranslator( k -> candidateKeys( applicationKey, nonNullLocale, baseNames ) )
                 .processor( resources -> createMessageBundle( resources, nonNullLocale ) )

--- a/modules/core/core-i18n/src/test/java/com/enonic/xp/core/impl/i18n/LocaleServiceImplTest.java
+++ b/modules/core/core-i18n/src/test/java/com/enonic/xp/core/impl/i18n/LocaleServiceImplTest.java
@@ -13,21 +13,19 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 
-import com.enonic.xp.app.Application;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.i18n.MessageBundle;
 import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceKeys;
 import com.enonic.xp.resource.ResourceService;
+import com.enonic.xp.resource.ResourcesProcessor;
 import com.enonic.xp.resource.UrlResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -44,12 +42,24 @@ class LocaleServiceImplTest
     {
         this.resourceService = Mockito.mock( ResourceService.class );
         when( resourceService.getResource( any() ) ).thenAnswer( this::loadResource );
+        when( resourceService.processResources( any() ) ).thenAnswer( this::processResources );
         this.localeService = new LocaleServiceImpl( resourceService );
+    }
+
+    private Object processResources( final InvocationOnMock invocation )
+    {
+        final ResourcesProcessor<?, ?> processor = invocation.getArgument( 0 );
+        return processor.process( processor.toResourceKeys().stream().map( this::loadResource ).collect( Collectors.toList() ) );
     }
 
     private Resource loadResource( final InvocationOnMock invocation )
     {
         final ResourceKey resourceKey = invocation.getArgument( 0 );
+        return loadResource( resourceKey );
+    }
+
+    private Resource loadResource( final ResourceKey resourceKey )
+    {
         final String path = resourceKey.getName();
         final URL url = getClass().getResource( path.substring( path.lastIndexOf( '/' ) + 1 ) );
         return new UrlResource( resourceKey, url );
@@ -157,35 +167,6 @@ class LocaleServiceImplTest
         assertTrue( locales.contains( new Locale( "en", "US", "1" ) ) );
         assertTrue( locales.contains( new Locale( "fr" ) ) );
         assertTrue( locales.contains( new Locale( "ca" ) ) );
-    }
-
-    @Test
-    void bundleInvalidateCaching()
-    {
-        final ResourceKeys resourceKeys = ResourceKeys.empty();
-        when( resourceService.findFiles( any(), anyString() ) ).thenReturn( resourceKeys );
-
-        final ApplicationKey myApp = ApplicationKey.from( "myapplication" );
-        final ApplicationKey otherApp = ApplicationKey.from( "otherapp" );
-
-        MessageBundle bundleCached = localeService.getBundle( myApp, Locale.ENGLISH, "/phrases", "/override" );
-        MessageBundle bundle = localeService.getBundle( myApp, Locale.ENGLISH, "/phrases", "/override" );
-
-        MessageBundle otherBundleCached = localeService.getBundle( otherApp, Locale.ENGLISH, "/texts" );
-        MessageBundle otherBundle = localeService.getBundle( otherApp, Locale.ENGLISH, "/texts" );
-
-        assertSame( bundle, bundleCached );
-        assertSame( otherBundle, otherBundleCached );
-
-        Application application = Mockito.mock( Application.class );
-        when( application.getKey() ).thenReturn( myApp );
-        localeService.activated( application );
-
-        bundle = localeService.getBundle( myApp, Locale.ENGLISH, "/phrases", "/override" );
-        otherBundle = localeService.getBundle( otherApp, Locale.ENGLISH, "/texts" );
-
-        assertNotSame( bundle, bundleCached );
-        assertSame( otherBundle, otherBundleCached );
     }
 
     @Test

--- a/modules/core/core-i18n/src/test/java/com/enonic/xp/core/impl/i18n/LocaleServiceImplTest.java
+++ b/modules/core/core-i18n/src/test/java/com/enonic/xp/core/impl/i18n/LocaleServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.enonic.xp.core.impl.i18n;
 
+import java.io.IOException;
+import java.io.Reader;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
@@ -26,9 +28,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 class LocaleServiceImplTest
@@ -146,6 +151,46 @@ class LocaleServiceImplTest
         assertNotNull( bundle );
         assertEquals( 9, bundle.getKeys().size() );
         assertEquals( "override", bundle.localize( "msg" ) );
+    }
+
+    @Test
+    void get_bundle_no_processed_value()
+    {
+        doReturn( null ).when( resourceService ).processResources( any() );
+
+        final MessageBundle bundle = localeService.getBundle( ApplicationKey.from( "myapplication" ), Locale.ENGLISH );
+
+        assertNotNull( bundle );
+        assertEquals( 0, bundle.getKeys().size() );
+    }
+
+    @Test
+    void get_bundle_unreadable_resource()
+    {
+        final Resource broken = Mockito.mock( Resource.class );
+        when( broken.exists() ).thenReturn( true );
+        when( broken.getKey() ).thenReturn( ResourceKey.from( "myapplication:/i18n/phrases.properties" ) );
+        when( broken.openReader() ).thenReturn( new Reader()
+        {
+            @Override
+            public int read( final char[] cbuf, final int off, final int len )
+                throws IOException
+            {
+                throw new IOException( "broken" );
+            }
+
+            @Override
+            public void close()
+            {
+            }
+        } );
+
+        doAnswer( invocation -> {
+            final ResourcesProcessor<?, ?> processor = invocation.getArgument( 0 );
+            return processor.process( List.of( broken ) );
+        } ).when( resourceService ).processResources( any() );
+
+        assertThrows( LocalizationException.class, () -> localeService.getBundle( ApplicationKey.from( "myapplication" ), Locale.ENGLISH ) );
     }
 
     @Test

--- a/modules/core/core-i18n/src/test/java/com/enonic/xp/core/impl/i18n/LocaleServiceImplTest.java
+++ b/modules/core/core-i18n/src/test/java/com/enonic/xp/core/impl/i18n/LocaleServiceImplTest.java
@@ -17,11 +17,11 @@ import org.mockito.invocation.InvocationOnMock;
 
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.i18n.MessageBundle;
+import com.enonic.xp.resource.MultiResourceProcessor;
 import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceKeys;
 import com.enonic.xp.resource.ResourceService;
-import com.enonic.xp.resource.ResourcesProcessor;
 import com.enonic.xp.resource.UrlResource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,7 +53,7 @@ class LocaleServiceImplTest
 
     private Object processResources( final InvocationOnMock invocation )
     {
-        final ResourcesProcessor<?, ?> processor = invocation.getArgument( 0 );
+        final MultiResourceProcessor<?, ?> processor = invocation.getArgument( 0 );
         return processor.process( processor.toResourceKeys().stream().map( this::loadResource ).collect( Collectors.toList() ) );
     }
 
@@ -186,7 +186,7 @@ class LocaleServiceImplTest
         } );
 
         doAnswer( invocation -> {
-            final ResourcesProcessor<?, ?> processor = invocation.getArgument( 0 );
+            final MultiResourceProcessor<?, ?> processor = invocation.getArgument( 0 );
             return processor.process( List.of( broken ) );
         } ).when( resourceService ).processResources( any() );
 

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/LocalTaskManagerImpl.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/LocalTaskManagerImpl.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.Collectors;
 
 import org.osgi.service.component.annotations.Activate;
@@ -48,7 +48,7 @@ public final class LocalTaskManagerImpl
 
     private final TaskManagerCleanupScheduler cleanupScheduler;
 
-    private final Executor executor;
+    private final TaskManagerExecutor executor;
 
     static Clock clock = Clock.systemUTC();
 
@@ -57,7 +57,7 @@ public final class LocalTaskManagerImpl
     private volatile ClusterConfig clusterConfig;
 
     @Activate
-    public LocalTaskManagerImpl( @Reference(service = TaskManagerExecutor.class) final Executor executor,
+    public LocalTaskManagerImpl( @Reference final TaskManagerExecutor executor,
                                  @Reference TaskManagerCleanupScheduler cleanupScheduler, @Reference final EventPublisher eventPublisher )
     {
         this.executor = executor;
@@ -190,7 +190,16 @@ public final class LocalTaskManagerImpl
 
         eventPublisher.publish( TaskEvents.submitted( info ) );
 
-        executor.execute( new TaskRunnable( runnableTask, new ProgressReporterAdapter( id ) ) );
+        final ProgressReporterAdapter progressReporter = new ProgressReporterAdapter( id );
+        try
+        {
+            executor.execute( runnableTask.getApplicationKey(), new TaskRunnable( runnableTask, progressReporter ) );
+        }
+        catch ( RejectedExecutionException e )
+        {
+            progressReporter.failed( "Task execution rejected" );
+            throw e;
+        }
     }
 
     private void removeExpiredTasks()

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/LocalTaskManagerImpl.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/LocalTaskManagerImpl.java
@@ -35,6 +35,8 @@ import com.enonic.xp.task.TaskProgress;
 import com.enonic.xp.task.TaskState;
 import com.enonic.xp.trace.Tracer;
 
+import static java.util.Objects.requireNonNullElse;
+
 @Component(immediate = true)
 @Local
 public final class LocalTaskManagerImpl
@@ -197,7 +199,7 @@ public final class LocalTaskManagerImpl
         }
         catch ( RejectedExecutionException e )
         {
-            progressReporter.failed( "Task execution rejected" );
+            progressReporter.failed( requireNonNullElse( e.getMessage(), "Task execution rejected" ) );
             throw e;
         }
     }

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutor.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutor.java
@@ -1,8 +1,16 @@
 package com.enonic.xp.impl.task;
 
-import java.util.concurrent.Executor;
+import com.enonic.xp.app.ApplicationKey;
 
 public interface TaskManagerExecutor
-    extends Executor
 {
+    /**
+     * Executes a task command on the executor dedicated to the given application.
+     * The application's executor is shut down when the application stops, interrupting its running tasks.
+     *
+     * @param applicationKey application the task belongs to
+     * @param command        task command
+     * @throws java.util.concurrent.RejectedExecutionException if the executor is already shut down
+     */
+    void execute( ApplicationKey applicationKey, Runnable command );
 }

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutor.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutor.java
@@ -10,7 +10,8 @@ public interface TaskManagerExecutor
      *
      * @param applicationKey application the task belongs to
      * @param command        task command
-     * @throws java.util.concurrent.RejectedExecutionException if the executor is already shut down
+     * @throws java.util.concurrent.RejectedExecutionException if the application is stopped, or the executor
+     *                                                         is already shut down
      */
     void execute( ApplicationKey applicationKey, Runnable command );
 }

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutorImpl.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutorImpl.java
@@ -108,7 +108,7 @@ public class TaskManagerExecutorImpl
         }
     }
 
-    private static void failNotCommenced( final ApplicationKey applicationKey, final List<Runnable> neverCommenced )
+    static void failNotCommenced( final ApplicationKey applicationKey, final List<Runnable> neverCommenced )
     {
         for ( final Runnable runnable : neverCommenced )
         {

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutorImpl.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutorImpl.java
@@ -69,7 +69,7 @@ public class TaskManagerExecutorImpl
         }
         final ApplicationKey applicationKey = application.getKey();
         final ApplicationTaskExecutor created = new ApplicationTaskExecutor( reference, SimpleExecutor.ofVirtual(
-            "task-" + applicationKey + "-", e -> LOG.error( "Task execution failed", e ) ) );
+            "task-manager-" + applicationKey + "-thread-", e -> LOG.error( "Task execution failed", e ) ) );
         final ApplicationTaskExecutor stale = applicationExecutors.put( applicationKey, created );
         if ( stale != null )
         {

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutorImpl.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutorImpl.java
@@ -109,7 +109,7 @@ public class TaskManagerExecutorImpl
         // tombstone in addingService.
         final ApplicationKey applicationKey = application.getKey();
         final ApplicationTaskExecutor current = applicationExecutors.get( applicationKey );
-        if ( current != null && current.reference() == reference )
+        if ( current != null && reference.equals( current.reference() ) )
         {
             shutdown( applicationKey, current );
             applicationExecutors.replace( applicationKey, current, TOMBSTONE );

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutorImpl.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutorImpl.java
@@ -1,36 +1,121 @@
 package com.enonic.xp.impl.task;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.enonic.xp.app.Application;
+import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.core.internal.concurrent.SimpleExecutor;
 
-@Component
+@Component(service = TaskManagerExecutor.class)
 public class TaskManagerExecutorImpl
-    implements TaskManagerExecutor
+    implements TaskManagerExecutor, ServiceTrackerCustomizer<Application, Application>
 {
     private static final Logger LOG = LoggerFactory.getLogger( TaskManagerExecutorImpl.class );
 
-    private final SimpleExecutor simpleExecutor;
+    private final BundleContext context;
 
-    public TaskManagerExecutorImpl()
+    private final ServiceTracker<Application, Application> tracker;
+
+    private final ConcurrentMap<ApplicationKey, ApplicationTaskExecutor> applicationExecutors = new ConcurrentHashMap<>();
+
+    private final SimpleExecutor sharedExecutor;
+
+    private record ApplicationTaskExecutor(ServiceReference<Application> reference, SimpleExecutor executor) {}
+
+    @Activate
+    public TaskManagerExecutorImpl( final BundleContext context )
     {
-        simpleExecutor = SimpleExecutor.ofVirtual( "task-manager-thread", e -> LOG.error( "Task execution failed", e ) );
+        this.context = context;
+        this.sharedExecutor = SimpleExecutor.ofVirtual( "task-manager-thread", e -> LOG.error( "Task execution failed", e ) );
+        this.tracker = new ServiceTracker<>( context, Application.class, this );
+        this.tracker.open();
     }
 
     @Deactivate
     public void deactivate()
     {
-        simpleExecutor.shutdownAndAwaitTermination( Duration.ofSeconds( 5 ), neverCommenced -> LOG.warn( "Not all tasks were executed" ) );
+        tracker.close();
+        sharedExecutor.shutdownAndAwaitTermination( Duration.ofSeconds( 5 ),
+                                                    neverCommenced -> LOG.warn( "Not all tasks were executed" ) );
     }
 
     @Override
-    public void execute( final Runnable command )
+    public void execute( final ApplicationKey applicationKey, final Runnable command )
     {
-        simpleExecutor.execute( command );
+        final ApplicationTaskExecutor applicationExecutor = applicationExecutors.get( applicationKey );
+        ( applicationExecutor != null ? applicationExecutor.executor() : sharedExecutor ).execute( command );
+    }
+
+    @Override
+    public Application addingService( final ServiceReference<Application> reference )
+    {
+        final Application application = context.getService( reference );
+        if ( application == null )
+        {
+            return null;
+        }
+        final ApplicationKey applicationKey = application.getKey();
+        final ApplicationTaskExecutor created = new ApplicationTaskExecutor( reference, SimpleExecutor.ofVirtual(
+            "task-" + applicationKey + "-", e -> LOG.error( "Task execution failed", e ) ) );
+        final ApplicationTaskExecutor stale = applicationExecutors.put( applicationKey, created );
+        if ( stale != null )
+        {
+            shutdown( applicationKey, stale );
+        }
+        return application;
+    }
+
+    @Override
+    public void modifiedService( final ServiceReference<Application> reference, final Application application )
+    {
+    }
+
+    @Override
+    public void removedService( final ServiceReference<Application> reference, final Application application )
+    {
+        // the application stopped or is being redeployed: its tasks belong to the gone incarnation - stop them,
+        // so the executor never outlives the incarnation it was created for
+        final ApplicationKey applicationKey = application.getKey();
+        final ApplicationTaskExecutor current = applicationExecutors.get( applicationKey );
+        if ( current != null && current.reference() == reference && applicationExecutors.remove( applicationKey, current ) )
+        {
+            shutdown( applicationKey, current );
+        }
+        context.ungetService( reference );
+    }
+
+    private static void shutdown( final ApplicationKey applicationKey, final ApplicationTaskExecutor applicationExecutor )
+    {
+        LOG.debug( "Stopping task executor for {}", applicationKey );
+        final boolean terminated =
+            applicationExecutor.executor().shutdownAndAwaitTermination( Duration.ZERO, neverCommenced -> failNotCommenced( applicationKey, neverCommenced ) );
+        if ( !terminated )
+        {
+            LOG.warn( "Some tasks of application {} are still running after its task executor shutdown", applicationKey );
+        }
+    }
+
+    private static void failNotCommenced( final ApplicationKey applicationKey, final List<Runnable> neverCommenced )
+    {
+        for ( final Runnable runnable : neverCommenced )
+        {
+            if ( runnable instanceof TaskRunnable taskRunnable )
+            {
+                taskRunnable.failNotCommenced( "Application " + applicationKey + " stopped" );
+            }
+        }
     }
 }

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutorImpl.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutorImpl.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.RejectedExecutionException;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -35,6 +36,10 @@ public class TaskManagerExecutorImpl
 
     private record ApplicationTaskExecutor(ServiceReference<Application> reference, SimpleExecutor executor) {}
 
+    // marks a stopped application: rejects submits without retaining anything of the dead incarnation
+    // (a reference to its ServiceReference or executor could pin the gone bundle's classloader)
+    private static final ApplicationTaskExecutor TOMBSTONE = new ApplicationTaskExecutor( null, null );
+
     @Activate
     public TaskManagerExecutorImpl( final BundleContext context )
     {
@@ -56,7 +61,18 @@ public class TaskManagerExecutorImpl
     public void execute( final ApplicationKey applicationKey, final Runnable command )
     {
         final ApplicationTaskExecutor applicationExecutor = applicationExecutors.get( applicationKey );
-        ( applicationExecutor != null ? applicationExecutor.executor() : sharedExecutor ).execute( command );
+        if ( applicationExecutor == null )
+        {
+            sharedExecutor.execute( command );
+        }
+        else if ( applicationExecutor.executor() == null )
+        {
+            throw new RejectedExecutionException( "Application " + applicationKey + " is stopped" );
+        }
+        else
+        {
+            applicationExecutor.executor().execute( command );
+        }
     }
 
     @Override
@@ -71,7 +87,7 @@ public class TaskManagerExecutorImpl
         final ApplicationTaskExecutor created = new ApplicationTaskExecutor( reference, SimpleExecutor.ofVirtual(
             "task-manager-" + applicationKey + "-thread-", e -> LOG.error( "Task execution failed", e ) ) );
         final ApplicationTaskExecutor stale = applicationExecutors.put( applicationKey, created );
-        if ( stale != null )
+        if ( stale != null && stale.executor() != null )
         {
             shutdown( applicationKey, stale );
         }
@@ -87,15 +103,16 @@ public class TaskManagerExecutorImpl
     public void removedService( final ServiceReference<Application> reference, final Application application )
     {
         // the application stopped or is being redeployed: its tasks belong to the gone incarnation - stop them,
-        // so the executor never outlives the incarnation it was created for. The shut-down executor stays in the
-        // map as a tombstone: a submit racing or following the stop is rejected instead of silently landing on
-        // the shared executor, where the application's lifecycle could never reach it. A successor incarnation
-        // replaces the tombstone in addingService.
+        // so the executor never outlives the incarnation it was created for. A tombstone takes the map slot:
+        // a submit racing or following the stop is rejected instead of silently landing on the shared executor,
+        // where the application's lifecycle could never reach it. A successor incarnation replaces the
+        // tombstone in addingService.
         final ApplicationKey applicationKey = application.getKey();
         final ApplicationTaskExecutor current = applicationExecutors.get( applicationKey );
         if ( current != null && current.reference() == reference )
         {
             shutdown( applicationKey, current );
+            applicationExecutors.replace( applicationKey, current, TOMBSTONE );
         }
         context.ungetService( reference );
     }

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutorImpl.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskManagerExecutorImpl.java
@@ -87,10 +87,13 @@ public class TaskManagerExecutorImpl
     public void removedService( final ServiceReference<Application> reference, final Application application )
     {
         // the application stopped or is being redeployed: its tasks belong to the gone incarnation - stop them,
-        // so the executor never outlives the incarnation it was created for
+        // so the executor never outlives the incarnation it was created for. The shut-down executor stays in the
+        // map as a tombstone: a submit racing or following the stop is rejected instead of silently landing on
+        // the shared executor, where the application's lifecycle could never reach it. A successor incarnation
+        // replaces the tombstone in addingService.
         final ApplicationKey applicationKey = application.getKey();
         final ApplicationTaskExecutor current = applicationExecutors.get( applicationKey );
-        if ( current != null && current.reference() == reference && applicationExecutors.remove( applicationKey, current ) )
+        if ( current != null && current.reference() == reference )
         {
             shutdown( applicationKey, current );
         }

--- a/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskRunnable.java
+++ b/modules/core/core-task/src/main/java/com/enonic/xp/impl/task/TaskRunnable.java
@@ -91,6 +91,11 @@ final class TaskRunnable
         return context.build();
     }
 
+    void failNotCommenced( final String message )
+    {
+        progressReporter.failed( message );
+    }
+
     private String betterThreadName()
     {
         final String defaultName = "task-" + runnableTask.getApplicationKey() + "-" + runnableTask.getTaskId();

--- a/modules/core/core-task/src/test/java/com/enonic/xp/impl/task/LocalTaskManagerImplTest.java
+++ b/modules/core/core-task/src/test/java/com/enonic/xp/impl/task/LocalTaskManagerImplTest.java
@@ -57,7 +57,8 @@ class LocalTaskManagerImplTest
 
         cleanupScheduler = new TaskManagerCleanupSchedulerMock();
 
-        taskMan = new LocalTaskManagerImpl( Runnable::run, cleanupScheduler, event -> this.eventsPublished.add( event ) );
+        taskMan = new LocalTaskManagerImpl( ( applicationKey, command ) -> command.run(), cleanupScheduler,
+                                            event -> this.eventsPublished.add( event ) );
         taskMan.activate();
 
         this.eventsPublished = new ArrayList<>();

--- a/modules/core/core-task/src/test/java/com/enonic/xp/impl/task/LocalTaskManagerImplTest.java
+++ b/modules/core/core-task/src/test/java/com/enonic/xp/impl/task/LocalTaskManagerImplTest.java
@@ -8,6 +8,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
@@ -31,6 +32,7 @@ import com.enonic.xp.task.TaskState;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -162,6 +164,31 @@ class LocalTaskManagerImplTest
         assertEquals( 0, taskMan.getRunningTasks().size() );
         assertEquals( 4, eventsPublished.size() );
         assertEquals( "task.submitted , task.updated , task.finished , task.removed", eventTypes() );
+    }
+
+    @Test
+    void submitTaskRejected()
+    {
+        final TaskManagerCleanupSchedulerMock rejectedCleanupScheduler = new TaskManagerCleanupSchedulerMock();
+        final LocalTaskManagerImpl rejectingTaskMan = new LocalTaskManagerImpl( ( applicationKey, command ) -> {
+            throw new RejectedExecutionException( "executor stopped" );
+        }, rejectedCleanupScheduler, event -> this.eventsPublished.add( event ) );
+        rejectingTaskMan.activate();
+        try
+        {
+            final DescribedTaskImpl describedTask =
+                new DescribedTaskImpl( ( id, progressReporter ) -> {
+                }, "task-1", "task 1", TEST_TASK_CONTEXT );
+
+            assertThrows( RejectedExecutionException.class, () -> rejectingTaskMan.submitTask( describedTask ) );
+
+            assertEquals( TaskState.FAILED, rejectingTaskMan.getTaskInfo( describedTask.getTaskId() ).getState() );
+        }
+        finally
+        {
+            rejectingTaskMan.deactivate();
+            rejectedCleanupScheduler.verifyStopped();
+        }
     }
 
     private String eventTypes()

--- a/modules/core/core-task/src/test/java/com/enonic/xp/impl/task/TaskManagerExecutorImplTest.java
+++ b/modules/core/core-task/src/test/java/com/enonic/xp/impl/task/TaskManagerExecutorImplTest.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.impl.task;
 
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
@@ -10,9 +11,12 @@ import org.osgi.framework.ServiceReference;
 
 import com.enonic.xp.app.Application;
 import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.impl.task.distributed.DescribedTask;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class TaskManagerExecutorImplTest
@@ -29,6 +33,90 @@ class TaskManagerExecutorImplTest
 
         phaser.arriveAndAwaitAdvance();
         taskManagerExecutor.deactivate();
+    }
+
+    @Test
+    void addingService_noService()
+    {
+        final BundleContext bundleContext = mock( BundleContext.class );
+        final ServiceReference<Application> reference = mock( ServiceReference.class );
+
+        final TaskManagerExecutorImpl taskManagerExecutor = new TaskManagerExecutorImpl( bundleContext );
+        try
+        {
+            assertNull( taskManagerExecutor.addingService( reference ) );
+            taskManagerExecutor.modifiedService( reference, null );
+        }
+        finally
+        {
+            taskManagerExecutor.deactivate();
+        }
+    }
+
+    @Test
+    void addingService_staleExecutorReplacedAndStopped()
+        throws Exception
+    {
+        final ApplicationKey applicationKey = ApplicationKey.from( "myapp" );
+
+        final BundleContext bundleContext = mock( BundleContext.class );
+        final ServiceReference<Application> reference = mock( ServiceReference.class );
+        final ServiceReference<Application> newReference = mock( ServiceReference.class );
+        final Application application = mock( Application.class );
+        when( application.getKey() ).thenReturn( applicationKey );
+        when( bundleContext.getService( reference ) ).thenReturn( application );
+        when( bundleContext.getService( newReference ) ).thenReturn( application );
+
+        final TaskManagerExecutorImpl taskManagerExecutor = new TaskManagerExecutorImpl( bundleContext );
+        try
+        {
+            taskManagerExecutor.addingService( reference );
+
+            final CountDownLatch started = new CountDownLatch( 1 );
+            final CountDownLatch interrupted = new CountDownLatch( 1 );
+            taskManagerExecutor.execute( applicationKey, () -> {
+                started.countDown();
+                try
+                {
+                    Thread.sleep( 60_000 );
+                }
+                catch ( InterruptedException e )
+                {
+                    interrupted.countDown();
+                }
+            } );
+
+            assertTrue( started.await( 5, TimeUnit.SECONDS ) );
+
+            // a new incarnation registering replaces the stale executor and stops it
+            taskManagerExecutor.addingService( newReference );
+
+            assertTrue( interrupted.await( 5, TimeUnit.SECONDS ) );
+
+            // removal of the old incarnation must not stop the new incarnation's executor
+            taskManagerExecutor.removedService( reference, application );
+
+            final CountDownLatch executed = new CountDownLatch( 1 );
+            taskManagerExecutor.execute( applicationKey, executed::countDown );
+            assertTrue( executed.await( 5, TimeUnit.SECONDS ) );
+        }
+        finally
+        {
+            taskManagerExecutor.deactivate();
+        }
+    }
+
+    @Test
+    void neverCommencedTasksAreFailed()
+    {
+        final InternalProgressReporter progressReporter = mock( InternalProgressReporter.class );
+        final DescribedTask task = mock( DescribedTask.class );
+        final TaskRunnable taskRunnable = new TaskRunnable( task, progressReporter );
+
+        TaskManagerExecutorImpl.failNotCommenced( ApplicationKey.from( "myapp" ), List.of( taskRunnable, () -> {
+        } ) );
+
+        verify( progressReporter ).failed( "Application myapp stopped" );
     }
 
     @Test

--- a/modules/core/core-task/src/test/java/com/enonic/xp/impl/task/TaskManagerExecutorImplTest.java
+++ b/modules/core/core-task/src/test/java/com/enonic/xp/impl/task/TaskManagerExecutorImplTest.java
@@ -1,19 +1,76 @@
 package com.enonic.xp.impl.task;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+import com.enonic.xp.app.Application;
+import com.enonic.xp.app.ApplicationKey;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class TaskManagerExecutorImplTest
 {
     @Test
     void lifecycle()
+        throws Exception
     {
+        final BundleContext bundleContext = mock( BundleContext.class );
+
         Phaser phaser = new Phaser( 2 );
-        final TaskManagerExecutorImpl taskManagerExecutor = new TaskManagerExecutorImpl();
-        taskManagerExecutor.execute( phaser::arriveAndAwaitAdvance );
+        final TaskManagerExecutorImpl taskManagerExecutor = new TaskManagerExecutorImpl( bundleContext );
+        taskManagerExecutor.execute( ApplicationKey.from( "myapp" ), phaser::arriveAndAwaitAdvance );
 
         phaser.arriveAndAwaitAdvance();
         taskManagerExecutor.deactivate();
+    }
+
+    @Test
+    void applicationTasksInterruptedOnApplicationRemoval()
+        throws Exception
+    {
+        final ApplicationKey applicationKey = ApplicationKey.from( "myapp" );
+
+        final BundleContext bundleContext = mock( BundleContext.class );
+        final ServiceReference<Application> reference = mock( ServiceReference.class );
+        final Application application = mock( Application.class );
+        when( application.getKey() ).thenReturn( applicationKey );
+        when( bundleContext.getService( reference ) ).thenReturn( application );
+
+        final TaskManagerExecutorImpl taskManagerExecutor = new TaskManagerExecutorImpl( bundleContext );
+        try
+        {
+            taskManagerExecutor.addingService( reference );
+
+            final CountDownLatch started = new CountDownLatch( 1 );
+            final CountDownLatch interrupted = new CountDownLatch( 1 );
+            taskManagerExecutor.execute( applicationKey, () -> {
+                started.countDown();
+                try
+                {
+                    Thread.sleep( 60_000 );
+                }
+                catch ( InterruptedException e )
+                {
+                    interrupted.countDown();
+                }
+            } );
+
+            assertTrue( started.await( 5, TimeUnit.SECONDS ) );
+
+            taskManagerExecutor.removedService( reference, application );
+
+            assertTrue( interrupted.await( 5, TimeUnit.SECONDS ) );
+        }
+        finally
+        {
+            taskManagerExecutor.deactivate();
+        }
     }
 }

--- a/modules/core/core-task/src/test/java/com/enonic/xp/impl/task/TaskManagerExecutorImplTest.java
+++ b/modules/core/core-task/src/test/java/com/enonic/xp/impl/task/TaskManagerExecutorImplTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 import org.osgi.framework.BundleContext;
@@ -138,7 +139,9 @@ class TaskManagerExecutorImplTest
 
             final CountDownLatch started = new CountDownLatch( 1 );
             final CountDownLatch interrupted = new CountDownLatch( 1 );
+            final AtomicReference<String> threadName = new AtomicReference<>();
             taskManagerExecutor.execute( applicationKey, () -> {
+                threadName.set( Thread.currentThread().getName() );
                 started.countDown();
                 try
                 {
@@ -151,6 +154,7 @@ class TaskManagerExecutorImplTest
             } );
 
             assertTrue( started.await( 5, TimeUnit.SECONDS ) );
+            assertTrue( threadName.get().startsWith( "task-manager-myapp-thread-" ), threadName.get() );
 
             taskManagerExecutor.removedService( reference, application );
 

--- a/modules/core/core-task/src/test/java/com/enonic/xp/impl/task/TaskManagerExecutorImplTest.java
+++ b/modules/core/core-task/src/test/java/com/enonic/xp/impl/task/TaskManagerExecutorImplTest.java
@@ -3,6 +3,7 @@ package com.enonic.xp.impl.task;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Phaser;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -15,6 +16,7 @@ import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.impl.task.distributed.DescribedTask;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -159,6 +161,10 @@ class TaskManagerExecutorImplTest
             taskManagerExecutor.removedService( reference, application );
 
             assertTrue( interrupted.await( 5, TimeUnit.SECONDS ) );
+
+            // a submit racing or following the stop is rejected, never quietly run on the shared executor
+            assertThrows( RejectedExecutionException.class, () -> taskManagerExecutor.execute( applicationKey, () -> {
+            } ) );
         }
         finally
         {

--- a/modules/tools/testing/src/main/java/com/enonic/xp/testing/resource/ClassLoaderResourceService.java
+++ b/modules/tools/testing/src/main/java/com/enonic/xp/testing/resource/ClassLoaderResourceService.java
@@ -10,12 +10,12 @@ import com.google.common.io.CharSource;
 import com.google.common.io.Resources;
 
 import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.resource.MultiResourceProcessor;
 import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceKeys;
 import com.enonic.xp.resource.ResourceProcessor;
 import com.enonic.xp.resource.ResourceService;
-import com.enonic.xp.resource.ResourcesProcessor;
 import com.enonic.xp.resource.UrlResource;
 import com.enonic.xp.vfs.VirtualFile;
 import com.enonic.xp.vfs.VirtualFilePath;
@@ -53,7 +53,7 @@ public final class ClassLoaderResourceService
     }
 
     @Override
-    public <K, V> V processResources( final ResourcesProcessor<K, V> processor )
+    public <K, V> V processResources( final MultiResourceProcessor<K, V> processor )
     {
         return processor.process( processor.toResourceKeys().stream().map( this::getResource ).collect( Collectors.toList() ) );
     }

--- a/modules/tools/testing/src/main/java/com/enonic/xp/testing/resource/ClassLoaderResourceService.java
+++ b/modules/tools/testing/src/main/java/com/enonic/xp/testing/resource/ClassLoaderResourceService.java
@@ -3,6 +3,8 @@ package com.enonic.xp.testing.resource;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import com.google.common.io.ByteSource;
 import com.google.common.io.CharSource;
 import com.google.common.io.Resources;
@@ -13,6 +15,7 @@ import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceKeys;
 import com.enonic.xp.resource.ResourceProcessor;
 import com.enonic.xp.resource.ResourceService;
+import com.enonic.xp.resource.ResourcesProcessor;
 import com.enonic.xp.resource.UrlResource;
 import com.enonic.xp.vfs.VirtualFile;
 import com.enonic.xp.vfs.VirtualFilePath;
@@ -47,6 +50,12 @@ public final class ClassLoaderResourceService
     public <K, V> V processResource( final ResourceProcessor<K, V> processor )
     {
         return processor.process( getResource( processor.toResourceKey() ) );
+    }
+
+    @Override
+    public <K, V> V processResources( final ResourcesProcessor<K, V> processor )
+    {
+        return processor.process( processor.toResourceKeys().stream().map( this::getResource ).collect( Collectors.toList() ) );
     }
 
     @Override


### PR DESCRIPTION
Issue: #7966

Builds on the lifecycle groundwork merged in #12198. Finishes the three remaining event-driven application services by moving them to pull-based revalidation against the application bundle identity, and by scoping task execution to the application it serves.

## ResourceService: processing cache invalidated by bundle identity, not events

`ResourceServiceImpl` no longer implements the deprecated `ApplicationInvalidator` (it was the last in-repo implementor). Instead every cache entry is stamped with the identity of the application's current bundle (`BundleStamp`: bundle id + last modified, resolved via new `ApplicationFactoryService.findActiveBundle`) and revalidated on every access:

- **A new bundle invalidates** — including a rollback to an older version and a rebuild with identical timestamps.
- **Stop/start of the same bundle does not invalidate** — resources exist independently of the application's running state, so unlike script executors or websocket connections, this cache must not be torn down by `Application` service lifecycle. No event is observed at all.
- Stamps are read before resources, so a redeploy racing a lookup costs a recompute, never persistent staleness.

**Resource timestamps are unreliable and are treated with care.** Modern Gradle produces reproducible archives with constant entry timestamps, so for a resource inside an application bundle a changed timestamp proves nothing and an unchanged one guarantees nothing — a new bundle is the *only* signal that files may be new in production. Accordingly, when a resource resolves through the plain bundle resolver (production without dev source paths or virtual schema override), cache entries validate by bundle stamp alone and the resource is not even opened — no per-access I/O. Timestamps are still used where they actually mean something: dev mode reads files from the filesystem, and virtual apps / schema overrides read node-backed resources, so those resolutions keep the per-access timestamp probe (tightened from `newer-than` to `not-equal`, catching file rollbacks in dev). The stability decision is made per access from the resolver instance actually serving the application, and both the cached entry and the current resolution must be bundle-stable for the probe-free path, so mode switches degrade safely to probing.

## ResourceService: multi-resource support; LocaleService delegates all caching to it

New public API `ResourceService.processResources(MultiResourceProcessor)` caches one value computed from an ordered set of resources ("file bundle"), revalidated by the bundle stamp(s) plus — for mutable resolutions — each resource's timestamp: a resource appearing, disappearing or changing invalidates the value, and an all-missing result is safely cacheable because per-file probes detect a file coming into existence.

`LocaleServiceImpl` now builds each `MessageBundle` as a `MultiResourceProcessor` over its candidate `.properties` chain (root → language → country → variant, same merge order as before) and inherits invalidation from the resource service. Gone with that: its `ApplicationListener`, both event-cleared caches, and the "clear on activate because the cache was populated while the application was uninstalled" workaround. In production a cached message bundle validates with one bundle-stamp lookup and zero I/O. `getLocales` computes from `findFiles` directly (memoized per resolver instance for bundle apps, live for node-backed resolvers).

## Task executors: per application, shut down with the application

`TaskManagerExecutor` changes from one global executor to `execute(ApplicationKey, Runnable)`. The implementation tracks `Application` services (same pattern as `MainExecutor` / the websocket and SSE managers from #12198; the tracker callback interface is not published):

- Every registered application gets its own virtual-thread executor (threads named `task-manager-{app}-thread-N`), stamped with the `ServiceReference` incarnation that created it — a late removal of a predecessor can never kill a successor's executor.
- On stop or redeploy the executor is shut down: running tasks are interrupted (surfacing as FAILED via the existing `TaskRunnable` handling), never-commenced ones are failed with "Application X stopped". Tasks cannot outlive the incarnation they were submitted to.
- **A submit racing or following the stop is rejected, never run unsupervised**: a field-less tombstone takes the registry slot (retaining nothing of the dead incarnation — no `ServiceReference`, no executor — so the gone bundle's classloader cannot be pinned), and a late submit for that application gets `RejectedExecutionException` (and the task is marked FAILED) instead of falling through to the shared executor where the application's lifecycle could never reach it. A successor incarnation replaces the tombstone when it registers.
- Tasks from bundles that never had an `Application` service (core services submitting `RunnableTask`s) keep a shared executor with the previous 5-second-grace shutdown semantics.
- `LocalTaskManagerImpl` marks a task FAILED if submission is rejected, so no WAITING zombie lingers in the task list.

## Verification

- New tests: bundle-change invalidation for both cache paths, bundle-resolved entries ignoring timestamp changes (probe-free path) while a new bundle still invalidates, resource-appears / resource-modified invalidation for mutable resolutions, all-missing-then-appears caching, a running task interrupted when its application's service is removed, a post-stop submit rejected instead of falling back to the shared executor, per-application thread naming, stale-executor replacement, and the rejected/never-commenced task failure paths.
- Green: core-app, core-i18n, core-task, tools:testing, lib-i18n (Nashorn and GraalJS legs), lib-task, portal-impl, core-content, core-schema, core-auth, core-macro, admin-impl, and the `DynamicSchemaServiceImplTest` integration test against real Felix bundles.
- `ClassLoaderResourceService` (xp-testing) implements the new `processResources` pass-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ns3oGjrFEe8DgtEpU3Eou