### PR TITLE
Harden read-through cache index seeding and eviction logging

### DIFF
--- a/modules/core/core-blobstore/src/main/java/com/enonic/xp/internal/blobstore/readthrough/SizeBoundedBlobStore.java
+++ b/modules/core/core-blobstore/src/main/java/com/enonic/xp/internal/blobstore/readthrough/SizeBoundedBlobStore.java
@@ -112,6 +112,8 @@ public final class SizeBoundedBlobStore
         }
         catch ( InterruptedException e )
         {
+            LOG.warn( "Interrupted while indexing existing blobs."
+                          + " Capacity is enforced on the indexed records only until unindexed records are read" );
             Thread.currentThread().interrupt();
         }
         finally

--- a/modules/core/core-blobstore/src/main/java/com/enonic/xp/internal/blobstore/readthrough/SizeBoundedBlobStore.java
+++ b/modules/core/core-blobstore/src/main/java/com/enonic/xp/internal/blobstore/readthrough/SizeBoundedBlobStore.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.internal.blobstore.readthrough;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -43,16 +44,29 @@ public final class SizeBoundedBlobStore
 
     private final Cache<IndexKey, Long> index;
 
+    private final Duration seedRetryDelay;
+
     private volatile boolean seeded;
+
+    private static final int SEED_ATTEMPTS = 3;
+
+    private static final Duration SEED_RETRY_DELAY = Duration.ofSeconds( 10 );
 
     public SizeBoundedBlobStore( final BlobStore store, final long capacity )
     {
-        this( store, capacity, null, task -> Thread.ofVirtual().name( "blobstore-cache-seed" ).start( task ) );
+        this( store, capacity, null, task -> Thread.ofVirtual().name( "blobstore-cache-seed" ).start( task ), SEED_RETRY_DELAY );
     }
 
     SizeBoundedBlobStore( final BlobStore store, final long capacity, final Executor indexExecutor, final Executor seedExecutor )
     {
+        this( store, capacity, indexExecutor, seedExecutor, Duration.ZERO );
+    }
+
+    SizeBoundedBlobStore( final BlobStore store, final long capacity, final Executor indexExecutor, final Executor seedExecutor,
+                          final Duration seedRetryDelay )
+    {
         this.store = store;
+        this.seedRetryDelay = seedRetryDelay;
 
         final Caffeine<IndexKey, Long> builder = Caffeine.newBuilder()
             .maximumWeight( capacity )
@@ -69,37 +83,65 @@ public final class SizeBoundedBlobStore
 
     private void seed()
     {
-        final long start = System.nanoTime();
-        long count = 0;
         try
         {
-            final List<Segment> segments;
-            try (Stream<Segment> segmentStream = this.store.listSegments())
+            for ( int attempt = 1; attempt <= SEED_ATTEMPTS; attempt++ )
             {
-                segments = segmentStream.toList();
-            }
-            for ( final Segment segment : segments )
-            {
-                try (Stream<BlobRecord> records = this.store.list( segment ))
+                try
                 {
-                    for ( final Iterator<BlobRecord> it = records.iterator(); it.hasNext(); )
+                    doSeed();
+                    return;
+                }
+                catch ( Exception e )
+                {
+                    if ( attempt < SEED_ATTEMPTS )
                     {
-                        final BlobRecord record = it.next();
-                        this.index.put( new IndexKey( segment, record.getKey() ), record.getLength() );
-                        count++;
+                        LOG.debug( "Failed to index existing blobs, retrying", e );
+                        Thread.sleep( this.seedRetryDelay );
+                    }
+                    else
+                    {
+                        // Capacity is still enforced: a partial index bounds all new growth, while unindexed
+                        // records are indexed on their first read. Staying in pass-through mode would bound nothing.
+                        LOG.warn( "Failed to index existing blobs after {} attempts."
+                                      + " Capacity is enforced on the indexed records only until unindexed records are read",
+                                  SEED_ATTEMPTS, e );
                     }
                 }
             }
-            LOG.debug( "Indexed {} existing blobs in {} ms", count, ( System.nanoTime() - start ) / 1_000_000 );
         }
-        catch ( Exception e )
+        catch ( InterruptedException e )
         {
-            LOG.warn( "Failed to index existing blobs", e );
+            Thread.currentThread().interrupt();
         }
         finally
         {
             this.seeded = true;
         }
+    }
+
+    private void doSeed()
+    {
+        final long start = System.nanoTime();
+        long count = 0;
+        final List<Segment> segments;
+        try (Stream<Segment> segmentStream = this.store.listSegments())
+        {
+            segments = segmentStream.toList();
+        }
+        for ( final Segment segment : segments )
+        {
+            try (Stream<BlobRecord> records = this.store.list( segment ))
+            {
+                for ( final Iterator<BlobRecord> it = records.iterator(); it.hasNext(); )
+                {
+                    final BlobRecord record = it.next();
+                    this.index.put( new IndexKey( segment, record.getKey() ), record.getLength() );
+                    count++;
+                }
+            }
+        }
+        LOG.debug( "Indexed {} existing blobs in {} ms", count, ( System.nanoTime() - start ) / 1_000_000 );
     }
 
     private void removeEvicted( final IndexKey key )
@@ -110,7 +152,8 @@ public final class SizeBoundedBlobStore
         }
         catch ( Exception e )
         {
-            LOG.debug( "Failed to remove evicted blob [{}]", key.key(), e );
+            LOG.warn( "Failed to remove evicted blob [{}]. The record stays in the store untracked until it is read again",
+                      key.key(), e );
         }
     }
 
@@ -123,7 +166,8 @@ public final class SizeBoundedBlobStore
             return this.store.getRecord( segment, key );
         }
 
-        // records the access in the admission filter, also when the record is not present yet
+        // a hit refreshes the record in the admission policy; a missed record gains admission
+        // priority through the repeated population attempts that follow the fallback reads
         final Long indexed = this.index.getIfPresent( new IndexKey( segment, key ) );
 
         final BlobRecord record = this.store.getRecord( segment, key );

--- a/modules/core/core-blobstore/src/test/java/com/enonic/xp/internal/blobstore/readthrough/SizeBoundedBlobStoreTest.java
+++ b/modules/core/core-blobstore/src/test/java/com/enonic/xp/internal/blobstore/readthrough/SizeBoundedBlobStoreTest.java
@@ -6,10 +6,12 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import com.google.common.io.ByteSource;
 
 import com.enonic.xp.blob.BlobRecord;
+import com.enonic.xp.blob.BlobStoreException;
 import com.enonic.xp.blob.Segment;
 import com.enonic.xp.internal.blobstore.MemoryBlobStore;
 
@@ -129,6 +131,38 @@ class SizeBoundedBlobStoreTest
         {
             assertEquals( 0, segments.count() );
         }
+    }
+
+    @Test
+    void seeding_retries_on_failure()
+    {
+        this.delegate.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 1".getBytes() ) );
+        this.delegate.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 2".getBytes() ) );
+        this.delegate.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 3".getBytes() ) );
+
+        final MemoryBlobStore flaky = Mockito.spy( this.delegate );
+        Mockito.doThrow( new BlobStoreException( "transient failure" ) ).doCallRealMethod().when( flaky ).listSegments();
+
+        final SizeBoundedBlobStore boundedStore = new SizeBoundedBlobStore( flaky, 25, Runnable::run, Runnable::run );
+        boundedStore.cleanUp();
+
+        assertTrue( delegateTotalSize() <= 25 );
+    }
+
+    @Test
+    void seeding_failure_still_enforces_capacity_for_new_records()
+    {
+        final MemoryBlobStore failing = Mockito.spy( this.delegate );
+        Mockito.doThrow( new BlobStoreException( "permanent failure" ) ).when( failing ).listSegments();
+
+        final SizeBoundedBlobStore boundedStore = new SizeBoundedBlobStore( failing, 25, Runnable::run, Runnable::run );
+
+        boundedStore.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 1".getBytes() ) );
+        boundedStore.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 2".getBytes() ) );
+        boundedStore.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 3".getBytes() ) );
+        boundedStore.cleanUp();
+
+        assertTrue( delegateTotalSize() <= 25 );
     }
 
     @Test

--- a/modules/core/core-blobstore/src/test/java/com/enonic/xp/internal/blobstore/readthrough/SizeBoundedBlobStoreTest.java
+++ b/modules/core/core-blobstore/src/test/java/com/enonic/xp/internal/blobstore/readthrough/SizeBoundedBlobStoreTest.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.internal.blobstore.readthrough;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -162,6 +163,65 @@ class SizeBoundedBlobStoreTest
         boundedStore.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 3".getBytes() ) );
         boundedStore.cleanUp();
 
+        assertTrue( delegateTotalSize() <= 25 );
+    }
+
+    @Test
+    void seeding_interrupted_still_enforces_capacity_for_new_records()
+        throws Exception
+    {
+        final MemoryBlobStore failing = Mockito.spy( this.delegate );
+        Mockito.doThrow( new BlobStoreException( "failure" ) ).when( failing ).listSegments();
+
+        final List<Runnable> seedTask = new ArrayList<>();
+        final SizeBoundedBlobStore boundedStore =
+            new SizeBoundedBlobStore( failing, 25, Runnable::run, seedTask::add, Duration.ofDays( 1 ) );
+
+        final Thread seeder = new Thread( seedTask.get( 0 ) );
+        seeder.start();
+        seeder.interrupt();
+        seeder.join( 10_000 );
+
+        boundedStore.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 1".getBytes() ) );
+        boundedStore.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 2".getBytes() ) );
+        boundedStore.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 3".getBytes() ) );
+        boundedStore.cleanUp();
+
+        assertTrue( delegateTotalSize() <= 25 );
+    }
+
+    @Test
+    void eviction_removal_failure_is_tolerated()
+    {
+        final MemoryBlobStore failing = Mockito.spy( this.delegate );
+        Mockito.doThrow( new BlobStoreException( "no removal" ) ).when( failing ).removeRecord( Mockito.any(), Mockito.any() );
+
+        final SizeBoundedBlobStore boundedStore = new SizeBoundedBlobStore( failing, 25, Runnable::run, Runnable::run );
+
+        boundedStore.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 1".getBytes() ) );
+        boundedStore.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 2".getBytes() ) );
+        boundedStore.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 3".getBytes() ) );
+        boundedStore.cleanUp();
+
+        // records stay in the delegate because removal fails, but no exception surfaces
+        assertEquals( 30, delegateTotalSize() );
+    }
+
+    @Test
+    void seeds_in_background()
+        throws Exception
+    {
+        this.delegate.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 1".getBytes() ) );
+        this.delegate.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 2".getBytes() ) );
+        this.delegate.addRecord( SEGMENT, ByteSource.wrap( "10 bytes 3".getBytes() ) );
+
+        new SizeBoundedBlobStore( this.delegate, 25 );
+
+        // seeding and eviction run on background threads - wait for the bound to take effect
+        for ( int i = 0; i < 200 && delegateTotalSize() > 25; i++ )
+        {
+            Thread.sleep( 50 );
+        }
         assertTrue( delegateTotalSize() <= 25 );
     }
 


### PR DESCRIPTION
Follow-up to the review comments on #12223 ([review](https://github.com/enonic/xp/pull/12223#pullrequestreview-4845022682)).

- **Seeding failure** ([comment](https://github.com/enonic/xp/pull/12223#discussion_r3704702649)): the seeding walk now retries up to 3 times (10 s apart) before giving up — a failed walk at startup is most likely a transient disk hiccup. After a definitive failure, capacity enforcement still starts, deliberately: a partial index bounds all new growth and unindexed records join the index on their first read, whereas staying in pass-through mode would bound nothing and let the store grow without limit. The warning now states this consequence explicitly.
- **Eviction removal failure** ([comment](https://github.com/enonic/xp/pull/12223#discussion_r3704702691)): raised from DEBUG to WARN — the record stays in the store untracked until it is read again, which erodes the size guarantee if it keeps happening.
- **Misleading comment** ([comment](https://github.com/enonic/xp/pull/12223#discussion_r3704702596)): correct — `getIfPresent` records only hits in the admission policy. The design property still holds functionally: a repeatedly requested blob gains admission priority through the repeated population attempts (`put` increments the frequency sketch) that follow each fallback read. The comment now says so instead of claiming misses are recorded.

New tests cover seeding retry and capacity enforcement of new records after a definitive seeding failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpnQqLvHBmzrPMekohs4Tu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpnQqLvHBmzrPMekohs4Tu)_