### PR TITLE
#12200 main.js controller is not executed for system applications

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/main/MainExecutor.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/main/MainExecutor.java
@@ -2,41 +2,91 @@ package com.enonic.xp.portal.impl.main;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.condition.Condition;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.enonic.xp.app.Application;
-import com.enonic.xp.app.ApplicationListener;
 import com.enonic.xp.portal.script.PortalScriptService;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.script.ScriptExports;
 
-@Component(immediate = true)
+/**
+ * Executes each application's {@code main.js} once it becomes active.
+ * <p>
+ * Applications are OSGi {@link Application} services, registered while active and unregistered on
+ * stop, so this component simply tracks them: DS activation is gated on the deploy-ready Condition
+ * (so nothing runs until the initial deployment is complete), and opening the tracker replays every
+ * already-active application plus delivers future ones — no {@code ApplicationListener}, no missed
+ * events regardless of boot order.
+ */
+// a pure side-effect component: it executes main.js and provides no service
+@Component(immediate = true, service = {})
 public final class MainExecutor
-    implements ApplicationListener
+    implements ServiceTrackerCustomizer<Application, Application>
 {
     private static final Logger LOG = LoggerFactory.getLogger( MainExecutor.class );
 
+    /**
+     * Gates activation: {@code main.js} does not run until the initial application deployment is
+     * complete, so the tracker's open-time replay sees the full set. Injected only to gate; never
+     * dereferenced.
+     */
+    @SuppressWarnings("unused")
+    @Reference(target = "(" + Condition.CONDITION_ID + "=com.enonic.xp.server.deploy.ready)")
+    private volatile Condition deployReady;
+
     private final PortalScriptService scriptService;
 
+    private final BundleContext bundleContext;
+
+    private final ServiceTracker<Application, Application> tracker;
+
     @Activate
-    public MainExecutor( @Reference final PortalScriptService scriptService )
+    public MainExecutor( @Reference final PortalScriptService scriptService, final BundleContext bundleContext )
     {
         this.scriptService = scriptService;
+        this.bundleContext = bundleContext;
+        this.tracker = new ServiceTracker<>( bundleContext, Application.class, this );
+        this.tracker.open();
+    }
+
+    @Deactivate
+    public void deactivate()
+    {
+        this.tracker.close();
     }
 
     @Override
-    public void activated( final Application app )
+    public Application addingService( final ServiceReference<Application> reference )
     {
-        executeMain( ResourceKey.from( app.getKey(), "/main.js" ) );
+        final Application application = this.bundleContext.getService( reference );
+        if ( application == null )
+        {
+            // unregistered between the tracker event and getService: nothing to track or execute
+            return null;
+        }
+        executeMain( ResourceKey.from( application.getKey(), "/main.js" ) );
+        return application;
     }
 
     @Override
-    public void deactivated( final Application app )
+    public void modifiedService( final ServiceReference<Application> reference, final Application application )
     {
+    }
+
+    @Override
+    public void removedService( final ServiceReference<Application> reference, final Application application )
+    {
+        this.bundleContext.ungetService( reference );
     }
 
     private void executeMain( final ResourceKey key )

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/main/MainExecutorTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/main/MainExecutorTest.java
@@ -7,67 +7,134 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 
 import com.enonic.xp.app.Application;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.portal.script.PortalScriptService;
 import com.enonic.xp.resource.ResourceKey;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class MainExecutorTest
 {
-    private MainExecutor executor;
+    private static final ResourceKey MAIN_JS = ResourceKey.from( "foo.bar:/main.js" );
 
     @Mock
     private PortalScriptService scriptService;
 
+    @Mock
+    private BundleContext bundleContext;
+
+    private MainExecutor executor;
+
     @BeforeEach
     void setup()
+        throws Exception
     {
-        this.executor = new MainExecutor( this.scriptService );
+        // let the ServiceTracker construct and open against the mock registry (no initial services)
+        lenient().when( this.bundleContext.createFilter( anyString() ) )
+            .thenAnswer( invocation -> FrameworkUtil.createFilter( invocation.getArgument( 0 ) ) );
+        lenient().when( this.bundleContext.getServiceReferences( anyString(), nullable( String.class ) ) ).thenReturn( null );
+
+        this.executor = new MainExecutor( this.scriptService, this.bundleContext );
+    }
+
+    @SuppressWarnings("unchecked")
+    private ServiceReference<Application> appReference( final String applicationKey )
+    {
+        final Application application = mock( Application.class );
+        when( application.getKey() ).thenReturn( ApplicationKey.from( applicationKey ) );
+        final ServiceReference<Application> reference = mock( ServiceReference.class );
+        when( this.bundleContext.getService( reference ) ).thenReturn( application );
+        return reference;
     }
 
     @Test
-    void mainJsMissing()
+    void addingService_executesMain()
     {
-        final Application app = mock( Application.class );
-        when( app.getKey() ).thenReturn( ApplicationKey.from( "foo.bar" ) );
+        when( this.scriptService.hasScript( MAIN_JS ) ).thenReturn( true );
+        when( this.scriptService.executeAsync( MAIN_JS ) ).thenReturn( CompletableFuture.completedFuture( null ) );
 
-        this.executor.activated( app );
+        this.executor.addingService( appReference( "foo.bar" ) );
 
-        verify( this.scriptService, times( 1 ) ).hasScript( any() );
-        verify( this.scriptService, times( 0 ) ).execute( any() );
+        verify( this.scriptService ).executeAsync( MAIN_JS );
     }
 
     @Test
-    void mainJsError()
+    void alreadyActiveApplication_isReplayedOnOpen()
+        throws Exception
     {
-        final ResourceKey key = ResourceKey.from( "foo.bar:/main.js" );
-        when( this.scriptService.hasScript( key ) ).thenReturn( true );
-        when( this.scriptService.executeAsync( key ) ).thenReturn( CompletableFuture.failedFuture( new RuntimeException() ) );
+        final ServiceReference<Application> reference = appReference( "foo.bar" );
+        when( this.bundleContext.getServiceReferences( Application.class.getName(), null ) ).thenReturn(
+            new ServiceReference[]{reference} );
+        when( this.scriptService.hasScript( MAIN_JS ) ).thenReturn( true );
+        when( this.scriptService.executeAsync( MAIN_JS ) ).thenReturn( CompletableFuture.completedFuture( null ) );
 
-        final Application app = mock( Application.class );
-        when( app.getKey() ).thenReturn( ApplicationKey.from( "foo.bar" ) );
+        assertDoesNotThrow( () -> new MainExecutor( this.scriptService, this.bundleContext ) );
 
-        this.executor.activated( app );
+        verify( this.scriptService ).executeAsync( MAIN_JS );
     }
 
     @Test
-    void mainJsExecute()
+    void addingService_mainJsMissing()
     {
-        final ResourceKey key = ResourceKey.from( "foo.bar:/main.js" );
-        when( this.scriptService.hasScript( key ) ).thenReturn( true );
-        when( this.scriptService.executeAsync( key ) ).thenReturn( CompletableFuture.completedFuture( null ) );
+        when( this.scriptService.hasScript( MAIN_JS ) ).thenReturn( false );
 
-        final Application app = mock( Application.class );
-        when( app.getKey() ).thenReturn( ApplicationKey.from( "foo.bar" ) );
+        this.executor.addingService( appReference( "foo.bar" ) );
 
-        this.executor.activated( app );
+        verify( this.scriptService, never() ).executeAsync( any() );
+    }
+
+    @Test
+    void addingService_mainJsError_isSwallowed()
+    {
+        when( this.scriptService.hasScript( MAIN_JS ) ).thenReturn( true );
+        when( this.scriptService.executeAsync( MAIN_JS ) ).thenReturn( CompletableFuture.failedFuture( new RuntimeException() ) );
+
+        assertDoesNotThrow( () -> this.executor.addingService( appReference( "foo.bar" ) ) );
+
+        verify( this.scriptService ).executeAsync( MAIN_JS );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void addingService_vanishedService_isIgnored()
+    {
+        final ServiceReference<Application> reference = mock( ServiceReference.class );
+        when( this.bundleContext.getService( reference ) ).thenReturn( null );
+
+        assertNull( this.executor.addingService( reference ) );
+
+        verify( this.scriptService, never() ).hasScript( any() );
+    }
+
+    @Test
+    void removedService_ungetsService()
+    {
+        final ServiceReference<Application> reference = appReference( "foo.bar" );
+        final Application application = this.executor.addingService( reference );
+
+        this.executor.removedService( reference, application );
+
+        verify( this.bundleContext ).ungetService( reference );
+    }
+
+    @Test
+    void deactivate_closesTracker()
+    {
+        assertDoesNotThrow( () -> this.executor.deactivate() );
     }
 }


### PR DESCRIPTION
Fixes #12200 on the 8.0 branch.

`main.js` was never executed for system applications (`X-Bundle-Type: system`) because they activate before `MainExecutor` registers as an `ApplicationListener`, so the activation events were missed.

This aligns 8.0 with the master design: `MainExecutor` no longer uses `ApplicationListener` at all. It is a DS component gated on the `com.enonic.xp.server.deploy.ready` OSGi `Condition`, and it opens a `ServiceTracker` over `Application` OSGi services — the tracker's open-time replay delivers already-active applications, so boot order cannot cause missed events.

Unlike master, no bootstrap-gate backport is needed: 8.0's `PortalScriptService.executeAsync` already runs on the script engine's own async executor, so `main.js` execution keeps its existing semantics. No `ApplicationListenerHub` changes are required.

Alternative to #12202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)