### PR TITLE
#12243 Dependency Updates

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,9 +4,9 @@ junit5 = "6.1.2"
 mockito = "5.23.0"
 slf4j = "2.0.18"
 jetty = "12.1.12"
-resteasy = "7.0.2.Final"
+resteasy = "7.0.3.Final"
 hazelcast = "5.7.0"
-tika = "3.3.1"
+tika = "3.3.2"
 log4j = "2.26.1"
 micrometer = "1.17.0"
 prometheus = "1.8.0"
@@ -35,7 +35,7 @@ slf4j-jultoslf4j = { module = "org.slf4j:jul-to-slf4j", version.ref = "slf4j" }
 slf4j-jcloverslf4j = { module = "org.slf4j:jcl-over-slf4j", version.ref = "slf4j" }
 slf4j-log4joverslf4j = { module = "org.slf4j:log4j-over-slf4j", version.ref = "slf4j" }
 jboss-logging = { module = "org.jboss.logging:jboss-logging", version = "3.6.3.Final" }
-logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.37" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.5.38" }
 
 jakarta-activation = { module = "jakarta.activation:jakarta.activation-api", version = "2.1.4" }
 jakarta-mail = { module = "com.sun.mail:jakarta.mail", version = "2.0.2" }
@@ -59,7 +59,7 @@ felix-configadmin = { module = "org.apache.felix:org.apache.felix.configadmin", 
 felix-scr = { module = "org.apache.felix:org.apache.felix.scr", version = "2.2.18" }
 felix-framework = { module = "org.apache.felix:org.apache.felix.framework", version = "7.0.5" }
 felix-utils = { module = "org.apache.felix:org.apache.felix.utils", version = "1.11.8" }
-felix-log = { module = "org.apache.felix:org.apache.felix.log", version = "1.3.0" }
+felix-log = { module = "org.apache.felix:org.apache.felix.log", version = "1.3.2" }
 
 bcprov-jdk18on = { module = "org.bouncycastle:bcprov-jdk18on", version = "1.85" }
 
@@ -69,13 +69,13 @@ icu4j = { module = "com.ibm.icu:icu4j", version = "78.3" }
 
 jna = { module = "net.java.dev.jna:jna", version = "5.19.1" }
 
-jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
+jspecify = { module = "org.jspecify:jspecify", version = "1.0.1" }
 
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 guava-guava = { module = "com.google.guava:guava", version.ref = "guava" }
 guava-failureaccess = { module = "com.google.guava:failureaccess", version = "1.0.3" }
 
-jsoup = { module = "org.jsoup:jsoup", version = "1.22.2" }
+jsoup = { module = "org.jsoup:jsoup", version = "1.23.1" }
 
 owaspsanitizer = { module = "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer", version = "20260313.1" }
 
@@ -132,7 +132,7 @@ tika-parser-xml = { module = "org.apache.tika:tika-parser-xml-module", version.r
 tika-parser-xmpcommons = { module = "org.apache.tika:tika-parser-xmp-commons", version.ref = "tika" }
 tika-parser-zipcommons = { module = "org.apache.tika:tika-parser-zip-commons", version.ref = "tika" }
 
-pdfbox-io = { module = "org.apache.pdfbox:pdfbox-io", version = "3.0.7" }
+pdfbox-io = { module = "org.apache.pdfbox:pdfbox-io", version = "3.0.8" }
 commons-logging = { module = "commons-logging:commons-logging", version = "1.4.0" }
 log4j-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "log4j" }
 log4j-tojul = { module = "org.apache.logging.log4j:log4j-to-jul", version.ref = "log4j" }


### PR DESCRIPTION
Closes #12243

Update third-party dependencies to latest bugfix/minor versions within the same major line.

### Patch updates
| Dependency | Old | New | Notes |
|---|---|---|---|
| tika | 3.3.1 | 3.3.2 | paired with pdfbox-io (tika-parent 3.3.2 declares pdfbox 3.0.8; commons-logging 1.4.0 and log4j 2.26.1 already aligned) |
| pdfbox-io | 3.0.7 | 3.0.8 | keeps repack-tika embedded jars aligned, see #12036 |
| resteasy | 7.0.2.Final | 7.0.3.Final | |
| logback-classic | 1.5.37 | 1.5.38 | |
| felix-log | 1.3.0 | 1.3.2 | |
| jspecify | 1.0.0 | 1.0.1 | |

### Minor updates
| Dependency | Old | New | Notes |
|---|---|---|---|
| jsoup | 1.22.2 | 1.23.1 | OSGi verified: `core-internal` manifest imports `org.jspecify.annotations;[1.0,2)` (non-optional, generated from jsoup's embedded annotations) — resolves against the `jspecify-1.0.1` bundle at system level 04; `com.google.re2j` stays optional |

### Deliberately excluded
- **networknt json-schema-validator** stays at 2.0.0 (validation behavior can shift even in patch releases).

### Verification
- `./gradlew test` — full unit test suite green.
- Server smoke test: `installDist` + system apps from xp-distro master SDK build, started on the distro's JDK 25.0.4 — started in 2.2s, welcome page 200, `:2609/health` responds, zero ERROR lines, zero BundleExceptions / unresolved requirements in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)