### PR TITLE
Node storage commands must not read from search index #12216

### DIFF
--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ApplyNodePermissionsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ApplyNodePermissionsCommand.java
@@ -19,7 +19,6 @@ import com.enonic.xp.node.Attributes;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeNotFoundException;
-import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.NodeVersion;
 import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.repo.impl.InternalContext;
@@ -79,7 +78,9 @@ public class ApplyNodePermissionsCommand
             throw new NodeNotFoundException( "Node not found: " + params.getNodeId() );
         }
 
-        final List<Map<Branch, NodeVersion>> versionsToApply = findVersionsToApply();
+        NodePermissionsResolver.requireContextUserPermissionOrAdmin( Permission.READ, persistedNode );
+
+        final List<Map<Branch, NodeVersion>> versionsToApply = findVersionsToApply( persistedNode );
 
         if ( listener != NoopApplyNodePermissionsListener.INSTANCE )
         {
@@ -95,7 +96,7 @@ public class ApplyNodePermissionsCommand
         return results.build();
     }
 
-    private List<Map<Branch, NodeVersion>> findVersionsToApply()
+    private List<Map<Branch, NodeVersion>> findVersionsToApply( final Node persistedNode )
     {
         final List<Map<Branch, NodeVersion>> result = new ArrayList<>();
 
@@ -106,11 +107,8 @@ public class ApplyNodePermissionsCommand
 
         if ( ApplyPermissionsScope.SUBTREE == params.getScope() || ApplyPermissionsScope.TREE == params.getScope() )
         {
-            final NodePath parentPath =
-                this.nodeStorageService.get( params.getNodeId(), InternalContext.from( ContextAccessor.current() ) ).path();
-
             FindNodeBranchEntriesByParentCommand.create( this )
-                .parentPath( parentPath )
+                .parentPath( persistedNode.path() )
                 .requiredPermission( Permission.READ )
                 .build()
                 .execute()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ApplyNodePermissionsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ApplyNodePermissionsCommand.java
@@ -2,9 +2,11 @@ package com.enonic.xp.repo.impl.node;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import com.google.common.base.Preconditions;
 
@@ -123,51 +125,77 @@ public class ApplyNodePermissionsCommand
 
     private void doApply( List<Map<Branch, NodeVersion>> versionsToApply, final AccessControlList permissions )
     {
-        for ( Branch branch : branches )
+        // permissions are applied equally on all branches, authorized on the reference (context) branch, which goes first
+        final Branch referenceBranch = ContextAccessor.current().getBranch();
+
+        final List<Branch> orderedBranches = new ArrayList<>();
+        orderedBranches.add( referenceBranch );
+        branches.stream().filter( branch -> !branch.equals( referenceBranch ) ).forEach( orderedBranches::add );
+
+        final Set<NodeId> deniedNodes = new HashSet<>();
+
+        for ( Branch branch : orderedBranches )
         {
             versionsToApply.stream()
                 .map( versionMap -> versionMap.get( branch ) )
                 .filter( Objects::nonNull )
-                .forEach( node -> doApplyOnNode( node, branch, permissions ) );
+                .forEach( node -> doApplyOnNode( node, branch, branch.equals( referenceBranch ), deniedNodes, permissions ) );
         }
     }
 
-    private void doApplyOnNode( final NodeVersion nodeVersion, final Branch branch, final AccessControlList permissions )
+    private void doApplyOnNode( final NodeVersion nodeVersion, final Branch branch, final boolean isReferenceBranch,
+                                final Set<NodeId> deniedNodes, final AccessControlList permissions )
     {
-        final InternalContext targetContext = InternalContext.create( ContextAccessor.current() ).branch( branch ).build();
+        if ( isReferenceBranch && !allowedOnReferenceBranch( nodeVersion, branch ) )
+        {
+            deniedNodes.add( nodeVersion.getNodeId() );
+        }
 
-        final Node originalNode = nodeStorageService.get( nodeVersion.getNodeId(), targetContext );
-
-        if ( originalNode == null || !NodePermissionsResolver.hasPermission( targetContext.getPrincipalKeys(), Permission.WRITE_PERMISSIONS,
-                                                                             originalNode.getPermissions() ) )
+        if ( deniedNodes.contains( nodeVersion.getNodeId() ) )
         {
             listener.notEnoughRights( 1 );
             results.addResult( nodeVersion.getNodeId(), branch, null, null );
+            return;
         }
 
         NodeHelper.runAsAdmin( () -> {
+            final InternalContext adminContext = InternalContext.create( ContextAccessor.current() ).branch( branch ).build();
+
             final NodePatchCache.Entry<AccessControlList> cachedVersionData = appliedVersions.get( nodeVersion.getNodeVersionId() );
 
             if ( cachedVersionData != null )
             {
-                this.nodeStorageService.push( NodeBranchEntry.fromNodeVersion( cachedVersionData.version() ), targetContext );
+                this.nodeStorageService.push( NodeBranchEntry.fromNodeVersion( cachedVersionData.version() ), adminContext );
 
                 results.addResult( nodeVersion.getNodeId(), branch, cachedVersionData.version(), cachedVersionData.data() );
             }
             else
             {
+                final Node originalNode = nodeStorageService.get( nodeVersion.getNodeId(), adminContext );
+
                 final Node editedNode = Node.create( originalNode ).timestamp( Millis.now() ).permissions( permissions ).build();
                 final Attributes resolvedAttributes =
                     resolveVersionAttributes( params.getVersionAttributesResolver(), originalNode, editedNode, branch,
                                               nodeVersion.getAttributes() );
                 final NodeVersionData result =
-                    this.nodeStorageService.store( StoreNodeParams.newVersion( editedNode, resolvedAttributes ), targetContext );
+                    this.nodeStorageService.store( StoreNodeParams.newVersion( editedNode, resolvedAttributes ), adminContext );
                 appliedVersions.put( nodeVersion.getNodeVersionId(), branch, result.version(), result.node().getPermissions() );
 
                 listener.permissionsApplied( 1 );
                 results.addResult( nodeVersion.getNodeId(), branch, result.version(), result.node().getPermissions() );
             }
         } );
+    }
+
+    private boolean allowedOnReferenceBranch( final NodeVersion nodeVersion, final Branch referenceBranch )
+    {
+        final InternalContext referenceContext = InternalContext.create( ContextAccessor.current() ).branch( referenceBranch ).build();
+
+        final Node referenceNode = nodeStorageService.get( nodeVersion.getNodeId(), referenceContext );
+
+        return referenceNode != null &&
+            NodePermissionsResolver.hasPermission( referenceContext.getPrincipalKeys(), Permission.WRITE_PERMISSIONS,
+                                                   referenceNode.getPermissions() );
     }
 
     private Map<Branch, NodeVersion> getActiveNodes( NodeId nodeId )

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ApplyNodePermissionsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ApplyNodePermissionsCommand.java
@@ -18,17 +18,12 @@ import com.enonic.xp.node.ApplyPermissionsScope;
 import com.enonic.xp.node.Attributes;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
-import com.enonic.xp.node.NodeIndexPath;
 import com.enonic.xp.node.NodeNotFoundException;
 import com.enonic.xp.node.NodePath;
-import com.enonic.xp.node.NodeQuery;
 import com.enonic.xp.node.NodeVersion;
 import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.NodeBranchEntry;
-import com.enonic.xp.repo.impl.SingleRepoSearchSource;
-import com.enonic.xp.repo.impl.search.NodeSearchService;
-import com.enonic.xp.repo.impl.search.result.SearchResult;
 import com.enonic.xp.repo.impl.storage.NodeVersionData;
 import com.enonic.xp.repo.impl.storage.StoreNodeParams;
 import com.enonic.xp.security.PrincipalKey;
@@ -111,32 +106,19 @@ public class ApplyNodePermissionsCommand
 
         if ( ApplyPermissionsScope.SUBTREE == params.getScope() || ApplyPermissionsScope.TREE == params.getScope() )
         {
-            refresh( RefreshMode.SEARCH );
-            result.addAll( findChildrenVersionsToApply(
-                this.nodeStorageService.get( params.getNodeId(), InternalContext.from( ContextAccessor.current() ) ).path() ) );
+            final NodePath parentPath =
+                this.nodeStorageService.get( params.getNodeId(), InternalContext.from( ContextAccessor.current() ) ).path();
+
+            FindNodeBranchEntriesByParentCommand.create( this )
+                .parentPath( parentPath )
+                .requiredPermission( Permission.READ )
+                .build()
+                .execute()
+                .stream()
+                .map( NodeBranchEntry::getNodeId )
+                .map( this::getActiveNodes )
+                .forEach( result::add );
         }
-
-        return result;
-    }
-
-    private List<Map<Branch, NodeVersion>> findChildrenVersionsToApply( final NodePath node )
-    {
-        final List<Map<Branch, NodeVersion>> result = new ArrayList<>();
-
-        final InternalContext internalContext = InternalContext.from( ContextAccessor.current() );
-
-        final SearchResult queryResult = this.nodeSearchService.query(
-            NodeQuery.create().size( NodeSearchService.GET_ALL_SIZE_FLAG ).withPath( true ).parent( node ).build(),
-            SingleRepoSearchSource.from( internalContext ) );
-
-        queryResult.getIds().stream().map( NodeId::from ).map( this::getActiveNodes ).forEach( result::add );
-
-        queryResult.getHits()
-            .stream()
-            .map(
-                hit -> hit.getReturnValues().getOptional( NodeIndexPath.PATH ).map( Object::toString ).map( NodePath::new ).orElse( null ) )
-            .filter( Objects::nonNull )
-            .forEach( path -> result.addAll( findChildrenVersionsToApply( path ) ) );
 
         return result;
     }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ApplyNodePermissionsCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/ApplyNodePermissionsCommand.java
@@ -125,32 +125,32 @@ public class ApplyNodePermissionsCommand
 
     private void doApply( List<Map<Branch, NodeVersion>> versionsToApply, final AccessControlList permissions )
     {
-        // permissions are applied equally on all branches, authorized on the reference (context) branch, which goes first
+        // permissions are read/authorized from the reference (context) branch, but applied equally on all specified branches,
+        // preserving the caller-supplied branch order (which determines the version origin)
         final Branch referenceBranch = ContextAccessor.current().getBranch();
 
-        final List<Branch> orderedBranches = new ArrayList<>();
-        orderedBranches.add( referenceBranch );
-        branches.stream().filter( branch -> !branch.equals( referenceBranch ) ).forEach( orderedBranches::add );
-
         final Set<NodeId> deniedNodes = new HashSet<>();
+        for ( final Map<Branch, NodeVersion> versionMap : versionsToApply )
+        {
+            final NodeVersion referenceVersion = versionMap.get( referenceBranch );
+            if ( referenceVersion != null && !allowedOnReferenceBranch( referenceVersion, referenceBranch ) )
+            {
+                deniedNodes.add( referenceVersion.getNodeId() );
+            }
+        }
 
-        for ( Branch branch : orderedBranches )
+        for ( Branch branch : branches )
         {
             versionsToApply.stream()
                 .map( versionMap -> versionMap.get( branch ) )
                 .filter( Objects::nonNull )
-                .forEach( node -> doApplyOnNode( node, branch, branch.equals( referenceBranch ), deniedNodes, permissions ) );
+                .forEach( node -> doApplyOnNode( node, branch, deniedNodes, permissions ) );
         }
     }
 
-    private void doApplyOnNode( final NodeVersion nodeVersion, final Branch branch, final boolean isReferenceBranch,
-                                final Set<NodeId> deniedNodes, final AccessControlList permissions )
+    private void doApplyOnNode( final NodeVersion nodeVersion, final Branch branch, final Set<NodeId> deniedNodes,
+                                final AccessControlList permissions )
     {
-        if ( isReferenceBranch && !allowedOnReferenceBranch( nodeVersion, branch ) )
-        {
-            deniedNodes.add( nodeVersion.getNodeId() );
-        }
-
         if ( deniedNodes.contains( nodeVersion.getNodeId() ) )
         {
             listener.notEnoughRights( 1 );

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CreateNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CreateNodeCommand.java
@@ -39,12 +39,15 @@ public final class CreateNodeCommand
 
     private final boolean skipVerification;
 
+    private final Node knownParentNode;
+
     private CreateNodeCommand( final Builder builder )
     {
         super( builder );
         this.params = builder.params;
         this.binaryService = builder.binaryService;
         this.skipVerification = builder.skipVerification;
+        this.knownParentNode = builder.knownParentNode;
     }
 
     public static Builder create()
@@ -63,7 +66,7 @@ public final class CreateNodeCommand
         {
             NodeHelper.runAsAdmin( this::verifyNotExistsAlready );
         }
-        final Node parentNode = NodeHelper.runAsAdmin( this::getParentNode );
+        final Node parentNode = knownParentNode != null ? knownParentNode : NodeHelper.runAsAdmin( this::getParentNode );
 
         NodePermissionsResolver.requireContextUserPermissionOrAdmin( Permission.CREATE, parentNode );
 
@@ -198,6 +201,8 @@ public final class CreateNodeCommand
 
         private boolean skipVerification;
 
+        private Node knownParentNode;
+
         private Builder()
         {
             super();
@@ -223,6 +228,15 @@ public final class CreateNodeCommand
         public Builder skipVerification( boolean skipVerification )
         {
             this.skipVerification = skipVerification;
+            return this;
+        }
+
+        /**
+         * Parent node already known by the caller, so that it does not have to be looked up again.
+         */
+        public Builder knownParentNode( final Node knownParentNode )
+        {
+            this.knownParentNode = knownParentNode;
             return this;
         }
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CreateNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CreateNodeCommand.java
@@ -245,6 +245,11 @@ public final class CreateNodeCommand
         {
             super.validate();
             requireNonNull( params, "params cannot be null" );
+            if ( knownParentNode != null && !knownParentNode.path().equals( params.getParent() ) )
+            {
+                throw new IllegalArgumentException(
+                    "knownParentNode [" + knownParentNode.path() + "] is not the parent [" + params.getParent() + "] to create node in" );
+            }
         }
 
         public CreateNodeCommand build()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/DeleteNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/DeleteNodeCommand.java
@@ -5,27 +5,16 @@ import com.google.common.collect.Iterables;
 
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
-import com.enonic.xp.data.ValueFactory;
 import com.enonic.xp.node.DeleteNodeListener;
 import com.enonic.xp.node.NodeAccessException;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.OperationNotPermittedException;
 import com.enonic.xp.node.RefreshMode;
-import com.enonic.xp.query.expr.CompareExpr;
-import com.enonic.xp.query.expr.FieldExpr;
-import com.enonic.xp.query.expr.FieldOrderExpr;
 import com.enonic.xp.query.expr.OrderExpr;
-import com.enonic.xp.query.expr.QueryExpr;
-import com.enonic.xp.query.expr.ValueExpr;
-import com.enonic.xp.query.filter.ValueFilter;
 import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.NodeBranchEntries;
 import com.enonic.xp.repo.impl.NodeBranchEntry;
-import com.enonic.xp.repo.impl.branch.search.NodeBranchQuery;
-import com.enonic.xp.repo.impl.branch.search.NodeBranchQueryResultFactory;
-import com.enonic.xp.repo.impl.branch.storage.BranchIndexPath;
-import com.enonic.xp.repo.impl.search.NodeSearchService;
 import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.acl.Permission;
@@ -83,19 +72,11 @@ public class DeleteNodeCommand
 
         final NodePath effectiveNodePath = node.getNodePath();
 
-        refresh( RefreshMode.STORAGE );
-
-        final NodeBranchEntries childrenBranchEntries = NodeBranchQueryResultFactory.create( this.nodeSearchService.query(
-            NodeBranchQuery.create()
-                .query( QueryExpr.from(
-                    CompareExpr.like( FieldExpr.from( BranchIndexPath.PATH ), ValueExpr.string( effectiveNodePath + "/*" ) ) ) )
-                .addQueryFilter( ValueFilter.create()
-                                     .fieldName( BranchIndexPath.BRANCH_NAME.getPath() )
-                                     .addValue( ValueFactory.newString( internalContext.getBranch().getValue() ) )
-                                     .build() )
-                .addOrderBy( FieldOrderExpr.create( BranchIndexPath.PATH, OrderExpr.Direction.DESC ) )
-                .size( NodeSearchService.GET_ALL_SIZE_FLAG )
-                .build(), internalContext.getRepositoryId() ) );
+        final NodeBranchEntries childrenBranchEntries = FindNodeBranchEntriesByParentCommand.create( this )
+            .parentPath( effectiveNodePath )
+            .pathOrder( OrderExpr.Direction.DESC )
+            .build()
+            .execute();
 
         final NodeBranchEntries nodeBranchEntries = NodeBranchEntries.create().addAll( childrenBranchEntries ).add( node ).build();
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/DuplicateNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/DuplicateNodeCommand.java
@@ -1,8 +1,10 @@
 package com.enonic.xp.repo.impl.node;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -20,13 +22,14 @@ import com.enonic.xp.node.DuplicateNodeResult;
 import com.enonic.xp.node.InsertManualStrategy;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeAlreadyExistAtPathException;
+import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeIds;
 import com.enonic.xp.node.NodeNotFoundException;
 import com.enonic.xp.node.NodePath;
-import com.enonic.xp.node.Nodes;
 import com.enonic.xp.node.OperationNotPermittedException;
 import com.enonic.xp.node.PatchNodeParams;
 import com.enonic.xp.repo.impl.InternalContext;
+import com.enonic.xp.repo.impl.NodeBranchEntries;
 import com.enonic.xp.repo.impl.NodeBranchEntry;
 import com.enonic.xp.repo.impl.binary.BinaryService;
 import com.enonic.xp.repository.RepositoryId;
@@ -77,14 +80,7 @@ public final class DuplicateNodeCommand
 
         if ( params.getIncludeChildren() )
         {
-            final Map<NodePath, List<NodeBranchEntry>> childrenByParent = FindNodeBranchEntriesByParentCommand.create( this )
-                .parentPath( existingNode.path() )
-                .build()
-                .execute()
-                .stream()
-                .collect( Collectors.groupingBy( entry -> entry.getNodePath().getParentPath() ) );
-
-            storeChildNodes( existingNode, duplicatedNode, builder, childrenByParent, createdChildren );
+            storeChildNodes( existingNode, duplicatedNode, builder, createdChildren );
         }
 
         final NodeReferenceUpdatesHolder nodesToBeUpdated = builder.build();
@@ -181,22 +177,37 @@ public final class DuplicateNodeCommand
     }
 
     private void storeChildNodes( final Node originalParent, final Node newParent, final NodeReferenceUpdatesHolder.Builder builder,
-                                  final Map<NodePath, List<NodeBranchEntry>> childrenByParent, final List<Node> createdChildren )
+                                  final List<Node> createdChildren )
     {
         final InternalContext internalContext = InternalContext.from( ContextAccessor.current() );
 
-        final NodeIds childrenIds = childrenByParent.getOrDefault( originalParent.path(), List.of() )
+        final NodeBranchEntries subTree =
+            FindNodeBranchEntriesByParentCommand.create( this ).parentPath( originalParent.path() ).build().execute();
+
+        final NodeIds subTreeIds = subTree.stream().map( NodeBranchEntry::getNodeId ).collect( NodeIds.collector() );
+
+        // nodes not readable by the caller are not returned, and neither they nor their children are duplicated
+        final Map<NodeId, Node> originalNodes = this.nodeStorageService.get( subTreeIds, internalContext )
             .stream()
-            .map( NodeBranchEntry::getNodeId )
-            .collect( NodeIds.collector() );
+            .collect( Collectors.toMap( Node::id, Function.identity() ) );
 
-        final Nodes children = this.nodeStorageService.get( childrenIds, internalContext );
+        // entries are ordered by path, so a node is always duplicated before any of its children
+        final Map<NodePath, DuplicatedParent> duplicatedParents = new HashMap<>();
+        duplicatedParents.put( originalParent.path(), new DuplicatedParent( originalParent, newParent ) );
 
-        for ( final Node node : children )
+        for ( final NodeBranchEntry entry : subTree )
         {
-            final CreateNodeParams.Builder paramsBuilder = CreateNodeParams.from( node ).parent( newParent.path() );
+            final Node node = originalNodes.get( entry.getNodeId() );
+            final DuplicatedParent parent = duplicatedParents.get( entry.getNodePath().getParentPath() );
 
-            decideInsertStrategy( originalParent, node, paramsBuilder );
+            if ( node == null || parent == null )
+            {
+                continue;
+            }
+
+            final CreateNodeParams.Builder paramsBuilder = CreateNodeParams.from( node ).parent( parent.copy().path() );
+
+            decideInsertStrategy( parent.original(), node, paramsBuilder );
 
             attachBinaries( node, paramsBuilder );
 
@@ -206,8 +217,14 @@ public final class DuplicateNodeCommand
 
             final CreateNodeParams processedParams = executeProcessors( originalParams );
 
-            final Node newChildNode =
-                CreateNodeCommand.create( this ).params( processedParams ).binaryService( this.binaryService ).build().execute();
+            // the parent was just created, so it is both known and known to be empty
+            final Node newChildNode = CreateNodeCommand.create( this )
+                .params( processedParams )
+                .binaryService( this.binaryService )
+                .knownParentNode( parent.copy() )
+                .skipVerification( true )
+                .build()
+                .execute();
 
             builder.add( node.id(), newChildNode.id() );
 
@@ -215,8 +232,12 @@ public final class DuplicateNodeCommand
             createdChildren.add( newChildNode );
             listener.nodesDuplicated( 1 );
 
-            storeChildNodes( node, newChildNode, builder, childrenByParent, createdChildren );
+            duplicatedParents.put( node.path(), new DuplicatedParent( node, newChildNode ) );
         }
+    }
+
+    private record DuplicatedParent(Node original, Node copy)
+    {
     }
 
     private void decideInsertStrategy( final Node originalParent, final Node node, final CreateNodeParams.Builder paramsBuilder )

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/DuplicateNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/DuplicateNodeCommand.java
@@ -217,7 +217,7 @@ public final class DuplicateNodeCommand
 
             final CreateNodeParams processedParams = executeProcessors( originalParams );
 
-            // the parent was just created, so it is both known and known to be empty
+            // the parent copy is already at hand, and every child path below it is created exactly once
             final Node newChildNode = CreateNodeCommand.create( this )
                 .params( processedParams )
                 .binaryService( this.binaryService )

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/DuplicateNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/DuplicateNodeCommand.java
@@ -1,5 +1,10 @@
 package com.enonic.xp.repo.impl.node;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,18 +20,15 @@ import com.enonic.xp.node.DuplicateNodeResult;
 import com.enonic.xp.node.InsertManualStrategy;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeAlreadyExistAtPathException;
-import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeIds;
 import com.enonic.xp.node.NodeNotFoundException;
-import com.enonic.xp.node.NodeQuery;
+import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.Nodes;
 import com.enonic.xp.node.OperationNotPermittedException;
 import com.enonic.xp.node.PatchNodeParams;
-import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.repo.impl.InternalContext;
-import com.enonic.xp.repo.impl.SingleRepoSearchSource;
+import com.enonic.xp.repo.impl.NodeBranchEntry;
 import com.enonic.xp.repo.impl.binary.BinaryService;
-import com.enonic.xp.repo.impl.search.NodeSearchService;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.util.Reference;
 
@@ -71,17 +73,27 @@ public final class DuplicateNodeCommand
         final NodeReferenceUpdatesHolder.Builder builder =
             NodeReferenceUpdatesHolder.create().add( existingNode.id(), duplicatedNode.id() );
 
+        final List<Node> createdChildren = new ArrayList<>();
+
         if ( params.getIncludeChildren() )
         {
-            storeChildNodes( existingNode, duplicatedNode, builder );
+            final Map<NodePath, List<NodeBranchEntry>> childrenByParent = FindNodeBranchEntriesByParentCommand.create( this )
+                .parentPath( existingNode.path() )
+                .build()
+                .execute()
+                .stream()
+                .collect( Collectors.groupingBy( entry -> entry.getNodePath().getParentPath() ) );
+
+            storeChildNodes( existingNode, duplicatedNode, builder, childrenByParent, createdChildren );
         }
 
         final NodeReferenceUpdatesHolder nodesToBeUpdated = builder.build();
 
-        refresh( RefreshMode.SEARCH );
-
         updateNodeReferences( duplicatedNode, nodesToBeUpdated );
-        updateChildReferences( duplicatedNode, nodesToBeUpdated );
+        for ( final Node createdChild : createdChildren )
+        {
+            updateNodeReferences( createdChild, nodesToBeUpdated );
+        }
 
         refresh( params.getRefresh() );
         return result.build();
@@ -168,20 +180,14 @@ public final class DuplicateNodeCommand
         return updatedParams;
     }
 
-    private void storeChildNodes( final Node originalParent, final Node newParent, final NodeReferenceUpdatesHolder.Builder builder )
+    private void storeChildNodes( final Node originalParent, final Node newParent, final NodeReferenceUpdatesHolder.Builder builder,
+                                  final Map<NodePath, List<NodeBranchEntry>> childrenByParent, final List<Node> createdChildren )
     {
-        refresh( RefreshMode.SEARCH );
-
         final InternalContext internalContext = InternalContext.from( ContextAccessor.current() );
-        final NodeIds childrenIds = this.nodeSearchService.query( NodeQuery.create()
-                                                                      .size( NodeSearchService.GET_ALL_SIZE_FLAG )
-                                                                      .parent( originalParent.path() )
-                                                                      .setOrderExpressions(
-                                                                          originalParent.getChildOrder().getOrderExpressions() )
-                                                                      .build(), SingleRepoSearchSource.from( internalContext ) )
-            .getIds()
+
+        final NodeIds childrenIds = childrenByParent.getOrDefault( originalParent.path(), List.of() )
             .stream()
-            .map( NodeId::from )
+            .map( NodeBranchEntry::getNodeId )
             .collect( NodeIds.collector() );
 
         final Nodes children = this.nodeStorageService.get( childrenIds, internalContext );
@@ -206,9 +212,10 @@ public final class DuplicateNodeCommand
             builder.add( node.id(), newChildNode.id() );
 
             result.addChild( newChildNode );
+            createdChildren.add( newChildNode );
             listener.nodesDuplicated( 1 );
 
-            storeChildNodes( node, newChildNode, builder );
+            storeChildNodes( node, newChildNode, builder, childrenByParent, createdChildren );
         }
     }
 
@@ -226,22 +233,6 @@ public final class DuplicateNodeCommand
         for ( final AttachedBinary attachedBinary : node.getAttachedBinaries() )
         {
             paramsBuilder.attachBinary( attachedBinary.getBinaryReference(), this.binaryService.get( repositoryId, attachedBinary ) );
-        }
-    }
-
-    private void updateChildReferences( final Node duplicatedParent, final NodeReferenceUpdatesHolder nodeReferenceUpdatesHolder )
-    {
-        final InternalContext internalContext = InternalContext.from( ContextAccessor.current() );
-        final NodeIds childrenIds = this.nodeSearchService.query(
-            NodeQuery.create().size( NodeSearchService.GET_ALL_SIZE_FLAG ).parent( duplicatedParent.path() ).build(),
-            SingleRepoSearchSource.from( internalContext ) ).getIds().stream().map( NodeId::from ).collect( NodeIds.collector() );
-
-        final Nodes children = this.nodeStorageService.get( childrenIds, internalContext );
-
-        for ( final Node node : children )
-        {
-            updateNodeReferences( node, nodeReferenceUpdatesHolder );
-            updateChildReferences( node, nodeReferenceUpdatesHolder );
         }
     }
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodeBranchEntriesByParentCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodeBranchEntriesByParentCommand.java
@@ -1,0 +1,146 @@
+package com.enonic.xp.repo.impl.node;
+
+import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.data.ValueFactory;
+import com.enonic.xp.node.NodePath;
+import com.enonic.xp.node.RefreshMode;
+import com.enonic.xp.query.expr.CompareExpr;
+import com.enonic.xp.query.expr.FieldExpr;
+import com.enonic.xp.query.expr.FieldOrderExpr;
+import com.enonic.xp.query.expr.OrderExpr;
+import com.enonic.xp.query.expr.QueryExpr;
+import com.enonic.xp.query.expr.ValueExpr;
+import com.enonic.xp.query.filter.ValueFilter;
+import com.enonic.xp.repo.impl.InternalContext;
+import com.enonic.xp.repo.impl.NodeBranchEntries;
+import com.enonic.xp.repo.impl.NodeBranchEntry;
+import com.enonic.xp.repo.impl.branch.search.NodeBranchQuery;
+import com.enonic.xp.repo.impl.branch.search.NodeBranchQueryResultFactory;
+import com.enonic.xp.repo.impl.branch.storage.BranchIndexPath;
+import com.enonic.xp.repo.impl.search.NodeSearchService;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.acl.AccessControlList;
+import com.enonic.xp.security.acl.Permission;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Finds all branch entries below a parent path by querying the branch storage index,
+ * so that storage operations never depend on the search index.
+ */
+final class FindNodeBranchEntriesByParentCommand
+    extends AbstractNodeCommand
+{
+    private final NodePath parentPath;
+
+    private final OrderExpr.Direction pathOrder;
+
+    private final Permission requiredPermission;
+
+    private FindNodeBranchEntriesByParentCommand( final Builder builder )
+    {
+        super( builder );
+        this.parentPath = builder.parentPath;
+        this.pathOrder = builder.pathOrder;
+        this.requiredPermission = builder.requiredPermission;
+    }
+
+    static Builder create( final AbstractNodeCommand source )
+    {
+        return new Builder( source );
+    }
+
+    NodeBranchEntries execute()
+    {
+        final InternalContext context = InternalContext.from( ContextAccessor.current() );
+
+        refresh( RefreshMode.STORAGE );
+
+        final NodeBranchQuery query = NodeBranchQuery.create()
+            .query( QueryExpr.from( createParentExpr() ) )
+            .addQueryFilter( ValueFilter.create()
+                                 .fieldName( BranchIndexPath.BRANCH_NAME.getPath() )
+                                 .addValue( ValueFactory.newString( context.getBranch().getValue() ) )
+                                 .build() )
+            .addOrderBy( FieldOrderExpr.create( BranchIndexPath.PATH, pathOrder ) )
+            .size( NodeSearchService.GET_ALL_SIZE_FLAG )
+            .build();
+
+        final NodeBranchEntries entries =
+            NodeBranchQueryResultFactory.create( this.nodeSearchService.query( query, context.getRepositoryId() ) );
+
+        return filterByPermission( entries, context );
+    }
+
+    private CompareExpr createParentExpr()
+    {
+        return parentPath.isRoot()
+            ? CompareExpr.neq( FieldExpr.from( BranchIndexPath.PATH ), ValueExpr.string( NodePath.ROOT.toString() ) )
+            : CompareExpr.like( FieldExpr.from( BranchIndexPath.PATH ), ValueExpr.string( parentPath + "/*" ) );
+    }
+
+    private NodeBranchEntries filterByPermission( final NodeBranchEntries entries, final InternalContext context )
+    {
+        if ( requiredPermission == null || context.getPrincipalKeys().contains( RoleKeys.ADMIN ) )
+        {
+            return entries;
+        }
+
+        final NodeBranchEntries.Builder filtered = NodeBranchEntries.create();
+        for ( final NodeBranchEntry entry : entries )
+        {
+            final AccessControlList permissions = this.nodeStorageService.getNodePermissions( entry.getNodeVersionKey(), context );
+            if ( NodePermissionsResolver.hasPermission( context.getPrincipalKeys(), requiredPermission, permissions ) )
+            {
+                filtered.add( entry );
+            }
+        }
+        return filtered.build();
+    }
+
+    static final class Builder
+        extends AbstractNodeCommand.Builder<Builder>
+    {
+        private NodePath parentPath;
+
+        private OrderExpr.Direction pathOrder = OrderExpr.Direction.ASC;
+
+        private Permission requiredPermission;
+
+        private Builder( final AbstractNodeCommand source )
+        {
+            super( source );
+        }
+
+        Builder parentPath( final NodePath parentPath )
+        {
+            this.parentPath = parentPath;
+            return this;
+        }
+
+        Builder pathOrder( final OrderExpr.Direction pathOrder )
+        {
+            this.pathOrder = pathOrder;
+            return this;
+        }
+
+        Builder requiredPermission( final Permission requiredPermission )
+        {
+            this.requiredPermission = requiredPermission;
+            return this;
+        }
+
+        FindNodeBranchEntriesByParentCommand build()
+        {
+            validate();
+            return new FindNodeBranchEntriesByParentCommand( this );
+        }
+
+        @Override
+        void validate()
+        {
+            super.validate();
+            requireNonNull( parentPath, "parentPath is required" );
+        }
+    }
+}

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodeBranchEntriesByParentCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/FindNodeBranchEntriesByParentCommand.java
@@ -37,12 +37,15 @@ final class FindNodeBranchEntriesByParentCommand
 
     private final Permission requiredPermission;
 
+    private final boolean refreshStorage;
+
     private FindNodeBranchEntriesByParentCommand( final Builder builder )
     {
         super( builder );
         this.parentPath = builder.parentPath;
         this.pathOrder = builder.pathOrder;
         this.requiredPermission = builder.requiredPermission;
+        this.refreshStorage = builder.refreshStorage;
     }
 
     static Builder create( final AbstractNodeCommand source )
@@ -54,7 +57,10 @@ final class FindNodeBranchEntriesByParentCommand
     {
         final InternalContext context = InternalContext.from( ContextAccessor.current() );
 
-        refresh( RefreshMode.STORAGE );
+        if ( refreshStorage )
+        {
+            refresh( RefreshMode.STORAGE );
+        }
 
         final NodeBranchQuery query = NodeBranchQuery.create()
             .query( QueryExpr.from( createParentExpr() ) )
@@ -107,6 +113,8 @@ final class FindNodeBranchEntriesByParentCommand
 
         private Permission requiredPermission;
 
+        private boolean refreshStorage = true;
+
         private Builder( final AbstractNodeCommand source )
         {
             super( source );
@@ -127,6 +135,12 @@ final class FindNodeBranchEntriesByParentCommand
         Builder requiredPermission( final Permission requiredPermission )
         {
             this.requiredPermission = requiredPermission;
+            return this;
+        }
+
+        Builder refreshStorage( final boolean refreshStorage )
+        {
+            this.refreshStorage = refreshStorage;
             return this;
         }
 

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/MoveNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/MoveNodeCommand.java
@@ -1,5 +1,9 @@
 package com.enonic.xp.repo.impl.node;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.context.ContextBuilder;
@@ -12,19 +16,12 @@ import com.enonic.xp.node.MoveNodeResult;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeAlreadyExistAtPathException;
 import com.enonic.xp.node.NodeId;
-import com.enonic.xp.node.NodeIndexPath;
 import com.enonic.xp.node.NodeName;
 import com.enonic.xp.node.NodeNotFoundException;
 import com.enonic.xp.node.NodePath;
-import com.enonic.xp.node.NodeQuery;
 import com.enonic.xp.node.OperationNotPermittedException;
-import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.repo.impl.InternalContext;
-import com.enonic.xp.repo.impl.ReturnFields;
-import com.enonic.xp.repo.impl.SingleRepoSearchSource;
-import com.enonic.xp.repo.impl.search.NodeSearchService;
-import com.enonic.xp.repo.impl.search.result.SearchHit;
-import com.enonic.xp.repo.impl.search.result.SearchResult;
+import com.enonic.xp.repo.impl.NodeBranchEntry;
 import com.enonic.xp.repo.impl.storage.NodeVersionData;
 import com.enonic.xp.repo.impl.storage.StoreNodeParams;
 import com.enonic.xp.security.RoleKeys;
@@ -96,7 +93,13 @@ public class MoveNodeCommand
             .authInfo( AuthenticationInfo.copyOf( context.getAuthInfo() ).principals( RoleKeys.ADMIN ).build() )
             .build();
 
-        adminContext.callWith( () -> doMoveNode( newParentPath, newNodeName, params.getNodeId() ) );
+        final Map<NodePath, List<NodeBranchEntry>> childrenByParent = adminContext.callWith(
+            () -> FindNodeBranchEntriesByParentCommand.create( this ).parentPath( existingNode.path() ).build()
+                .execute()
+                .stream()
+                .collect( Collectors.groupingBy( entry -> entry.getNodePath().getParentPath() ) ) );
+
+        adminContext.callWith( () -> doMoveNode( newParentPath, newNodeName, params.getNodeId(), childrenByParent ) );
 
         refresh( params.getRefresh() );
 
@@ -134,7 +137,8 @@ public class MoveNodeCommand
         return existingNode.parentPath().equals( newParentPath ) && existingNode.name().equals( newNodeName );
     }
 
-    private Node doMoveNode( final NodePath newParentPath, final NodeName newNodeName, final NodeId id )
+    private Node doMoveNode( final NodePath newParentPath, final NodeName newNodeName, final NodeId id,
+                             final Map<NodePath, List<NodeBranchEntry>> childrenByParent )
     {
         final InternalContext internalContext = InternalContext.from( ContextAccessor.current() );
         final NodeVersionData persistedData = this.nodeStorageService.getNodeVersionData( id, internalContext );
@@ -177,16 +181,9 @@ public class MoveNodeCommand
 
         moveListener.nodesMoved( 1 );
 
-        refresh( RefreshMode.SEARCH );
-
-        final SearchResult children = this.nodeSearchService.query(
-            NodeQuery.create().parent( persistedNode.path() ).size( NodeSearchService.GET_ALL_SIZE_FLAG ).build(),
-            ReturnFields.from( NodeIndexPath.NAME ), SingleRepoSearchSource.from( internalContext ) );
-
-        for ( final SearchHit nodeBranchEntry : children.getHits() )
+        for ( final NodeBranchEntry childEntry : childrenByParent.getOrDefault( persistedNode.path(), List.of() ) )
         {
-            doMoveNode( movedNode.path(), NodeName.from( nodeBranchEntry.getReturnValues().getStringValue( NodeIndexPath.NAME ) ),
-                        NodeId.from( nodeBranchEntry.getId() ) );
+            doMoveNode( movedNode.path(), NodeName.from( childEntry.getNodePath().getName() ), childEntry.getNodeId(), childrenByParent );
         }
 
         return movedNode;

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/MoveNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/MoveNodeCommand.java
@@ -1,8 +1,7 @@
 package com.enonic.xp.repo.impl.node;
 
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
@@ -21,6 +20,7 @@ import com.enonic.xp.node.NodeNotFoundException;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.OperationNotPermittedException;
 import com.enonic.xp.repo.impl.InternalContext;
+import com.enonic.xp.repo.impl.NodeBranchEntries;
 import com.enonic.xp.repo.impl.NodeBranchEntry;
 import com.enonic.xp.repo.impl.storage.NodeVersionData;
 import com.enonic.xp.repo.impl.storage.StoreNodeParams;
@@ -93,13 +93,7 @@ public class MoveNodeCommand
             .authInfo( AuthenticationInfo.copyOf( context.getAuthInfo() ).principals( RoleKeys.ADMIN ).build() )
             .build();
 
-        final Map<NodePath, List<NodeBranchEntry>> childrenByParent = adminContext.callWith(
-            () -> FindNodeBranchEntriesByParentCommand.create( this ).parentPath( existingNode.path() ).build()
-                .execute()
-                .stream()
-                .collect( Collectors.groupingBy( entry -> entry.getNodePath().getParentPath() ) ) );
-
-        adminContext.callWith( () -> doMoveNode( newParentPath, newNodeName, params.getNodeId(), childrenByParent ) );
+        adminContext.runWith( () -> doMoveNodeTree( existingNode, newParentPath, newNodeName ) );
 
         refresh( params.getRefresh() );
 
@@ -137,8 +131,30 @@ public class MoveNodeCommand
         return existingNode.parentPath().equals( newParentPath ) && existingNode.name().equals( newNodeName );
     }
 
-    private Node doMoveNode( final NodePath newParentPath, final NodeName newNodeName, final NodeId id,
-                             final Map<NodePath, List<NodeBranchEntry>> childrenByParent )
+    private void doMoveNodeTree( final Node existingNode, final NodePath newParentPath, final NodeName newNodeName )
+    {
+        final NodeBranchEntries subTree =
+            FindNodeBranchEntriesByParentCommand.create( this ).parentPath( existingNode.path() ).build().execute();
+
+        doMoveNode( newParentPath, newNodeName, params.getNodeId() );
+
+        // entries are ordered by path, so a node is always moved before any of its children
+        final Map<NodePath, NodePath> newPaths = new HashMap<>();
+        newPaths.put( existingNode.path(), new NodePath( newParentPath, newNodeName ) );
+
+        for ( final NodeBranchEntry entry : subTree )
+        {
+            final NodePath newChildParentPath = requireNonNull( newPaths.get( entry.getNodePath().getParentPath() ),
+                                                                () -> "Parent of [" + entry.getNodePath() + "] was not moved yet" );
+            final NodeName childName = NodeName.from( entry.getNodePath().getName() );
+
+            newPaths.put( entry.getNodePath(), new NodePath( newChildParentPath, childName ) );
+
+            doMoveNode( newChildParentPath, childName, entry.getNodeId() );
+        }
+    }
+
+    private void doMoveNode( final NodePath newParentPath, final NodeName newNodeName, final NodeId id )
     {
         final InternalContext internalContext = InternalContext.from( ContextAccessor.current() );
         final NodeVersionData persistedData = this.nodeStorageService.getNodeVersionData( id, internalContext );
@@ -180,13 +196,6 @@ public class MoveNodeCommand
         this.result.addMovedNode( MoveNodeResult.MovedNode.create().previousPath( persistedNode.path() ).node( movedNode ).build() );
 
         moveListener.nodesMoved( 1 );
-
-        for ( final NodeBranchEntry childEntry : childrenByParent.getOrDefault( persistedNode.path(), List.of() ) )
-        {
-            doMoveNode( movedNode.path(), NodeName.from( childEntry.getNodePath().getName() ), childEntry.getNodeId(), childrenByParent );
-        }
-
-        return movedNode;
     }
 
     private void verifyNoExistingAtNewPath( final NodePath newParentPath, final NodeName newNodeName )

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/PushNodesCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/PushNodesCommand.java
@@ -75,8 +75,10 @@ public class PushNodesCommand
         {
             if ( comparison.getCompareStatus() == NodeCompareStatus.MOVED )
             {
+                // storage index is per-repository, so the refresh( STORAGE ) at the start of execute() already covers the target branch
                 final NodeIds childrenIds = targetContext().callWith( () -> FindNodeBranchEntriesByParentCommand.create( this )
                     .parentPath( comparison.getTargetPath() )
+                    .refreshStorage( false )
                     .build()
                     .execute()
                     .stream()

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/PushNodesCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/PushNodesCommand.java
@@ -17,28 +17,19 @@ import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeCompareStatus;
 import com.enonic.xp.node.NodeComparison;
 import com.enonic.xp.node.NodeComparisons;
-import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeIds;
-import com.enonic.xp.node.NodeIndexPath;
 import com.enonic.xp.node.NodePath;
-import com.enonic.xp.node.NodeQuery;
 import com.enonic.xp.node.PushNodeParams;
 import com.enonic.xp.node.PushNodeResult;
 import com.enonic.xp.node.PushNodesListener;
 import com.enonic.xp.node.PushNodesResult;
 import com.enonic.xp.node.RefreshMode;
-import com.enonic.xp.query.expr.CompareExpr;
-import com.enonic.xp.query.expr.FieldExpr;
-import com.enonic.xp.query.expr.QueryExpr;
-import com.enonic.xp.query.expr.ValueExpr;
 import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.NodeBranchEntries;
 import com.enonic.xp.repo.impl.NodeBranchEntry;
 import com.enonic.xp.repo.impl.NodeStoreVersion;
 import com.enonic.xp.repo.impl.SearchPreference;
-import com.enonic.xp.repo.impl.SingleRepoSearchSource;
 import com.enonic.xp.repo.impl.branch.storage.NodeFactory;
-import com.enonic.xp.repo.impl.search.NodeSearchService;
 import com.enonic.xp.repo.impl.storage.NodeVersionData;
 import com.enonic.xp.repo.impl.storage.StoreNodeParams;
 import com.enonic.xp.security.RoleKeys;
@@ -71,7 +62,7 @@ public class PushNodesCommand
 
     public PushNodesResult execute()
     {
-        refresh( RefreshMode.ALL );
+        refresh( RefreshMode.STORAGE );
 
         final InternalContext internalContext =
             InternalContext.create( ContextAccessor.current() ).searchPreference( SearchPreference.PRIMARY ).build();
@@ -80,23 +71,17 @@ public class PushNodesCommand
 
         final NodeComparisons comparisons = getNodeComparisons( params.getIds() );
 
-        final SingleRepoSearchSource targetSearchSource = SingleRepoSearchSource.from( InternalContext.from( targetContext() ) );
         for ( NodeComparison comparison : comparisons )
         {
             if ( comparison.getCompareStatus() == NodeCompareStatus.MOVED )
             {
-                final NodeIds childrenIds = this.nodeSearchService.query( NodeQuery.create()
-                                                                              .query( QueryExpr.from(
-                                                                                  CompareExpr.like( FieldExpr.from( NodeIndexPath.PATH ),
-                                                                                                    ValueExpr.string(
-                                                                                                        comparison.getTargetPath() +
-                                                                                                            "/*" ) ) ) )
-                                                                              .size( NodeSearchService.GET_ALL_SIZE_FLAG )
-                                                                              .build(), targetSearchSource )
-                    .getIds()
+                final NodeIds childrenIds = targetContext().callWith( () -> FindNodeBranchEntriesByParentCommand.create( this )
+                    .parentPath( comparison.getTargetPath() )
+                    .build()
+                    .execute()
                     .stream()
-                    .map( NodeId::from )
-                    .collect( NodeIds.collector() );
+                    .map( NodeBranchEntry::getNodeId )
+                    .collect( NodeIds.collector() ) );
                 allIdsBuilder.addAll( childrenIds );
             }
         }

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/ApplyNodePermissionsCommandTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/ApplyNodePermissionsCommandTest.java
@@ -310,6 +310,61 @@ class ApplyNodePermissionsCommandTest
 
         assertEquals( 1, result.getResults().size() );
         assertNull( result.getResult( createdNode.id(), ContentConstants.BRANCH_DRAFT ).permissions() );
+
+        final Node unchangedNode = ctxDefaultAdmin().callWith( () -> nodeService.getById( createdNode.id() ) );
+        assertEquals( createdNode.getPermissions(), unchangedNode.getPermissions() );
+    }
+
+    @Test
+    void applied_on_all_branches_when_allowed_on_reference_branch()
+    {
+        final PrincipalKey user = ContextAccessor.current().getAuthInfo().getUser().getKey();
+
+        // active version in master is not even readable by the user
+        final Node createdNode = ctxDefaultAdmin().callWith( () -> nodeService.create( CreateNodeParams.create()
+                                                                                           .name( "my-node" )
+                                                                                           .parent( NodePath.ROOT )
+                                                                                           .permissions( AccessControlList.of(
+                                                                                               AccessControlEntry.create()
+                                                                                                   .principal( PrincipalKey.from(
+                                                                                                       "user:system:someone-else" ) )
+                                                                                                   .allowAll()
+                                                                                                   .build() ) )
+                                                                                           .build() ) );
+
+        ctxDefaultAdmin().runWith( () -> pushNodes( WS_OTHER, createdNode.id() ) );
+
+        // reference (draft) version grants the user full access
+        ctxDefaultAdmin().runWith( () -> nodeService.applyPermissions( ApplyNodePermissionsParams.create()
+                                                                           .nodeId( createdNode.id() )
+                                                                           .branches( Branches.from( WS_DEFAULT ) )
+                                                                           .permissions( AccessControlList.of( AccessControlEntry.create()
+                                                                                                                   .principal( user )
+                                                                                                                   .allowAll()
+                                                                                                                   .build() ) )
+                                                                           .build() ) );
+
+        refresh();
+
+        final AccessControlList newPermissions = AccessControlList.create()
+            .add( AccessControlEntry.create().principal( user ).allowAll().build() )
+            .add( AccessControlEntry.create().principal( PrincipalKey.from( "user:my-provider:my-user" ) ).allowAll().build() )
+            .build();
+
+        final ApplyNodePermissionsResult result = nodeService.applyPermissions( ApplyNodePermissionsParams.create()
+                                                                                    .nodeId( createdNode.id() )
+                                                                                    .branches( Branches.from( WS_DEFAULT, WS_OTHER ) )
+                                                                                    .permissions( newPermissions )
+                                                                                    .build() );
+
+        assertEquals( newPermissions, result.getResult( createdNode.id(), ContentConstants.BRANCH_DRAFT ).permissions() );
+        assertEquals( newPermissions, result.getResult( createdNode.id(), ContentConstants.BRANCH_MASTER ).permissions() );
+
+        final Node masterNode = ContextBuilder.from( ctxDefaultAdmin() )
+            .branch( ContentConstants.BRANCH_MASTER )
+            .build()
+            .callWith( () -> nodeService.getById( createdNode.id() ) );
+        assertEquals( newPermissions, masterNode.getPermissions() );
     }
 
     @Test

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/CreateNodeCommandTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/CreateNodeCommandTest.java
@@ -23,6 +23,7 @@ import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.NodeQuery;
 import com.enonic.xp.node.RefreshMode;
 import com.enonic.xp.query.filter.ValueFilter;
+import com.enonic.xp.repo.impl.node.CreateNodeCommand;
 import com.enonic.xp.repo.impl.node.FindNodesByQueryCommand;
 import com.enonic.xp.util.BinaryReference;
 import com.enonic.xp.util.Reference;
@@ -287,4 +288,19 @@ class CreateNodeCommandTest
         doDeleteNode( defaultNode.id() );
     }
 
+    @Test
+    void known_parent_node_must_match_parent_to_create_in()
+    {
+        final Node otherParent = createNode( CreateNodeParams.create().name( "other-parent" ).parent( NodePath.ROOT ).build() );
+
+        final CreateNodeCommand.Builder builder = CreateNodeCommand.create()
+            .params( CreateNodeParams.create().name( "myNode" ).parent( NodePath.ROOT ).build() )
+            .knownParentNode( otherParent )
+            .binaryService( this.binaryService )
+            .indexServiceInternal( this.indexServiceInternal )
+            .storageService( this.storageService )
+            .searchService( this.searchService );
+
+        assertThrows( IllegalArgumentException.class, builder::build );
+    }
 }

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/FindNodeIdsByParentCommandTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/FindNodeIdsByParentCommandTest.java
@@ -81,6 +81,8 @@ class FindNodeIdsByParentCommandTest
 
         moveNode( node1_1.id(), node2.path() );
 
+        nodeService.refresh( RefreshMode.ALL );
+
         final FindNodesByParentResult children = FindNodeIdsByParentCommand.create()
             .parentPath( node.path() )
             .recursive( true )

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/FindNodeIdsByParentCommandTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/FindNodeIdsByParentCommandTest.java
@@ -81,7 +81,7 @@ class FindNodeIdsByParentCommandTest
 
         moveNode( node1_1.id(), node2.path() );
 
-        nodeService.refresh( RefreshMode.ALL );
+        nodeService.refresh( RefreshMode.SEARCH );
 
         final FindNodesByParentResult children = FindNodeIdsByParentCommand.create()
             .parentPath( node.path() )

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/NodeServiceImplTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/NodeServiceImplTest.java
@@ -256,7 +256,7 @@ class NodeServiceImplTest
         this.nodeService.refresh( RefreshMode.SEARCH );
 
         final Node duplicatedNode =
-            this.nodeService.duplicate( DuplicateNodeParams.create().nodeId( node_1.id() ).refresh( RefreshMode.ALL ).build() ).getNode();
+            this.nodeService.duplicate( DuplicateNodeParams.create().nodeId( node_1.id() ).refresh( RefreshMode.SEARCH ).build() ).getNode();
 
         final NodeId node_1_2_dup_id =
             this.nodeService.findByParent( FindNodesByParentParams.create().parentId( duplicatedNode.id() ).build() ).getNodeIds().first();

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/NodeServiceImplTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/NodeServiceImplTest.java
@@ -255,7 +255,8 @@ class NodeServiceImplTest
 
         this.nodeService.refresh( RefreshMode.SEARCH );
 
-        final Node duplicatedNode = this.nodeService.duplicate( DuplicateNodeParams.create().nodeId( node_1.id() ).build() ).getNode();
+        final Node duplicatedNode =
+            this.nodeService.duplicate( DuplicateNodeParams.create().nodeId( node_1.id() ).refresh( RefreshMode.ALL ).build() ).getNode();
 
         final NodeId node_1_2_dup_id =
             this.nodeService.findByParent( FindNodesByParentParams.create().parentId( duplicatedNode.id() ).build() ).getNodeIds().first();


### PR DESCRIPTION
Part of #12216

Child and subtree enumeration in storage-semantics node commands now reads the branch storage index instead of the search index, via a new shared `FindNodeBranchEntriesByParentCommand` (path prefix + branch filter, ordered by path, optional permission filtering from version ACLs, optional internal `refresh(STORAGE)`):

- `DeleteNodeCommand` — its existing inline branch-index query is extracted into the shared command (unchanged semantics).
- `MoveNodeCommand` — fetches the subtree once up front, removing the `refresh(SEARCH)` previously issued **per moved node**. The command already ran in an admin context, so dropping the search-index ACL filter changes nothing.
- `DuplicateNodeCommand` — child enumeration comes from the branch index (READ filtering still happens in `NodeStorageService.get`), and reference updates walk the in-memory created nodes instead of re-querying the new subtree. Both internal `refresh(SEARCH)` calls are gone.
- `ApplyNodePermissionsCommand` — recursive search enumeration replaced with one flat subtree fetch, READ-filtered via version ACLs to preserve user-context semantics; the target node itself gets the same explicit READ check.
- `PushNodesCommand` — children of MOVED nodes on the target branch are resolved from the branch index; the initial `refresh(ALL)` is downgraded to `STORAGE`. The final `refresh(ALL)` publish contract is unchanged.

Since the whole subtree is now available up front, move and duplicate no longer recurse. Branch entries come back ordered by path, which places every node before its children, so a single flat pass derives each new parent path (move) or parent copy (duplicate). Duplicate also stops re-reading the parent it just created for every child — `CreateNodeCommand` accepts a known parent node (still used for the CREATE check, permission inheritance and manual-order resolution), and child creates skip path-uniqueness verification because a freshly created parent cannot already contain them. Its subtree is read with a single bulk storage get rather than one per tree level. Nodes the caller cannot read are still skipped along with their children, and destination-parent checks are unchanged in both commands.

`ApplyNodePermissionsCommand` semantics are also fixed to match the intended model — permissions are read/authorized on the reference (context) branch and applied equally on all specified branches:

- Reference nodes (context branch) are the only candidates.
- WRITE_PERMISSIONS is checked once per node on the reference branch; denied nodes are skipped on **every** branch. Previously the per-branch guard recorded `notEnoughRights` but fell through and applied anyway, producing contradictory result rows and spurious `permissionsUpdated` events.
- Allowed nodes are applied as admin on all specified branches, so a branch whose active version is not readable by the caller no longer NPEs (`Node.create( null )`) and cannot block the uniform write. Diverged branch versions keep their own content — only the ACL changes.
- The caller-supplied branch order is preserved, since it determines the version origin.

Two tests relied on the removed implicit search refreshes and now refresh explicitly; the no-write-permissions test now asserts stored permissions stay unchanged, and a new test covers equal application to a branch whose active version the caller cannot read. Full `com.enonic.xp.core.node` (378 tests) and `itest-core-content` (385 tests) packages pass.

Still reading the search index (left for follow-up since each needs a design decision): `ResolveInsertOrderValueCommand` (needs `manualOrderValue`, absent from branch index documents), `SortNodeCommand` (needs to evaluate the previous arbitrary `ChildOrder` when seeding manual order), and `FindNodesDependenciesCommand` (reads indexed reference fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhDbJ4aQ4tJwUJw6qB22Lh