### PR TITLE
Report a failure from baseUrl instead of encoding it into the result

### DIFF
--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -928,6 +928,8 @@ interface BaseUrlHandler {
 /**
  * This function generates a baseURL.
  *
+ * Never returns an error URL: raises an error when the content does not exist.
+ *
  * @example-ref examples/portal/baseUrl.js
  *
  * @param {object} params Input parameters as JSON.

--- a/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/PortalUrlService.java
+++ b/modules/portal/portal-api/src/main/java/com/enonic/xp/portal/url/PortalUrlService.java
@@ -13,6 +13,10 @@ public interface PortalUrlService
      * instead: {@code <baseUrl>/_} when a Base URL is configured and the API is mounted on the
      * anchored site, the {@code media.defaultBaseUrl} configuration for media APIs when set,
      * or {@code null} when URLs should stay request-based.
+     * <p>
+     * Never returns an error URL: failures are reported to the caller.
+     *
+     * @throws com.enonic.xp.content.ContentNotFoundException if the anchor does not exist
      */
     String baseUrl( BaseUrlParams params );
 

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/PortalUrlServiceImpl.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/PortalUrlServiceImpl.java
@@ -146,8 +146,11 @@ public final class PortalUrlServiceImpl
             return runWithAdminRole( () -> resolveApiBaseUrl( params ) );
         }
 
-        final Supplier<String> baseUrlStrategy = new ContentBaseUrlSupplier( contentService, projectService, params );
-        return portalUrlGeneratorService.generateUrl( UrlGeneratorParams.create().setBaseUrl( baseUrlStrategy ).build() );
+        // a base URL is a prefix of other URLs, so a failure is reported to the caller instead
+        // of being encoded into the result: an error URL used as a base would silently prefix
+        // every URL built from it
+        return runWithAdminRole( () -> UrlGenerator.removeTrailingSlash(
+            new ContentBaseUrlSupplier( contentService, projectService, params ).get() ) );
     }
 
     private String resolveApiBaseUrl( final BaseUrlParams params )

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/UrlGenerator.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/UrlGenerator.java
@@ -35,7 +35,7 @@ final class UrlGenerator
         }
     }
 
-    private static String removeTrailingSlash( final String path )
+    static String removeTrailingSlash( final String path )
     {
         if ( isNullOrEmpty( path ) )
         {

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/url/PortalUrlService_baseUrlTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/url/PortalUrlService_baseUrlTest.java
@@ -33,6 +33,7 @@ import com.enonic.xp.site.SiteDescriptor;
 import com.enonic.xp.web.vhost.VirtualHost;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
@@ -49,8 +50,9 @@ class PortalUrlService_baseUrlTest
 
         final BaseUrlParams params = BaseUrlParams.create().setId( "contentid" ).build();
 
-        final String url = ContextBuilder.create().build().callWith( () -> this.service.baseUrl( params ) );
-        assertThat( url ).startsWith( "/_/error/500?message=Something+went+wrong." );
+        // a base URL is a prefix of other URLs: a failure is reported, never encoded into it
+        assertThatThrownBy( () -> ContextBuilder.create().build().callWith( () -> this.service.baseUrl( params ) ) ).isInstanceOf(
+            IllegalArgumentException.class ).hasMessageContaining( "RepositoryId must be set" );
     }
 
     @Test
@@ -60,12 +62,12 @@ class PortalUrlService_baseUrlTest
 
         final BaseUrlParams params = BaseUrlParams.create().setId( "contentid" ).build();
 
-        final String url = ContextBuilder.create()
+        assertThatThrownBy( () -> ContextBuilder.create()
             .repositoryId( RepositoryId.from( "non.content.project" ) )
             .branch( Branch.from( "branch" ) )
             .build()
-            .callWith( () -> this.service.baseUrl( params ) );
-        assertThat( url ).startsWith( "/_/error/500?message=Something+went+wrong." );
+            .callWith( () -> this.service.baseUrl( params ) ) ).isInstanceOf( IllegalArgumentException.class )
+            .hasMessageContaining( "not a content repository" );
     }
 
     @Test
@@ -75,11 +77,11 @@ class PortalUrlService_baseUrlTest
 
         final BaseUrlParams params = BaseUrlParams.create().setId( "contentid" ).build();
 
-        final String url = ContextBuilder.create()
+        assertThatThrownBy( () -> ContextBuilder.create()
             .repositoryId( RepositoryId.from( "com.enonic.cms.myproject" ) )
             .build()
-            .callWith( () -> this.service.baseUrl( params ) );
-        assertThat( url ).startsWith( "/_/error/500?message=Something+went+wrong." );
+            .callWith( () -> this.service.baseUrl( params ) ) ).isInstanceOf( IllegalArgumentException.class )
+            .hasMessageContaining( "Branch not set" );
     }
 
     @Test
@@ -97,13 +99,13 @@ class PortalUrlService_baseUrlTest
 
         final BaseUrlParams params = BaseUrlParams.create().setId( contentId.toString() ).build();
 
-        final String url = ContextBuilder.create()
+        // the anchor does not exist: the caller is told, instead of receiving an error URL
+        // that would silently prefix every URL built from it
+        assertThatThrownBy( () -> ContextBuilder.create()
             .repositoryId( RepositoryId.from( "com.enonic.cms.myproject" ) )
             .branch( Branch.from( "draft" ) )
             .build()
-            .callWith( () -> this.service.baseUrl( params ) );
-
-        assertThat( url ).startsWith( "/_/error/404?message=Not+Found" );
+            .callWith( () -> this.service.baseUrl( params ) ) ).isInstanceOf( ContentNotFoundException.class );
     }
 
     private static void mockDataWithSiteConfig( final SiteConfigs siteConfigs, final Site site )


### PR DESCRIPTION
`PortalUrlService.baseUrl` answered a missing content anchor in two different ways, depending on whether `api` was set on the params:

```
baseUrl(path=/nosuch)                    → "/_/error/404?message=Not+Found…"   (a String)
baseUrl(path=/nosuch, api=media:image)   → throws ContentNotFoundException
```

The string is the harmful half. Methods that generate a complete URL route through `UrlGenerator`, which catches everything and encodes the failure as an `/_/error/…` URL - reasonable there, because the result *is* the URL and it describes itself where it is used. A base URL is not a result but a prefix: a caller that stores it goes on to build every other URL from `/_/error/404?…`, and nothing ever fails.

That is not hypothetical. It is how enonic/app-guillotine#1487 presented: `siteKey` resolution stored the error URL as the site base, and every `pageUrl` in the response came back pointing at it.

Failures from `baseUrl` now reach the caller in both cases, so the method has one contract. The methods that generate a complete URL are untouched.

Behavior change worth noting for review: `portal.baseUrl({id: 'bogus'})` in lib-portal now raises instead of returning an error-URL string, and so does an anchor resolved out of the scope of the current request. The URL-parts methods (`pageUrlParts`, `imageUrlParts`, `attachmentUrlParts`) already behaved this way, so this aligns the whole family of methods that return something other than a finished URL.

Tests that asserted the error URLs now assert the exceptions; the Javadoc and the lib-portal documentation state the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8TCeZWgJjKTDhmntR9JtB

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8TCeZWgJjKTDhmntR9JtB)_