### PR TITLE
#12241 Dependency Updates

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-jackson = "2.21.2"
-junit5 = "5.14.1"
-mockito = "5.21.0"
+jackson = "2.22.1"
+junit5 = "5.14.4"
+mockito = "5.23.0"
 slf4j = "1.7.36"
 jetty = "9.4.58.v20250814"
-tika = "3.3.0"
-graalvm = "23.1.11"
-log4j = "2.26.0"
+tika = "3.3.2"
+graalvm = "23.1.12"
+log4j = "2.26.1"
 
 [libraries]
 junit-junit4 = { module = "junit:junit", version = "4.13.2" }
@@ -19,7 +19,7 @@ mockito-junitjupiter = { module = "org.mockito:mockito-junit-jupiter", version.r
 
 equalsverifier = { module = "nl.jqno.equalsverifier:equalsverifier", version = "3.19.4" }
 
-assertj-core = { module = "org.assertj:assertj-core", version = "3.27.4" }
+assertj-core = { module = "org.assertj:assertj-core", version = "3.27.7" }
 
 tinybundles = { module = "org.ops4j.pax.tinybundles:tinybundles", version = "3.0.0" }
 
@@ -35,7 +35,7 @@ logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.3.16
 jansi = { module = "org.fusesource.jansi:jansi", version = "1.18" }
 
 jakarta-activation = { module = "com.sun.activation:jakarta.activation", version = "1.2.2" }
-jakarta-mail = { module = "com.sun.mail:jakarta.mail", version = "1.6.7" }
+jakarta-mail = { module = "com.sun.mail:jakarta.mail", version = "1.6.8" }
 jakarta-annotation = { module = "jakarta.annotation:jakarta.annotation-api", version = "1.3.5" }
 jakarta-validation = { module = "jakarta.validation:jakarta.validation-api", version = "2.0.2" }
 jakarta-jaxrs = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version = "2.1.6" }
@@ -59,7 +59,7 @@ felix-configadmin = { module = "org.apache.felix:org.apache.felix.configadmin", 
 felix-scr = { module = "org.apache.felix:org.apache.felix.scr", version = "2.2.18" }
 felix-framework = { module = "org.apache.felix:org.apache.felix.framework", version = "7.0.5" }
 felix-utils = { module = "org.apache.felix:org.apache.felix.utils", version = "1.11.8" }
-felix-log = { module = "org.apache.felix:org.apache.felix.log", version = "1.3.0" }
+felix-log = { module = "org.apache.felix:org.apache.felix.log", version = "1.3.2" }
 felix-logback = { module = "org.apache.felix:org.apache.felix.logback", version = "1.0.6" }
 felix-logextension = { module = "org.apache.felix:org.apache.felix.log.extension", version = "1.0.0" }
 felix-gogo-command = { module = "org.apache.felix:org.apache.felix.gogo.command", version = "0.16.0" }
@@ -67,7 +67,7 @@ felix-gogo-runtime = { module = "org.apache.felix:org.apache.felix.gogo.runtime"
 felix-gogo-shell = { module = "org.apache.felix:org.apache.felix.gogo.shell", version = "0.12.0" }
 felix-shell-remote = { module = "org.apache.felix:org.apache.felix.shell.remote", version = "1.1.2" }
 
-bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version = "1.84" }
+bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version = "1.85" }
 
 elasticsearch = { module = "org.elasticsearch:elasticsearch", version = "2.4.6" }
 
@@ -75,11 +75,11 @@ jna = { module = "net.java.dev.jna:jna", version = "4.1.0" }
 
 guava = { module = "com.google.guava:guava", version = "26.0-jre" }
 
-jsoup = { module = "org.jsoup:jsoup", version = "1.22.2" }
+jsoup = { module = "org.jsoup:jsoup", version = "1.23.1" }
 
 owaspsanitizer = { module = "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer", version = "20260313.1" }
 
-bytebuddy = { module = "net.bytebuddy:byte-buddy", version = "1.18.8" }
+bytebuddy = { module = "net.bytebuddy:byte-buddy", version = "1.18.11" }
 
 cronutils = { module = "com.cronutils:cron-utils", version = "9.2.0" }
 
@@ -98,7 +98,7 @@ commons-io = { module = "commons-io:commons-io", version = "2.22.0" }
 commons-compress = { module = "org.apache.commons:commons-compress", version = "1.28.0" }
 
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
-jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version = "2.21" }
+jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version = "2.22" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 jackson-jaxrs-base = { module = "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base", version.ref = "jackson" }
@@ -132,16 +132,16 @@ tika-parser-xml = { module = "org.apache.tika:tika-parser-xml-module", version.r
 tika-parser-xmpcommons = { module = "org.apache.tika:tika-parser-xmp-commons", version.ref = "tika" }
 tika-parser-zipcommons = { module = "org.apache.tika:tika-parser-zip-commons", version.ref = "tika" }
 
-pdfbox-io = { module = "org.apache.pdfbox:pdfbox-io", version = "3.0.7" }
-commons-logging = { module = "commons-logging:commons-logging", version = "1.3.6" }
+pdfbox-io = { module = "org.apache.pdfbox:pdfbox-io", version = "3.0.8" }
+commons-logging = { module = "commons-logging:commons-logging", version = "1.4.0" }
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j-tojul = { module = "org.apache.logging.log4j:log4j-to-jul", version.ref = "log4j" }
 
-metrics-core = { module = "io.dropwizard.metrics:metrics-core", version = "4.2.38" }
-metrics-json = { module = "io.dropwizard.metrics:metrics-json", version = "4.2.38" }
-metrics-jvm = { module = "io.dropwizard.metrics:metrics-jvm", version = "4.2.38" }
-metrics-jetty9 = { module = "io.dropwizard.metrics:metrics-jetty9", version = "4.2.38" }
-metrics-annotation = { module = "io.dropwizard.metrics:metrics-annotation", version = "4.2.38" }
+metrics-core = { module = "io.dropwizard.metrics:metrics-core", version = "4.2.39" }
+metrics-json = { module = "io.dropwizard.metrics:metrics-json", version = "4.2.39" }
+metrics-jvm = { module = "io.dropwizard.metrics:metrics-jvm", version = "4.2.39" }
+metrics-jetty9 = { module = "io.dropwizard.metrics:metrics-jetty9", version = "4.2.39" }
+metrics-annotation = { module = "io.dropwizard.metrics:metrics-annotation", version = "4.2.39" }
 
 hazelcast-hazelcast = { module = "com.hazelcast:hazelcast", version = "3.12.13" }
 hazelcast-client = { module = "com.hazelcast:hazelcast-client", version = "3.12.13" }


### PR DESCRIPTION
Closes #12241

Update third-party dependencies to latest bugfix/minor versions within the same major line.

### Patch updates
| Dependency | Old | New |
|---|---|---|
| junit5 | 5.14.1 | 5.14.4 |
| tika | 3.3.0 | 3.3.2 |
| graalvm | 23.1.11 | 23.1.12 |
| log4j | 2.26.0 | 2.26.1 |
| assertj-core | 3.27.4 | 3.27.7 |
| byte-buddy | 1.18.8 | 1.18.11 |
| pdfbox-io | 3.0.7 | 3.0.8 |
| metrics-* | 4.2.38 | 4.2.39 |
| jakarta.mail | 1.6.7 | 1.6.8 |
| felix-log | 1.3.0 | 1.3.2 |

### Minor updates
| Dependency | Old | New |
|---|---|---|
| jackson | 2.21.2 | 2.22.1 (annotations 2.21 → 2.22) |
| mockito | 5.21.0 | 5.23.0 |
| jsoup | 1.22.2 | 1.23.1 |
| bcprov-jdk18on | 1.84 | 1.85 |
| commons-logging | 1.3.6 | 1.4.0 |

### Excluded
- **cron-utils stays at 9.2.0**: 9.2.1 bumps its slf4j-api dependency to 2.0.7, which makes bnd compute `Import-Package: org.slf4j;version="[2.0,3)"` for `core-scheduler` — unresolvable against the slf4j 1.7.36 runtime (BundleException at startup). See issue comment for details.
- Deliberately frozen lines untouched: elasticsearch 2.4.6, guava 26, hazelcast 3.12, jetty 9.4, slf4j 1.7, javax.*.

### Verification
- `./gradlew test` — full unit test suite green with the final catalog.
- Server smoke test: built `installDist`, started XP — all bundles resolve, started in ~4s, `/admin` and `:2609/health` respond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)