### PR TITLE
Fix restore snapshot task ignoring 'latest' and 'force' params #12230

### DIFF
--- a/modules/app/app-system/src/main/resources/tasks/restore/restore.js
+++ b/modules/app/app-system/src/main/resources/tasks/restore/restore.js
@@ -4,8 +4,8 @@ exports.run = function (params, taskId) {
     var bean = __.newBean('com.enonic.xp.app.system.RestoreTaskHandler');
     bean.setSnapshotName(__.nullOrValue(params.snapshotName));
     bean.setRepositoryId(__.nullOrValue(params.repositoryId));
-    bean.setLatest(params.latest === 'true');
-    bean.setForce(params.force === 'true');
+    bean.setLatest(params.latest === true);
+    bean.setForce(params.force === true);
     bean.setTaskId(__.nullOrValue(taskId));
     bean.execute();
 };

--- a/modules/app/app-system/src/test/resources/test/RestoreTaskHandlerTest.js
+++ b/modules/app/app-system/src/test/resources/test/RestoreTaskHandlerTest.js
@@ -1,11 +1,11 @@
 var system = require('/tasks/restore/restore.js');
 
 exports.restore = function () {
-    let params = {snapshotName: 'my-snapshot', repositoryId: 'my-repo', latest: 'false', force: 'true'};
+    let params = {snapshotName: 'my-snapshot', repositoryId: 'my-repo', latest: false, force: true};
     system.run(params, "task");
 };
 
 exports.restoreLatest = function () {
-    let params = {latest: 'true'};
+    let params = {latest: true};
     system.run(params, "task");
 };

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/snapshot/SnapshotServiceImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/snapshot/SnapshotServiceImpl.java
@@ -135,6 +135,11 @@ public class SnapshotServiceImpl
     {
         final String snapshotName = restoreParams.isLatest() ? determineNameOfLatestSnapshot() : restoreParams.getSnapshotName();
 
+        if ( snapshotName == null || snapshotName.isBlank() )
+        {
+            throw new SnapshotException( "Failed to restore snapshot: Snapshot name is required when 'latest' is not set" );
+        }
+
         validateSnapshot( snapshotName );
 
         final RepositoryId repositoryToRestore = restoreParams.getRepositoryId();


### PR DESCRIPTION
The /repo/snapshot/restore endpoint stores 'latest' and 'force' as
boolean properties, but restore.js compared them strictly against the
string 'true', so they were always treated as false. A restore request
with {"latest": true} then proceeded with a null snapshot name, which
failed deep in Elasticsearch with an obscure NullPointerException.

Read the flags as booleans in restore.js, align the tests with what
SnapshotResource actually submits, and fail fast with a clear message
when neither 'latest' nor a snapshot name is given.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XR4KY8Bzqx2pzEzKrXsRD5