### PR TITLE
Allow content filter to re-route rendering to another content #10028

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/FilterNextFunctionWrapper.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/FilterNextFunctionWrapper.java
@@ -4,6 +4,7 @@ import java.util.function.Function;
 
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalResponse;
+import com.enonic.xp.portal.impl.PortalRequestHelper;
 import com.enonic.xp.portal.impl.mapper.PortalResponseMapper;
 import com.enonic.xp.portal.script.PortalScriptService;
 import com.enonic.xp.resource.ResourceKey;
@@ -26,16 +27,19 @@ public final class FilterNextFunctionWrapper
 
     private final PortalScriptService scriptService;
 
+    private final PortalRequestRerouter rerouter;
+
     private boolean functionWasCalled;
 
     public FilterNextFunctionWrapper( WebHandlerChain webHandlerChain, PortalRequest request, WebResponse response, ResourceKey script,
-                                      final PortalScriptService scriptService )
+                                      final PortalScriptService scriptService, final PortalRequestRerouter rerouter )
     {
         this.webHandlerChain = webHandlerChain;
         this.response = response;
         this.request = request;
         this.script = script;
         this.scriptService = scriptService;
+        this.rerouter = rerouter;
     }
 
     @Override
@@ -51,6 +55,11 @@ public final class FilterNextFunctionWrapper
         try
         {
             final PortalRequest portalRequest = new PortalRequestSerializer( request, scriptRequestParam ).serialize();
+
+            if ( !portalRequest.getRawPath().equals( request.getRawPath() ) && PortalRequestHelper.isSiteBase( portalRequest ) )
+            {
+                rerouter.reroute( portalRequest );
+            }
 
             final WebResponse newResponse = webHandlerChain.handle( portalRequest, response );
             final PortalResponseMapper response = new PortalResponseMapper( (PortalResponse) newResponse );

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/FilterNextFunctionWrapper.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/FilterNextFunctionWrapper.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.portal.impl.filter;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 import com.enonic.xp.portal.PortalRequest;
@@ -56,7 +57,8 @@ public final class FilterNextFunctionWrapper
         {
             final PortalRequest portalRequest = new PortalRequestSerializer( request, scriptRequestParam ).serialize();
 
-            if ( !portalRequest.getRawPath().equals( request.getRawPath() ) && PortalRequestHelper.isSiteBase( portalRequest ) )
+            if ( !Objects.equals( portalRequest.getContentPath(), request.getContentPath() ) &&
+                PortalRequestHelper.isSiteBase( portalRequest ) )
             {
                 rerouter.reroute( portalRequest );
             }

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/FilterScriptFactoryImpl.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/FilterScriptFactoryImpl.java
@@ -8,7 +8,6 @@ import com.enonic.xp.content.ContentService;
 import com.enonic.xp.portal.filter.FilterScript;
 import com.enonic.xp.portal.filter.FilterScriptFactory;
 import com.enonic.xp.portal.script.PortalScriptService;
-import com.enonic.xp.project.ProjectService;
 import com.enonic.xp.resource.ResourceKey;
 
 @Component
@@ -20,11 +19,10 @@ public final class FilterScriptFactoryImpl
     private final PortalRequestRerouter rerouter;
 
     @Activate
-    public FilterScriptFactoryImpl( @Reference final PortalScriptService scriptService, @Reference final ContentService contentService,
-                                    @Reference final ProjectService projectService )
+    public FilterScriptFactoryImpl( @Reference final PortalScriptService scriptService, @Reference final ContentService contentService )
     {
         this.scriptService = scriptService;
-        this.rerouter = new PortalRequestRerouter( contentService, projectService );
+        this.rerouter = new PortalRequestRerouter( contentService );
     }
 
     @Override

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/FilterScriptFactoryImpl.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/FilterScriptFactoryImpl.java
@@ -4,9 +4,11 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import com.enonic.xp.content.ContentService;
 import com.enonic.xp.portal.filter.FilterScript;
 import com.enonic.xp.portal.filter.FilterScriptFactory;
 import com.enonic.xp.portal.script.PortalScriptService;
+import com.enonic.xp.project.ProjectService;
 import com.enonic.xp.resource.ResourceKey;
 
 @Component
@@ -15,15 +17,19 @@ public final class FilterScriptFactoryImpl
 {
     private final PortalScriptService scriptService;
 
+    private final PortalRequestRerouter rerouter;
+
     @Activate
-    public FilterScriptFactoryImpl( @Reference final PortalScriptService scriptService )
+    public FilterScriptFactoryImpl( @Reference final PortalScriptService scriptService, @Reference final ContentService contentService,
+                                    @Reference final ProjectService projectService )
     {
         this.scriptService = scriptService;
+        this.rerouter = new PortalRequestRerouter( contentService, projectService );
     }
 
     @Override
     public FilterScript fromScript( final ResourceKey script )
     {
-        return new FilterScriptImpl( scriptService, script );
+        return new FilterScriptImpl( scriptService, script, rerouter );
     }
 }

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/FilterScriptImpl.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/FilterScriptImpl.java
@@ -27,10 +27,13 @@ final class FilterScriptImpl
 
     private final PortalScriptService scriptService;
 
-    FilterScriptImpl( final PortalScriptService scriptService, final ResourceKey script )
+    private final PortalRequestRerouter rerouter;
+
+    FilterScriptImpl( final PortalScriptService scriptService, final ResourceKey script, final PortalRequestRerouter rerouter )
     {
         this.scriptExports = scriptService.execute( script );
         this.scriptService = scriptService;
+        this.rerouter = rerouter;
     }
 
     @Override
@@ -73,7 +76,7 @@ final class FilterScriptImpl
 
         final PortalRequestMapper requestMapper = new PortalRequestMapper( request );
         final FilterNextFunctionWrapper nextHandler =
-            new FilterNextFunctionWrapper( webHandlerChain, request, response, scriptExports.getScript(), scriptService );
+            new FilterNextFunctionWrapper( webHandlerChain, request, response, scriptExports.getScript(), scriptService, rerouter );
 
         final ScriptValue result = this.scriptExports.executeMethod( FILTER_SCRIPT_METHOD, requestMapper, nextHandler );
         return new PortalResponseSerializer( result ).serialize();

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/PortalRequestRerouter.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/PortalRequestRerouter.java
@@ -1,0 +1,134 @@
+package com.enonic.xp.portal.impl.filter;
+
+import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.enonic.xp.branch.Branch;
+import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ContentNotFoundException;
+import com.enonic.xp.content.ContentPath;
+import com.enonic.xp.content.ContentService;
+import com.enonic.xp.context.Context;
+import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.portal.PortalRequest;
+import com.enonic.xp.project.Project;
+import com.enonic.xp.project.ProjectName;
+import com.enonic.xp.project.ProjectService;
+import com.enonic.xp.repository.RepositoryId;
+import com.enonic.xp.repository.RepositoryUtils;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.auth.AuthenticationInfo;
+import com.enonic.xp.site.Site;
+import com.enonic.xp.web.WebException;
+
+final class PortalRequestRerouter
+{
+    private static final Pattern SITE_RELATIVE_PATH_PATTERN = Pattern.compile( "^/(?<project>[^/]+)/(?<branch>[^/]+)(?<path>.*)$" );
+
+    private final ContentService contentService;
+
+    private final ProjectService projectService;
+
+    PortalRequestRerouter( final ContentService contentService, final ProjectService projectService )
+    {
+        this.contentService = contentService;
+        this.projectService = projectService;
+    }
+
+    void reroute( final PortalRequest request )
+    {
+        final String baseUri = request.getBaseUri();
+        final String basePath = request.getBasePath();
+
+        if ( baseUri == null || baseUri.isEmpty() || !basePath.startsWith( baseUri + "/" ) )
+        {
+            throw WebException.notFound( "Invalid site URL" );
+        }
+
+        final Matcher matcher = SITE_RELATIVE_PATH_PATTERN.matcher( basePath.substring( baseUri.length() ) );
+        if ( !matcher.matches() )
+        {
+            throw WebException.notFound( "Invalid site URL" );
+        }
+
+        final ProjectName projectName;
+        final Branch branch;
+        final ContentPath contentPath;
+        try
+        {
+            projectName = ProjectName.from( matcher.group( "project" ) );
+            branch = Branch.from( matcher.group( "branch" ) );
+            contentPath = ContentPath.from( matcher.group( "path" ) );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw WebException.badRequest( "Invalid site URL", e );
+        }
+
+        final RepositoryId repositoryId = projectName.getRepoId();
+
+        request.setRepositoryId( repositoryId );
+        request.setBranch( branch );
+        request.setContentPath( contentPath );
+        request.setContent( null );
+        request.setSite( null );
+        request.setComponent( null );
+        request.setPageDescriptor( null );
+        request.setControllerScript( null );
+
+        request.setProject( callAsContentAdmin( repositoryId, branch, () -> projectService.get( projectName ) ) );
+
+        if ( !contentPath.isRoot() )
+        {
+            final Content content = callAsContentAdmin( repositoryId, branch, () -> getContentByPath( contentPath ) );
+
+            if ( content != null )
+            {
+                request.setContent( content );
+                request.setContentPath( content.getPath() );
+                request.setSite( content.isSite()
+                                     ? (Site) content
+                                     : callAsContentAdmin( repositoryId, branch,
+                                                           () -> this.contentService.findNearestSiteByPath( content.getPath() ) ) );
+            }
+            else
+            {
+                request.setSite(
+                    callAsContentAdmin( repositoryId, branch, () -> this.contentService.findNearestSiteByPath( contentPath ) ) );
+            }
+        }
+
+        final Site site = request.getSite();
+        request.setContextPath( baseUri + "/" + RepositoryUtils.getContentRepoName( repositoryId ) + "/" + branch +
+                                    ( site != null ? site.getPath() : ContentPath.ROOT ) );
+
+        final Context context = ContextAccessor.current();
+        context.getLocalScope().setAttribute( repositoryId );
+        context.getLocalScope().setAttribute( branch );
+    }
+
+    private Content getContentByPath( final ContentPath contentPath )
+    {
+        try
+        {
+            return this.contentService.getByPath( contentPath );
+        }
+        catch ( final ContentNotFoundException e )
+        {
+            return null;
+        }
+    }
+
+    private static <T> T callAsContentAdmin( final RepositoryId repositoryId, final Branch branch, final Callable<T> callable )
+    {
+        final Context context = ContextAccessor.current();
+        return ContextBuilder.from( context )
+            .repositoryId( repositoryId )
+            .branch( branch )
+            .authInfo( AuthenticationInfo.copyOf( context.getAuthInfo() ).principals( RoleKeys.CONTENT_MANAGER_ADMIN ).build() )
+            .build()
+            .callWith( callable );
+    }
+}

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/PortalRequestRerouter.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/PortalRequestRerouter.java
@@ -1,8 +1,6 @@
 package com.enonic.xp.portal.impl.filter;
 
 import java.util.concurrent.Callable;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.content.Content;
@@ -13,72 +11,32 @@ import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.context.ContextBuilder;
 import com.enonic.xp.portal.PortalRequest;
-import com.enonic.xp.project.Project;
-import com.enonic.xp.project.ProjectName;
-import com.enonic.xp.project.ProjectService;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.repository.RepositoryUtils;
 import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.site.Site;
-import com.enonic.xp.web.WebException;
 
 final class PortalRequestRerouter
 {
-    private static final Pattern SITE_RELATIVE_PATH_PATTERN = Pattern.compile( "^/(?<project>[^/]+)/(?<branch>[^/]+)(?<path>.*)$" );
-
     private final ContentService contentService;
 
-    private final ProjectService projectService;
-
-    PortalRequestRerouter( final ContentService contentService, final ProjectService projectService )
+    PortalRequestRerouter( final ContentService contentService )
     {
         this.contentService = contentService;
-        this.projectService = projectService;
     }
 
     void reroute( final PortalRequest request )
     {
-        final String baseUri = request.getBaseUri();
-        final String basePath = request.getBasePath();
+        final ContentPath contentPath = request.getContentPath();
+        final RepositoryId repositoryId = request.getRepositoryId();
+        final Branch branch = request.getBranch();
 
-        if ( baseUri == null || baseUri.isEmpty() || !basePath.startsWith( baseUri + "/" ) )
-        {
-            throw WebException.notFound( "Invalid site URL" );
-        }
-
-        final Matcher matcher = SITE_RELATIVE_PATH_PATTERN.matcher( basePath.substring( baseUri.length() ) );
-        if ( !matcher.matches() )
-        {
-            throw WebException.notFound( "Invalid site URL" );
-        }
-
-        final ProjectName projectName;
-        final Branch branch;
-        final ContentPath contentPath;
-        try
-        {
-            projectName = ProjectName.from( matcher.group( "project" ) );
-            branch = Branch.from( matcher.group( "branch" ) );
-            contentPath = ContentPath.from( matcher.group( "path" ) );
-        }
-        catch ( IllegalArgumentException e )
-        {
-            throw WebException.badRequest( "Invalid site URL", e );
-        }
-
-        final RepositoryId repositoryId = projectName.getRepoId();
-
-        request.setRepositoryId( repositoryId );
-        request.setBranch( branch );
-        request.setContentPath( contentPath );
         request.setContent( null );
         request.setSite( null );
         request.setComponent( null );
         request.setPageDescriptor( null );
         request.setControllerScript( null );
-
-        request.setProject( callAsContentAdmin( repositoryId, branch, () -> projectService.get( projectName ) ) );
 
         if ( !contentPath.isRoot() )
         {
@@ -101,12 +59,8 @@ final class PortalRequestRerouter
         }
 
         final Site site = request.getSite();
-        request.setContextPath( baseUri + "/" + RepositoryUtils.getContentRepoName( repositoryId ) + "/" + branch +
+        request.setContextPath( request.getBaseUri() + "/" + RepositoryUtils.getContentRepoName( repositoryId ) + "/" + branch +
                                     ( site != null ? site.getPath() : ContentPath.ROOT ) );
-
-        final Context context = ContextAccessor.current();
-        context.getLocalScope().setAttribute( repositoryId );
-        context.getLocalScope().setAttribute( branch );
     }
 
     private Content getContentByPath( final ContentPath contentPath )

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/PortalRequestSerializer.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/PortalRequestSerializer.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Locale;
 
 import com.enonic.xp.branch.Branch;
+import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.RenderMode;
 import com.enonic.xp.script.ScriptValue;
@@ -45,7 +46,7 @@ public final class PortalRequestSerializer
         populateHost( req, value.getMember( "host" ) );
         populatePort( req, value.getMember( "port" ) );
         populatePath( req, value.getMember( "path" ) );
-        populateRawPath( req, value.getMember( "rawPath" ) );
+        populateContentPath( req, value.getMember( "contentPath" ) );
         populateUrl( req, value.getMember( "url" ) );
         populateRemoteAddress( req, value.getMember( "remoteAddress" ) );
         populateMode( req, value.getMember( "mode" ) );
@@ -117,12 +118,12 @@ public final class PortalRequestSerializer
         }
     }
 
-    private void populateRawPath( final PortalRequest req, final ScriptValue scriptValue )
+    private void populateContentPath( final PortalRequest req, final ScriptValue scriptValue )
     {
         final String value = ( scriptValue != null ) ? scriptValue.getValue( String.class ) : null;
         if ( value != null )
         {
-            req.setRawPath( value );
+            req.setContentPath( ContentPath.from( value ) );
         }
     }
 

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/PortalRequestSerializer.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/filter/PortalRequestSerializer.java
@@ -45,6 +45,7 @@ public final class PortalRequestSerializer
         populateHost( req, value.getMember( "host" ) );
         populatePort( req, value.getMember( "port" ) );
         populatePath( req, value.getMember( "path" ) );
+        populateRawPath( req, value.getMember( "rawPath" ) );
         populateUrl( req, value.getMember( "url" ) );
         populateRemoteAddress( req, value.getMember( "remoteAddress" ) );
         populateMode( req, value.getMember( "mode" ) );
@@ -113,6 +114,15 @@ public final class PortalRequestSerializer
         if ( value != null )
         {
             req.setPath( value );
+        }
+    }
+
+    private void populateRawPath( final PortalRequest req, final ScriptValue scriptValue )
+    {
+        final String value = ( scriptValue != null ) ? scriptValue.getValue( String.class ) : null;
+        if ( value != null )
+        {
+            req.setRawPath( value );
         }
     }
 

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/mapping/MappingFilterHandlerWorker.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/mapping/MappingFilterHandlerWorker.java
@@ -21,7 +21,7 @@ final class MappingFilterHandlerWorker
     @FunctionalInterface
     interface ControllerInvoker
     {
-        PortalResponse invoke( ControllerMappingDescriptor mapping )
+        PortalResponse invoke( PortalRequest request, ControllerMappingDescriptor mapping )
             throws Exception;
     }
 
@@ -79,17 +79,19 @@ final class MappingFilterHandlerWorker
                 return webHandlerChain.handle( webRequest, webResponse );
             }
 
+            final PortalRequest portalRequest = (PortalRequest) webRequest;
+
             final ControllerMappingDescriptor mapping = mappingDescriptors.get( index++ );
             final Trace trace = Tracer.current();
             if ( trace != null )
             {
-                trace.put( "contentPath", request.getContentPath() != null ? request.getContentPath().toString() : null );
+                trace.put( "contentPath", portalRequest.getContentPath() != null ? portalRequest.getContentPath().toString() : null );
             }
 
             if ( mapping.isController() )
             {
-                request.setApplicationKey( mapping.getApplication() );
-                return controllerInvoker.invoke( mapping );
+                portalRequest.setApplicationKey( mapping.getApplication() );
+                return controllerInvoker.invoke( portalRequest, mapping );
             }
 
             if ( trace != null )
@@ -98,7 +100,7 @@ final class MappingFilterHandlerWorker
                 trace.put( "filter", mapping.getFilter().toString() );
             }
 
-            return getScript( mapping ).execute( (PortalRequest) webRequest, webResponse, this );
+            return getScript( mapping ).execute( portalRequest, webResponse, this );
         }
     }
 }

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/mapping/MappingHandlerHelper.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/mapping/MappingHandlerHelper.java
@@ -163,7 +163,7 @@ class MappingHandlerHelper
         throws Exception
     {
         final MappingFilterHandlerWorker worker =
-            new MappingFilterHandlerWorker( request, response, webHandlerChain, mappings, mapping -> handleController( request, mapping ) );
+            new MappingFilterHandlerWorker( request, response, webHandlerChain, mappings, this::handleController );
         worker.resourceService = this.resourceService;
         worker.filterScriptFactory = this.filterScriptFactory;
 

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/mapper/PortalRequestMapper.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/mapper/PortalRequestMapper.java
@@ -48,6 +48,11 @@ public final class PortalRequestMapper
             gen.value( "branch", this.request.getBranch().getValue() );
         }
 
+        if ( this.request.getContentPath() != null )
+        {
+            gen.value( "contentPath", this.request.getContentPath().toString() );
+        }
+
         if ( this.request.getContextPath() != null )
         {
             gen.value( "contextPath", this.request.getContextPath() );

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/filter/FilterScriptImplTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/filter/FilterScriptImplTest.java
@@ -23,9 +23,7 @@ import com.enonic.xp.portal.PortalResponse;
 import com.enonic.xp.portal.RenderMode;
 import com.enonic.xp.portal.filter.FilterScript;
 import com.enonic.xp.portal.impl.script.PortalScriptServiceImpl;
-import com.enonic.xp.project.Project;
 import com.enonic.xp.project.ProjectName;
-import com.enonic.xp.project.ProjectService;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceProblemException;
 import com.enonic.xp.resource.ResourceService;
@@ -66,8 +64,6 @@ class FilterScriptImplTest
 
     protected ContentService contentService;
 
-    protected ProjectService projectService;
-
     public FilterScriptImplTest()
     {
     }
@@ -101,9 +97,8 @@ class FilterScriptImplTest
         scriptService.initialize();
 
         this.contentService = Mockito.mock( ContentService.class );
-        this.projectService = Mockito.mock( ProjectService.class );
 
-        this.factory = new FilterScriptFactoryImpl( scriptService, contentService, projectService );
+        this.factory = new FilterScriptFactoryImpl( scriptService, contentService );
     }
 
     @Test
@@ -222,7 +217,7 @@ class FilterScriptImplTest
     }
 
     @Test
-    void testRerouteOnRawPathChange()
+    void testRerouteOnContentPathChange()
         throws Exception
     {
         WebHandlerChain webHandlerChain = Mockito.mock( WebHandlerChain.class );
@@ -231,11 +226,9 @@ class FilterScriptImplTest
         this.portalRequest.setMethod( HttpMethod.GET );
         this.portalRequest.setBaseUri( "/site" );
         this.portalRequest.setRawPath( "/site/myproject/draft/mysite/municipalities" );
+        this.portalRequest.setContentPath( ContentPath.from( "/mysite/municipalities" ) );
         this.portalRequest.setRepositoryId( ProjectName.from( "myproject" ).getRepoId() );
         this.portalRequest.setBranch( Branch.from( "draft" ) );
-
-        final Project project = Mockito.mock( Project.class );
-        when( projectService.get( eq( ProjectName.from( "myproject" ) ) ) ).thenReturn( project );
 
         final Content content = newContent();
         when( contentService.getByPath( eq( ContentPath.from( "/mysite/municipalities/oslo" ) ) ) ).thenReturn( content );
@@ -249,18 +242,17 @@ class FilterScriptImplTest
         Mockito.verify( webHandlerChain ).handle( requestCaptor.capture(), Mockito.any() );
 
         final PortalRequest reroutedRequest = (PortalRequest) requestCaptor.getValue();
-        assertEquals( "/site/myproject/draft/mysite/municipalities/oslo", reroutedRequest.getRawPath() );
+        assertEquals( "/site/myproject/draft/mysite/municipalities", reroutedRequest.getRawPath() );
         assertEquals( ContentPath.from( "/mysite/municipalities/oslo" ), reroutedRequest.getContentPath() );
         assertEquals( ProjectName.from( "myproject" ).getRepoId(), reroutedRequest.getRepositoryId() );
         assertEquals( Branch.from( "draft" ), reroutedRequest.getBranch() );
         assertEquals( content, reroutedRequest.getContent() );
         assertEquals( site, reroutedRequest.getSite() );
-        assertEquals( project, reroutedRequest.getProject() );
         assertEquals( "/site/myproject/draft/mysite", reroutedRequest.getContextPath() );
     }
 
     @Test
-    void testRerouteToInvalidPath()
+    void testRerouteToNonExistentContent()
         throws Exception
     {
         WebHandlerChain webHandlerChain = Mockito.mock( WebHandlerChain.class );
@@ -268,17 +260,24 @@ class FilterScriptImplTest
 
         this.portalRequest.setMethod( HttpMethod.GET );
         this.portalRequest.setBaseUri( "/site" );
-        this.portalRequest.setRawPath( "/site/myproject/draft/mysite" );
+        this.portalRequest.setRawPath( "/site/myproject/draft/mysite/municipalities" );
+        this.portalRequest.setContentPath( ContentPath.from( "/mysite/municipalities" ) );
+        this.portalRequest.setRepositoryId( ProjectName.from( "myproject" ).getRepoId() );
+        this.portalRequest.setBranch( Branch.from( "draft" ) );
 
-        final WebException e =
-            assertThrows( WebException.class, () -> execute( "myapplication:/filter/reroute_invalid.js", webHandlerChain ) );
-        assertEquals( HttpStatus.NOT_FOUND, e.getStatus() );
+        execute( "myapplication:/filter/reroute.js", webHandlerChain );
 
-        Mockito.verifyNoInteractions( webHandlerChain );
+        final ArgumentCaptor<WebRequest> requestCaptor = ArgumentCaptor.forClass( WebRequest.class );
+        Mockito.verify( webHandlerChain ).handle( requestCaptor.capture(), Mockito.any() );
+
+        final PortalRequest reroutedRequest = (PortalRequest) requestCaptor.getValue();
+        assertEquals( ContentPath.from( "/mysite/municipalities/oslo" ), reroutedRequest.getContentPath() );
+        Assertions.assertNull( reroutedRequest.getContent() );
+        Assertions.assertNull( reroutedRequest.getSite() );
     }
 
     @Test
-    void testNoRerouteWhenRawPathUnchanged()
+    void testNoRerouteWhenContentPathUnchanged()
         throws Exception
     {
         WebHandlerChain webHandlerChain = Mockito.mock( WebHandlerChain.class );
@@ -287,11 +286,12 @@ class FilterScriptImplTest
         this.portalRequest.setMethod( HttpMethod.GET );
         this.portalRequest.setBaseUri( "/site" );
         this.portalRequest.setRawPath( "/site/myproject/draft/mysite" );
+        this.portalRequest.setContentPath( ContentPath.from( "/mysite" ) );
 
         execute( "myapplication:/filter/callnext.js", webHandlerChain );
 
         Mockito.verify( webHandlerChain ).handle( Mockito.any(), Mockito.any() );
-        Mockito.verifyNoInteractions( contentService, projectService );
+        Mockito.verifyNoInteractions( contentService );
     }
 
     private Content newContent()

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/filter/FilterScriptImplTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/filter/FilterScriptImplTest.java
@@ -1,30 +1,49 @@
 package com.enonic.xp.portal.impl.filter;
 
 import java.net.URL;
+import java.time.Instant;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import com.enonic.xp.app.Application;
 import com.enonic.xp.app.ApplicationKey;
+import com.enonic.xp.branch.Branch;
 import com.enonic.xp.config.ConfigBuilder;
+import com.enonic.xp.content.Content;
+import com.enonic.xp.content.ContentId;
+import com.enonic.xp.content.ContentPath;
+import com.enonic.xp.content.ContentService;
+import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.PortalResponse;
 import com.enonic.xp.portal.RenderMode;
 import com.enonic.xp.portal.filter.FilterScript;
 import com.enonic.xp.portal.impl.script.PortalScriptServiceImpl;
+import com.enonic.xp.project.Project;
+import com.enonic.xp.project.ProjectName;
+import com.enonic.xp.project.ProjectService;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceProblemException;
 import com.enonic.xp.resource.ResourceService;
 import com.enonic.xp.resource.UrlResource;
+import com.enonic.xp.schema.content.ContentTypeName;
 import com.enonic.xp.script.ScriptFixturesFacade;
 import com.enonic.xp.script.runtime.ScriptRuntimeFactory;
+import com.enonic.xp.security.PrincipalKey;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.acl.AccessControlEntry;
+import com.enonic.xp.security.acl.AccessControlList;
+import com.enonic.xp.security.acl.Permission;
+import com.enonic.xp.site.Site;
 import com.enonic.xp.util.Version;
 import com.enonic.xp.web.HttpMethod;
 import com.enonic.xp.web.HttpStatus;
 import com.enonic.xp.web.WebException;
+import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.handler.WebHandlerChain;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 class FilterScriptImplTest
@@ -43,6 +63,10 @@ class FilterScriptImplTest
     protected PortalResponse portalResponse;
 
     protected ResourceService resourceService;
+
+    protected ContentService contentService;
+
+    protected ProjectService projectService;
 
     public FilterScriptImplTest()
     {
@@ -76,7 +100,10 @@ class FilterScriptImplTest
         final PortalScriptServiceImpl scriptService = new PortalScriptServiceImpl( runtimeFactory );
         scriptService.initialize();
 
-        this.factory = new FilterScriptFactoryImpl( scriptService );
+        this.contentService = Mockito.mock( ContentService.class );
+        this.projectService = Mockito.mock( ProjectService.class );
+
+        this.factory = new FilterScriptFactoryImpl( scriptService, contentService, projectService );
     }
 
     @Test
@@ -192,6 +219,111 @@ class FilterScriptImplTest
         assertEquals( "Error executing filter script: myapplication:/filter/callnext.js", exception.getMessage() );
 
         Mockito.verify( webHandlerChain, Mockito.times( 1 ) ).handle( Mockito.any(), Mockito.any() );
+    }
+
+    @Test
+    void testRerouteOnRawPathChange()
+        throws Exception
+    {
+        WebHandlerChain webHandlerChain = Mockito.mock( WebHandlerChain.class );
+        when( webHandlerChain.handle( Mockito.any(), Mockito.any() ) ).thenReturn( this.portalResponse );
+
+        this.portalRequest.setMethod( HttpMethod.GET );
+        this.portalRequest.setBaseUri( "/site" );
+        this.portalRequest.setRawPath( "/site/myproject/draft/mysite/municipalities" );
+        this.portalRequest.setRepositoryId( ProjectName.from( "myproject" ).getRepoId() );
+        this.portalRequest.setBranch( Branch.from( "draft" ) );
+
+        final Project project = Mockito.mock( Project.class );
+        when( projectService.get( eq( ProjectName.from( "myproject" ) ) ) ).thenReturn( project );
+
+        final Content content = newContent();
+        when( contentService.getByPath( eq( ContentPath.from( "/mysite/municipalities/oslo" ) ) ) ).thenReturn( content );
+
+        final Site site = newSite();
+        when( contentService.findNearestSiteByPath( eq( content.getPath() ) ) ).thenReturn( site );
+
+        execute( "myapplication:/filter/reroute.js", webHandlerChain );
+
+        final ArgumentCaptor<WebRequest> requestCaptor = ArgumentCaptor.forClass( WebRequest.class );
+        Mockito.verify( webHandlerChain ).handle( requestCaptor.capture(), Mockito.any() );
+
+        final PortalRequest reroutedRequest = (PortalRequest) requestCaptor.getValue();
+        assertEquals( "/site/myproject/draft/mysite/municipalities/oslo", reroutedRequest.getRawPath() );
+        assertEquals( ContentPath.from( "/mysite/municipalities/oslo" ), reroutedRequest.getContentPath() );
+        assertEquals( ProjectName.from( "myproject" ).getRepoId(), reroutedRequest.getRepositoryId() );
+        assertEquals( Branch.from( "draft" ), reroutedRequest.getBranch() );
+        assertEquals( content, reroutedRequest.getContent() );
+        assertEquals( site, reroutedRequest.getSite() );
+        assertEquals( project, reroutedRequest.getProject() );
+        assertEquals( "/site/myproject/draft/mysite", reroutedRequest.getContextPath() );
+    }
+
+    @Test
+    void testRerouteToInvalidPath()
+        throws Exception
+    {
+        WebHandlerChain webHandlerChain = Mockito.mock( WebHandlerChain.class );
+        when( webHandlerChain.handle( Mockito.any(), Mockito.any() ) ).thenReturn( this.portalResponse );
+
+        this.portalRequest.setMethod( HttpMethod.GET );
+        this.portalRequest.setBaseUri( "/site" );
+        this.portalRequest.setRawPath( "/site/myproject/draft/mysite" );
+
+        final WebException e =
+            assertThrows( WebException.class, () -> execute( "myapplication:/filter/reroute_invalid.js", webHandlerChain ) );
+        assertEquals( HttpStatus.NOT_FOUND, e.getStatus() );
+
+        Mockito.verifyNoInteractions( webHandlerChain );
+    }
+
+    @Test
+    void testNoRerouteWhenRawPathUnchanged()
+        throws Exception
+    {
+        WebHandlerChain webHandlerChain = Mockito.mock( WebHandlerChain.class );
+        when( webHandlerChain.handle( Mockito.any(), Mockito.any() ) ).thenReturn( this.portalResponse );
+
+        this.portalRequest.setMethod( HttpMethod.GET );
+        this.portalRequest.setBaseUri( "/site" );
+        this.portalRequest.setRawPath( "/site/myproject/draft/mysite" );
+
+        execute( "myapplication:/filter/callnext.js", webHandlerChain );
+
+        Mockito.verify( webHandlerChain ).handle( Mockito.any(), Mockito.any() );
+        Mockito.verifyNoInteractions( contentService, projectService );
+    }
+
+    private Content newContent()
+    {
+        final Content.Builder<?> builder = Content.create();
+        builder.id( ContentId.from( "c8da0c10-0002-4b68-b407-87412f3e45c8" ) );
+        builder.name( "oslo" );
+        builder.displayName( "Oslo" );
+        builder.parentPath( ContentPath.from( "/mysite/municipalities" ) );
+        builder.type( ContentTypeName.from( ApplicationKey.from( "com.enonic.test.app" ), "municipality" ) );
+        builder.modifier( PrincipalKey.from( "user:system:admin" ) );
+        builder.modifiedTime( Instant.ofEpochSecond( 0 ) );
+        builder.creator( PrincipalKey.from( "user:system:admin" ) );
+        builder.createdTime( Instant.ofEpochSecond( 0 ) );
+        builder.data( new PropertyTree() );
+        builder.permissions( AccessControlList.create()
+                                 .add( AccessControlEntry.create().allow( Permission.READ ).principal( RoleKeys.EVERYONE ).build() )
+                                 .build() );
+        return builder.build();
+    }
+
+    private Site newSite()
+    {
+        final Site.Builder site = Site.create();
+        site.id( ContentId.from( "site0c10-0002-4b68-b407-87412f3e45c9" ) );
+        site.data( new PropertyTree() );
+        site.name( "mysite" );
+        site.parentPath( ContentPath.ROOT );
+        site.permissions( AccessControlList.create()
+                              .add( AccessControlEntry.create().allow( Permission.READ ).principal( RoleKeys.EVERYONE ).build() )
+                              .build() );
+        return site.build();
     }
 
     protected final void execute( final String script, final WebHandlerChain webHandlerChain )

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/filter/PortalRequestSerializerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/filter/PortalRequestSerializerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.enonic.xp.branch.Branch;
+import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.RenderMode;
 import com.enonic.xp.script.ScriptFixturesFacade;
@@ -114,30 +115,29 @@ class PortalRequestSerializerTest
     }
 
     @Test
-    void serializeRawPath()
+    void serializeContentPath()
     {
         final PortalRequest sourceRequest = new PortalRequest();
-        sourceRequest.setRawPath( "/site/myproject/draft/mysite" );
+        sourceRequest.setContentPath( ContentPath.from( "/mysite/municipalities" ) );
 
-        final ScriptValue value = factory.evalValue( "var result = {rawPath: '/site/myproject/draft/mysite/oslo'}; result;" );
+        final ScriptValue value = factory.evalValue( "var result = {contentPath: '/mysite/municipalities/oslo'}; result;" );
 
         final PortalRequest portalRequest = new PortalRequestSerializer( sourceRequest, value ).serialize();
 
-        assertEquals( "/site/myproject/draft/mysite/oslo", portalRequest.getRawPath() );
-        assertEquals( "/site/myproject/draft/mysite/oslo", portalRequest.getBasePath() );
+        assertEquals( ContentPath.from( "/mysite/municipalities/oslo" ), portalRequest.getContentPath() );
     }
 
     @Test
-    void serializeRawPathUnchanged()
+    void serializeContentPathUnchanged()
     {
         final PortalRequest sourceRequest = new PortalRequest();
-        sourceRequest.setRawPath( "/site/myproject/draft/mysite" );
+        sourceRequest.setContentPath( ContentPath.from( "/mysite/municipalities" ) );
 
         final ScriptValue value = factory.evalValue( "var result = {path: '/other'}; result;" );
 
         final PortalRequest portalRequest = new PortalRequestSerializer( sourceRequest, value ).serialize();
 
-        assertEquals( "/site/myproject/draft/mysite", portalRequest.getRawPath() );
+        assertEquals( ContentPath.from( "/mysite/municipalities" ), portalRequest.getContentPath() );
     }
 
     @Test

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/filter/PortalRequestSerializerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/filter/PortalRequestSerializerTest.java
@@ -114,6 +114,33 @@ class PortalRequestSerializerTest
     }
 
     @Test
+    void serializeRawPath()
+    {
+        final PortalRequest sourceRequest = new PortalRequest();
+        sourceRequest.setRawPath( "/site/myproject/draft/mysite" );
+
+        final ScriptValue value = factory.evalValue( "var result = {rawPath: '/site/myproject/draft/mysite/oslo'}; result;" );
+
+        final PortalRequest portalRequest = new PortalRequestSerializer( sourceRequest, value ).serialize();
+
+        assertEquals( "/site/myproject/draft/mysite/oslo", portalRequest.getRawPath() );
+        assertEquals( "/site/myproject/draft/mysite/oslo", portalRequest.getBasePath() );
+    }
+
+    @Test
+    void serializeRawPathUnchanged()
+    {
+        final PortalRequest sourceRequest = new PortalRequest();
+        sourceRequest.setRawPath( "/site/myproject/draft/mysite" );
+
+        final ScriptValue value = factory.evalValue( "var result = {path: '/other'}; result;" );
+
+        final PortalRequest portalRequest = new PortalRequestSerializer( sourceRequest, value ).serialize();
+
+        assertEquals( "/site/myproject/draft/mysite", portalRequest.getRawPath() );
+    }
+
+    @Test
     void serializeNonObject()
     {
         final PortalRequest sourceRequest = new PortalRequest();

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/mapper/PortalRequestMapperTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/mapper/PortalRequestMapperTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.content.ContentConstants;
+import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.portal.RenderMode;
 import com.enonic.xp.portal.impl.ContentFixtures;
@@ -78,6 +79,14 @@ class PortalRequestMapperTest
         this.portalRequest.setBody( "Hello World" );
 
         assertHelper.assertJson( "request-body.json", new PortalRequestMapper( this.portalRequest ) );
+    }
+
+    @Test
+    void contentPath()
+    {
+        this.portalRequest.setContentPath( ContentPath.from( "/a/b" ) );
+        final ScriptValue value = MapSerializableAssert.serializeJs( new PortalRequestMapper( this.portalRequest ) );
+        assertEquals( "/a/b", value.getMember( "contentPath" ).getValue( String.class ) );
     }
 
     @Test

--- a/modules/portal/portal-impl/src/test/resources/myapplication/filter/reroute.js
+++ b/modules/portal/portal-impl/src/test/resources/myapplication/filter/reroute.js
@@ -1,4 +1,4 @@
 exports.filter = function (req, next) {
-    req.rawPath = '/site/myproject/draft/mysite/municipalities/oslo';
+    req.contentPath = '/mysite/municipalities/oslo';
     return next(req);
 };

--- a/modules/portal/portal-impl/src/test/resources/myapplication/filter/reroute.js
+++ b/modules/portal/portal-impl/src/test/resources/myapplication/filter/reroute.js
@@ -1,0 +1,4 @@
+exports.filter = function (req, next) {
+    req.rawPath = '/site/myproject/draft/mysite/municipalities/oslo';
+    return next(req);
+};

--- a/modules/portal/portal-impl/src/test/resources/myapplication/filter/reroute_invalid.js
+++ b/modules/portal/portal-impl/src/test/resources/myapplication/filter/reroute_invalid.js
@@ -1,4 +1,0 @@
-exports.filter = function (req, next) {
-    req.rawPath = '/webapp/otherapp/path';
-    return next(req);
-};

--- a/modules/portal/portal-impl/src/test/resources/myapplication/filter/reroute_invalid.js
+++ b/modules/portal/portal-impl/src/test/resources/myapplication/filter/reroute_invalid.js
@@ -1,0 +1,4 @@
+exports.filter = function (req, next) {
+    req.rawPath = '/webapp/otherapp/path';
+    return next(req);
+};


### PR DESCRIPTION
Closes #10028

Allows a site mapping filter to re-route rendering to another content without proxying.

### How it works

The request object in controllers and filters now exposes `contentPath`. When a filter passes a request with a **modified `contentPath`** to `next()`, the portal re-resolves `content`, `site` and `contextPath` for the new path (within the current project and branch) before continuing the handler chain, so downstream rendering targets the re-routed content instead of the originally resolved one.

```js
exports.filter = function (req, next) {
    var selected = req.params.selected;
    if (selected) {
        req.contentPath = req.contentPath + '/' + selected.toLowerCase();
    }
    return next(req);
};
```

### Semantics

- The request URL (`path`, `rawPath`, `url`) stays untouched — the page is served at the original URL while rendering the re-routed content.
- Re-routing is scoped to the current project and branch (`contentPath` cannot express another repository), so re-routed requests stay within the current vhost scope and generated URLs do not go out of scope.
- Content lookup is done elevated (same as initial request resolution), while read-permission enforcement still happens at render time — a re-route to unreadable content yields 403, to non-existent content 404.
- Controller mappings invoked after a filter in the same mapping chain now receive the current (possibly re-routed) request instead of the request captured before the filters ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMdv95e9ExhZQVXsndeGPW