### PR TITLE
Patch does not refresh search index when pushing to other branches #12214

### DIFF
--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/PatchNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/PatchNodeCommand.java
@@ -18,6 +18,7 @@ import com.enonic.xp.node.NodeVersion;
 import com.enonic.xp.node.NodeVersionId;
 import com.enonic.xp.node.PatchNodeParams;
 import com.enonic.xp.node.PatchNodeResult;
+import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.NodeBranchEntry;
 import com.enonic.xp.repo.impl.NodeStoreVersion;
@@ -81,9 +82,36 @@ public final class PatchNodeCommand
 
         doPatchNode( persistedNode.id(), internalContext );
 
-        refresh( params.getRefresh() );
+        final PatchNodeResult result = results.build();
 
-        return results.build();
+        refresh( resolveRefreshMode( result ) );
+
+        return result;
+    }
+
+    private RefreshMode resolveRefreshMode( final PatchNodeResult result )
+    {
+        final RefreshMode requested = params.getRefresh();
+
+        if ( requested == RefreshMode.ALL || !pushedToOtherBranches( result ) )
+        {
+            return requested;
+        }
+
+        // A patch that propagates the context branch version to other branches is effectively a push (publish),
+        // so the search index must be refreshed before push events are published.
+        return requested == RefreshMode.STORAGE ? RefreshMode.ALL : RefreshMode.SEARCH;
+    }
+
+    private boolean pushedToOtherBranches( final PatchNodeResult result )
+    {
+        final Branch contextBranch = ContextAccessor.current().getBranch();
+        final Node contextNode = result.getResult( contextBranch );
+
+        return contextNode != null && result.getResults()
+            .stream()
+            .anyMatch( branchResult -> branchResult.node() != null && !contextBranch.equals( branchResult.branch() ) &&
+                contextNode.getNodeVersionId().equals( branchResult.node().getNodeVersionId() ) );
     }
 
     private void doPatchNode( NodeId nodeId, InternalContext internalContext )

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/PatchNodeCommandTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/PatchNodeCommandTest.java
@@ -21,6 +21,7 @@ import com.enonic.xp.index.IndexConfig;
 import com.enonic.xp.index.PatternIndexConfigDocument;
 import com.enonic.xp.node.ApplyNodePermissionsParams;
 import com.enonic.xp.node.CreateNodeParams;
+import com.enonic.xp.node.FindNodesByQueryResult;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeAccessException;
 import com.enonic.xp.node.NodeId;
@@ -170,6 +171,27 @@ class PatchNodeCommandTest
             return NodeId.from( node.get( "id" ) ).equals( createdNode.id() ) &&
                 node.get( "branch" ).equals( RepositoryConstants.MASTER_BRANCH.getValue() );
         } ).count() );
+    }
+
+    @Test
+    void patch_pushed_to_other_branch_refreshes_search_index()
+    {
+        final Node createdNode = createNode( CreateNodeParams.create().name( "my-node" ).parent( NodePath.ROOT ).build() );
+
+        pushNodes( RepositoryConstants.MASTER_BRANCH, createdNode.id() );
+
+        nodeService.patch( PatchNodeParams.create()
+                               .id( createdNode.id() )
+                               .branches( Branches.from( ContextAccessor.current().getBranch(), RepositoryConstants.MASTER_BRANCH ) )
+                               .editor( toBeEdited -> toBeEdited.data.addString( "another", "stuff" ) )
+                               .build() );
+
+        final FindNodesByQueryResult result = ContextBuilder.from( ContextAccessor.current() )
+            .branch( RepositoryConstants.MASTER_BRANCH )
+            .build()
+            .callWith( () -> doQuery( "another = 'stuff'" ) );
+
+        assertEquals( 1, result.getTotalHits() );
     }
 
     @Test


### PR DESCRIPTION
Fixes #12214

`PatchNodeCommand` now detects when a patch effectively pushes the context branch version to other branches — mirroring the condition `NodeServiceImpl.patch` uses to publish `node.pushed` events — and escalates the refresh to include the search index (none/`SEARCH` → `SEARCH`, `STORAGE` → `ALL`, explicit `ALL` unchanged) before the command returns, so the refresh lands before pushed events are published. This matches the contract of `PushNodesCommand`, which always ends a publish with `refresh(ALL)`.

Single-branch patches and callers that already request `RefreshMode.ALL` (e.g. the content layer via `PatchNodeParamsFactory`) are unaffected.

Added `patch_pushed_to_other_branch_refreshes_search_index` to `PatchNodeCommandTest`: patches a node across draft and master with no explicit refresh mode and asserts the patched property is findable in master. Verified it fails (`expected: <1> but was: <0>`) without the fix and passes with it; the full test class is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhDbJ4aQ4tJwUJw6qB22Lh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhDbJ4aQ4tJwUJw6qB22Lh)_