### PR TITLE
readThrough.sizeThreshold not honored on read #12221

### DIFF
--- a/modules/core/core-blobstore/src/main/java/com/enonic/xp/internal/blobstore/readthrough/ReadThroughBlobStore.java
+++ b/modules/core/core-blobstore/src/main/java/com/enonic/xp/internal/blobstore/readthrough/ReadThroughBlobStore.java
@@ -45,7 +45,7 @@ public class ReadThroughBlobStore
 
         record = store.getRecord( segment, key );
 
-        if ( record != null )
+        if ( record != null && withinLimit( record ) )
         {
             this.readThroughStore.addRecord( segment, record );
         }
@@ -77,7 +77,10 @@ public class ReadThroughBlobStore
         throws BlobStoreException
     {
         this.store.addRecord( segment, record );
-        this.readThroughStore.addRecord( segment, record );
+        if ( withinLimit( record ) )
+        {
+            this.readThroughStore.addRecord( segment, record );
+        }
         return record;
     }
 

--- a/modules/core/core-blobstore/src/test/java/com/enonic/xp/internal/blobstore/BlobStoreFactoryTest.java
+++ b/modules/core/core-blobstore/src/test/java/com/enonic/xp/internal/blobstore/BlobStoreFactoryTest.java
@@ -94,7 +94,7 @@ class BlobStoreFactoryTest
             @Override
             public long readThroughSizeThreshold()
             {
-                return 0;
+                return 1024;
             }
 
             @Override

--- a/modules/core/core-blobstore/src/test/java/com/enonic/xp/internal/blobstore/readthrough/ReadThroughBlobStoreTest.java
+++ b/modules/core/core-blobstore/src/test/java/com/enonic/xp/internal/blobstore/readthrough/ReadThroughBlobStoreTest.java
@@ -1,6 +1,9 @@
 package com.enonic.xp.internal.blobstore.readthrough;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -86,7 +89,7 @@ class ReadThroughBlobStoreTest
             .sizeThreshold( ByteSizeParser.parse( "80kb" ) )
             .build();
 
-        final ByteSource binary = ByteSource.wrap( ByteStreams.toByteArray( this.getClass().getResourceAsStream( "fish-86kb.jpg" ) ) );
+        final ByteSource binary = overThresholdBinary();
 
         final Segment segment = Segment.from( "test", "blob" );
         final BlobRecord record = actualBlobStore.addRecord( segment, binary );
@@ -99,7 +102,7 @@ class ReadThroughBlobStoreTest
     void obey_size_threshold_after_read()
         throws Exception
     {
-        final ByteSource binary = ByteSource.wrap( ByteStreams.toByteArray( this.getClass().getResourceAsStream( "fish-86kb.jpg" ) ) );
+        final ByteSource binary = overThresholdBinary();
         final Segment segment = Segment.from( "test", "blob" );
 
         final BlobRecord record = this.finalStore.addRecord( segment, binary );
@@ -119,7 +122,7 @@ class ReadThroughBlobStoreTest
     void obey_size_threshold_on_record_add()
         throws Exception
     {
-        final ByteSource binary = ByteSource.wrap( ByteStreams.toByteArray( this.getClass().getResourceAsStream( "fish-86kb.jpg" ) ) );
+        final ByteSource binary = overThresholdBinary();
         final Segment segment = Segment.from( "test", "blob" );
 
         final MemoryBlobStore sourceStore = new MemoryBlobStore();
@@ -135,6 +138,36 @@ class ReadThroughBlobStoreTest
 
         assertNull( this.readThroughStore.getRecord( segment, record.getKey() ) );
         assertNotNull( this.finalStore.getRecord( segment, record.getKey() ) );
+    }
+
+    @Test
+    void stored_in_readthrough_on_record_add()
+    {
+        final ByteSource binary = ByteSource.wrap( "this is a record".getBytes() );
+        final Segment segment = Segment.from( "test", "blob" );
+
+        final MemoryBlobStore sourceStore = new MemoryBlobStore();
+        final BlobRecord record = sourceStore.addRecord( segment, binary );
+
+        final ReadThroughBlobStore actualBlobStore = ReadThroughBlobStore.create()
+            .readThroughStore( this.readThroughStore )
+            .store( this.finalStore )
+            .sizeThreshold( ByteSizeParser.parse( "80kb" ) )
+            .build();
+
+        actualBlobStore.addRecord( segment, record );
+
+        assertNotNull( this.readThroughStore.getRecord( segment, record.getKey() ) );
+        assertNotNull( this.finalStore.getRecord( segment, record.getKey() ) );
+    }
+
+    private ByteSource overThresholdBinary()
+        throws IOException
+    {
+        try (InputStream in = Objects.requireNonNull( this.getClass().getResourceAsStream( "fish-86kb.jpg" ) ))
+        {
+            return ByteSource.wrap( ByteStreams.toByteArray( in ) );
+        }
     }
 
     @Test

--- a/modules/core/core-blobstore/src/test/java/com/enonic/xp/internal/blobstore/readthrough/ReadThroughBlobStoreTest.java
+++ b/modules/core/core-blobstore/src/test/java/com/enonic/xp/internal/blobstore/readthrough/ReadThroughBlobStoreTest.java
@@ -63,8 +63,11 @@ class ReadThroughBlobStoreTest
 
         final BlobRecord record = this.finalStore.addRecord( segment, binary );
 
-        final ReadThroughBlobStore actualBlobStore =
-            ReadThroughBlobStore.create().readThroughStore( this.readThroughStore ).store( this.finalStore ).build();
+        final ReadThroughBlobStore actualBlobStore = ReadThroughBlobStore.create()
+            .readThroughStore( this.readThroughStore )
+            .store( this.finalStore )
+            .sizeThreshold( ByteSizeParser.parse( "80kb" ) )
+            .build();
 
         assertNull( this.readThroughStore.getRecord( segment, record.getKey() ) );
 
@@ -93,14 +96,59 @@ class ReadThroughBlobStoreTest
     }
 
     @Test
+    void obey_size_threshold_after_read()
+        throws Exception
+    {
+        final ByteSource binary = ByteSource.wrap( ByteStreams.toByteArray( this.getClass().getResourceAsStream( "fish-86kb.jpg" ) ) );
+        final Segment segment = Segment.from( "test", "blob" );
+
+        final BlobRecord record = this.finalStore.addRecord( segment, binary );
+
+        final ReadThroughBlobStore actualBlobStore = ReadThroughBlobStore.create()
+            .readThroughStore( this.readThroughStore )
+            .store( this.finalStore )
+            .sizeThreshold( ByteSizeParser.parse( "80kb" ) )
+            .build();
+
+        assertNotNull( actualBlobStore.getRecord( segment, record.getKey() ) );
+
+        assertNull( this.readThroughStore.getRecord( segment, record.getKey() ) );
+    }
+
+    @Test
+    void obey_size_threshold_on_record_add()
+        throws Exception
+    {
+        final ByteSource binary = ByteSource.wrap( ByteStreams.toByteArray( this.getClass().getResourceAsStream( "fish-86kb.jpg" ) ) );
+        final Segment segment = Segment.from( "test", "blob" );
+
+        final MemoryBlobStore sourceStore = new MemoryBlobStore();
+        final BlobRecord record = sourceStore.addRecord( segment, binary );
+
+        final ReadThroughBlobStore actualBlobStore = ReadThroughBlobStore.create()
+            .readThroughStore( this.readThroughStore )
+            .store( this.finalStore )
+            .sizeThreshold( ByteSizeParser.parse( "80kb" ) )
+            .build();
+
+        actualBlobStore.addRecord( segment, record );
+
+        assertNull( this.readThroughStore.getRecord( segment, record.getKey() ) );
+        assertNotNull( this.finalStore.getRecord( segment, record.getKey() ) );
+    }
+
+    @Test
     void removeRecord()
     {
         final ByteSource binary = ByteSource.wrap( "this is a record".getBytes() );
         final Segment segment = Segment.from( "test", "blob" );
 
         final BlobRecord record = this.finalStore.addRecord( segment, binary );
-        final ReadThroughBlobStore actualBlobStore =
-            ReadThroughBlobStore.create().readThroughStore( this.readThroughStore ).store( this.finalStore ).build();
+        final ReadThroughBlobStore actualBlobStore = ReadThroughBlobStore.create()
+            .readThroughStore( this.readThroughStore )
+            .store( this.finalStore )
+            .sizeThreshold( ByteSizeParser.parse( "80kb" ) )
+            .build();
 
         assertNull( this.readThroughStore.getRecord( segment, record.getKey() ) );
         actualBlobStore.getRecord( segment, record.getKey() );
@@ -134,8 +182,11 @@ class ReadThroughBlobStoreTest
         final Segment segment = Segment.from( "test", "blob" );
 
         final BlobRecord record = this.finalStore.addRecord( segment, binary );
-        final ReadThroughBlobStore actualBlobStore =
-            ReadThroughBlobStore.create().readThroughStore( this.readThroughStore ).store( this.finalStore ).build();
+        final ReadThroughBlobStore actualBlobStore = ReadThroughBlobStore.create()
+            .readThroughStore( this.readThroughStore )
+            .store( this.finalStore )
+            .sizeThreshold( ByteSizeParser.parse( "80kb" ) )
+            .build();
 
         assertNull( this.readThroughStore.getRecord( segment, record.getKey() ) );
         actualBlobStore.getRecord( segment, record.getKey() );
@@ -214,8 +265,11 @@ class ReadThroughBlobStoreTest
     @Test
     void deleteSegment()
     {
-        final ReadThroughBlobStore actualBlobStore =
-            ReadThroughBlobStore.create().readThroughStore( readThroughStore ).store( finalStore ).build();
+        final ReadThroughBlobStore actualBlobStore = ReadThroughBlobStore.create()
+            .readThroughStore( readThroughStore )
+            .store( finalStore )
+            .sizeThreshold( ByteSizeParser.parse( "80kb" ) )
+            .build();
         final ByteSource binary = ByteSource.wrap( "this is a record".getBytes() );
         final Segment segment = Segment.from( "test", "blob" );
         final BlobRecord record = finalStore.addRecord( segment, binary );


### PR DESCRIPTION
Fixes #12221

`ReadThroughBlobStore` applied `sizeThreshold` only in `addRecord( Segment, ByteSource )`. Blobs larger than the threshold were still copied into the read-through store when read (`getRecord`) or added as a record (`addRecord( Segment, BlobRecord )`).

Changes:
- `getRecord` and `addRecord( Segment, BlobRecord )` now populate the read-through store only when the blob is within `sizeThreshold`.
- New tests `obey_size_threshold_after_read` and `obey_size_threshold_on_record_add` cover both paths.
- Existing tests that implicitly relied on the unconditional population (built without a threshold, or with a `0` threshold in `BlobStoreFactoryTest`) now set a realistic threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpnQqLvHBmzrPMekohs4Tu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpnQqLvHBmzrPMekohs4Tu)_