### PR TITLE
Deprecate the baseUrl parameter of imageUrl, attachmentUrl and apiUrl

### DIFF
--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/url/ApiUrlHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/url/ApiUrlHandler.java
@@ -64,6 +64,10 @@ public final class ApiUrlHandler
         this.type = value;
     }
 
+    /**
+     * @deprecated kept for the deprecated {@code baseUrl} parameter of the JS API
+     */
+    @Deprecated
     public void setBaseUrl( final String baseUrl )
     {
         this.baseUrl = baseUrl;

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/url/AttachmentUrlHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/url/AttachmentUrlHandler.java
@@ -76,6 +76,10 @@ public final class AttachmentUrlHandler
         this.branch = branch;
     }
 
+    /**
+     * @deprecated kept for the deprecated {@code baseUrl} parameter of the JS API
+     */
+    @Deprecated
     public void setBaseUrl( final String baseUrl )
     {
         this.baseUrl = baseUrl;

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/url/ImageUrlHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/url/ImageUrlHandler.java
@@ -94,6 +94,10 @@ public final class ImageUrlHandler
         this.branch = branch;
     }
 
+    /**
+     * @deprecated kept for the deprecated {@code baseUrl} parameter of the JS API
+     */
+    @Deprecated
     public void setBaseUrl( final String baseUrl )
     {
         this.baseUrl = baseUrl;

--- a/modules/lib/lib-portal/src/main/resources/lib/xp/examples/portal/apiUrl.js
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/examples/portal/apiUrl.js
@@ -30,7 +30,9 @@ const apiUrlAppRelative = portalLib.apiUrl({
 
 // END
 
-assert.assertEquals('/site/mocksite/_/api/com.enonic.app.myapp:myapi?%C3%A5=a&%C3%B8=o&%C3%A6=a&%C3%A6=e&empty=&a=1&b=2', url);
-assert.assertEquals('/site/mocksite/_/api/com.enonic.app.myapp:myapi', apiUrlWithPathSegments);
-assert.assertEquals('/site/mocksite/_/api/com.enonic.app.myapp:myapi', apiUrl);
-assert.assertEquals('/site/mocksite/_/api/myapplication:myapi', apiUrlAppRelative);
+assert.assertEquals(
+    '/site/mocksite/_/com.enonic.app.myapp:myapi/segment1/segment2?%C3%A5=a&%C3%B8=o&%C3%A6=a&%C3%A6=e&empty=&a=1&b=2',
+    url);
+assert.assertEquals('/site/mocksite/_/com.enonic.app.myapp:myapi/mypath/myotherpath', apiUrlWithPathSegments);
+assert.assertEquals('/site/mocksite/_/com.enonic.app.myapp:myapi', apiUrl);
+assert.assertEquals('/site/mocksite/_/myapplication:myapi', apiUrlAppRelative);

--- a/modules/lib/lib-portal/src/main/resources/lib/xp/examples/portal/apiUrl.js
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/examples/portal/apiUrl.js
@@ -13,7 +13,6 @@ const url = portalLib.apiUrl({
         b: 2
     },
     path: ['segment1', 'segment2'],
-    baseUrl: 'https://example.com',
 });
 
 const apiUrlWithPathSegments = portalLib.apiUrl({
@@ -25,9 +24,8 @@ const apiUrl = portalLib.apiUrl({
     api: 'com.enonic.app.myapp:myapi',
 });
 
-const apiUrlWithBaseUrl = portalLib.apiUrl({
+const apiUrlAppRelative = portalLib.apiUrl({
     api: 'myapi',
-    baseUrl: 'https://example.com',
 });
 
 // END
@@ -35,4 +33,4 @@ const apiUrlWithBaseUrl = portalLib.apiUrl({
 assert.assertEquals('/site/mocksite/_/api/com.enonic.app.myapp:myapi?%C3%A5=a&%C3%B8=o&%C3%A6=a&%C3%A6=e&empty=&a=1&b=2', url);
 assert.assertEquals('/site/mocksite/_/api/com.enonic.app.myapp:myapi', apiUrlWithPathSegments);
 assert.assertEquals('/site/mocksite/_/api/com.enonic.app.myapp:myapi', apiUrl);
-assert.assertEquals('/site/mocksite/_/api/myapplication:myapi', apiUrlWithBaseUrl);
+assert.assertEquals('/site/mocksite/_/api/myapplication:myapi', apiUrlAppRelative);

--- a/modules/lib/lib-portal/src/main/resources/lib/xp/examples/portal/attachmentUrl.js
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/examples/portal/attachmentUrl.js
@@ -6,7 +6,6 @@ var url = portalLib.attachmentUrl({
     name: '1234.pdf',
     project: 'myproject',
     branch: 'mybranch',
-    baseUrl: 'mybaseUrl',
     download: true,
 });
 // END

--- a/modules/lib/lib-portal/src/main/resources/lib/xp/examples/portal/imageUrl.js
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/examples/portal/imageUrl.js
@@ -6,7 +6,6 @@ var url = portalLib.imageUrl({
     id: '1234',
     project: 'myproject',
     branch: 'mybranch',
-    baseUrl: 'mybaseUrl',
     scale: 'block(1024,768)',
     filter: 'rounded(5);sharpen()',
 });

--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -119,6 +119,9 @@ export type ImageUrlParams = IdXorPath & {
         | 'full';
     project?: string;
     branch?: string;
+    /**
+     * @deprecated Configure `media.defaultBaseUrl` in `com.enonic.xp.portal.cfg`, or a Base URL on the site, instead.
+     */
     baseUrl?: string;
 };
 
@@ -166,7 +169,7 @@ interface ImageUrlHandler {
  * @param {string} [params.type=server] URL type. Either `server` (server-relative URL) or `absolute`.
  * @param {string} [params.project] Name of the project.
  * @param {string} [params.branch] Name of the branch.
- * @param {string} [params.baseUrl] Custom baseUrl.
+ * @param {string} [params.baseUrl] Deprecated. Configure `media.defaultBaseUrl` in `com.enonic.xp.portal.cfg`, or a Base URL on the site, instead.
  * @param {object} [params.params] Custom query parameters to append to the URL.
  *
  * @returns {string} The generated URL.
@@ -250,6 +253,9 @@ export interface AttachmentUrlParams {
     params?: object;
     project?: string;
     branch?: string;
+    /**
+     * @deprecated Configure `media.defaultBaseUrl` in `com.enonic.xp.portal.cfg`, or a Base URL on the site, instead.
+     */
     baseUrl?: string
 }
 
@@ -291,7 +297,7 @@ interface AttachmentUrlHandler {
  * @param {string} [params.type=server] URL type. Either `server` (server-relative URL) or `absolute`.
  * @param {string} [params.project] Name of the project.
  * @param {string} [params.branch] Name of the branch.
- * @param {string} [params.baseUrl] Custom baseUrl.
+ * @param {string} [params.baseUrl] Deprecated. Configure `media.defaultBaseUrl` in `com.enonic.xp.portal.cfg`, or a Base URL on the site, instead.
  * @param {object} [params.params] Custom query parameters to append to the URL.
  *
  * @returns {string} The generated URL.

--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -848,6 +848,9 @@ export interface ApiUrlParams {
     type?: 'server' | 'absolute' | 'websocket';
     params?: Record<string, string | string[]>;
     path?: string | string[];
+    /**
+     * @deprecated Expose the API location as a vhost mapping instead.
+     */
     baseUrl?: string;
 }
 
@@ -875,7 +878,7 @@ interface ApiUrlHandler {
  * @param {string} [params.type=server] URL type. Either `server` (server-relative URL) or `absolute` or `websocket`. Ignored when a base URL applies.
  * @param {string|string[]} [params.path] Path(s) to be appended to the base URL following the api segment to complete request URL.
  * @param {object} [params.params] Custom query parameters to append to the URL.
- * @param {string} [params.baseUrl] Custom baseUrl.
+ * @param {string} [params.baseUrl] Deprecated. Expose the API location as a vhost mapping instead.
  *
  * @returns {string} The generated URL.
  */

--- a/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/url/UrlServiceScriptTest.java
+++ b/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/url/UrlServiceScriptTest.java
@@ -37,6 +37,19 @@ class UrlServiceScriptTest
 {
     private PortalUrlService portalUrlService;
 
+    private static String buildApiPath( final ApiUrlParams params )
+    {
+        if ( params.getPathSegments() != null )
+        {
+            return params.getPathSegments().stream().collect( Collectors.joining( "/", "/", "" ) );
+        }
+        if ( params.getPath() != null )
+        {
+            return params.getPath().startsWith( "/" ) ? params.getPath() : "/" + params.getPath();
+        }
+        return "";
+    }
+
     private String buildQueryString( final Multimap<String, String> params )
     {
         if ( params == null || params.isEmpty() )
@@ -139,7 +152,7 @@ class UrlServiceScriptTest
             final ApiUrlParams params = invocation.getArgument( 0, ApiUrlParams.class );
             final Multimap<String, String> queryParams = LinkedListMultimap.create();
             params.getQueryParams().forEach( queryParams::putAll );
-            return "/site/mocksite/_/api/" + params.getApi() + buildQueryString( queryParams );
+            return "/site/mocksite/_/" + params.getApi() + buildApiPath( params ) + buildQueryString( queryParams );
         } );
 
         when( portalUrlService.baseUrl( any( BaseUrlParams.class ) ) ).thenAnswer( invocation -> "/site/mocksite" );

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/ApiUrlGeneratorParams.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/ApiUrlGeneratorParams.java
@@ -16,6 +16,8 @@ public final class ApiUrlGeneratorParams
 {
     private final String baseUrl;
 
+    private final String apiBaseUrl;
+
     private final String urlType;
 
     private final DescriptorKey descriptorKey;
@@ -27,6 +29,7 @@ public final class ApiUrlGeneratorParams
     private ApiUrlGeneratorParams( final Builder builder )
     {
         this.baseUrl = builder.baseUrl;
+        this.apiBaseUrl = builder.apiBaseUrl;
         this.urlType = requireNonNullElse( builder.urlType, UrlTypeConstants.SERVER_RELATIVE );
         this.descriptorKey = requireNonNull( builder.descriptorKey );
         this.pathSupplier = builder.pathSupplier;
@@ -36,6 +39,11 @@ public final class ApiUrlGeneratorParams
     public String getBaseUrl()
     {
         return baseUrl;
+    }
+
+    public String getApiBaseUrl()
+    {
+        return apiBaseUrl;
     }
 
     public String getUrlType()
@@ -69,6 +77,8 @@ public final class ApiUrlGeneratorParams
 
         private String baseUrl;
 
+        private String apiBaseUrl;
+
         private DescriptorKey descriptorKey;
 
         private Supplier<String> pathSupplier;
@@ -81,9 +91,28 @@ public final class ApiUrlGeneratorParams
             return this;
         }
 
+        /**
+         * Base URL of a mount where the API lives under the "_" endpoint segment:
+         * {@code <baseUrl>/_/<application>:<api>/...}.
+         *
+         * @deprecated expose the API location as a vhost mapping instead, or use
+         * {@link #setApiBaseUrl(String)} when the API root is known.
+         */
+        @Deprecated
         public Builder setBaseUrl( final String baseUrl )
         {
             this.baseUrl = emptyToNull( baseUrl );
+            return this;
+        }
+
+        /**
+         * The root where this API is exposed, used verbatim: no "_" endpoint segment and no
+         * API descriptor are appended - only the path and query parameters follow. Takes
+         * precedence over {@code baseUrl}.
+         */
+        public Builder setApiBaseUrl( final String apiBaseUrl )
+        {
+            this.apiBaseUrl = emptyToNull( apiBaseUrl );
             return this;
         }
 

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/ApiUrlParams.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/ApiUrlParams.java
@@ -22,6 +22,8 @@ public final class ApiUrlParams
 
     private final String baseUrl;
 
+    private final String apiBaseUrl;
+
     private final Map<String, List<String>> queryParams;
 
     private ApiUrlParams( final Builder builder )
@@ -31,6 +33,7 @@ public final class ApiUrlParams
         this.path = builder.path;
         this.pathSegments = builder.pathSegments;
         this.baseUrl = builder.baseUrl;
+        this.apiBaseUrl = builder.apiBaseUrl;
         this.queryParams = builder.queryParams.build();
 
         if ( this.path != null && this.pathSegments != null )
@@ -64,6 +67,11 @@ public final class ApiUrlParams
         return baseUrl;
     }
 
+    public String getApiBaseUrl()
+    {
+        return apiBaseUrl;
+    }
+
     public Map<String, List<String>> getQueryParams()
     {
         return queryParams;
@@ -83,6 +91,8 @@ public final class ApiUrlParams
         private List<String> pathSegments;
 
         private String baseUrl;
+
+        private String apiBaseUrl;
 
         private DescriptorKey api;
 
@@ -119,9 +129,28 @@ public final class ApiUrlParams
             return this;
         }
 
+        /**
+         * Base URL of a mount where the API lives under the "_" endpoint segment:
+         * {@code <baseUrl>/_/<application>:<api>/...}.
+         *
+         * @deprecated expose the API location as a vhost mapping instead, or use
+         * {@link #setApiBaseUrl(String)} when the API root is known.
+         */
+        @Deprecated
         public Builder setBaseUrl( final String baseUrl )
         {
             this.baseUrl = baseUrl;
+            return this;
+        }
+
+        /**
+         * The root where this API is exposed, used verbatim: no "_" endpoint segment and no
+         * API descriptor are appended - only the path and query parameters follow. Takes
+         * precedence over {@code baseUrl}.
+         */
+        public Builder setApiBaseUrl( final String apiBaseUrl )
+        {
+            this.apiBaseUrl = apiBaseUrl;
             return this;
         }
 
@@ -154,6 +183,7 @@ public final class ApiUrlParams
         helper.add( "path", this.path );
         helper.add( "pathSegments", this.pathSegments );
         helper.add( "baseUrl", this.baseUrl );
+        helper.add( "apiBaseUrl", this.apiBaseUrl );
         return helper.toString();
     }
 }

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/AttachmentUrlParams.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/AttachmentUrlParams.java
@@ -114,6 +114,15 @@ public final class AttachmentUrlParams
         return this;
     }
 
+    /**
+     * Base URL of a mount where the generated media URL lives under the "_" endpoint segment:
+     * {@code <baseUrl>/_/media:attachment/...}.
+     *
+     * @deprecated configure {@code media.defaultBaseUrl} in {@code com.enonic.xp.portal.cfg},
+     * or a Base URL on the site, instead. Use {@link #mediaBaseUrl(String)} to address the media
+     * API root directly.
+     */
+    @Deprecated
     public AttachmentUrlParams baseUrl( final String baseUrl )
     {
         this.baseUrl = Strings.emptyToNull( baseUrl );

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/ImageUrlParams.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/ImageUrlParams.java
@@ -140,6 +140,15 @@ public final class ImageUrlParams
         return this;
     }
 
+    /**
+     * Base URL of a mount where the generated media URL lives under the "_" endpoint segment:
+     * {@code <baseUrl>/_/media:image/...}.
+     *
+     * @deprecated configure {@code media.defaultBaseUrl} in {@code com.enonic.xp.portal.cfg},
+     * or a Base URL on the site, instead. Use {@link #mediaBaseUrl(String)} to address the media
+     * API root directly.
+     */
+    @Deprecated
     public ImageUrlParams baseUrl( final String baseUrl )
     {
         this.baseUrl = Strings.emptyToNull( baseUrl );

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ApiUrlBaseUrlResolver.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ApiUrlBaseUrlResolver.java
@@ -21,6 +21,8 @@ final class ApiUrlBaseUrlResolver
 
     private final String baseUrl;
 
+    private final String apiBaseUrl;
+
     private final String urlType;
 
     private final String defaultMediaBaseUrl;
@@ -35,6 +37,7 @@ final class ApiUrlBaseUrlResolver
     {
         this.descriptorKey = requireNonNull( builder.descriptorKey, "DescriptorKey must be set" );
         this.baseUrl = builder.baseUrl;
+        this.apiBaseUrl = builder.apiBaseUrl;
         this.urlType = builder.urlType;
         this.defaultMediaBaseUrl = builder.defaultMediaBaseUrl;
         this.mediaApiAutoMount = builder.mediaApiAutoMount;
@@ -52,6 +55,8 @@ final class ApiUrlBaseUrlResolver
         private DescriptorKey descriptorKey;
 
         private String baseUrl;
+
+        private String apiBaseUrl;
 
         private String urlType;
 
@@ -72,6 +77,12 @@ final class ApiUrlBaseUrlResolver
         Builder setBaseUrl( final String baseUrl )
         {
             this.baseUrl = baseUrl;
+            return this;
+        }
+
+        Builder setApiBaseUrl( final String apiBaseUrl )
+        {
+            this.apiBaseUrl = apiBaseUrl;
             return this;
         }
 
@@ -115,6 +126,12 @@ final class ApiUrlBaseUrlResolver
     public String get()
     {
         final PortalRequest portalRequest = PortalRequestAccessor.get();
+
+        // the root where this API is exposed, verbatim: nothing but path and query follow
+        if ( apiBaseUrl != null )
+        {
+            return apiBaseUrl;
+        }
 
         if ( baseUrl != null )
         {

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/PortalUrlGeneratorServiceImpl.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/PortalUrlGeneratorServiceImpl.java
@@ -238,6 +238,7 @@ public class PortalUrlGeneratorServiceImpl
         final UrlGeneratorParams generatorParams = UrlGeneratorParams.create()
             .setBaseUrl( ApiUrlBaseUrlResolver.create()
                              .setBaseUrl( params.getBaseUrl() )
+                             .setApiBaseUrl( params.getApiBaseUrl() )
                              .setDescriptorKey( params.getDescriptorKey() )
                              .setUrlType( params.getUrlType() )
                              .setDefaultMediaBaseUrl( defaultMediaBaseUrl )

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/PortalUrlServiceImpl.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/PortalUrlServiceImpl.java
@@ -409,6 +409,7 @@ public final class PortalUrlServiceImpl
     {
         final ApiUrlGeneratorParams generatorParams = ApiUrlGeneratorParams.create()
             .setBaseUrl( params.getBaseUrl() )
+            .setApiBaseUrl( params.getApiBaseUrl() )
             .setUrlType( params.getType() )
             .setDescriptorKey( params.getApi() )
             .setPath( new ApiUrlPathResolver( params.getPath(), params.getPathSegments() ) )

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/url/PortalUrlServiceImpl_apiUrlTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/url/PortalUrlServiceImpl_apiUrlTest.java
@@ -97,6 +97,72 @@ class PortalUrlServiceImpl_apiUrlTest
     }
 
     @Test
+    void testNoRequestWithApiBaseUrl()
+    {
+        PortalRequestAccessor.set( null );
+
+        final ApiUrlParams params = ApiUrlParams.create()
+            .setApi( DescriptorKey.from( "com.enonic.app.myapp:myapi" ) )
+            .setPath( "path" )
+            .setQueryParam( "k", "v" )
+            .setApiBaseUrl( "https://myapi.example.com" )
+            .build();
+
+        // the API root is used verbatim: no "_" segment and no descriptor are appended
+        final String url = this.service.apiUrl( params );
+        assertEquals( "https://myapi.example.com/path?k=v", url );
+    }
+
+    @Test
+    void testNoRequestWithApiBaseUrlWithTrailingSlash()
+    {
+        PortalRequestAccessor.set( null );
+
+        final ApiUrlParams params = ApiUrlParams.create()
+            .setApi( DescriptorKey.from( "com.enonic.app.myapp:myapi" ) )
+            .setPath( "path" )
+            .setApiBaseUrl( "https://apis.example.com/my:api/" )
+            .build();
+
+        final String url = this.service.apiUrl( params );
+        assertEquals( "https://apis.example.com/my:api/path", url );
+    }
+
+    @Test
+    void testSiteRequestWithApiBaseUrl()
+    {
+        portalRequest.setBaseUri( "/site" );
+        portalRequest.setRepositoryId( RepositoryId.from( "com.enonic.cms.request-project" ) );
+        portalRequest.setBranch( Branch.from( "request-branch" ) );
+        portalRequest.setRawPath( "/site/request-project/request-branch/sitePath" );
+        portalRequest.setContentPath( ContentPath.from( "/sitePath" ) );
+
+        final ApiUrlParams params = ApiUrlParams.create()
+            .setApi( DescriptorKey.from( "com.enonic.app.myapp:myapi" ) )
+            .setApiBaseUrl( "https://apis.example.com/myapi" )
+            .build();
+
+        // an explicit API root skips all resolution, request or not
+        final String url = this.service.apiUrl( params );
+        assertEquals( "https://apis.example.com/myapi", url );
+    }
+
+    @Test
+    void testApiBaseUrlTakesPrecedenceOverBaseUrl()
+    {
+        PortalRequestAccessor.set( null );
+
+        final ApiUrlParams params = ApiUrlParams.create()
+            .setApi( DescriptorKey.from( "com.enonic.app.myapp:myapi" ) )
+            .setBaseUrl( "baseUrl" )
+            .setApiBaseUrl( "https://myapi.example.com" )
+            .build();
+
+        final String url = this.service.apiUrl( params );
+        assertEquals( "https://myapi.example.com", url );
+    }
+
+    @Test
     void testSiteRequest()
     {
         final ContentPath contentPath = ContentPath.from( "sitePath" );


### PR DESCRIPTION
Follow-up to #12181.

The `baseUrl` parameter of `imageUrl`, `attachmentUrl` and `apiUrl` is broken the same way in all three: it encodes mount topology into a parameter — the value points at a *mount*, so an `_` endpoint segment is appended before the API descriptor — which is wrong the moment the API is not `_`-mounted at that address. It is also hard to document honestly. That made sense before URLs became mount-aware; it does not anymore.

Nothing is lost by deprecating it:

- callers with a request get request-anchored, vhost-rewritten URLs already;
- callers without one are served by configuration: `media.defaultBaseUrl` or a Base URL on the site for media, vhost mappings for generic APIs.

**Media** (`imageUrl` / `attachmentUrl`):

- `@Deprecated` on `ImageUrlParams.baseUrl` and `AttachmentUrlParams.baseUrl`, with Javadoc pointing at the configuration options and at `mediaBaseUrl` for addressing the media API root directly;
- the same deprecation on the corresponding lib-portal handler setters and TypeScript/JSDoc, and the parameter removed from the examples (asserted URLs unchanged — the examples run without a base).

**Generic APIs** (`apiUrl`):

- `@Deprecated` on `ApiUrlParams.setBaseUrl` and `ApiUrlGeneratorParams.setBaseUrl`;
- new `apiBaseUrl` on both Java params for callers that are told out-of-band where an API is exposed: the root of *this* API, used verbatim — no `_` segment and no descriptor appended, only path and query parameters follow. Whether a location is a full API-set root or a single-API exposure is the caller's knowledge: they hold the descriptor and append it themselves for set roots (`https://apis.example.com/my:api`, `https://apis.example.com/myapi`, `https://myapi.example.com` all work);
- the JS API deliberately does **not** get `apiBaseUrl` — JS callers rely on the vhost configuration, where API locations belong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8TCeZWgJjKTDhmntR9JtB