### PR TITLE
lib-content: sync TS declarations with runtime, expose publish failure reasons

### DIFF
--- a/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/mapper/PublishContentResultMapper.java
+++ b/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/mapper/PublishContentResultMapper.java
@@ -45,12 +45,6 @@ public class PublishContentResultMapper
             gen.value( "reason", result.failureReason() );
             gen.end();
         }
-        for ( ContentPath path : this.contentNotFound )
-        {
-            gen.map();
-            gen.value( "id", path.toString() );
-            gen.end();
-        }
         gen.end();
     }
 

--- a/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/mapper/PublishContentResultMapper.java
+++ b/modules/lib/lib-content/src/main/java/com/enonic/xp/lib/content/mapper/PublishContentResultMapper.java
@@ -32,6 +32,26 @@ public class PublishContentResultMapper
     {
         serializeContentIds( gen, "pushedContents", value.getPushedContents() );
         serializeFailedContent( gen, "failedContents", value.getFailedContents() );
+        serializeFailed( gen, "failed", value.getFailed() );
+    }
+
+    private void serializeFailed( final MapGenerator gen, final String name, final List<PublishContentResult.Result> failed )
+    {
+        gen.array( name );
+        for ( PublishContentResult.Result result : failed )
+        {
+            gen.map();
+            gen.value( "id", result.contentId().toString() );
+            gen.value( "reason", result.failureReason() );
+            gen.end();
+        }
+        for ( ContentPath path : this.contentNotFound )
+        {
+            gen.map();
+            gen.value( "id", path.toString() );
+            gen.end();
+        }
+        gen.end();
     }
 
     private void serializeContentIds( final MapGenerator gen, final String name, final ContentIds contents )

--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -184,7 +184,10 @@ export interface PatchableContent<
     variantOf: string;
     attachments: Attachments;
     validationErrors: ValidationError[];
-    type: Type;
+    /**
+     * Read-only. Available on the content passed to the patcher, but assigning it has no effect.
+     */
+    readonly type: Type;
     childOrder: string;
     originProject: string;
     originalParentPath: string;
@@ -1036,9 +1039,20 @@ export interface PublishContentParams {
     message?: string;
 }
 
+export type PublishFailureReason = 'ALREADY_EXIST' | 'PARENT_NOT_FOUND' | 'ACCESS_DENIED' | 'INVALID' | 'NOT_READY';
+
+export interface PublishFailure {
+    id: string;
+    /**
+     * Absent for content that could not be resolved from the given path.
+     */
+    reason?: PublishFailureReason;
+}
+
 export interface PublishContentResult {
     pushedContents: string[];
     failedContents: string[];
+    failed: PublishFailure[];
 }
 
 interface PublishContentHandler {
@@ -1071,7 +1085,10 @@ interface PublishContentHandler {
  * @param {boolean} [params.includeDependencies=true] Whether all related content should be included when publishing content.
  * @param {string} [params.message] Publish message.
  *
- * @returns {object} Status of the publish operation in JSON.
+ * @returns {object} Status of the publish operation in JSON. In addition to the `pushedContents` and `failedContents` id arrays,
+ * `failed` holds one entry per failed item with the reason it could not be published
+ * (`ALREADY_EXIST`, `PARENT_NOT_FOUND`, `ACCESS_DENIED`, `INVALID` or `NOT_READY`). The reason is absent for keys given as a path
+ * that could not be resolved to any content.
  */
 export function publish(params: PublishContentParams): PublishContentResult {
     const keys = checkRequired(params, 'keys');
@@ -1351,12 +1368,7 @@ export interface ApplyPermissionsParams {
     removePermissions?: AccessControlEntry[];
 }
 
-export type ApplyPermissionsResult = Record<string, BranchResult[]>;
-
-export interface BranchResult {
-    branch: string;
-    permissions: AccessControlEntry[];
-}
+export type ApplyPermissionsResult = Record<string, Permissions>;
 
 export interface Permissions {
     permissions?: AccessControlEntry[];
@@ -1857,6 +1869,14 @@ export interface ContentVersion {
 
 export interface ContentVersionAction {
     operation: string;
+    /**
+     * Branch the operation was performed in.
+     */
+    origin?: string;
+    /**
+     * Version id of the editorial content this version originates from.
+     */
+    editorial?: string;
     user: string;
     opTime: string;
 }

--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -1043,15 +1043,18 @@ export type PublishFailureReason = 'ALREADY_EXIST' | 'PARENT_NOT_FOUND' | 'ACCES
 
 export interface PublishFailure {
     id: string;
-    /**
-     * Absent for content that could not be resolved from the given path.
-     */
-    reason?: PublishFailureReason;
+    reason: PublishFailureReason;
 }
 
 export interface PublishContentResult {
     pushedContents: string[];
     failedContents: string[];
+    /**
+     * One entry per content the publish engine rejected, with the reason it was rejected.
+     *
+     * Keys that could not be resolved to any content never reach the engine and so have no reason;
+     * they are listed in `failedContents` only.
+     */
     failed: PublishFailure[];
 }
 
@@ -1086,9 +1089,9 @@ interface PublishContentHandler {
  * @param {string} [params.message] Publish message.
  *
  * @returns {object} Status of the publish operation in JSON. In addition to the `pushedContents` and `failedContents` id arrays,
- * `failed` holds one entry per failed item with the reason it could not be published
- * (`ALREADY_EXIST`, `PARENT_NOT_FOUND`, `ACCESS_DENIED`, `INVALID` or `NOT_READY`). The reason is absent for keys given as a path
- * that could not be resolved to any content.
+ * `failed` holds one `{id, reason}` entry per content the engine rejected, where reason is one of
+ * `ALREADY_EXIST`, `PARENT_NOT_FOUND`, `ACCESS_DENIED`, `INVALID` or `NOT_READY`. Keys that could not be resolved to any
+ * content never reach the engine and are listed in `failedContents` only.
  */
 export function publish(params: PublishContentParams): PublishContentResult {
     const keys = checkRequired(params, 'keys');
@@ -1369,6 +1372,15 @@ export interface ApplyPermissionsParams {
 }
 
 export type ApplyPermissionsResult = Record<string, Permissions>;
+
+/**
+ * @deprecated Never emitted by `applyPermissions`, which returns one `Permissions` object per content id.
+ * Kept only so existing imports keep resolving.
+ */
+export interface BranchResult {
+    branch: string;
+    permissions: AccessControlEntry[];
+}
 
 export interface Permissions {
     permissions?: AccessControlEntry[];

--- a/modules/lib/lib-content/src/main/resources/lib/xp/examples/content/publish.js
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/examples/content/publish.js
@@ -18,6 +18,11 @@ var result = contentLib.publish({
 if (result) {
     log.info('Pushed ' + result.pushedContents.length + ' content.');
     log.info('Content that failed operation: ' + result.failedContents.length);
+
+    // Inspect why each item failed
+    result.failed.forEach(function (failure) {
+        log.info(failure.id + ' failed: ' + (failure.reason || 'NOT_FOUND'));
+    });
 } else {
     log.info('Operation failed.');
 }
@@ -33,6 +38,12 @@ var expected = {
     ],
     'failedContents': [
         '79e21db0-5b43-45ce-b58c-6e1c420b22bd'
+    ],
+    'failed': [
+        {
+            'id': '79e21db0-5b43-45ce-b58c-6e1c420b22bd',
+            'reason': 'INVALID'
+        }
     ]
 };
 // END

--- a/modules/lib/lib-content/src/main/resources/lib/xp/examples/content/publish.js
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/examples/content/publish.js
@@ -19,9 +19,9 @@ if (result) {
     log.info('Pushed ' + result.pushedContents.length + ' content.');
     log.info('Content that failed operation: ' + result.failedContents.length);
 
-    // Inspect why each item failed
+    // Inspect why each item was rejected
     result.failed.forEach(function (failure) {
-        log.info(failure.id + ' failed: ' + (failure.reason || 'NOT_FOUND'));
+        log.info(failure.id + ' failed: ' + failure.reason);
     });
 } else {
     log.info('Operation failed.');

--- a/modules/lib/lib-content/src/test/java/com/enonic/xp/lib/content/PublishContentHandlerTest.java
+++ b/modules/lib/lib-content/src/test/java/com/enonic/xp/lib/content/PublishContentHandlerTest.java
@@ -161,6 +161,19 @@ class PublishContentHandlerTest
     }
 
     @Test
+    void publishMixedFailures()
+    {
+        final PublishContentResult result = PublishContentResult.create()
+            .add( PublishContentResult.Result.success( ContentId.from( PUB_ID_3 ) ) )
+            .add( PublishContentResult.Result.failure( ContentId.from( FAIL_ID ), PublishContentResult.Reason.NOT_READY ) )
+            .build();
+
+        when( this.contentService.publish( any() ) ).thenReturn( result );
+
+        runFunction( "/test/PublishContentHandlerTest.js", "publishMixedFailures" );
+    }
+
+    @Test
     void testContentNotFound()
     {
         runFunction( "/test/PublishContentHandlerTest.js", "contentNotFound" );

--- a/modules/lib/lib-content/src/test/java/com/enonic/xp/lib/content/PublishContentHandlerTest.java
+++ b/modules/lib/lib-content/src/test/java/com/enonic/xp/lib/content/PublishContentHandlerTest.java
@@ -17,6 +17,7 @@ import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.security.PrincipalKey;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 class PublishContentHandlerTest
@@ -144,6 +145,19 @@ class PublishContentHandlerTest
 
         assertThat( captor.getValue() ).extracting( "contentIds", "message" )
             .containsExactly( ContentIds.from( PUB_ID_2, DEL_ID, FAIL_ID ), "My first publish" );
+    }
+
+    @Test
+    void publishAllFailed()
+    {
+        final PublishContentResult result = PublishContentResult.create()
+            .add( PublishContentResult.Result.failure( ContentId.from( PUB_ID_2 ), PublishContentResult.Reason.NOT_READY ) )
+            .add( PublishContentResult.Result.failure( ContentId.from( FAIL_ID ), PublishContentResult.Reason.ACCESS_DENIED ) )
+            .build();
+
+        when( this.contentService.publish( any() ) ).thenReturn( result );
+
+        runFunction( "/test/PublishContentHandlerTest.js", "publishAllFailed" );
     }
 
     @Test

--- a/modules/lib/lib-content/src/test/resources/test/PublishContentHandlerTest.js
+++ b/modules/lib/lib-content/src/test/resources/test/PublishContentHandlerTest.js
@@ -117,3 +117,31 @@ exports.contentNotFound = function () {
 
     assert.assertJsonEquals(contentNotFoundExpectedJson, result);
 };
+
+// Engine-reported failures come first, then keys that could not be resolved to any content.
+var mixedFailuresExpectedJson = {
+    'pushedContents': [
+        'e1f57280-d672-4cd8-b674-98e26e5b69ae'
+    ],
+    'failedContents': [
+        '79e21db0-5b43-45ce-b58c-6e1c420b22bd',
+        '/non-existing-content'
+    ],
+    'failed': [
+        {
+            'id': '79e21db0-5b43-45ce-b58c-6e1c420b22bd',
+            'reason': 'NOT_READY'
+        },
+        {
+            'id': '/non-existing-content'
+        }
+    ]
+};
+
+exports.publishMixedFailures = function () {
+    var result = content.publish({
+        keys: ['79e21db0-5b43-45ce-b58c-6e1c420b22bd', '/non-existing-content']
+    });
+
+    assert.assertJsonEquals(mixedFailuresExpectedJson, result);
+};

--- a/modules/lib/lib-content/src/test/resources/test/PublishContentHandlerTest.js
+++ b/modules/lib/lib-content/src/test/resources/test/PublishContentHandlerTest.js
@@ -74,11 +74,7 @@ var contentNotFoundExpectedJson = {
     "failedContents": [
         "/non-existing-content"
     ],
-    "failed": [
-        {
-            "id": "/non-existing-content"
-        }
-    ]
+    "failed": []
 };
 
 var allFailedExpectedJson = {
@@ -118,7 +114,8 @@ exports.contentNotFound = function () {
     assert.assertJsonEquals(contentNotFoundExpectedJson, result);
 };
 
-// Engine-reported failures come first, then keys that could not be resolved to any content.
+// An unresolvable key is reported in failedContents only - it never reaches the publish engine,
+// so there is no reason for it and it gets no entry in failed.
 var mixedFailuresExpectedJson = {
     'pushedContents': [
         'e1f57280-d672-4cd8-b674-98e26e5b69ae'
@@ -131,9 +128,6 @@ var mixedFailuresExpectedJson = {
         {
             'id': '79e21db0-5b43-45ce-b58c-6e1c420b22bd',
             'reason': 'NOT_READY'
-        },
-        {
-            'id': '/non-existing-content'
         }
     ]
 };

--- a/modules/lib/lib-content/src/test/resources/test/PublishContentHandlerTest.js
+++ b/modules/lib/lib-content/src/test/resources/test/PublishContentHandlerTest.js
@@ -9,6 +9,12 @@ var expectedJson = {
     ],
     'failedContents': [
         '79e21db0-5b43-45ce-b58c-6e1c420b22bd'
+    ],
+    'failed': [
+        {
+            'id': '79e21db0-5b43-45ce-b58c-6e1c420b22bd',
+            'reason': 'INVALID'
+        }
     ]
 };
 
@@ -16,7 +22,8 @@ var expectedLimitedJson = {
     'pushedContents': [
         'e1f57280-d672-4cd8-b674-98e26e5b69ae'
     ],
-    'failedContents': []
+    'failedContents': [],
+    'failed': []
 };
 
 exports.publishById = function () {
@@ -66,7 +73,38 @@ var contentNotFoundExpectedJson = {
     "pushedContents": [],
     "failedContents": [
         "/non-existing-content"
+    ],
+    "failed": [
+        {
+            "id": "/non-existing-content"
+        }
     ]
+};
+
+var allFailedExpectedJson = {
+    'pushedContents': [],
+    'failedContents': [
+        '9f5b0db0-38f9-4e81-b92e-116f25476b1c',
+        '79e21db0-5b43-45ce-b58c-6e1c420b22bd'
+    ],
+    'failed': [
+        {
+            'id': '9f5b0db0-38f9-4e81-b92e-116f25476b1c',
+            'reason': 'NOT_READY'
+        },
+        {
+            'id': '79e21db0-5b43-45ce-b58c-6e1c420b22bd',
+            'reason': 'ACCESS_DENIED'
+        }
+    ]
+};
+
+exports.publishAllFailed = function () {
+    var result = content.publish({
+        keys: ['9f5b0db0-38f9-4e81-b92e-116f25476b1c', '79e21db0-5b43-45ce-b58c-6e1c420b22bd']
+    });
+
+    assert.assertJsonEquals(allFailedExpectedJson, result);
 };
 
 exports.contentNotFound = function () {


### PR DESCRIPTION
Fixes #12219.

Four places where the JS-facing surface of `modules/lib/lib-content` disagreed with what its own Java layer actually emits or accepts. Three are TypeScript declarations published as `@enonic-types/lib-content`; the fourth is runtime information the Java layer computed and then discarded.

## 1. `ApplyPermissionsResult` declared a branch dimension that doesn't exist

Was `Record<string, BranchResult[]>`, now `Record<string, Permissions>` — which is what `ApplyPermissionsResultMapper` actually serializes: one key per content id, each value a `Permissions` object. No array, no `branch` field. Code written against the old declaration (`result[id][0].branch`) dereferenced a shape that never arrived; `ApplyPermissionsHandlerTest.js` has always read `result['123456'].permissions`.

`BranchResult` is kept as an exported interface, marked `@deprecated`, since removing an exported type would break compilation for anyone importing the name.

## 2. `ContentVersionAction` omitted `origin` and `editorial`

`ContentVersionMapper` emits `operation`, `origin`, `editorial`, `user`, `opTime`; the interface declared only three of those. Added `origin?: string` and `editorial?: string` — both already reach JS at runtime (`examples/content/getVersions.js` shows `editorial` in its expected output).

## 3. `PatchableContent.type` is not writable

`PatchContentHandler.patchContent()` enumerates the keys it reads back from the patcher's return value, and `type` is not among them — assigning it was silently ignored. Marked `readonly` rather than removed: `ContentMapper` does emit `type`, so it is legitimately readable on the content handed to the patcher, and removing it would break patchers that branch on `c.type`. Only the write is now a type error.

## 4. `publish()` discarded the per-item failure reason

`PublishContentCommand` records a `Reason` for every failed item (`ALREADY_EXIST`, `PARENT_NOT_FOUND`, `ACCESS_DENIED`, `INVALID`, `NOT_READY`), but `PublishContentResultMapper` serialized only the flat id arrays, dropping it one step before it reached JavaScript. Publishing 29 items of which 13 were not `READY` returned `pushedContents: []` and all 29 ids in `failedContents`, with no indication of what blocked the batch and nothing in the server log — callers had to re-query `valid` / `workflow.state` to reconstruct information the engine already had.

The mapper now also emits `failed`, deliberately matching the shape `lib-node`'s `push()` has always used in `PushNodesResultMapper`:

```json
{
  "pushedContents": [],
  "failedContents": ["79e21db0-...", "/non-existing-content"],
  "failed": [ { "id": "79e21db0-...", "reason": "NOT_READY" } ]
}
```

`failed` maps `PublishContentResult.getFailed()` and nothing else, so `id` is always a content id and `reason` is always present. Keys given as a path that resolves to nothing never reach the publish engine and therefore have no reason — they stay in `failedContents`, whose behaviour is unchanged. Additive: `pushedContents` and `failedContents` keep their existing contents.

## Backwards compatibility

Additive on the runtime side. On the type side the only breaking change is that assigning `PatchableContent.type` no longer compiles, which is the point of item 3 — that assignment never did anything.

## Cherry-pick to 8.0

Written to cherry-pick cleanly onto `8.0`, which is where the issue was reported against (`v8.0.3`). The Java mappers and `PublishContentResult.java` are byte-identical between the two branches, and `content.ts` differs only far from these edits. Verified in a throwaway worktree off `origin/8.0`: applies clean, `:lib:lib-content:test` green, `tsc --declaration` clean.

## Testing

`:lib:lib-content:test` green. `PublishContentHandlerTest.js` expectations extended with `failed`, plus two new cases: `publishAllFailed` (whole batch rejected, distinct `NOT_READY` / `ACCESS_DENIED` reasons — the scenario from the issue) and `publishMixedFailures` (an engine failure and an unresolvable key in one call, pinning that the latter appears in `failedContents` only). `tsc --declaration` and `eslint lib-content` clean. `examples/content/publish.js`, which feeds the reference docs, now iterates `failed`.

Note: the `testGraalJs` task fails wholesale in some sandboxes (all 154 tests die at `ExceptionInInitializerError` in `LibGraal.java:204`, including untouched ones) — environmental, not related to this change. CI's `build` job passes.

https://claude.ai/code/session_01T9NtqZhPAujHGVi1s16qTU