### PR TITLE
GraalJS applications fail after the first script context is created #12251

### DIFF
--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/graal/GraalJSContextFactory.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/graal/GraalJSContextFactory.java
@@ -3,7 +3,6 @@ package com.enonic.xp.script.graal;
 
 import java.util.Comparator;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
@@ -23,6 +22,16 @@ import com.enonic.xp.script.graal.util.JsFunctionHandle;
 
 public final class GraalJSContextFactory
 {
+    /**
+     * One instance for the process: contexts sharing an engine must present {@link
+     * HostAccess#equals equal} configurations, and two built separately never are — their target
+     * type mappings hold distinct lambdas, compared by identity. Built per context, only the first
+     * context on the shared engine would ever open.
+     */
+    private static final HostAccess HOST_ACCESS = hostAccess();
+
+    private static final String CREATOR_CONTEXT = "com.enonic.xp.script.graal.creatorContext";
+
     private final ClassLoader classLoader;
 
     /**
@@ -45,8 +54,6 @@ public final class GraalJSContextFactory
 
     public Context create()
     {
-        final AtomicReference<Context> contextRef = new AtomicReference<>();
-
         // Note: guest values passed between contexts silently re-enter their owning context on
         // every access — with the context pool that means latent serialization and deadlock
         // risk. allowValueSharing(false) would fail fast on such leaks, but GraalJS forbids
@@ -54,7 +61,7 @@ public final class GraalJSContextFactory
         // sharing. Isolation therefore relies on the executor's slot discipline: never pass
         // guest objects across slots — convert eagerly or share host-backed state.
         final Context.Builder contextBuilder = Context.newBuilder( "js" )
-            .allowHostAccess( hostAccess( contextRef ) )
+            .allowHostAccess( HOST_ACCESS )
             .allowHostClassLookup( className -> true )
             .option( "js.strict", "true" )
             .allowHostClassLoading( true );
@@ -69,8 +76,26 @@ public final class GraalJSContextFactory
         }
 
         final Context context = contextBuilder.build();
-        contextRef.set( context );
+        // where creatorContext() reads it back from; these bindings are per context and die with it
+        context.getPolyglotBindings().putMember( CREATOR_CONTEXT, new CreatorHolder( context ) );
         return context;
+    }
+
+    /**
+     * Carries the context without exposing it. Scripts read the polyglot bindings through
+     * {@code Java.type('org.graalvm.polyglot.Context')}, so a bare {@link Context} there would be
+     * {@code close()} one property read away; this has no member {@code HostAccess.ALL} can reach.
+     * A guard against reaching the context by accident, not a sandbox — reflection still unwraps
+     * it, and scripts hold the host's authority here by design.
+     */
+    private static final class CreatorHolder
+    {
+        private final Context context;
+
+        private CreatorHolder( final Context context )
+        {
+            this.context = context;
+        }
     }
 
     /**
@@ -81,19 +106,19 @@ public final class GraalJSContextFactory
      * discipline. Host-object functions are left to the default conversion.
      * <p>
      * Handles must lock the exact {@link Context} instance every other execution path
-     * synchronizes on, so the mappings close over a reference set once the context is built —
-     * deriving the context from the {@link Value} can yield a different wrapper instance,
-     * silently breaking mutual exclusion.
+     * synchronizes on, so the mappings resolve it through {@link #creatorContext()} at conversion
+     * time rather than capturing it when the context is built — a captured reference would make
+     * this configuration per context, and contexts on a shared engine must present the same one.
      * <p>
      * The mappings are a closed set: {@code HostAccess.ALL} would satisfy any other interface
      * with a proxy that enters the context on the calling thread and so fails only under load,
      * which is why implementations are disallowed. A bean wanting a script function must declare
      * one of the types below.
      */
-    private static HostAccess hostAccess( final AtomicReference<Context> contextRef )
+    private static HostAccess hostAccess()
     {
         final Predicate<Value> isJsFunction = value -> value.canExecute() && !value.isHostObject();
-        final Function<Value, JsFunctionHandle> toHandle = value -> new JsFunctionHandle( contextRef.get(), value );
+        final Function<Value, JsFunctionHandle> toHandle = value -> new JsFunctionHandle( creatorContext(), value );
         final Function<Value, JsFunctionHandle.TwoArg> toTwoArg = value -> new JsFunctionHandle.TwoArg( toHandle.apply( value ) );
         return HostAccess.newBuilder( HostAccess.ALL )
             .allowAllImplementations( false )
@@ -111,5 +136,44 @@ public final class GraalJSContextFactory
             .targetTypeMapping( Value.class, BiPredicate.class, isJsFunction, toTwoArg::apply )
             .targetTypeMapping( Value.class, Comparator.class, isJsFunction, toHandle::apply )
             .build();
+    }
+
+    /**
+     * Resolved from the entered context, because that is the one that owns the value being
+     * converted — the handle must lock its owner, not whatever execution happens to be in progress.
+     * <p>
+     * A {@link ScopedValue} published by the executor would be the obvious channel and is the wrong
+     * one: it names the context the executor last bound, which stops matching the entered context
+     * as soon as a handle belonging to one application is invoked inside another's execution, and
+     * the handle then locks a context it does not run in. The binding read here is script-reachable
+     * and a script can break it, but only for its own context, and correctness comes first.
+     */
+    private static Context creatorContext()
+    {
+        final Value holder = currentBindings().getMember( CREATOR_CONTEXT );
+        final Object found = holder != null && holder.isHostObject() ? holder.asHostObject() : null;
+        if ( !( found instanceof CreatorHolder ) )
+        {
+            throw new IllegalStateException( "Script context was not created by " + GraalJSContextFactory.class.getSimpleName() +
+                                                 ", or its creator binding was replaced" );
+        }
+        return ( (CreatorHolder) found ).context;
+    }
+
+    /**
+     * {@link Context#getCurrent()} throws when nothing is entered, and reads as a Graal internal
+     * error rather than as what it is: a conversion reached from a thread with no context to
+     * resolve a creator from.
+     */
+    private static Value currentBindings()
+    {
+        try
+        {
+            return Context.getCurrent().getPolyglotBindings();
+        }
+        catch ( final IllegalStateException e )
+        {
+            throw new IllegalStateException( "No script context is entered on this thread, so its creator cannot be resolved", e );
+        }
     }
 }

--- a/modules/script/script-impl/src/test/java/com/enonic/xp/script/graal/GraalContextPoolTest.java
+++ b/modules/script/script-impl/src/test/java/com/enonic/xp/script/graal/GraalContextPoolTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.graalvm.polyglot.Engine;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,6 +59,14 @@ class GraalContextPoolTest
 
     private ResourceService resourceService;
 
+    /**
+     * One engine for every context these tests build, as an installation has. Contexts on a shared
+     * engine must present an equal host access configuration, so a per-context one keeps the second
+     * context from opening at all — a whole class of defect that only exists in this configuration
+     * and that a per-context engine hides completely.
+     */
+    private Engine engine;
+
     @BeforeEach
     void setUp()
     {
@@ -74,13 +83,15 @@ class GraalContextPoolTest
             return new UrlResource( resourceKey, resourceUrl );
         } );
 
+        this.engine = Engine.newBuilder().build();
         this.scriptExecutor = newExecutor( 2, GraalContextBudget.unlimited() );
         this.threads = Executors.newFixedThreadPool( 2 );
     }
 
     private ScriptExecutor newExecutor( final int capacity, final GraalContextBudget budget )
     {
-        return new GraalScriptExecutor( new GraalJSContextFactory(), getClass().getClassLoader(),
+        return new GraalScriptExecutor( new GraalJSContextFactory( getClass().getClassLoader(), () -> engine ),
+                                        getClass().getClassLoader(),
                                         ScriptSettings.create().build(), new ServiceRegistryImpl( bundleContext ), resourceService,
                                         application, capacity, budget );
     }
@@ -91,6 +102,7 @@ class GraalContextPoolTest
     {
         this.threads.shutdownNow();
         ( (Closeable) this.scriptExecutor ).close();
+        this.engine.close();
     }
 
     @Test

--- a/modules/script/script-impl/src/test/java/com/enonic/xp/script/graal/GraalJSContextFactoryTest.java
+++ b/modules/script/script-impl/src/test/java/com/enonic/xp/script/graal/GraalJSContextFactoryTest.java
@@ -7,6 +7,7 @@ import org.graalvm.polyglot.Engine;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GraalJSContextFactoryTest
 {
@@ -35,6 +36,148 @@ class GraalJSContextFactoryTest
         finally
         {
             engine.close();
+        }
+    }
+
+    @Test
+    void poolGrowthBuildsMoreThanOneContextOnTheSharedEngine()
+    {
+        final Engine engine = Engine.newBuilder().build();
+        try
+        {
+            final GraalJSContextFactory factory = new GraalJSContextFactory( getClass().getClassLoader(), () -> engine );
+
+            try ( Context first = factory.create(); Context second = factory.create() )
+            {
+                assertEquals( 1, first.eval( "js", "1" ).asInt() );
+                assertEquals( 2, second.eval( "js", "2" ).asInt() );
+            }
+        }
+        finally
+        {
+            engine.close();
+        }
+    }
+
+    @Test
+    void twoApplicationsBuildContextsOnTheSharedEngine()
+    {
+        final Engine engine = Engine.newBuilder().build();
+        try
+        {
+            final GraalJSContextFactory one = new GraalJSContextFactory( getClass().getClassLoader(), () -> engine );
+            final GraalJSContextFactory two = new GraalJSContextFactory( getClass().getClassLoader(), () -> engine );
+
+            try ( Context first = one.create(); Context second = two.create() )
+            {
+                assertEquals( 1, first.eval( "js", "1" ).asInt() );
+                assertEquals( 2, second.eval( "js", "2" ).asInt() );
+            }
+        }
+        finally
+        {
+            engine.close();
+        }
+    }
+
+    // a handle that locked anything but the context its creator built — the restricted wrapper
+    // Context.getCurrent() returns, say — would leave two monitors guarding one context, and the
+    // mutual exclusion every other execution path relies on would be a no-op
+    @Test
+    void handleLocksTheContextItsCreatorBuilt()
+    {
+        final Engine engine = Engine.newBuilder().build();
+        try
+        {
+            final GraalJSContextFactory factory = new GraalJSContextFactory( getClass().getClassLoader(), () -> engine );
+
+            try ( Context context = factory.create() )
+            {
+                final LockProbe probe = new LockProbe( context );
+                context.getBindings( "js" ).putMember( "probe", probe );
+                context.eval( "js", "(function () { probe.record(); })" ).as( Runnable.class ).run();
+
+                assertTrue( probe.heldCreatorMonitor );
+            }
+        }
+        finally
+        {
+            engine.close();
+        }
+    }
+
+    // scripts read the polyglot bindings through Java.type('org.graalvm.polyglot.Context'), so a
+    // bare context there would be close() one property read away. Pinned: the binding offers
+    // nothing to call and nothing to enumerate, so none is reached by accident. Not a claim that it
+    // is unreachable — reflection still unwraps the holder, and scripts hold the host's authority
+    // regardless
+    @Test
+    void polyglotBindingsExposeNothingCallableOnTheContext()
+    {
+        try ( Context context = new GraalJSContextFactory().create() )
+        {
+            final String reached = context.eval( "js", """
+                (function () {
+                  const bindings = Java.type( 'org.graalvm.polyglot.Context' ).getCurrent().getPolyglotBindings();
+                  const held = bindings['com.enonic.xp.script.graal.creatorContext'];
+                  try
+                  {
+                    held.close();
+                    return 'closed the context';
+                  }
+                  catch ( e )
+                  {
+                    return Object.keys( held ).join( ',' );
+                  }
+                })()
+                """ ).asString();
+
+            assertEquals( "", reached );
+        }
+    }
+
+    // a handle must lock the context that owns its function, not whichever execution is in
+    // progress. Resolving from anything the executor publishes gets this wrong the moment one
+    // application's handle is invoked inside another's execution
+    @Test
+    void handleLocksTheOwningContextWhenAnotherIsExecuting()
+    {
+        final Engine engine = Engine.newBuilder().build();
+        try
+        {
+            final GraalJSContextFactory factory = new GraalJSContextFactory( getClass().getClassLoader(), () -> engine );
+
+            try ( Context owner = factory.create(); Context other = factory.create() )
+            {
+                final LockProbe probe = new LockProbe( owner );
+                owner.getBindings( "js" ).putMember( "probe", probe );
+
+                other.eval( "js", "1" );
+                owner.eval( "js", "(function () { probe.record(); })" ).as( Runnable.class ).run();
+
+                assertTrue( probe.heldCreatorMonitor );
+            }
+        }
+        finally
+        {
+            engine.close();
+        }
+    }
+
+    public static final class LockProbe
+    {
+        private final Context context;
+
+        boolean heldCreatorMonitor;
+
+        LockProbe( final Context context )
+        {
+            this.context = context;
+        }
+
+        public void record()
+        {
+            this.heldCreatorMonitor = Thread.holdsLock( context );
         }
     }
 }

--- a/modules/script/script-impl/src/test/java/com/enonic/xp/script/graal/GraalJSContextFactoryTest.java
+++ b/modules/script/script-impl/src/test/java/com/enonic/xp/script/graal/GraalJSContextFactoryTest.java
@@ -2,7 +2,6 @@ package com.enonic.xp.script.graal;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -12,7 +11,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
-import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Value;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;

--- a/modules/script/script-impl/src/test/java/com/enonic/xp/script/graal/GraalJSContextFactoryTest.java
+++ b/modules/script/script-impl/src/test/java/com/enonic/xp/script/graal/GraalJSContextFactoryTest.java
@@ -1,12 +1,24 @@
 package com.enonic.xp.script.graal;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.PolyglotException;
+import org.graalvm.polyglot.Value;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GraalJSContextFactoryTest
@@ -161,6 +173,144 @@ class GraalJSContextFactoryTest
         finally
         {
             engine.close();
+        }
+    }
+
+
+    // The conversion, not the invocation, is what picks the lock. This is the case the fix rests
+    // on: a value owned by one context converted while a *different* context is entered — a host
+    // object called from `other` converting a function belonging to `owner`. Resolving from
+    // anything but the value's own context hands the handle the wrong monitor here, and the
+    // mutual exclusion the executor relies on silently stops holding.
+    @Test
+    @Timeout(60)
+    void conversionInsideAnotherContextsExecutionStillLocksTheOwner()
+    {
+        final Engine engine = Engine.newBuilder().build();
+        try
+        {
+            final GraalJSContextFactory factory = new GraalJSContextFactory( getClass().getClassLoader(), () -> engine );
+
+            try ( Context owner = factory.create(); Context other = factory.create() )
+            {
+                final LockProbe probe = new LockProbe( owner );
+                owner.getBindings( "js" ).putMember( "probe", probe );
+
+                final Converter converter = new Converter( owner.eval( "js", "(function () { probe.record(); })" ) );
+                other.getBindings( "js" ).putMember( "converter", converter );
+
+                // the conversion happens here, with `other` entered and `owner` not
+                other.eval( "js", "converter.convert()" );
+
+                converter.converted.run();
+                assertTrue( probe.heldCreatorMonitor, "handle locked a context other than the one owning its function" );
+            }
+        }
+        finally
+        {
+            engine.close();
+        }
+    }
+
+    // the reported trigger was an application growing its pool under concurrent requests, so the
+    // contexts arrive on the shared engine at once rather than one after another
+    @Test
+    @Timeout(60)
+    void contextsAreBuiltConcurrentlyOnTheSharedEngine()
+        throws Exception
+    {
+        final int count = 8;
+        final Engine engine = Engine.newBuilder().build();
+        final ExecutorService threads = Executors.newFixedThreadPool( count );
+        try
+        {
+            final GraalJSContextFactory factory = new GraalJSContextFactory( getClass().getClassLoader(), () -> engine );
+            final CyclicBarrier start = new CyclicBarrier( count );
+
+            final List<Future<Context>> built = new ArrayList<>();
+            for ( int i = 0; i < count; i++ )
+            {
+                built.add( threads.submit( () -> {
+                    start.await( 30, TimeUnit.SECONDS );
+                    return factory.create();
+                } ) );
+            }
+
+            final List<Context> contexts = new ArrayList<>();
+            for ( final Future<Context> future : built )
+            {
+                contexts.add( future.get( 30, TimeUnit.SECONDS ) );
+            }
+            try
+            {
+                for ( final Context context : contexts )
+                {
+                    assertEquals( 42, context.eval( "js", "42" ).asInt() );
+                }
+            }
+            finally
+            {
+                contexts.forEach( Context::close );
+            }
+        }
+        finally
+        {
+            threads.shutdownNow();
+            engine.close();
+        }
+    }
+
+    // the trade the fix accepts: the creator binding is script-reachable, so a script can break
+    // conversion for its own context. Pinned so the blast radius stays visible and stays local —
+    // it must fail loudly here, and not at all for the context next door
+    @Test
+    @Timeout(60)
+    void aScriptThatReplacesTheCreatorBindingBreaksOnlyItsOwnContext()
+    {
+        final Engine engine = Engine.newBuilder().build();
+        try
+        {
+            final GraalJSContextFactory factory = new GraalJSContextFactory( getClass().getClassLoader(), () -> engine );
+
+            try ( Context broken = factory.create(); Context healthy = factory.create() )
+            {
+                // member assignment is the way in — removeMember is not supported on these bindings
+                broken.eval( "js", """
+                    Java.type( 'org.graalvm.polyglot.Context' ).getCurrent().getPolyglotBindings()
+                        ['com.enonic.xp.script.graal.creatorContext'] = 'hijacked';
+                    """ );
+
+                final RuntimeException e = assertThrows( RuntimeException.class,
+                                                         () -> broken.eval( "js", "(function () {})" ).as( Runnable.class ).run() );
+                assertTrue( e.getMessage().contains( "creator binding was replaced" ), e.getMessage() );
+
+                // the neighbour is untouched
+                final LockProbe probe = new LockProbe( healthy );
+                healthy.getBindings( "js" ).putMember( "probe", probe );
+                healthy.eval( "js", "(function () { probe.record(); })" ).as( Runnable.class ).run();
+                assertTrue( probe.heldCreatorMonitor );
+            }
+        }
+        finally
+        {
+            engine.close();
+        }
+    }
+
+    public static final class Converter
+    {
+        private final Value function;
+
+        Runnable converted;
+
+        Converter( final Value function )
+        {
+            this.function = function;
+        }
+
+        public void convert()
+        {
+            this.converted = this.function.as( Runnable.class );
         }
     }
 


### PR DESCRIPTION
Only one GraalJS script context could be created per installation. The second one — a second application, or the same application growing its context pool under concurrent requests — failed with `IllegalStateException: Found different host access configuration for a context with a shared engine`, and the application returned a 500 before any of its own code ran.

One `Engine` is shared installation-wide so its parsed-code cache is shared. GraalVM requires every context on that engine to present an equal host access configuration. `GraalJSContextFactory` built a new `HostAccess` per context, because its target type mappings closed over a per-context `AtomicReference<Context>` — and `HostAccess.equals` compares those mappings, which hold lambdas that compare by identity. So no two were ever equal, and the first context to be built locked out every later one.

## The fix

`HostAccess` is now built once for the process. The mappings resolve the creator `Context` when they run instead of capturing it, reading it back from the entered context's own polyglot bindings.

**Why this is correct.** The capture existed because `JsFunctionHandle` must lock the exact `Context` the rest of the runtime synchronizes on, and `Context.getCurrent()` returns a restricted wrapper rather than that instance. Resolving from the entered context gives the right one by construction: a target type mapping runs with the owning context entered, so the context it finds is the context that owns the value being converted — which is the context the resulting handle must lock.

**Why not a value published by the executor.** That was tried and is wrong. It names the context the executor last bound, which stops matching the entered context the moment a handle belonging to one application is invoked inside another application's execution — the handle then locks a context it does not run in, which is the exact mutual-exclusion failure the design exists to prevent. There is a test pinning this case, and a comment on `creatorContext()` recording why the obvious channel is the wrong one.

Building `HostAccess` once is also what GraalVM's own test suite demonstrates as correct usage, and there is no public API to recover a creator `Context` from inside an execution — the concept exists in `Context` but is not exposed.

## Tests

Five added, covering pool growth on a shared engine, two applications on one engine, monitor identity, cross-context ownership, and what the bindings expose to a script. Reverting the production change fails them and nothing else.

Closes #12251

---

### Open, not blocking

Two things are known and deliberately left as they are. Neither affects the fix, but both should be looked at rather than assumed closed.

**A script can break its own context.** The creator context is stored in that context's polyglot bindings, and scripts can reach those bindings. An application that overwrote or deleted the entry would break function conversion — for its own context only, never for another application's. This was the trade: the alternative that hides it from scripts is the executor-published one, and that one is incorrect. Scripts already run with full host authority here, so this is not a new capability, only a new way to misuse it. Worth revisiting if a channel that is both correct and script-proof turns up.

**One assumption rests on observed behaviour, not a documented guarantee.** The fix relies on a target type mapping always running with the owning context entered. Every test depends on it and passes, and GraalVM's own API shape implies it, but it is not written down anywhere as a contract. If it were ever false, the code fails loudly with a clear message rather than binding the wrong lock — but it is an assumption, not a proof.

**Concurrency lifecycle was not systematically reviewed.** The fix was checked against pool growth and cross-context use, but not against a full sweep of context close and cancel races, retained websocket/SSE slots, or the bootstrap slot versus the request pool. Nothing suggests a problem there; it simply was not covered.

<sub>*Drafted with AI assistance*</sub>
