### PR TITLE
Keep workflow state when unpublishing content #12199

### DIFF
--- a/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UnpublishContentCommand.java
+++ b/modules/core/core-content/src/main/java/com/enonic/xp/core/impl/content/UnpublishContentCommand.java
@@ -8,7 +8,6 @@ import com.enonic.xp.content.ContentId;
 import com.enonic.xp.content.ContentPropertyNames;
 import com.enonic.xp.content.UnpublishContentParams;
 import com.enonic.xp.content.UnpublishContentsResult;
-import com.enonic.xp.content.WorkflowState;
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.context.ContextBuilder;
@@ -105,12 +104,6 @@ public class UnpublishContentCommand
         {
             final UpdateNodeParams updateParams =
                 UpdateNodeParams.create().id( deleted ).versionAttributesResolver( unpublishInfoAttr ).editor( toBeEdited -> {
-                    PropertySet workflowInfo = toBeEdited.data.getSet( ContentPropertyNames.WORKFLOW_INFO );
-                    if ( workflowInfo != null )
-                    {
-                        workflowInfo.setString( ContentPropertyNames.WORKFLOW_INFO_STATE, WorkflowState.READY.toString() );
-                    }
-
                     PropertySet publishInfo = toBeEdited.data.getSet( ContentPropertyNames.PUBLISH_INFO );
                     if ( publishInfo != null )
                     {

--- a/modules/itest/itest-core-content/src/test/java/com/enonic/xp/core/content/ContentServiceImplTest_unpublish.java
+++ b/modules/itest/itest-core-content/src/test/java/com/enonic/xp/core/content/ContentServiceImplTest_unpublish.java
@@ -12,6 +12,8 @@ import com.enonic.xp.content.ContentPath;
 import com.enonic.xp.content.CreateContentParams;
 import com.enonic.xp.content.PushContentParams;
 import com.enonic.xp.content.UnpublishContentParams;
+import com.enonic.xp.content.UpdateContentParams;
+import com.enonic.xp.content.WorkflowInfo;
 import com.enonic.xp.content.WorkflowState;
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
@@ -57,6 +59,51 @@ class ContentServiceImplTest_unpublish
         assertNull( unpublishedContent.getPublishInfo().to() );
         assertNotNull( unpublishedContent.getPublishInfo().first() );
         assertEquals( WorkflowState.READY, unpublishedContent.getWorkflowInfo().getState() );
+    }
+
+    @Test
+    void unpublish_keeps_workflow_state()
+    {
+        final Content content = this.contentService.create( CreateContentParams.create()
+                                                                .contentData( new PropertyTree() )
+                                                                .displayName( "This is my content" )
+                                                                .parent( ContentPath.ROOT )
+                                                                .type( ContentTypeName.folder() )
+                                                                .workflowInfo( WorkflowInfo.ready() )
+                                                                .build() );
+
+        this.contentService.publish( PushContentParams.create().contentIds( ContentIds.from( content.getId() ) ).build() );
+
+        this.contentService.unpublish( UnpublishContentParams.create().contentIds( ContentIds.from( content.getId() ) ).build() );
+
+        assertEquals( WorkflowState.READY, this.contentService.getById( content.getId() ).getWorkflowInfo().getState() );
+    }
+
+    @Test
+    void unpublish_modified_content_keeps_in_progress_workflow_state()
+    {
+        final Content content = this.contentService.create( CreateContentParams.create()
+                                                                .contentData( new PropertyTree() )
+                                                                .displayName( "This is my content" )
+                                                                .parent( ContentPath.ROOT )
+                                                                .type( ContentTypeName.folder() )
+                                                                .workflowInfo( WorkflowInfo.ready() )
+                                                                .build() );
+
+        this.contentService.publish( PushContentParams.create().contentIds( ContentIds.from( content.getId() ) ).build() );
+
+        final UpdateContentParams updateParams = new UpdateContentParams();
+        updateParams.contentId( content.getId() ).editor( edit -> edit.displayName = "new display name" );
+
+        this.contentService.update( updateParams );
+
+        assertEquals( WorkflowState.IN_PROGRESS, this.contentService.getById( content.getId() ).getWorkflowInfo().getState() );
+
+        this.contentService.unpublish( UnpublishContentParams.create().contentIds( ContentIds.from( content.getId() ) ).build() );
+
+        final Content unpublishedContent = this.contentService.getById( content.getId() );
+        assertEquals( "new display name", unpublishedContent.getDisplayName() );
+        assertEquals( WorkflowState.IN_PROGRESS, unpublishedContent.getWorkflowInfo().getState() );
     }
 
     @Test


### PR DESCRIPTION
Unpublish force-wrote workflow.state=READY on the draft node, which
discarded the IN_PROGRESS state set by edits made after the content was
published. Publishing does not change the workflow state, so preserving
the draft state is enough to keep the state the content had before it
was published, and to keep IN_PROGRESS when the content was modified
while online.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GoUQuvBmL6SWZHRa2Vi3Ng