### PR TITLE
Add contentPath to the Request type #10028

### DIFF
--- a/modules/lib/core/index.d.ts
+++ b/modules/lib/core/index.d.ts
@@ -278,6 +278,13 @@ export interface DefaultRequestHeaders
 export interface RequestConstructorParams {
     body?: string;
     branch?: LiteralUnion<RequestBranch>;
+    /**
+     * Path of the content being rendered. Set by the site service.
+     *
+     * Assigning it in a site mapping filter, on the request passed to `next`, re-routes rendering to
+     * that content: the requested URL is unchanged, but content, site and context path are re-resolved.
+     */
+    contentPath?: string;
     contentType?: string;
     contextPath?: string;
     cookies: RequestCookies;

--- a/modules/lib/test/HttpFilter.test-d.ts
+++ b/modules/lib/test/HttpFilter.test-d.ts
@@ -89,3 +89,17 @@ const httpFilterController4 = {
     },
 };
 expectAssignable<HttpFilterController>(httpFilterController4);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Filter re-routing rendering to another content
+// ────────────────────────────────────────────────────────────────────────────
+const httpFilterController5 = {
+    filter: function (req: Request, next: HttpFilterNext<SerializableRequest<Request>, Response>) {
+        if (req.cookies.experiment === 'b') {
+            // contentPath is settable: the site service re-resolves content from it
+            req.contentPath = `${req.contentPath}/variant-b`;
+        }
+        return next(req) as unknown as Response;
+    },
+};
+expectAssignable<HttpFilterController<Request, Response, Response>>(httpFilterController5);


### PR DESCRIPTION
Closes the TypeScript gap left by #10028 (filter re-routing).

## Problem

The site service emits `contentPath` on the request object (`PortalRequestMapper`) and reads it back from the object passed to `next()` (`PortalRequestSerializer.populateContentPath`) — that round trip *is* the re-route mechanism. But `RequestConstructorParams` never declared the field, so the documented pattern does not compile:

```
✖  Property contentPath does not exist on type DefaultRequest. Did you mean contextPath?
```

App authors had to widen the type or cast to use a shipped feature.

## Change

- `contentPath?: string` on `RequestConstructorParams`, optional because only the site service sets it — same as `branch`, `contextPath` and `repositoryId`.
- Deliberately **not** added to `SerializableRequest`'s `Omit` list. That list names the fields a filter cannot set (`body`, `contextPath`, `rawPath`, `repositoryId`, `webSocket`), and it matches `PortalRequestSerializer.serialize()` exactly: everything with a `populate*` call is settable. `contentPath` has one, so it must remain assignable on the object handed to `next()`.
- A `tsd` case in `HttpFilter.test-d.ts` covering the re-route pattern.

## Verification

```
$ npm run test:types      # in modules/lib
✔ clean

$ npm run lint
✔ clean
```

Negative control — with the `index.d.ts` change stashed and the declarations rebuilt, the new test fails with exactly the error above (2 errors at `HttpFilter.test-d.ts:101`), so the case genuinely exercises the field rather than passing vacuously.

The test case uses a cookie check rather than a query parameter: `params` values are `string | string[]`, which trips `@typescript-eslint/restrict-template-expressions`, and interpolating raw user input into a content path is not a pattern worth showing.

Docs for the feature are in enonic/doc-code#72; the note there about needing to widen the type can be dropped once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)