### PR TITLE
Store scheduled job run state in node attributes

### DIFF
--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/AbstractSchedulerCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/AbstractSchedulerCommand.java
@@ -1,6 +1,10 @@
 package com.enonic.xp.impl.scheduler;
 
+import com.enonic.xp.impl.scheduler.serializer.SchedulerSerializer;
+import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeService;
+import com.enonic.xp.node.NodeVersion;
+import com.enonic.xp.scheduler.ScheduledJob;
 
 import static java.util.Objects.requireNonNull;
 
@@ -11,6 +15,12 @@ public abstract class AbstractSchedulerCommand
     protected <B extends Builder<B>> AbstractSchedulerCommand( final Builder<B> builder )
     {
         this.nodeService = builder.nodeService;
+    }
+
+    protected ScheduledJob toScheduledJob( final Node node )
+    {
+        final NodeVersion version = node.getNodeVersionId() != null ? nodeService.getVersion( node.id(), node.getNodeVersionId() ) : null;
+        return SchedulerSerializer.fromNode( node, version != null ? version.getAttributes() : null );
     }
 
     public abstract static class Builder<B extends Builder<B>>

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/GetScheduledJobCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/GetScheduledJobCommand.java
@@ -1,6 +1,5 @@
 package com.enonic.xp.impl.scheduler;
 
-import com.enonic.xp.impl.scheduler.serializer.SchedulerSerializer;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeName;
 import com.enonic.xp.node.NodePath;
@@ -35,7 +34,7 @@ public class GetScheduledJobCommand
         final Node node = nodeService.getByPath( new NodePath( NodePath.ROOT, NodeName.from( name.getValue() ) ) );
         if ( node != null )
         {
-            return SchedulerSerializer.fromNode( node );
+            return toScheduledJob( node );
         }
 
         return null;

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/ListScheduledJobsCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/ListScheduledJobsCommand.java
@@ -3,7 +3,6 @@ package com.enonic.xp.impl.scheduler;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.enonic.xp.impl.scheduler.serializer.SchedulerSerializer;
 import com.enonic.xp.node.ListNodesParams;
 import com.enonic.xp.node.ListNodesResult;
 import com.enonic.xp.node.NodePath;
@@ -34,7 +33,7 @@ public class ListScheduledJobsCommand
 
         return nodeService.getByIds( result.getNodeIds() ).
             stream().
-            map( SchedulerSerializer::fromNode ).
+            map( this::toScheduledJob ).
             collect( Collectors.toList() );
     }
 

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/ModifyScheduledJobCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/ModifyScheduledJobCommand.java
@@ -43,8 +43,6 @@ public class ModifyScheduledJobCommand
         final UpdateNodeParams updateNodeParams = UpdateNodeParams.create().
             path( new NodePath( NodePath.ROOT, NodeName.from( params.getName().getValue() ) ) ).
             editor( toBeEdited -> toBeEdited.data = SchedulerSerializer.toUpdateNodeData( params, original ) ).
-            versionAttributesResolver(
-                ( editedNode, originalNode, branch, attributes ) -> SchedulerSerializer.toVersionAttributes( original, attributes ) ).
             refresh( RefreshMode.ALL ).
             build();
 

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/ModifyScheduledJobCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/ModifyScheduledJobCommand.java
@@ -43,12 +43,14 @@ public class ModifyScheduledJobCommand
         final UpdateNodeParams updateNodeParams = UpdateNodeParams.create().
             path( new NodePath( NodePath.ROOT, NodeName.from( params.getName().getValue() ) ) ).
             editor( toBeEdited -> toBeEdited.data = SchedulerSerializer.toUpdateNodeData( params, original ) ).
+            versionAttributesResolver(
+                ( editedNode, originalNode, branch, attributes ) -> SchedulerSerializer.toVersionAttributes( original, attributes ) ).
             refresh( RefreshMode.ALL ).
             build();
 
         final Node updatedNode = nodeService.update( updateNodeParams );
 
-        return SchedulerSerializer.fromNode( updatedNode );
+        return toScheduledJob( updatedNode );
     }
 
     public static final class Builder

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/ScheduledJobPropertyNames.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/ScheduledJobPropertyNames.java
@@ -24,6 +24,12 @@ public class ScheduledJobPropertyNames
 
     public static final String LAST_TASK_ID = "lastTaskId";
 
+    public static final String LAST_RUN_ATTRIBUTE = "scheduler.lastRun";
+
+    public static final String LAST_RUN_TIME_PROPERTY = "time";
+
+    public static final String LAST_RUN_TASK_ID_PROPERTY = "taskId";
+
     public static final String CALENDAR = "calendar";
 
     public static final String CALENDAR_VALUE = "value";

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommand.java
@@ -1,15 +1,19 @@
 package com.enonic.xp.impl.scheduler;
 
 import java.time.Instant;
+import java.util.Set;
+
 import com.enonic.xp.impl.scheduler.serializer.SchedulerSerializer;
+import com.enonic.xp.node.ApplyVersionAttributesParams;
+import com.enonic.xp.node.Attributes;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeName;
+import com.enonic.xp.node.NodeNotFoundException;
 import com.enonic.xp.node.NodePath;
-import com.enonic.xp.node.RefreshMode;
-import com.enonic.xp.node.UpdateNodeParams;
 import com.enonic.xp.scheduler.ScheduledJob;
 import com.enonic.xp.scheduler.ScheduledJobName;
 import com.enonic.xp.task.TaskId;
+import com.enonic.xp.util.GenericValue;
 
 import static java.util.Objects.requireNonNull;
 
@@ -42,18 +46,27 @@ public class UpdateLastRunCommand
 
     private ScheduledJob doExecute()
     {
-        final UpdateNodeParams updateNodeParams = UpdateNodeParams.create().
-            path( new NodePath( NodePath.ROOT, NodeName.from( name.getValue() ) ) ).
-            editor( toBeEdited -> {
-                toBeEdited.data.setInstant( ScheduledJobPropertyNames.LAST_RUN, lastRun );
-            toBeEdited.data.setString( ScheduledJobPropertyNames.LAST_TASK_ID, lastTaskId != null ? lastTaskId.toString() : null );
-            } ).
-            refresh( RefreshMode.ALL ).
-            build();
+        final NodePath path = new NodePath( NodePath.ROOT, NodeName.from( name.getValue() ) );
+        final Node node = nodeService.getByPath( path );
+        if ( node == null )
+        {
+            throw new NodeNotFoundException( "Node not found: " + path );
+        }
 
-        final Node updatedNode = nodeService.update( updateNodeParams );
+        final Attributes.Builder attributes = Attributes.create().
+            attribute( ScheduledJobPropertyNames.LAST_RUN, GenericValue.stringValue( lastRun.toString() ) );
+        if ( lastTaskId != null )
+        {
+            attributes.attribute( ScheduledJobPropertyNames.LAST_TASK_ID, GenericValue.stringValue( lastTaskId.toString() ) );
+        }
 
-        return SchedulerSerializer.fromNode( updatedNode );
+        final Attributes updatedAttributes = nodeService.applyVersionAttributes( ApplyVersionAttributesParams.create().
+            nodeVersionId( node.getNodeVersionId() ).
+            addAttributes( attributes.build() ).
+            removeAttributes( lastTaskId == null ? Set.of( ScheduledJobPropertyNames.LAST_TASK_ID ) : Set.of() ).
+            build() );
+
+        return SchedulerSerializer.fromNode( node, updatedAttributes );
     }
 
     public static final class Builder

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommand.java
@@ -1,6 +1,7 @@
 package com.enonic.xp.impl.scheduler;
 
 import java.time.Instant;
+import java.util.Set;
 
 import com.enonic.xp.impl.scheduler.serializer.SchedulerSerializer;
 import com.enonic.xp.node.ApplyVersionAttributesParams;
@@ -54,6 +55,7 @@ public class UpdateLastRunCommand
         final Attributes updatedAttributes = nodeService.applyVersionAttributes( ApplyVersionAttributesParams.create().
             nodeVersionId( node.getNodeVersionId() ).
             addAttributes( SchedulerSerializer.toLastRunAttributes( lastRun, lastTaskId ) ).
+            removeAttributes( Set.of( ScheduledJobPropertyNames.LAST_RUN, ScheduledJobPropertyNames.LAST_TASK_ID ) ).
             build() );
 
         return SchedulerSerializer.fromNode( node, updatedAttributes );

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommand.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommand.java
@@ -1,7 +1,6 @@
 package com.enonic.xp.impl.scheduler;
 
 import java.time.Instant;
-import java.util.Set;
 
 import com.enonic.xp.impl.scheduler.serializer.SchedulerSerializer;
 import com.enonic.xp.node.ApplyVersionAttributesParams;
@@ -13,7 +12,6 @@ import com.enonic.xp.node.NodePath;
 import com.enonic.xp.scheduler.ScheduledJob;
 import com.enonic.xp.scheduler.ScheduledJobName;
 import com.enonic.xp.task.TaskId;
-import com.enonic.xp.util.GenericValue;
 
 import static java.util.Objects.requireNonNull;
 
@@ -53,17 +51,9 @@ public class UpdateLastRunCommand
             throw new NodeNotFoundException( "Node not found: " + path );
         }
 
-        final Attributes.Builder attributes = Attributes.create().
-            attribute( ScheduledJobPropertyNames.LAST_RUN, GenericValue.stringValue( lastRun.toString() ) );
-        if ( lastTaskId != null )
-        {
-            attributes.attribute( ScheduledJobPropertyNames.LAST_TASK_ID, GenericValue.stringValue( lastTaskId.toString() ) );
-        }
-
         final Attributes updatedAttributes = nodeService.applyVersionAttributes( ApplyVersionAttributesParams.create().
             nodeVersionId( node.getNodeVersionId() ).
-            addAttributes( attributes.build() ).
-            removeAttributes( lastTaskId == null ? Set.of( ScheduledJobPropertyNames.LAST_TASK_ID ) : Set.of() ).
+            addAttributes( SchedulerSerializer.toLastRunAttributes( lastRun, lastTaskId ) ).
             build() );
 
         return SchedulerSerializer.fromNode( node, updatedAttributes );

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/serializer/SchedulerSerializer.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/serializer/SchedulerSerializer.java
@@ -3,6 +3,7 @@ package com.enonic.xp.impl.scheduler.serializer;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.TimeZone;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.enonic.xp.context.Context;
@@ -115,23 +116,6 @@ public class SchedulerSerializer
         return fromNode( node, null );
     }
 
-    public static Attributes toVersionAttributes( final ScheduledJob job, final Attributes originalAttributes )
-    {
-        final Attributes.Builder builder = Attributes.create();
-        if ( originalAttributes != null )
-        {
-            builder.addAll( originalAttributes.entrySet()
-                                .stream()
-                                .filter( entry -> !ScheduledJobPropertyNames.LAST_RUN_ATTRIBUTE.equals( entry.getKey() ) )
-                                .toList() );
-        }
-        if ( job.getLastRun() != null )
-        {
-            builder.addAll( toLastRunAttributes( job.getLastRun(), job.getLastTaskId() ).entrySet() );
-        }
-        return builder.build();
-    }
-
     public static Attributes toLastRunAttributes( final Instant lastRun, final TaskId lastTaskId )
     {
         final GenericValue.ObjectBuilder builder = GenericValue.newObject().
@@ -148,17 +132,27 @@ public class SchedulerSerializer
     public static ScheduledJob fromNode( final Node node, final Attributes attributes )
     {
         final PropertySet data = node.data().getRoot();
+
+        final Optional<Instant> legacyAttributeLastRun = attributes != null
+            ? parseAttribute( attributes.get( ScheduledJobPropertyNames.LAST_RUN ), Instant::parse )
+            : Optional.empty();
+        final Instant legacyLastRun = legacyAttributeLastRun.orElse( data.getInstant( ScheduledJobPropertyNames.LAST_RUN ) );
+        final TaskId legacyLastTaskId = legacyAttributeLastRun.isPresent()
+            ? parseAttribute( attributes.get( ScheduledJobPropertyNames.LAST_TASK_ID ), TaskId::from ).orElse( null )
+            : Optional.ofNullable( data.getString( ScheduledJobPropertyNames.LAST_TASK_ID ) ).map( TaskId::from ).orElse( null );
+
         final GenericValue lastRunAttribute =
             attributes != null ? attributes.get( ScheduledJobPropertyNames.LAST_RUN_ATTRIBUTE ) : null;
-        final Instant lastRun = lastRunAttribute != null
-            ? Instant.parse( lastRunAttribute.property( ScheduledJobPropertyNames.LAST_RUN_TIME_PROPERTY ).asString() )
-            : data.getInstant( ScheduledJobPropertyNames.LAST_RUN );
-        final TaskId lastTaskId = lastRunAttribute != null
+        final Optional<Instant> attributeLastRun = lastRunAttribute != null
+            ? lastRunAttribute.optional( ScheduledJobPropertyNames.LAST_RUN_TIME_PROPERTY )
+                .flatMap( value -> parseAttribute( value, Instant::parse ) )
+            : Optional.empty();
+        final Instant lastRun = attributeLastRun.orElse( legacyLastRun );
+        final TaskId lastTaskId = attributeLastRun.isPresent()
             ? lastRunAttribute.optional( ScheduledJobPropertyNames.LAST_RUN_TASK_ID_PROPERTY )
-                .map( GenericValue::asString )
-                .map( TaskId::from )
+                .flatMap( value -> parseAttribute( value, TaskId::from ) )
                 .orElse( null )
-            : Optional.ofNullable( data.getString( ScheduledJobPropertyNames.LAST_TASK_ID ) ).map( TaskId::from ).orElse( null );
+            : legacyLastTaskId;
 
         return ScheduledJob.create()
             .name( ScheduledJobName.from( node.name().toString() ) )
@@ -181,6 +175,22 @@ public class SchedulerSerializer
             .modifiedTime(
                 Optional.ofNullable( data.getString( ScheduledJobPropertyNames.MODIFIED_TIME ) ).map( Instant::parse ).orElse( null ) )
             .build();
+    }
+
+    private static <T> Optional<T> parseAttribute( final GenericValue value, final Function<String, T> parser )
+    {
+        if ( value == null )
+        {
+            return Optional.empty();
+        }
+        try
+        {
+            return Optional.of( parser.apply( value.asString() ) );
+        }
+        catch ( RuntimeException e )
+        {
+            return Optional.empty();
+        }
     }
 
     private static ScheduledJob editScheduledJob( final ScheduledJobEditor editor, final ScheduledJob original )

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/serializer/SchedulerSerializer.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/serializer/SchedulerSerializer.java
@@ -122,31 +122,39 @@ public class SchedulerSerializer
         {
             builder.addAll( originalAttributes.entrySet()
                                 .stream()
-                                .filter( entry -> !ScheduledJobPropertyNames.LAST_RUN.equals( entry.getKey() ) &&
-                                    !ScheduledJobPropertyNames.LAST_TASK_ID.equals( entry.getKey() ) )
+                                .filter( entry -> !ScheduledJobPropertyNames.LAST_RUN_ATTRIBUTE.equals( entry.getKey() ) )
                                 .toList() );
         }
         if ( job.getLastRun() != null )
         {
-            builder.attribute( ScheduledJobPropertyNames.LAST_RUN, GenericValue.stringValue( job.getLastRun().toString() ) );
-        }
-        if ( job.getLastTaskId() != null )
-        {
-            builder.attribute( ScheduledJobPropertyNames.LAST_TASK_ID,
-                               GenericValue.stringValue( job.getLastTaskId().toString() ) );
+            builder.addAll( toLastRunAttributes( job.getLastRun(), job.getLastTaskId() ).entrySet() );
         }
         return builder.build();
+    }
+
+    public static Attributes toLastRunAttributes( final Instant lastRun, final TaskId lastTaskId )
+    {
+        final GenericValue.ObjectBuilder builder = GenericValue.newObject().
+            put( ScheduledJobPropertyNames.LAST_RUN_TIME_PROPERTY, lastRun.toString() );
+        if ( lastTaskId != null )
+        {
+            builder.put( ScheduledJobPropertyNames.LAST_RUN_TASK_ID_PROPERTY, lastTaskId.toString() );
+        }
+        return Attributes.create().
+            attribute( ScheduledJobPropertyNames.LAST_RUN_ATTRIBUTE, builder.build() ).
+            build();
     }
 
     public static ScheduledJob fromNode( final Node node, final Attributes attributes )
     {
         final PropertySet data = node.data().getRoot();
-        final GenericValue lastRunAttribute = attributes != null ? attributes.get( ScheduledJobPropertyNames.LAST_RUN ) : null;
+        final GenericValue lastRunAttribute =
+            attributes != null ? attributes.get( ScheduledJobPropertyNames.LAST_RUN_ATTRIBUTE ) : null;
         final Instant lastRun = lastRunAttribute != null
-            ? Instant.parse( lastRunAttribute.asString() )
+            ? Instant.parse( lastRunAttribute.property( ScheduledJobPropertyNames.LAST_RUN_TIME_PROPERTY ).asString() )
             : data.getInstant( ScheduledJobPropertyNames.LAST_RUN );
         final TaskId lastTaskId = lastRunAttribute != null
-            ? Optional.ofNullable( attributes.get( ScheduledJobPropertyNames.LAST_TASK_ID ) )
+            ? lastRunAttribute.optional( ScheduledJobPropertyNames.LAST_RUN_TASK_ID_PROPERTY )
                 .map( GenericValue::asString )
                 .map( TaskId::from )
                 .orElse( null )

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/serializer/SchedulerSerializer.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/serializer/SchedulerSerializer.java
@@ -133,25 +133,26 @@ public class SchedulerSerializer
     {
         final PropertySet data = node.data().getRoot();
 
-        final Optional<Instant> legacyAttributeLastRun = attributes != null
-            ? parseAttribute( attributes.get( ScheduledJobPropertyNames.LAST_RUN ), Instant::parse )
-            : Optional.empty();
+        final Optional<Instant> legacyAttributeLastRun = Optional.ofNullable( attributes )
+            .flatMap( value -> parseAttribute( value.get( ScheduledJobPropertyNames.LAST_RUN ), Instant::parse ) );
+        final Optional<TaskId> legacyAttributeLastTaskId = Optional.ofNullable( attributes )
+            .flatMap( value -> parseAttribute( value.get( ScheduledJobPropertyNames.LAST_TASK_ID ), TaskId::from ) );
         final Instant legacyLastRun = legacyAttributeLastRun.orElse( data.getInstant( ScheduledJobPropertyNames.LAST_RUN ) );
         final TaskId legacyLastTaskId = legacyAttributeLastRun.isPresent()
-            ? parseAttribute( attributes.get( ScheduledJobPropertyNames.LAST_TASK_ID ), TaskId::from ).orElse( null )
+            ? legacyAttributeLastTaskId.orElse( null )
             : Optional.ofNullable( data.getString( ScheduledJobPropertyNames.LAST_TASK_ID ) ).map( TaskId::from ).orElse( null );
 
-        final GenericValue lastRunAttribute =
-            attributes != null ? attributes.get( ScheduledJobPropertyNames.LAST_RUN_ATTRIBUTE ) : null;
-        final Optional<Instant> attributeLastRun = lastRunAttribute != null
-            ? lastRunAttribute.optional( ScheduledJobPropertyNames.LAST_RUN_TIME_PROPERTY )
-                .flatMap( value -> parseAttribute( value, Instant::parse ) )
-            : Optional.empty();
+        final Optional<GenericValue> lastRunAttribute = Optional.ofNullable( attributes )
+            .map( value -> value.get( ScheduledJobPropertyNames.LAST_RUN_ATTRIBUTE ) );
+        final Optional<Instant> attributeLastRun = lastRunAttribute
+            .flatMap( value -> value.optional( ScheduledJobPropertyNames.LAST_RUN_TIME_PROPERTY ) )
+            .flatMap( value -> parseAttribute( value, Instant::parse ) );
+        final Optional<TaskId> attributeLastTaskId = lastRunAttribute
+            .flatMap( value -> value.optional( ScheduledJobPropertyNames.LAST_RUN_TASK_ID_PROPERTY ) )
+            .flatMap( value -> parseAttribute( value, TaskId::from ) );
         final Instant lastRun = attributeLastRun.orElse( legacyLastRun );
         final TaskId lastTaskId = attributeLastRun.isPresent()
-            ? lastRunAttribute.optional( ScheduledJobPropertyNames.LAST_RUN_TASK_ID_PROPERTY )
-                .flatMap( value -> parseAttribute( value, TaskId::from ) )
-                .orElse( null )
+            ? attributeLastTaskId.orElse( null )
             : legacyLastTaskId;
 
         return ScheduledJob.create()

--- a/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/serializer/SchedulerSerializer.java
+++ b/modules/core/core-scheduler/src/main/java/com/enonic/xp/impl/scheduler/serializer/SchedulerSerializer.java
@@ -14,6 +14,7 @@ import com.enonic.xp.descriptor.DescriptorKey;
 import com.enonic.xp.impl.scheduler.ScheduledJobPropertyNames;
 import com.enonic.xp.impl.scheduler.distributed.CronCalendarImpl;
 import com.enonic.xp.impl.scheduler.distributed.OneTimeCalendarImpl;
+import com.enonic.xp.node.Attributes;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.scheduler.CreateScheduledJobParams;
 import com.enonic.xp.scheduler.CronCalendar;
@@ -27,6 +28,7 @@ import com.enonic.xp.scheduler.ScheduledJobEditor;
 import com.enonic.xp.scheduler.ScheduledJobName;
 import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.task.TaskId;
+import com.enonic.xp.util.GenericValue;
 
 public class SchedulerSerializer
 {
@@ -110,7 +112,45 @@ public class SchedulerSerializer
 
     public static ScheduledJob fromNode( final Node node )
     {
+        return fromNode( node, null );
+    }
+
+    public static Attributes toVersionAttributes( final ScheduledJob job, final Attributes originalAttributes )
+    {
+        final Attributes.Builder builder = Attributes.create();
+        if ( originalAttributes != null )
+        {
+            builder.addAll( originalAttributes.entrySet()
+                                .stream()
+                                .filter( entry -> !ScheduledJobPropertyNames.LAST_RUN.equals( entry.getKey() ) &&
+                                    !ScheduledJobPropertyNames.LAST_TASK_ID.equals( entry.getKey() ) )
+                                .toList() );
+        }
+        if ( job.getLastRun() != null )
+        {
+            builder.attribute( ScheduledJobPropertyNames.LAST_RUN, GenericValue.stringValue( job.getLastRun().toString() ) );
+        }
+        if ( job.getLastTaskId() != null )
+        {
+            builder.attribute( ScheduledJobPropertyNames.LAST_TASK_ID,
+                               GenericValue.stringValue( job.getLastTaskId().toString() ) );
+        }
+        return builder.build();
+    }
+
+    public static ScheduledJob fromNode( final Node node, final Attributes attributes )
+    {
         final PropertySet data = node.data().getRoot();
+        final GenericValue lastRunAttribute = attributes != null ? attributes.get( ScheduledJobPropertyNames.LAST_RUN ) : null;
+        final Instant lastRun = lastRunAttribute != null
+            ? Instant.parse( lastRunAttribute.asString() )
+            : data.getInstant( ScheduledJobPropertyNames.LAST_RUN );
+        final TaskId lastTaskId = lastRunAttribute != null
+            ? Optional.ofNullable( attributes.get( ScheduledJobPropertyNames.LAST_TASK_ID ) )
+                .map( GenericValue::asString )
+                .map( TaskId::from )
+                .orElse( null )
+            : Optional.ofNullable( data.getString( ScheduledJobPropertyNames.LAST_TASK_ID ) ).map( TaskId::from ).orElse( null );
 
         return ScheduledJob.create()
             .name( ScheduledJobName.from( node.name().toString() ) )
@@ -123,9 +163,8 @@ public class SchedulerSerializer
                 Optional.ofNullable( data.getString( ScheduledJobPropertyNames.DESCRIPTOR ) ).map( DescriptorKey::from ).orElse( null ) )
             .config( Optional.ofNullable( data.getSet( ScheduledJobPropertyNames.CONFIG ) ).map( PropertySet::toTree ).orElse( null ) )
             .user( Optional.ofNullable( data.getString( ScheduledJobPropertyNames.USER ) ).map( PrincipalKey::from ).orElse( null ) )
-            .lastRun( Optional.ofNullable( data.getInstant( ScheduledJobPropertyNames.LAST_RUN ) ).orElse( null ) )
-            .lastTaskId(
-                Optional.ofNullable( data.getString( ScheduledJobPropertyNames.LAST_TASK_ID ) ).map( TaskId::from ).orElse( null ) )
+            .lastRun( lastRun )
+            .lastTaskId( lastTaskId )
             .creator( Optional.ofNullable( data.getString( ScheduledJobPropertyNames.CREATOR ) ).map( PrincipalKey::from ).orElse( null ) )
             .modifier(
                 Optional.ofNullable( data.getString( ScheduledJobPropertyNames.MODIFIER ) ).map( PrincipalKey::from ).orElse( null ) )

--- a/modules/core/core-scheduler/src/test/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommandTest.java
+++ b/modules/core/core-scheduler/src/test/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommandTest.java
@@ -1,8 +1,8 @@
 package com.enonic.xp.impl.scheduler;
 
 import java.time.Instant;
+import java.util.Set;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -12,16 +12,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.enonic.xp.data.PropertySet;
 import com.enonic.xp.data.PropertyTree;
-import com.enonic.xp.node.EditableNode;
+import com.enonic.xp.node.ApplyVersionAttributesParams;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.NodeService;
-import com.enonic.xp.node.UpdateNodeParams;
+import com.enonic.xp.node.NodeVersionId;
+import com.enonic.xp.scheduler.ScheduledJob;
 import com.enonic.xp.scheduler.ScheduledJobName;
 import com.enonic.xp.task.TaskId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,24 +36,22 @@ class UpdateLastRunCommandTest
     private NodeService nodeService;
 
     @Captor
-    private ArgumentCaptor<UpdateNodeParams> captor;
-
-    @BeforeEach
-    void setUp()
-    {
-
-    }
+    private ArgumentCaptor<ApplyVersionAttributesParams> captor;
 
     @Test
-    void testCreateJob()
+    void updateLastRunAttributes()
     {
         final TaskId lastTaskId = TaskId.from( "task-id" );
         final Instant lastRun = Instant.parse( "2021-02-25T10:44:33.170079900Z" );
 
         final Node node = mockNode();
-        when( nodeService.update( isA( UpdateNodeParams.class ) ) ).thenReturn( node );
+        node.data().setInstant( ScheduledJobPropertyNames.LAST_RUN, lastRun.minusSeconds( 1 ) );
+        node.data().setString( ScheduledJobPropertyNames.LAST_TASK_ID, "old-task-id" );
+        when( nodeService.getByPath( isA( NodePath.class ) ) ).thenReturn( node );
+        when( nodeService.applyVersionAttributes( isA( ApplyVersionAttributesParams.class ) ) ).thenAnswer(
+            invocation -> invocation.<ApplyVersionAttributesParams>getArgument( 0 ).getAddAttributes() );
 
-        UpdateLastRunCommand.create().
+        final ScheduledJob scheduledJob = UpdateLastRunCommand.create().
             name( ScheduledJobName.from( "job" ) ).
             lastTaskId( lastTaskId ).
             lastRun( lastRun ).
@@ -58,14 +59,42 @@ class UpdateLastRunCommandTest
             build().
             execute();
 
-        verify( nodeService ).update( captor.capture() );
+        verify( nodeService ).applyVersionAttributes( captor.capture() );
 
-        final EditableNode editableNode = new EditableNode( node );
+        final ApplyVersionAttributesParams params = captor.getValue();
+        assertEquals( node.getNodeVersionId(), params.getNodeVersionId() );
+        assertEquals( lastRun.toString(), params.getAddAttributes().get( ScheduledJobPropertyNames.LAST_RUN ).asString() );
+        assertEquals( lastTaskId.toString(), params.getAddAttributes().get( ScheduledJobPropertyNames.LAST_TASK_ID ).asString() );
+        assertTrue( params.getRemoveAttributes().isEmpty() );
+        assertEquals( lastRun, scheduledJob.getLastRun() );
+        assertEquals( lastTaskId, scheduledJob.getLastTaskId() );
+    }
 
-        captor.getValue().getEditor().edit( editableNode );
+    @Test
+    void removeLastTaskIdWhenMissing()
+    {
+        final Instant lastRun = Instant.parse( "2021-02-25T10:44:33.170079900Z" );
 
-        assertEquals( lastRun, editableNode.data.getProperty( ScheduledJobPropertyNames.LAST_RUN ).getInstant() );
-        assertEquals( lastTaskId.toString(), editableNode.data.getProperty( ScheduledJobPropertyNames.LAST_TASK_ID ).getString() );
+        final Node node = mockNode();
+        node.data().setString( ScheduledJobPropertyNames.LAST_TASK_ID, "old-task-id" );
+        when( nodeService.getByPath( isA( NodePath.class ) ) ).thenReturn( node );
+        when( nodeService.applyVersionAttributes( isA( ApplyVersionAttributesParams.class ) ) ).thenAnswer(
+            invocation -> invocation.<ApplyVersionAttributesParams>getArgument( 0 ).getAddAttributes() );
+
+        final ScheduledJob scheduledJob = UpdateLastRunCommand.create().
+            name( ScheduledJobName.from( "job" ) ).
+            lastRun( lastRun ).
+            nodeService( nodeService ).
+            build().
+            execute();
+
+        verify( nodeService ).applyVersionAttributes( captor.capture() );
+
+        final ApplyVersionAttributesParams params = captor.getValue();
+        assertNull( params.getAddAttributes().get( ScheduledJobPropertyNames.LAST_TASK_ID ) );
+        assertEquals( Set.of( ScheduledJobPropertyNames.LAST_TASK_ID ), params.getRemoveAttributes() );
+        assertEquals( lastRun, scheduledJob.getLastRun() );
+        assertNull( scheduledJob.getLastTaskId() );
     }
 
     private Node mockNode()
@@ -90,6 +119,7 @@ class UpdateLastRunCommandTest
             name( "test" ).
             parentPath( NodePath.ROOT ).
             data( jobData ).
+            nodeVersionId( new NodeVersionId() ).
             build();
 
     }

--- a/modules/core/core-scheduler/src/test/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommandTest.java
+++ b/modules/core/core-scheduler/src/test/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommandTest.java
@@ -1,6 +1,7 @@
 package com.enonic.xp.impl.scheduler;
 
 import java.time.Instant;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,7 +69,8 @@ class UpdateLastRunCommandTest
                       lastRunAttribute.property( ScheduledJobPropertyNames.LAST_RUN_TIME_PROPERTY ).asString() );
         assertEquals( lastTaskId.toString(),
                       lastRunAttribute.property( ScheduledJobPropertyNames.LAST_RUN_TASK_ID_PROPERTY ).asString() );
-        assertTrue( params.getRemoveAttributes().isEmpty() );
+        assertEquals( Set.of( ScheduledJobPropertyNames.LAST_RUN, ScheduledJobPropertyNames.LAST_TASK_ID ),
+                      params.getRemoveAttributes() );
         assertEquals( lastRun, scheduledJob.getLastRun() );
         assertEquals( lastTaskId, scheduledJob.getLastTaskId() );
     }
@@ -98,7 +100,8 @@ class UpdateLastRunCommandTest
         assertEquals( lastRun.toString(),
                       lastRunAttribute.property( ScheduledJobPropertyNames.LAST_RUN_TIME_PROPERTY ).asString() );
         assertTrue( lastRunAttribute.optional( ScheduledJobPropertyNames.LAST_RUN_TASK_ID_PROPERTY ).isEmpty() );
-        assertTrue( params.getRemoveAttributes().isEmpty() );
+        assertEquals( Set.of( ScheduledJobPropertyNames.LAST_RUN, ScheduledJobPropertyNames.LAST_TASK_ID ),
+                      params.getRemoveAttributes() );
         assertEquals( lastRun, scheduledJob.getLastRun() );
         assertNull( scheduledJob.getLastTaskId() );
     }

--- a/modules/core/core-scheduler/src/test/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommandTest.java
+++ b/modules/core/core-scheduler/src/test/java/com/enonic/xp/impl/scheduler/UpdateLastRunCommandTest.java
@@ -1,7 +1,6 @@
 package com.enonic.xp.impl.scheduler;
 
 import java.time.Instant;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +20,7 @@ import com.enonic.xp.node.NodeVersionId;
 import com.enonic.xp.scheduler.ScheduledJob;
 import com.enonic.xp.scheduler.ScheduledJobName;
 import com.enonic.xp.task.TaskId;
+import com.enonic.xp.util.GenericValue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -63,8 +63,11 @@ class UpdateLastRunCommandTest
 
         final ApplyVersionAttributesParams params = captor.getValue();
         assertEquals( node.getNodeVersionId(), params.getNodeVersionId() );
-        assertEquals( lastRun.toString(), params.getAddAttributes().get( ScheduledJobPropertyNames.LAST_RUN ).asString() );
-        assertEquals( lastTaskId.toString(), params.getAddAttributes().get( ScheduledJobPropertyNames.LAST_TASK_ID ).asString() );
+        final GenericValue lastRunAttribute = params.getAddAttributes().get( ScheduledJobPropertyNames.LAST_RUN_ATTRIBUTE );
+        assertEquals( lastRun.toString(),
+                      lastRunAttribute.property( ScheduledJobPropertyNames.LAST_RUN_TIME_PROPERTY ).asString() );
+        assertEquals( lastTaskId.toString(),
+                      lastRunAttribute.property( ScheduledJobPropertyNames.LAST_RUN_TASK_ID_PROPERTY ).asString() );
         assertTrue( params.getRemoveAttributes().isEmpty() );
         assertEquals( lastRun, scheduledJob.getLastRun() );
         assertEquals( lastTaskId, scheduledJob.getLastTaskId() );
@@ -91,8 +94,11 @@ class UpdateLastRunCommandTest
         verify( nodeService ).applyVersionAttributes( captor.capture() );
 
         final ApplyVersionAttributesParams params = captor.getValue();
-        assertNull( params.getAddAttributes().get( ScheduledJobPropertyNames.LAST_TASK_ID ) );
-        assertEquals( Set.of( ScheduledJobPropertyNames.LAST_TASK_ID ), params.getRemoveAttributes() );
+        final GenericValue lastRunAttribute = params.getAddAttributes().get( ScheduledJobPropertyNames.LAST_RUN_ATTRIBUTE );
+        assertEquals( lastRun.toString(),
+                      lastRunAttribute.property( ScheduledJobPropertyNames.LAST_RUN_TIME_PROPERTY ).asString() );
+        assertTrue( lastRunAttribute.optional( ScheduledJobPropertyNames.LAST_RUN_TASK_ID_PROPERTY ).isEmpty() );
+        assertTrue( params.getRemoveAttributes().isEmpty() );
         assertEquals( lastRun, scheduledJob.getLastRun() );
         assertNull( scheduledJob.getLastTaskId() );
     }

--- a/modules/core/core-scheduler/src/test/java/com/enonic/xp/impl/scheduler/distributed/RescheduleTaskTest.java
+++ b/modules/core/core-scheduler/src/test/java/com/enonic/xp/impl/scheduler/distributed/RescheduleTaskTest.java
@@ -28,11 +28,12 @@ import com.enonic.xp.data.PropertySet;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.descriptor.DescriptorKey;
 import com.enonic.xp.impl.scheduler.ScheduledJobPropertyNames;
+import com.enonic.xp.node.ApplyVersionAttributesParams;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.NodeService;
-import com.enonic.xp.node.UpdateNodeParams;
+import com.enonic.xp.node.NodeVersionId;
 import com.enonic.xp.scheduler.ScheduledJob;
 import com.enonic.xp.scheduler.ScheduledJobName;
 import com.enonic.xp.scheduler.SchedulerService;
@@ -108,6 +109,7 @@ class RescheduleTaskTest
         when( bundleContext.getService( taskReference ) ).thenReturn( taskService );
         when( bundleContext.getService( schedulerReference ) ).thenReturn( schedulerService );
         when( bundleContext.getService( securityReference ) ).thenReturn( securityService );
+        when( nodeService.getByPath( isA( NodePath.class ) ) ).thenReturn( mockNode() );
     }
 
     @AfterEach
@@ -121,9 +123,6 @@ class RescheduleTaskTest
     {
         mockJobs();
         when( taskService.submitTask( isA( SubmitTaskParams.class ) ) ).thenReturn( TaskId.from( "123" ) );
-
-        final Node node = mockNode();
-        when( nodeService.update( isA( UpdateNodeParams.class ) ) ).thenReturn( node );
 
         createAndRunTask();
 
@@ -147,9 +146,6 @@ class RescheduleTaskTest
             .thenReturn( TaskId.from( "2" ) )
             .thenReturn( TaskId.from( "3" ) );
 
-        final Node node = mockNode();
-        when( nodeService.update( isA( UpdateNodeParams.class ) ) ).thenReturn( node );
-
         createAndRunTask();
 
         verify( taskService, times( 3 ) ).submitTask( taskCaptor.capture() );
@@ -168,9 +164,6 @@ class RescheduleTaskTest
         ScheduledJob job2 = mockOneTimeJob( "job2", now );
 
         when( schedulerService.list() ).thenReturn( List.of( job1, job2 ) );
-
-        final Node node = mockNode();
-        when( nodeService.update( isA( UpdateNodeParams.class ) ) ).thenReturn( node );
 
         when( taskService.submitTask( isA( SubmitTaskParams.class ) ) ).thenThrow( RuntimeException.class )
             .thenReturn( TaskId.from( "1" ) );
@@ -207,9 +200,6 @@ class RescheduleTaskTest
 
         when( schedulerService.list() ).thenReturn( List.of( job1 ) );
 
-        final Node node = mockNode();
-        when( nodeService.update( isA( UpdateNodeParams.class ) ) ).thenReturn( node );
-
         when( taskService.submitTask( isA( SubmitTaskParams.class ) ) ).thenThrow( new Error() ).thenReturn( TaskId.from( "1" ) );
 
         createAndRunTask();
@@ -231,9 +221,6 @@ class RescheduleTaskTest
 
         when( schedulerService.list() ).thenReturn( List.of( job1 ) );
 
-        final Node node = mockNode();
-        when( nodeService.update( isA( UpdateNodeParams.class ) ) ).thenReturn( node );
-
         when( taskService.submitTask( isA( SubmitTaskParams.class ) ) ).thenThrow( new RuntimeException() );
 
         for ( int i = 0; i <= 10; i++ )
@@ -241,7 +228,7 @@ class RescheduleTaskTest
             createAndRunTask();
         }
         verify( taskService, times( 11 ) ).submitTask( taskCaptor.capture() );
-        verify( nodeService, times( 1 ) ).update( isA( UpdateNodeParams.class ) );
+        verify( nodeService, times( 1 ) ).applyVersionAttributes( isA( ApplyVersionAttributesParams.class ) );
     }
 
     @Test
@@ -253,9 +240,6 @@ class RescheduleTaskTest
         ScheduledJob job1 = mockOneTimeJob( "job1", now.minus( 1, ChronoUnit.SECONDS ), user );
 
         when( schedulerService.list() ).thenReturn( List.of( job1 ) );
-
-        final Node node = mockNode();
-        when( nodeService.update( isA( UpdateNodeParams.class ) ) ).thenReturn( node );
 
         when( taskService.submitTask( isA( SubmitTaskParams.class ) ) ).thenReturn( TaskId.from( "1" ) );
         when( securityService.authenticate( tokenCaptor.capture() ) ).thenReturn( mock( AuthenticationInfo.class ) );
@@ -273,9 +257,6 @@ class RescheduleTaskTest
         ScheduledJob job2 = mockCronJob( "job2", "* * * * *", Instant.now() );
 
         when( schedulerService.list() ).thenReturn( List.of( job1, job2 ) );
-
-        final Node node = mockNode();
-        when( nodeService.update( isA( UpdateNodeParams.class ) ) ).thenReturn( node );
 
         when( taskService.submitTask( isA( SubmitTaskParams.class ) ) ).thenReturn( TaskId.from( "1" ) ).thenReturn( TaskId.from( "2" ) );
         when( securityService.authenticate( tokenCaptor.capture() ) ).thenReturn( mock( AuthenticationInfo.class ) );
@@ -447,7 +428,13 @@ class RescheduleTaskTest
         jobData.setString( ScheduledJobPropertyNames.CREATED_TIME, "2021-02-26T10:44:33.170079900Z" );
         jobData.setString( ScheduledJobPropertyNames.MODIFIED_TIME, "2021-03-26T10:44:33.170079900Z" );
 
-        return Node.create().id( NodeId.from( "abc" ) ).name( "test" ).parentPath( NodePath.ROOT ).data( jobData ).build();
+        return Node.create()
+            .id( NodeId.from( "abc" ) )
+            .name( "test" )
+            .parentPath( NodePath.ROOT )
+            .data( jobData )
+            .nodeVersionId( new NodeVersionId() )
+            .build();
 
     }
 

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/scheduler/SchedulerServiceImplTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/scheduler/SchedulerServiceImplTest.java
@@ -29,6 +29,7 @@ import com.enonic.xp.impl.scheduler.ScheduledJobPropertyNames;
 import com.enonic.xp.impl.scheduler.SchedulerRepoInitializer;
 import com.enonic.xp.impl.scheduler.SchedulerServiceImpl;
 import com.enonic.xp.impl.scheduler.UpdateLastRunCommand;
+import com.enonic.xp.node.ApplyVersionAttributesParams;
 import com.enonic.xp.node.Attributes;
 import com.enonic.xp.node.GetNodeVersionsParams;
 import com.enonic.xp.node.Node;
@@ -345,7 +346,7 @@ class SchedulerServiceImplTest
     }
 
     @Test
-    void updateLastRunWithoutCreatingVersionAndPreserveOnModify()
+    void updateLastRunWithoutCreatingVersionAndClearOnCronModify()
     {
         final ScheduledJobName name = ScheduledJobName.from( "test" );
 
@@ -405,8 +406,101 @@ class SchedulerServiceImplTest
                 edit.enabled = true;
             } ).build() ) );
 
-        assertEquals( lastRun, modifiedJob.getLastRun() );
-        assertEquals( lastTaskId, modifiedJob.getLastTaskId() );
+        assertNull( modifiedJob.getLastRun() );
+        assertNull( modifiedJob.getLastTaskId() );
+
+        final Attributes modifiedAttributes = adminContext().callWith( () -> {
+            final Node node = nodeService.getById( NodeId.from( name.getValue() ) );
+            return nodeService.getVersion( node.id(), node.getNodeVersionId() ).getAttributes();
+        } );
+        assertNull( modifiedAttributes );
+    }
+
+    @Test
+    void modifyRearmsOneTimeJob()
+    {
+        final ScheduledJobName name = ScheduledJobName.from( "test" );
+
+        adminContext().callWith( () -> schedulerService.create( CreateScheduledJobParams.create()
+                                                                    .name( name )
+                                                                    .descriptor(
+                                                                        DescriptorKey.from( ApplicationKey.from( "com.enonic.app.test" ),
+                                                                                            "task1" ) )
+                                                                    .calendar( calendarService.oneTime(
+                                                                        Instant.parse( "2021-02-25T10:44:33Z" ) ) )
+                                                                    .config( new PropertyTree() )
+                                                                    .build() ) );
+
+        adminContext().runWith( () -> UpdateLastRunCommand.create()
+            .name( name )
+            .lastTaskId( TaskId.from( "task-id" ) )
+            .lastRun( Instant.parse( "2021-02-25T10:44:34Z" ) )
+            .nodeService( nodeService )
+            .build()
+            .execute() );
+
+        final Instant nextRun = Instant.parse( "2021-02-25T10:45:33Z" );
+        final ScheduledJob modifiedJob =
+            adminContext().callWith( () -> schedulerService.modify( ModifyScheduledJobParams.create().name( name ).editor( edit -> {
+                edit.calendar = calendarService.oneTime( nextRun );
+            } ).build() ) );
+
+        assertEquals( nextRun, ( (OneTimeCalendar) modifiedJob.getCalendar() ).getValue() );
+        assertNull( modifiedJob.getLastRun() );
+        assertNull( modifiedJob.getLastTaskId() );
+    }
+
+    @Test
+    void readLegacyRunAttributesAndIgnoreMalformedCompound()
+    {
+        final ScheduledJobName name = ScheduledJobName.from( "test" );
+
+        adminContext().callWith( () -> schedulerService.create( CreateScheduledJobParams.create()
+                                                                    .name( name )
+                                                                    .descriptor(
+                                                                        DescriptorKey.from( ApplicationKey.from( "com.enonic.app.test" ),
+                                                                                            "task1" ) )
+                                                                    .calendar( calendarService.cron( "* * * * *",
+                                                                                                     TimeZone.getTimeZone( "GMT+5:30" ) ) )
+                                                                    .config( new PropertyTree() )
+                                                                    .build() ) );
+
+        final Instant lastRun = Instant.parse( "2021-02-25T10:44:33.170079900Z" );
+        final TaskId lastTaskId = TaskId.from( "task-id" );
+        final Node node = adminContext().callWith( () -> nodeService.getById( NodeId.from( name.getValue() ) ) );
+
+        adminContext().runWith( () -> nodeService.applyVersionAttributes( ApplyVersionAttributesParams.create()
+            .nodeVersionId( node.getNodeVersionId() )
+            .addAttributes( Attributes.create()
+                                .attribute( ScheduledJobPropertyNames.LAST_RUN, GenericValue.stringValue( lastRun.toString() ) )
+                                .attribute( ScheduledJobPropertyNames.LAST_TASK_ID,
+                                            GenericValue.stringValue( lastTaskId.toString() ) )
+                                .build() )
+            .build() ) );
+
+        assertRunMetadata( name, lastRun, lastTaskId );
+
+        adminContext().runWith( () -> nodeService.applyVersionAttributes( ApplyVersionAttributesParams.create()
+            .nodeVersionId( node.getNodeVersionId() )
+            .addAttributes( Attributes.create()
+                                .attribute( ScheduledJobPropertyNames.LAST_RUN_ATTRIBUTE,
+                                            GenericValue.stringValue( lastRun.toString() ) )
+                                .build() )
+            .build() ) );
+
+        assertRunMetadata( name, lastRun, lastTaskId );
+
+        adminContext().runWith( () -> nodeService.applyVersionAttributes( ApplyVersionAttributesParams.create()
+            .nodeVersionId( node.getNodeVersionId() )
+            .addAttributes( Attributes.create()
+                                .attribute( ScheduledJobPropertyNames.LAST_RUN_ATTRIBUTE,
+                                            GenericValue.newObject()
+                                                .put( ScheduledJobPropertyNames.LAST_RUN_TIME_PROPERTY, "not-an-instant" )
+                                                .build() )
+                                .build() )
+            .build() ) );
+
+        assertRunMetadata( name, lastRun, lastTaskId );
     }
 
     @Test
@@ -560,5 +654,16 @@ class SchedulerServiceImplTest
                                                                     .build() ) );
 
         assertEquals( 2, adminContext().callWith( () -> schedulerService.list() ).size() );
+    }
+
+    private void assertRunMetadata( final ScheduledJobName name, final Instant lastRun, final TaskId lastTaskId )
+    {
+        final ScheduledJob fetchedJob = adminContext().callWith( () -> schedulerService.get( name ) );
+        assertEquals( lastRun, fetchedJob.getLastRun() );
+        assertEquals( lastTaskId, fetchedJob.getLastTaskId() );
+
+        final ScheduledJob listedJob = adminContext().callWith( () -> schedulerService.list() ).getFirst();
+        assertEquals( lastRun, listedJob.getLastRun() );
+        assertEquals( lastTaskId, listedJob.getLastTaskId() );
     }
 }

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/scheduler/SchedulerServiceImplTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/scheduler/SchedulerServiceImplTest.java
@@ -28,7 +28,9 @@ import com.enonic.xp.impl.scheduler.SchedulerExecutorServiceImpl;
 import com.enonic.xp.impl.scheduler.SchedulerRepoInitializer;
 import com.enonic.xp.impl.scheduler.SchedulerServiceImpl;
 import com.enonic.xp.impl.scheduler.UpdateLastRunCommand;
+import com.enonic.xp.node.GetNodeVersionsParams;
 import com.enonic.xp.node.NodeAccessException;
+import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeIdExistsException;
 import com.enonic.xp.node.NodeNotFoundException;
 import com.enonic.xp.scheduler.CreateScheduledJobParams;
@@ -339,7 +341,7 @@ class SchedulerServiceImplTest
     }
 
     @Test
-    void modifyClearLastRun()
+    void updateLastRunWithoutCreatingVersionAndPreserveOnModify()
     {
         final ScheduledJobName name = ScheduledJobName.from( "test" );
 
@@ -353,6 +355,11 @@ class SchedulerServiceImplTest
                                                                     .config( new PropertyTree() )
                                                                     .build() ) );
 
+        final GetNodeVersionsParams versionsParams =
+            GetNodeVersionsParams.create().nodeId( NodeId.from( name.getValue() ) ).build();
+        final long versionsBeforeUpdate =
+            adminContext().callWith( () -> nodeService.getVersions( versionsParams ).getTotalHits() );
+
         final TaskId lastTaskId = TaskId.from( "task-id" );
         final Instant lastRun = Instant.parse( "2021-02-25T10:44:33.170079900Z" );
 
@@ -364,18 +371,25 @@ class SchedulerServiceImplTest
             .build()
             .execute() );
 
+        assertEquals( versionsBeforeUpdate,
+                      adminContext().callWith( () -> nodeService.getVersions( versionsParams ).getTotalHits() ) );
+
         final ScheduledJob runJob = adminContext().callWith( () -> schedulerService.get( name ) );
 
         assertEquals( lastRun, runJob.getLastRun() );
         assertEquals( lastTaskId, runJob.getLastTaskId() );
+
+        final ScheduledJob listedJob = adminContext().callWith( () -> schedulerService.list() ).getFirst();
+        assertEquals( lastRun, listedJob.getLastRun() );
+        assertEquals( lastTaskId, listedJob.getLastTaskId() );
 
         final ScheduledJob modifiedJob =
             adminContext().callWith( () -> schedulerService.modify( ModifyScheduledJobParams.create().name( name ).editor( edit -> {
                 edit.enabled = true;
             } ).build() ) );
 
-        assertNull( modifiedJob.getLastRun() );
-        assertNull( modifiedJob.getLastTaskId() );
+        assertEquals( lastRun, modifiedJob.getLastRun() );
+        assertEquals( lastTaskId, modifiedJob.getLastTaskId() );
     }
 
     @Test

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/scheduler/SchedulerServiceImplTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/scheduler/SchedulerServiceImplTest.java
@@ -25,10 +25,13 @@ import com.enonic.xp.impl.scheduler.ScheduleAuditLogSupportImpl;
 import com.enonic.xp.impl.scheduler.SchedulerConfig;
 import com.enonic.xp.impl.scheduler.SchedulerExecutorService;
 import com.enonic.xp.impl.scheduler.SchedulerExecutorServiceImpl;
+import com.enonic.xp.impl.scheduler.ScheduledJobPropertyNames;
 import com.enonic.xp.impl.scheduler.SchedulerRepoInitializer;
 import com.enonic.xp.impl.scheduler.SchedulerServiceImpl;
 import com.enonic.xp.impl.scheduler.UpdateLastRunCommand;
+import com.enonic.xp.node.Attributes;
 import com.enonic.xp.node.GetNodeVersionsParams;
+import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeAccessException;
 import com.enonic.xp.node.NodeId;
 import com.enonic.xp.node.NodeIdExistsException;
@@ -48,6 +51,7 @@ import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.User;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.task.TaskId;
+import com.enonic.xp.util.GenericValue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -373,6 +377,19 @@ class SchedulerServiceImplTest
 
         assertEquals( versionsBeforeUpdate,
                       adminContext().callWith( () -> nodeService.getVersions( versionsParams ).getTotalHits() ) );
+
+        final Attributes attributes = adminContext().callWith( () -> {
+            final Node node = nodeService.getById( NodeId.from( name.getValue() ) );
+            return nodeService.getVersion( node.id(), node.getNodeVersionId() ).getAttributes();
+        } );
+        final GenericValue lastRunAttribute = attributes.get( ScheduledJobPropertyNames.LAST_RUN_ATTRIBUTE );
+        assertEquals( GenericValue.Type.OBJECT, lastRunAttribute.getType() );
+        assertEquals( lastRun.toString(),
+                      lastRunAttribute.property( ScheduledJobPropertyNames.LAST_RUN_TIME_PROPERTY ).asString() );
+        assertEquals( lastTaskId.toString(),
+                      lastRunAttribute.property( ScheduledJobPropertyNames.LAST_RUN_TASK_ID_PROPERTY ).asString() );
+        assertNull( attributes.get( ScheduledJobPropertyNames.LAST_RUN ) );
+        assertNull( attributes.get( ScheduledJobPropertyNames.LAST_TASK_ID ) );
 
         final ScheduledJob runJob = adminContext().callWith( () -> schedulerService.get( name ) );
 


### PR DESCRIPTION
Fixes #11512

## Summary

- store scheduled-job run metadata in the compound `scheduler.lastRun` node-version attribute
- update run metadata without creating a new node version
- clear run metadata when a job is modified so one-time jobs re-arm and cron jobs reschedule from the modification time
- read the first commit's top-level attribute layout and fall back to legacy node data
- treat malformed compound run metadata as absent so `get()` and `list()` remain operational

## Testing

- `:core:core-scheduler:check`
- `:itest:itest-core:integrationTest --tests 'com.enonic.xp.core.scheduler.SchedulerServiceImplTest'` (19 tests)