### PR TITLE
Anchor base URLs at the project when there is no content anchor

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/BaseUrlExtractor.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/BaseUrlExtractor.java
@@ -22,7 +22,6 @@ import com.enonic.xp.site.SiteConfigs;
 import com.enonic.xp.site.SiteConfigsDataSerializer;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.Objects.requireNonNullElse;
 
 record BaseUrlExtractor(ContentService contentService, ProjectService projectService)
 {
@@ -66,9 +65,7 @@ record BaseUrlExtractor(ContentService contentService, ProjectService projectSer
             final Context context =
                 ContextBuilder.copyOf( ContextAccessor.current() ).repositoryId( projectName.getRepoId() ).branch( branch ).build();
 
-            final Content content = params.getContent() != null
-                ? context.callWith( () -> params.getContent().get() )
-                : context.callWith( () -> getContent( requireNonNullElse( params.getId(), params.getPath() ) ) );
+            final Content content = context.callWith( () -> resolveContentAnchor( params ) );
 
             builder.setContent( content );
 
@@ -77,7 +74,7 @@ record BaseUrlExtractor(ContentService contentService, ProjectService projectSer
             {
                 site = (Site) content;
             }
-            else if ( !content.getPath().isRoot() )
+            else if ( content != null && !content.getPath().isRoot() )
             {
                 site = context.callWith( () -> contentService.getNearestSite( ContentId.from( content.getId() ) ) );
             }
@@ -135,15 +132,29 @@ record BaseUrlExtractor(ContentService contentService, ProjectService projectSer
         return null;
     }
 
-    private Content getContent( final String contentKey )
+    /**
+     * @return the content the URL is anchored to, or {@code null} when it is anchored at the
+     * project itself: the root of a project holds no content, so the URL is then resolved from
+     * the configuration of the project rather than of a site
+     */
+    private Content resolveContentAnchor( final BaseUrlParams params )
     {
-        if ( contentKey.startsWith( "/" ) )
+        if ( params.getContent() != null )
         {
-            return contentService.getByPath( ContentPath.from( contentKey ) );
+            return params.getContent().get();
         }
-        else
+
+        if ( params.getId() != null )
         {
-            return contentService.getById( ContentId.from( contentKey ) );
+            return contentService.getById( ContentId.from( params.getId() ) );
         }
+
+        if ( params.getPath() != null )
+        {
+            final ContentPath path = ContentPath.from( params.getPath() );
+            return path.isRoot() ? null : contentService.getByPath( path );
+        }
+
+        return null;
     }
 }

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/url/PortalUrlService_baseUrlTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/url/PortalUrlService_baseUrlTest.java
@@ -19,6 +19,8 @@ import com.enonic.xp.portal.impl.ContentFixtures;
 import com.enonic.xp.portal.impl.PortalConfig;
 import com.enonic.xp.portal.url.BaseUrlParams;
 import com.enonic.xp.portal.url.UrlTypeConstants;
+import com.enonic.xp.project.Project;
+import com.enonic.xp.project.ProjectName;
 import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.acl.AccessControlEntry;
@@ -786,5 +788,82 @@ class PortalUrlService_baseUrlTest
 
         // the anchor is taken from the supplier: no content lookup is made
         assertEquals( "https://cdn.company.com/_", url );
+    }
+
+    private void mockProjectWithBaseUrl( final String baseUrl )
+    {
+        final PropertyTree config = new PropertyTree();
+        config.addString( "baseUrl", baseUrl );
+
+        final Project project = Project.create()
+            .name( ProjectName.from( "myproject" ) )
+            .addSiteConfig( SiteConfig.create().application( ApplicationKey.from( "portal" ) ).config( config ).build() )
+            .build();
+
+        when( projectService.get( eq( ProjectName.from( "myproject" ) ) ) ).thenReturn( project );
+    }
+
+    private String projectRootBaseUrl( final DescriptorKey api )
+    {
+        return ContextBuilder.create()
+            .repositoryId( RepositoryId.from( "com.enonic.cms.myproject" ) )
+            .branch( Branch.from( "draft" ) )
+            .build()
+            .callWith( () -> this.service.baseUrl(
+                BaseUrlParams.create().setPath( "/" ).setProjectName( "myproject" ).setBranch( "draft" ).setApi( api ).build() ) );
+    }
+
+    @Test
+    void testProjectRootAnchorWithConfiguredBaseUrl()
+    {
+        PortalRequestAccessor.set( null );
+
+        mockProjectWithBaseUrl( "https://cdn.company.com" );
+
+        // the root of a project holds no content: the URL is resolved from the project configuration
+        assertEquals( "https://cdn.company.com", projectRootBaseUrl( null ) );
+    }
+
+    @Test
+    void testProjectRootAnchorWithoutConfiguredBaseUrl()
+    {
+        PortalRequestAccessor.set( null );
+
+        assertEquals( "/site/myproject/draft", projectRootBaseUrl( null ) );
+    }
+
+    @Test
+    void testProjectRootAnchorApiBaseUrlWithConfiguredBaseUrl()
+    {
+        PortalRequestAccessor.set( null );
+
+        mockProjectWithBaseUrl( "https://cdn.company.com" );
+
+        // media APIs are auto-mounted by default, so they live under the "_" endpoint of the base
+        assertEquals( "https://cdn.company.com/_", projectRootBaseUrl( DescriptorKey.from( "media:image" ) ) );
+    }
+
+    @Test
+    void testProjectRootAnchorApiBaseUrlWithoutConfiguredBaseUrl()
+    {
+        PortalRequestAccessor.set( null );
+
+        assertNull( projectRootBaseUrl( DescriptorKey.from( "media:image" ) ) );
+    }
+
+    @Test
+    void testAnchorWithoutContentKey()
+    {
+        PortalRequestAccessor.set( null );
+
+        mockProjectWithBaseUrl( "https://cdn.company.com" );
+
+        // no content key at all anchors at the project, like the root path does
+        assertEquals( "https://cdn.company.com", ContextBuilder.create()
+            .repositoryId( RepositoryId.from( "com.enonic.cms.myproject" ) )
+            .branch( Branch.from( "draft" ) )
+            .build()
+            .callWith( () -> this.service.baseUrl(
+                BaseUrlParams.create().setProjectName( "myproject" ).setBranch( "draft" ).build() ) ) );
     }
 }


### PR DESCRIPTION
Resolving a base URL anchored at the root of a project fails. The root holds no content, but the anchor is looked up unconditionally, so `contentService.getByPath(ContentPath.ROOT)` translates to the node path `/content`, which `isProtectedRoot` rejects, and the lookup throws `ContentNotFoundException`.

The failure surfaces in two ways, both reproduced before fixing:

```
page base for root anchor = /_/error/500?message=Something+went+wrong…
api base for root anchor  THREW ... because "content" is null
```

- a **page** base URL is built through `UrlGenerator`, which turns the failure into an error URL - a caller that stores the result then anchors every URL to `/_/error/500…`;
- an **API** base URL is resolved without that safety net, so the failure reaches the caller.

`BaseUrlExtractor` already falls back to the configuration of the project when the anchor has no nearest site, which is exactly what anchoring at the root means - but that fallback is unreachable, because the lookup throws first.

So the content lookup is skipped when there is nothing to look up: the root path, and equally a call that carries no content key at all. The base URL is then resolved from the project configuration, so a project with a configured `portal.baseUrl` anchors URLs there, and one without falls back to the `/site/{project}/{branch}` form as before. The nearest-site branch is guarded for the same reason.

Tests cover the project root with and without a configured base URL, the same for an API base URL, and a call with no content key.

This is what makes `guillotine(siteKey: "/")` fail in enonic/app-guillotine#1487 - the reported `getChildren` query asks for `pageUrl`, and the error URL is what comes back. With this fix guillotine needs no special case for the project root, and project-level base URLs keep applying to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8TCeZWgJjKTDhmntR9JtB

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8TCeZWgJjKTDhmntR9JtB)_