### PR TITLE
Deprecate Resource.getTimestamp and unreliable modifiedTime #12176

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/icon/Icon.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/icon/Icon.java
@@ -52,6 +52,16 @@ public final class Icon
         return iconData.length;
     }
 
+    /**
+     * Returns the modification time recorded for this icon.
+     *
+     * @return the recorded modification time, which may be {@code null}.
+     * @deprecated Not a dependable measure of when the icon last changed. Icons are loaded from
+     * application resources, so the value derives from a jar entry timestamp that build tools normalize
+     * to a constant for reproducibility, from the install time of the bundle providing the icon, or from
+     * the time the icon happened to be read. None of these reflect an edit to the icon itself.
+     */
+    @Deprecated
     public Instant getModifiedTime()
     {
         return this.modifiedTime;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/macro/MacroDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/macro/MacroDescriptor.java
@@ -82,6 +82,15 @@ public final class MacroDescriptor
         return icon;
     }
 
+    /**
+     * Returns the modification time recorded for this descriptor.
+     *
+     * @return the recorded modification time, which may be {@code null}.
+     * @deprecated Not a dependable measure of when the descriptor last changed. A macro descriptor is
+     * always read from an application resource, so the value derives from a jar entry timestamp that build
+     * tools normalize to a constant for reproducibility rather than from an edit to the descriptor.
+     */
+    @Deprecated
     public Instant getModifiedTime()
     {
         return modifiedTime;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/region/ComponentDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/region/ComponentDescriptor.java
@@ -63,14 +63,16 @@ public abstract class ComponentDescriptor
 
     /**
      * Returns the modification time recorded for this descriptor.
-     * <p>
-     * Dependable only for a descriptor stored in a repository node, as that of a virtual application is.
-     * When the descriptor is read from an application resource instead, the value derives from a jar entry
-     * timestamp that build tools normalize to a constant for reproducibility, and so does not reflect an
-     * edit to the descriptor.
      *
      * @return the recorded modification time, which may be {@code null}.
+     * @deprecated Not a dependable measure of when the descriptor last changed. A descriptor read from an
+     * application resource derives this value from a jar entry timestamp that build tools normalize to a
+     * constant for reproducibility. Only a descriptor stored in a repository node, as that of a virtual
+     * application is, carries a genuine time, and a caller cannot tell the two apart - so the value cannot
+     * be relied upon. Note that rendering additionally tests it for {@code null} as a way of telling a
+     * parsed descriptor from a synthesized one; that check is about presence rather than about time.
      */
+    @Deprecated
     public Instant getModifiedTime()
     {
         return modifiedTime;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/region/ComponentDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/region/ComponentDescriptor.java
@@ -61,6 +61,16 @@ public abstract class ComponentDescriptor
         return descriptionI18nKey;
     }
 
+    /**
+     * Returns the modification time recorded for this descriptor.
+     * <p>
+     * Dependable only for a descriptor stored in a repository node, as that of a virtual application is.
+     * When the descriptor is read from an application resource instead, the value derives from a jar entry
+     * timestamp that build tools normalize to a constant for reproducibility, and so does not reflect an
+     * edit to the descriptor.
+     *
+     * @return the recorded modification time, which may be {@code null}.
+     */
     public Instant getModifiedTime()
     {
         return modifiedTime;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/resource/Resource.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/resource/Resource.java
@@ -16,6 +16,21 @@ public interface Resource
 
     long getSize();
 
+    /**
+     * Returns the last modification time of this resource, in milliseconds since the epoch, or a negative
+     * value when it cannot be determined.
+     *
+     * @return the last modification time in milliseconds since the epoch, or a negative value if unknown.
+     * @deprecated Not a dependable measure of when a resource last changed. A resource served from an
+     * application bundle reports the time recorded in its jar entry, and build tools normalize that value
+     * to a constant so that builds are reproducible - Gradle does so by default as of version 9. Two
+     * different builds of an application therefore produce identical timestamps, making the value a
+     * property of the build rather than of the file. Only resources backed by a repository node carry a
+     * genuine modification time; for file-backed resources the value is meaningful in development mode
+     * alone. To detect that the resources of an application may have changed, compare
+     * {@link com.enonic.xp.app.Application#getModifiedTime()} instead.
+     */
+    @Deprecated
     long getTimestamp();
 
     InputStream openStream();

--- a/modules/core/core-api/src/main/java/com/enonic/xp/schema/BaseSchema.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/schema/BaseSchema.java
@@ -76,6 +76,16 @@ public abstract class BaseSchema<T extends BaseSchemaName>
         return createdTime;
     }
 
+    /**
+     * Returns the modification time recorded for this schema.
+     * <p>
+     * Dependable only for a schema stored in a repository node, as a dynamic schema of a virtual
+     * application is. When the schema is read from an application resource instead, the value derives from
+     * a jar entry timestamp that build tools normalize to a constant for reproducibility, and so does not
+     * reflect an edit to the schema.
+     *
+     * @return the recorded modification time, which may be {@code null}.
+     */
     public Instant getModifiedTime()
     {
         return modifiedTime;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/schema/BaseSchema.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/schema/BaseSchema.java
@@ -78,14 +78,15 @@ public abstract class BaseSchema<T extends BaseSchemaName>
 
     /**
      * Returns the modification time recorded for this schema.
-     * <p>
-     * Dependable only for a schema stored in a repository node, as a dynamic schema of a virtual
-     * application is. When the schema is read from an application resource instead, the value derives from
-     * a jar entry timestamp that build tools normalize to a constant for reproducibility, and so does not
-     * reflect an edit to the schema.
      *
      * @return the recorded modification time, which may be {@code null}.
+     * @deprecated Not a dependable measure of when the schema last changed. A schema read from an
+     * application resource derives this value from a jar entry timestamp that build tools normalize to a
+     * constant for reproducibility. Only a schema stored in a repository node, as a dynamic schema of a
+     * virtual application is, carries a genuine time, and a caller cannot tell the two apart - so the
+     * value cannot be relied upon.
      */
+    @Deprecated
     public Instant getModifiedTime()
     {
         return modifiedTime;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/site/CmsDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/site/CmsDescriptor.java
@@ -44,6 +44,16 @@ public final class CmsDescriptor
         return mixinMappings;
     }
 
+    /**
+     * Returns the modification time recorded for this descriptor.
+     * <p>
+     * Dependable only for a descriptor stored in a repository node, as that of a virtual application is.
+     * When the descriptor is read from an application resource instead, the value derives from a jar entry
+     * timestamp that build tools normalize to a constant for reproducibility, and so does not reflect an
+     * edit to the descriptor.
+     *
+     * @return the recorded modification time, which may be {@code null}.
+     */
     public Instant getModifiedTime()
     {
         return modifiedTime;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/site/CmsDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/site/CmsDescriptor.java
@@ -46,14 +46,15 @@ public final class CmsDescriptor
 
     /**
      * Returns the modification time recorded for this descriptor.
-     * <p>
-     * Dependable only for a descriptor stored in a repository node, as that of a virtual application is.
-     * When the descriptor is read from an application resource instead, the value derives from a jar entry
-     * timestamp that build tools normalize to a constant for reproducibility, and so does not reflect an
-     * edit to the descriptor.
      *
      * @return the recorded modification time, which may be {@code null}.
+     * @deprecated Not a dependable measure of when the descriptor last changed. A descriptor read from an
+     * application resource derives this value from a jar entry timestamp that build tools normalize to a
+     * constant for reproducibility. Only a descriptor stored in a repository node, as that of a virtual
+     * application is, carries a genuine time, and a caller cannot tell the two apart - so the value cannot
+     * be relied upon.
      */
+    @Deprecated
     public Instant getModifiedTime()
     {
         return modifiedTime;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/site/SiteDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/site/SiteDescriptor.java
@@ -41,6 +41,15 @@ public final class SiteDescriptor
         return applicationKey;
     }
 
+    /**
+     * Returns the modification time recorded for this descriptor.
+     *
+     * @return the recorded modification time, which may be {@code null}.
+     * @deprecated Not a dependable measure of when the descriptor last changed. A site descriptor is always
+     * read from an application resource, so the value derives from a jar entry timestamp that build tools
+     * normalize to a constant for reproducibility rather than from an edit to the descriptor.
+     */
+    @Deprecated
     public Instant getModifiedTime()
     {
         return modifiedTime;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/style/StyleDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/style/StyleDescriptor.java
@@ -40,14 +40,15 @@ public final class StyleDescriptor
 
     /**
      * Returns the modification time recorded for this descriptor.
-     * <p>
-     * Dependable only for a descriptor stored in a repository node, as that of a virtual application is.
-     * When the descriptor is read from an application resource instead, the value derives from a jar entry
-     * timestamp that build tools normalize to a constant for reproducibility, and so does not reflect an
-     * edit to the descriptor.
      *
      * @return the recorded modification time, which may be {@code null}.
+     * @deprecated Not a dependable measure of when the descriptor last changed. A descriptor read from an
+     * application resource derives this value from a jar entry timestamp that build tools normalize to a
+     * constant for reproducibility. Only a descriptor stored in a repository node, as that of a virtual
+     * application is, carries a genuine time, and a caller cannot tell the two apart - so the value cannot
+     * be relied upon.
      */
+    @Deprecated
     public Instant getModifiedTime()
     {
         return modifiedTime;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/style/StyleDescriptor.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/style/StyleDescriptor.java
@@ -38,6 +38,16 @@ public final class StyleDescriptor
         return elements;
     }
 
+    /**
+     * Returns the modification time recorded for this descriptor.
+     * <p>
+     * Dependable only for a descriptor stored in a repository node, as that of a virtual application is.
+     * When the descriptor is read from an application resource instead, the value derives from a jar entry
+     * timestamp that build tools normalize to a constant for reproducibility, and so does not reflect an
+     * edit to the descriptor.
+     *
+     * @return the recorded modification time, which may be {@code null}.
+     */
     public Instant getModifiedTime()
     {
         return modifiedTime;

--- a/modules/lib/core/index.d.ts
+++ b/modules/lib/core/index.d.ts
@@ -834,6 +834,15 @@ export type ByteSource = Brand<object, 'ByteSource'>;
 export interface Resource {
     getSize(): number;
 
+    /**
+     * @deprecated Not a dependable measure of when a resource last changed. A resource served from an
+     * application bundle reports the time recorded in its jar entry, and build tools normalize that value
+     * to a constant so that builds are reproducible — Gradle does so by default as of version 9. Two
+     * different builds of an application therefore report identical timestamps, making the value a
+     * property of the build rather than of the file. Only resources backed by a repository node carry a
+     * genuine modification time; for file-backed resources the value is meaningful in development mode
+     * alone.
+     */
     getTimestamp(): number;
 
     getStream(): ByteSource;

--- a/modules/lib/lib-app/src/main/resources/lib/xp/app.ts
+++ b/modules/lib/lib-app/src/main/resources/lib/xp/app.ts
@@ -137,6 +137,12 @@ export interface GetApplicationDescriptorParams {
 export interface Icon {
     data: ByteSource;
     mimeType: string;
+    /**
+     * @deprecated Not a dependable measure of when the icon last changed, and unsuitable for cache
+     * invalidation. Icons are loaded from application resources, so this derives from a jar entry timestamp
+     * that build tools normalize to a constant for reproducibility, from the install time of the bundle
+     * providing the icon, or from the time the icon happened to be read.
+     */
     modifiedTime: string;
 }
 

--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -1446,6 +1446,12 @@ export function getPermissions(params: GetPermissionsParams): Permissions | null
 export interface Icon {
     data: ByteSource;
     mimeType: string;
+    /**
+     * @deprecated Not a dependable measure of when the icon last changed, and unsuitable for cache
+     * invalidation. Icons are loaded from application resources, so this derives from a jar entry timestamp
+     * that build tools normalize to a constant for reproducibility, from the install time of the bundle
+     * providing the icon, or from the time the icon happened to be read.
+     */
     modifiedTime: string;
 }
 
@@ -1463,7 +1469,8 @@ export interface Icon {
  * @property {object} [icon] Icon of the content type.
  * @property {object} [icon.data] Stream with the binary data for the icon.
  * @property {string} [icon.mimeType] Mime type of the icon image.
- * @property {string} [icon.modifiedTime] Modified time of the icon. May be used for caching.
+ * @property {string} [icon.modifiedTime] Modified time of the icon. Deprecated: derives from the build
+ * rather than from an edit to the icon, so it must not be used for caching.
  * @property {object[]} form Form schema represented as an array of form items: Input, ItemSet, Layout, OptionSet.
  * @property {object} config Custom schema configuration for the descriptor.
  */

--- a/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
+++ b/modules/lib/lib-content/src/main/resources/lib/xp/content.ts
@@ -1465,7 +1465,8 @@ export interface Icon {
  * @property {boolean} abstract Whether or not content of this type may be instantiated.
  * @property {boolean} final Whether or not it may be used as super type of other content types.
  * @property {boolean} allowChildContent Whether or not allow creating child items on content of this type.
- * @property {string} modifiedTime Modified time of the content type.
+ * @property {string} modifiedTime Modified time of the content type. Deprecated: derives from the build
+ * rather than from an edit whenever the content type comes from an application.
  * @property {object} [icon] Icon of the content type.
  * @property {object} [icon.data] Stream with the binary data for the icon.
  * @property {string} [icon.mimeType] Mime type of the icon image.
@@ -1482,6 +1483,12 @@ export interface ContentType {
     abstract: boolean;
     final: boolean;
     allowChildContent: boolean;
+    /**
+     * @deprecated Not a dependable measure of when the content type last changed. Read from an application
+     * resource, this derives from a jar entry timestamp that build tools normalize to a constant for
+     * reproducibility; only a dynamic schema stored in a repository node carries a genuine time, and the two
+     * cannot be told apart here.
+     */
     modifiedTime: string;
     icon?: Icon;
     form: FormItem[];

--- a/modules/lib/lib-io/src/main/resources/lib/xp/examples/io/getResource.js
+++ b/modules/lib/lib-io/src/main/resources/lib/xp/examples/io/getResource.js
@@ -7,7 +7,6 @@ var res1 = ioLib.getResource('/lib/xp/examples/io/sample.txt');
 var exists = res1.exists();
 var size = res1.getSize();
 var stream = res1.getStream();
-var timestamp = res1.getTimestamp();
 // END
 
 // BEGIN
@@ -21,7 +20,6 @@ if (res2.exists()) {
 assert.assertEquals(true, exists);
 assert.assertEquals(11, size);
 assert.assertNotNull(stream);
-assert.assertTrue(typeof timestamp === 'number');
 assert.assertEquals(true, res2.exists());
 assert.assertEquals(11, res2.getSize());
 assert.assertNotNull(res2.getStream());

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
@@ -45,6 +45,12 @@ function checkRequired<T extends object, K extends keyof T>(
 export interface Icon {
     data: ByteSource;
     mimeType: string;
+    /**
+     * @deprecated Not a dependable measure of when the icon last changed, and unsuitable for cache
+     * invalidation. Icons are loaded from application resources, so this derives from a jar entry timestamp
+     * that build tools normalize to a constant for reproducibility, from the install time of the bundle
+     * providing the icon, or from the time the icon happened to be read.
+     */
     modifiedTime: string;
 }
 

--- a/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
+++ b/modules/lib/lib-schema/src/main/resources/lib/xp/schema.ts
@@ -80,6 +80,12 @@ export interface Schema {
     descriptionI18nKey: string;
     createdTime: string;
     creator: UserKey;
+    /**
+     * @deprecated Not a dependable measure of when this last changed. Read from an application resource,
+     * this derives from a jar entry timestamp that build tools normalize to a constant for reproducibility;
+     * only a dynamic schema stored in a repository node carries a genuine time, and the two cannot be told
+     * apart here.
+     */
     modifiedTime: string;
     modifier: UserKey;
     resource: string;
@@ -161,6 +167,12 @@ export interface ComponentDescriptor {
     description: string;
     descriptionI18nKey: string;
     componentPath: string;
+    /**
+     * @deprecated Not a dependable measure of when this last changed. Read from an application resource,
+     * this derives from a jar entry timestamp that build tools normalize to a constant for reproducibility;
+     * only a dynamic schema stored in a repository node carries a genuine time, and the two cannot be told
+     * apart here.
+     */
     modifiedTime: string;
     resource: string;
     type: ComponentDescriptorType;
@@ -225,6 +237,12 @@ export type EditorConfig = ConfigObject & {
 
 export interface StyleDescriptor {
     application: string;
+    /**
+     * @deprecated Not a dependable measure of when this last changed. Read from an application resource,
+     * this derives from a jar entry timestamp that build tools normalize to a constant for reproducibility;
+     * only a dynamic schema stored in a repository node carries a genuine time, and the two cannot be told
+     * apart here.
+     */
     modifiedTime: string;
     resource: string;
     elements: {
@@ -323,6 +341,12 @@ export function getComponent(params: GetDynamicComponentParams): LayoutDescripto
 export interface SiteDescriptor {
     application: string;
     resource: string;
+    /**
+     * @deprecated Not a dependable measure of when this last changed. Read from an application resource,
+     * this derives from a jar entry timestamp that build tools normalize to a constant for reproducibility;
+     * only a dynamic schema stored in a repository node carries a genuine time, and the two cannot be told
+     * apart here.
+     */
     modifiedTime: string;
     form: FormItem[];
     mixinMappings?: {


### PR DESCRIPTION
Gradle normalizes jar entry timestamps by default as of version 9, so a
resource served from an application bundle reports a build constant rather
than a modification time. Two different builds of an application yield
identical timestamps, which makes the value unusable as a production measure
of when a file last changed.

Deprecate Resource.getTimestamp, documenting that only node-backed resources
carry a genuine modification time and that file-backed resources are
meaningful in development mode alone.

The descriptor and icon accessors exposing such a timestamp are deprecated as
well. Icon, MacroDescriptor and SiteDescriptor are always built from
application resources, so their modifiedTime can never be dependable.
BaseSchema, StyleDescriptor, CmsDescriptor and ComponentDescriptor are also
populated from repository nodes for dynamic schemas of virtual applications,
where the value is genuine - but nothing in XP consumes it, and a caller
cannot tell the two sources apart, because SchemaMapper serializes
modifiedTime identically for both. A value that is trustworthy only in a case
the caller cannot identify is untrustworthy in practice, so these are
deprecated rather than left with a javadoc caveat alone.

Rendering compares ComponentDescriptor.getModifiedTime to null to tell a
parsed descriptor from a synthesized one. That is a presence check rather than
a use of the time, so it keeps working; the javadoc records it.

Mirror the deprecations in the TypeScript definitions, and correct the
lib-content jsdoc that advertised icon modifiedTime as usable for caching.
Drop getTimestamp from the lib-io getResource example so the documentation no
longer showcases a deprecated call.

Deliberately left alone: the asset fingerprint in AssetPathSupplier and
AssetHandler, and the descriptor loaders that still call the now-deprecated
Resource.getTimestamp. Choosing replacement values there is a separate
decision.