### PR TITLE
Publish single event for node duplication with all duplicated nodes

### DIFF
--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/NodeEvents.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/NodeEvents.java
@@ -53,9 +53,10 @@ public final class NodeEvents
         return buildEvent( NODE_DELETED_EVENT, deletedNodes.stream(), internalContext, node -> nodeToMap( node, internalContext ) );
     }
 
-    public static Event duplicated( final Node duplicatedNode, final InternalContext internalContext )
+    public static Event duplicated( final Collection<Node> duplicatedNodes, final InternalContext internalContext )
     {
-        return event( NODE_DUPLICATED_EVENT, duplicatedNode, internalContext );
+        return buildEvent( NODE_DUPLICATED_EVENT, duplicatedNodes.stream(), internalContext,
+                           node -> nodeToMap( node, internalContext ) );
     }
 
     public static Event updated( final Node updatedNode, final InternalContext internalContext )

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/NodeServiceImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/NodeServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.elasticsearch.index.IndexNotFoundException;
@@ -696,8 +697,9 @@ public class NodeServiceImpl
 
         final InternalContext internalContext = InternalContext.from( ContextAccessor.current() );
 
-        this.eventPublisher.publish( NodeEvents.duplicated( result.getNode(), internalContext ) );
-        result.getChildren().forEach( child -> this.eventPublisher.publish( NodeEvents.created( child, internalContext ) ) );
+        // the duplicated node and its duplicated children are reported in a single event, parents before children
+        this.eventPublisher.publish( NodeEvents.duplicated(
+            Stream.concat( Stream.of( result.getNode() ), result.getChildren().stream() ).toList(), internalContext ) );
 
         return result;
     }

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/NodeEventsTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/NodeEventsTest.java
@@ -82,13 +82,16 @@ class NodeEventsTest
     void testDuplicated()
     {
         final Node duplicated = createNode( "duplicated", new NodePath( "/mynode1/child1" ), "myid" );
+        final Node duplicatedChild = createNode( "child", new NodePath( "/mynode1/child1/duplicated" ), "mychildid" );
 
-        Event event = NodeEvents.duplicated( duplicated, InternalContext.from( createContext( "draft" ) ) );
+        Event event =
+            NodeEvents.duplicated( List.of( duplicated, duplicatedChild ), InternalContext.from( createContext( "draft" ) ) );
 
         assertNotNull( event );
         assertTrue( event.isDistributed() );
         assertEquals( NodeEvents.NODE_DUPLICATED_EVENT, event.getType() );
-        assertEquals( "[{id=myid, path=/mynode1/child1/duplicated, branch=draft, repo=com.enonic.cms.myproject}]",
+        assertEquals( "[{id=myid, path=/mynode1/child1/duplicated, branch=draft, repo=com.enonic.cms.myproject}, " +
+                          "{id=mychildid, path=/mynode1/child1/duplicated/child, branch=draft, repo=com.enonic.cms.myproject}]",
                       event.getValue( EventConstants.NODES_FIELD ).get().toString() );
     }
 

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/NodeServiceImplTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/NodeServiceImplTest.java
@@ -23,6 +23,7 @@ import com.enonic.xp.core.AbstractNodeTest;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.data.ValueFactory;
 import com.enonic.xp.event.Event;
+import com.enonic.xp.event.EventConstants;
 import com.enonic.xp.index.ChildOrder;
 import com.enonic.xp.node.ApplyNodePermissionsParams;
 import com.enonic.xp.node.ApplyVersionAttributesParams;
@@ -32,6 +33,7 @@ import com.enonic.xp.node.CreateNodeParams;
 import com.enonic.xp.node.DeleteNodeParams;
 import com.enonic.xp.node.DeleteNodeResult;
 import com.enonic.xp.node.DuplicateNodeParams;
+import com.enonic.xp.node.DuplicateNodeResult;
 import com.enonic.xp.node.FindNodesByMultiRepoQueryResult;
 import com.enonic.xp.node.FindNodesByParentParams;
 import com.enonic.xp.node.FindNodesByParentResult;
@@ -488,6 +490,45 @@ class NodeServiceImplTest
         final Node node_1_2_3_dup = this.nodeService.getById( node_1_2_3_dup_id );
 
         assertEquals( node_1_2_3.name(), node_1_2_3_dup.name() );
+    }
+
+    @Test
+    void duplicate_shouldPublishSingleEventWithAllDuplicatedNodes()
+    {
+        final PropertyTree data = new PropertyTree();
+
+        final Node node_1 =
+            this.nodeService.create( CreateNodeParams.create().name( "parent" ).parent( NodePath.ROOT ).data( data ).build() );
+
+        final Node node_1_1 =
+            this.nodeService.create( CreateNodeParams.create().name( "child" ).parent( node_1.path() ).data( data ).build() );
+
+        this.nodeService.create( CreateNodeParams.create().name( "child_of_child" ).parent( node_1_1.path() ).data( data ).build() );
+
+        this.nodeService.refresh( RefreshMode.SEARCH );
+
+        Mockito.clearInvocations( eventPublisher );
+
+        final DuplicateNodeResult result =
+            this.nodeService.duplicate( DuplicateNodeParams.create().nodeId( node_1.id() ).refresh( RefreshMode.SEARCH ).build() );
+
+        final ArgumentCaptor<Event> captor = ArgumentCaptor.forClass( Event.class );
+
+        verify( eventPublisher, times( 1 ) ).publish( captor.capture() );
+
+        final Event event = captor.getValue();
+
+        assertEquals( NodeEvents.NODE_DUPLICATED_EVENT, event.getType() );
+
+        final List<Map<String, String>> nodes = (List<Map<String, String>>) event.getData().get( EventConstants.NODES_FIELD );
+
+        // the duplicated node comes first, and every child comes after its parent
+        assertEquals( List.of( "/parent-copy", "/parent-copy/child", "/parent-copy/child/child_of_child" ),
+                      nodes.stream().map( node -> node.get( "path" ) ).toList() );
+
+        assertEquals( result.getNode().id().toString(), nodes.get( 0 ).get( "id" ) );
+        assertEquals( result.getChildren().stream().map( node -> node.id().toString() ).collect( Collectors.toSet() ),
+                      nodes.stream().skip( 1 ).map( node -> node.get( "id" ) ).collect( Collectors.toSet() ) );
     }
 
     @Test


### PR DESCRIPTION
## Summary
Changed the node duplication event publishing to emit a single event containing all duplicated nodes (parent and children) instead of publishing separate events for each node. This improves event consistency and allows subscribers to process the entire duplication operation atomically.

## Key Changes
- Modified `NodeServiceImpl.duplicate()` to publish a single `NODE_DUPLICATED_EVENT` containing both the duplicated parent node and all its children, rather than publishing individual events
- Updated `NodeEvents.duplicated()` method signature to accept a `Collection<Node>` instead of a single `Node`, allowing it to handle multiple nodes in one event
- Changed the event building logic to use the existing `buildEvent()` helper method for consistency with other multi-node events (like `deleted()`)
- Nodes are ordered in the event with parents before children to maintain hierarchy information

## Implementation Details
- The duplicated nodes are combined using `Stream.concat()` to ensure the parent node appears first, followed by all children
- The event data structure uses the same `nodeToMap()` conversion as other node events, including id, path, branch, and repo information
- Updated corresponding tests to verify the single event is published with all duplicated nodes in the correct order

https://claude.ai/code/session_017cKmPRVUyVbKcZDho2MDtX