### PR TITLE
Benchmark the whole-tree node operations

### DIFF
--- a/modules/ptest/ptest-content/build.gradle
+++ b/modules/ptest/ptest-content/build.gradle
@@ -67,6 +67,16 @@ tasks.register( 'performanceTest', JavaExec ) {
 
     systemProperty 'java.awt.headless', 'true'
 
+    // -Pptest.tree.children=<n> sizes the tree the whole-tree node benchmarks operate on; -Pptest.include=<regex> narrows the run.
+    if ( project.hasProperty( 'ptest.tree.children' ) )
+    {
+        systemProperty 'ptest.tree.children', project.property( 'ptest.tree.children' )
+    }
+    if ( project.hasProperty( 'ptest.include' ) )
+    {
+        args project.property( 'ptest.include' )
+    }
+
     workingDir = layout.buildDirectory.dir( 'perftest-report' ).get().asFile
     doFirst {
         workingDir.mkdirs()

--- a/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/BenchmarkMain.java
+++ b/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/BenchmarkMain.java
@@ -10,7 +10,6 @@ public final class BenchmarkMain
     public static void main( final String[] args )
         throws Exception
     {
-        // an argument narrows the run to the benchmarks whose name matches it, for measuring one operation at a time
         final String include =
             args.length > 0 ? args[0] : "com\\.enonic\\.xp\\.perftest\\.content\\..*Benchmark";
 

--- a/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/BenchmarkMain.java
+++ b/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/BenchmarkMain.java
@@ -10,8 +10,12 @@ public final class BenchmarkMain
     public static void main( final String[] args )
         throws Exception
     {
+        // an argument narrows the run to the benchmarks whose name matches it, for measuring one operation at a time
+        final String include =
+            args.length > 0 ? args[0] : "com\\.enonic\\.xp\\.perftest\\.content\\..*Benchmark";
+
         final Options opts = new OptionsBuilder()
-            .include( "com\\.enonic\\.xp\\.perftest\\.content\\..*Benchmark" )
+            .include( include )
             .resultFormat( ResultFormatType.JSON )
             .result( "results.json" )
             .output( "results.txt" )

--- a/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/NodeTreeOperationsBenchmark.java
+++ b/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/NodeTreeOperationsBenchmark.java
@@ -42,12 +42,6 @@ import com.enonic.xp.security.acl.AccessControlEntry;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.acl.Permission;
 
-/**
- * Whole-tree node operations on the simplest big shape: one parent with {@value #CHILDREN} direct children, one branch.
- * <p>
- * Every operation is a single shot over the whole tree, so each benchmark is one full walk. The index is settled - untimed - before
- * every invocation, so a measurement covers the operation alone, never the ground the previous one left behind.
- */
 @BenchmarkMode( Mode.SingleShotTime )
 @OutputTimeUnit( TimeUnit.MILLISECONDS )
 @Warmup( iterations = 1 )
@@ -57,41 +51,21 @@ public class NodeTreeOperationsBenchmark
 {
     private static final int CHILDREN = Integer.getInteger( "ptest.tree.children", 10_000 );
 
-    /** What one whole-tree operation covers: the parent and every child. */
     private static final int TREE_NODES = CHILDREN + 1;
 
     private static final com.sun.management.ThreadMXBean THREADS =
         (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
 
-    /**
-     * What one operation costs, reported next to the time: the nodes it covers, what it allocates, and how far the live set grows while
-     * it runs.
-     * <p>
-     * The two memory figures answer different questions. Allocation is churn - every node this operation rewrites is read, rebuilt and
-     * re-indexed, and that traffic is the same however the walk is organized. The live set is what the operation *holds*: a walk that
-     * keeps the whole subtree in memory at once shows here, a walk that keeps a stride at a time does not.
-     * <p>
-     * Both are measured close to the operation rather than through a GC profiler: the embedded search server allocates on its own
-     * threads throughout, and the corpus a benchmark rebuilds between invocations allocates too, both of which drown out the operation
-     * in a whole-process figure.
-     */
     @State( Scope.Thread )
     @AuxCounters( AuxCounters.Type.EVENTS )
     public static class Measured
     {
-        /**
-         * The operations counted, so the report can divide by it. JMH sums an event counter over the iterations of a run rather than
-         * averaging it, so every counter here is a total and only a ratio of two of them means anything.
-         */
         public long ops;
 
-        /** The nodes the operations covered, so every figure can be read per node as well as per operation. */
         public long nodes;
 
-        /** What the operation allocates on the thread that runs it. */
         public long allocKiB;
 
-        /** How far the live set grows above where it stood when the operation started. */
         public long peakLiveKiB;
 
         @Setup( Level.Iteration )
@@ -103,10 +77,6 @@ public class NodeTreeOperationsBenchmark
             peakLiveKiB = 0;
         }
 
-        /**
-         * The heap that survived the most recent collection. Reading it repeatedly while an operation runs, rather than once at the end,
-         * is what makes a peak out of it - the operation's own garbage is collected as it goes.
-         */
         private static long liveSetBytes()
         {
             long live = 0;
@@ -164,18 +134,12 @@ public class NodeTreeOperationsBenchmark
         }
     }
 
-    /**
-     * Readies the repository for one measured invocation: the index settles, and the heap is collected so that the live set the
-     * operation is measured against holds the corpus alone rather than whatever the previous invocation left uncollected. Both are
-     * untimed - single-shot timing covers the benchmark method only.
-     */
     private static void settle( final Bootstrap bs )
     {
         bs.refresh();
         System.gc();
     }
 
-    /** Builds one parent with {@link #CHILDREN} children under the content root, refresh disabled for speed, settled at the end. */
     private static Node buildTree( final Bootstrap bs, final String name )
     {
         bs.setRefreshInterval( "-1" );
@@ -244,7 +208,6 @@ public class NodeTreeOperationsBenchmark
         }
     }
 
-    /** One move of the tree parent, back and forth between two targets - every child follows. */
     @Benchmark
     public MoveNodeResult move( final MoveState s, final Measured measured )
         throws Exception
@@ -283,7 +246,6 @@ public class NodeTreeOperationsBenchmark
         }
     }
 
-    /** One duplication of the whole tree - every invocation leaves a new copy behind, so the corpus grows as it would in production. */
     @Benchmark
     @Measurement( iterations = 3 )
     public DuplicateNodeResult duplicate( final DuplicateState s, final Measured measured )
@@ -313,7 +275,6 @@ public class NodeTreeOperationsBenchmark
             bs = new Bootstrap();
             bs.start();
             treeId = buildTree( bs, "tree" ).id();
-            // the operating role keeps full access in both variants, so every invocation stays permitted
             aclA = AccessControlList.of(
                 AccessControlEntry.create().principal( RoleKeys.CONTENT_MANAGER_ADMIN ).allowAll().build(),
                 AccessControlEntry.create().principal( RoleKeys.AUTHENTICATED ).allow( Permission.READ ).build() );
@@ -341,7 +302,6 @@ public class NodeTreeOperationsBenchmark
         }
     }
 
-    /** One permission change over the whole tree, alternating between two lists so every invocation writes a real change. */
     @Benchmark
     public ApplyNodePermissionsResult applyPermissions( final ApplyPermissionsState s, final Measured measured )
         throws Exception
@@ -372,7 +332,6 @@ public class NodeTreeOperationsBenchmark
             bs.start();
         }
 
-        /** A deletion consumes its tree, so every invocation gets a fresh one - built and settled outside the measurement. */
         @Setup( Level.Invocation )
         public void rebuildTree()
         {
@@ -387,7 +346,6 @@ public class NodeTreeOperationsBenchmark
         }
     }
 
-    /** One deletion of the whole tree. */
     @Benchmark
     @Measurement( iterations = 3 )
     public DeleteNodeResult delete( final DeleteState s, final Measured measured )

--- a/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/NodeTreeOperationsBenchmark.java
+++ b/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/NodeTreeOperationsBenchmark.java
@@ -79,7 +79,13 @@ public class NodeTreeOperationsBenchmark
     @AuxCounters( AuxCounters.Type.EVENTS )
     public static class Measured
     {
-        /** The nodes the operation covers, so every figure can be read per node as well as per operation. */
+        /**
+         * The operations counted, so the report can divide by it. JMH sums an event counter over the iterations of a run rather than
+         * averaging it, so every counter here is a total and only a ratio of two of them means anything.
+         */
+        public long ops;
+
+        /** The nodes the operations covered, so every figure can be read per node as well as per operation. */
         public long nodes;
 
         /** What the operation allocates on the thread that runs it. */
@@ -91,6 +97,7 @@ public class NodeTreeOperationsBenchmark
         @Setup( Level.Iteration )
         public void reset()
         {
+            ops = 0;
             nodes = 0;
             allocKiB = 0;
             peakLiveKiB = 0;
@@ -120,6 +127,7 @@ public class NodeTreeOperationsBenchmark
         <T> T measure( final int nodeCount, final Callable<T> operation )
             throws Exception
         {
+            ops++;
             nodes += nodeCount;
 
             final long liveBefore = liveSetBytes();

--- a/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/NodeTreeOperationsBenchmark.java
+++ b/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/NodeTreeOperationsBenchmark.java
@@ -1,8 +1,12 @@
 package com.enonic.xp.perftest.content;
 
 import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.openjdk.jmh.annotations.AuxCounters;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -53,41 +57,114 @@ public class NodeTreeOperationsBenchmark
 {
     private static final int CHILDREN = Integer.getInteger( "ptest.tree.children", 10_000 );
 
+    /** What one whole-tree operation covers: the parent and every child. */
+    private static final int TREE_NODES = CHILDREN + 1;
+
     private static final com.sun.management.ThreadMXBean THREADS =
         (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
 
     /**
-     * What one operation allocates on the thread that runs it, reported next to the time.
+     * What one operation costs, reported next to the time: the nodes it covers, what it allocates, and how far the live set grows while
+     * it runs.
      * <p>
-     * The whole-process figure a GC profiler reports is of no use here: the embedded search server allocates on its own threads
-     * throughout, and the corpus a benchmark rebuilds between invocations allocates too, both of which drown out the operation. The
-     * operation runs on the calling thread, so that thread's own counter isolates it.
+     * The two memory figures answer different questions. Allocation is churn - every node this operation rewrites is read, rebuilt and
+     * re-indexed, and that traffic is the same however the walk is organized. The live set is what the operation *holds*: a walk that
+     * keeps the whole subtree in memory at once shows here, a walk that keeps a stride at a time does not.
+     * <p>
+     * Both are measured close to the operation rather than through a GC profiler: the embedded search server allocates on its own
+     * threads throughout, and the corpus a benchmark rebuilds between invocations allocates too, both of which drown out the operation
+     * in a whole-process figure.
      */
     @State( Scope.Thread )
     @AuxCounters( AuxCounters.Type.EVENTS )
-    public static class Allocation
+    public static class Measured
     {
+        /** The nodes the operation covers, so every figure can be read per node as well as per operation. */
+        public long nodes;
+
+        /** What the operation allocates on the thread that runs it. */
         public long allocKiB;
+
+        /** How far the live set grows above where it stood when the operation started. */
+        public long peakLiveKiB;
 
         @Setup( Level.Iteration )
         public void reset()
         {
+            nodes = 0;
             allocKiB = 0;
+            peakLiveKiB = 0;
         }
 
-        <T> T measure( final Callable<T> operation )
+        /**
+         * The heap that survived the most recent collection. Reading it repeatedly while an operation runs, rather than once at the end,
+         * is what makes a peak out of it - the operation's own garbage is collected as it goes.
+         */
+        private static long liveSetBytes()
+        {
+            long live = 0;
+            for ( final MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans() )
+            {
+                if ( pool.getType() == MemoryType.HEAP )
+                {
+                    final MemoryUsage afterCollection = pool.getCollectionUsage();
+                    if ( afterCollection != null )
+                    {
+                        live += afterCollection.getUsed();
+                    }
+                }
+            }
+            return live;
+        }
+
+        <T> T measure( final int nodeCount, final Callable<T> operation )
             throws Exception
         {
-            final long before = THREADS.getCurrentThreadAllocatedBytes();
+            nodes += nodeCount;
+
+            final long liveBefore = liveSetBytes();
+            final AtomicLong peakLive = new AtomicLong( liveBefore );
+            final Thread watcher = new Thread( () -> {
+                while ( !Thread.currentThread().isInterrupted() )
+                {
+                    peakLive.accumulateAndGet( liveSetBytes(), Math::max );
+                    try
+                    {
+                        TimeUnit.MILLISECONDS.sleep( 20 );
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        return;
+                    }
+                }
+            }, "live-set-watcher" );
+            watcher.setDaemon( true );
+
+            final long allocBefore = THREADS.getCurrentThreadAllocatedBytes();
+            watcher.start();
             try
             {
                 return operation.call();
             }
             finally
             {
-                allocKiB += ( THREADS.getCurrentThreadAllocatedBytes() - before ) / 1024;
+                allocKiB += ( THREADS.getCurrentThreadAllocatedBytes() - allocBefore ) / 1024;
+                watcher.interrupt();
+                watcher.join();
+                peakLiveKiB += Math.max( 0, peakLive.get() - liveBefore ) / 1024;
             }
         }
+    }
+
+    /**
+     * Readies the repository for one measured invocation: the index settles, and the heap is collected so that the live set the
+     * operation is measured against holds the corpus alone rather than whatever the previous invocation left uncollected. Both are
+     * untimed - single-shot timing covers the benchmark method only.
+     */
+    private static void settle( final Bootstrap bs )
+    {
+        bs.refresh();
+        System.gc();
     }
 
     /** Builds one parent with {@link #CHILDREN} children under the content root, refresh disabled for speed, settled at the end. */
@@ -141,9 +218,9 @@ public class NodeTreeOperationsBenchmark
         }
 
         @Setup( Level.Invocation )
-        public void settle()
+        public void settleForInvocation()
         {
-            bs.refresh();
+            settle( bs );
         }
 
         NodePath nextTarget()
@@ -161,11 +238,11 @@ public class NodeTreeOperationsBenchmark
 
     /** One move of the tree parent, back and forth between two targets - every child follows. */
     @Benchmark
-    public MoveNodeResult move( final MoveState s, final Allocation alloc )
+    public MoveNodeResult move( final MoveState s, final Measured measured )
         throws Exception
     {
         final NodePath target = s.nextTarget();
-        return alloc.measure( () -> s.bs.callInDraftContext(
+        return measured.measure( TREE_NODES, () -> s.bs.callInDraftContext(
             () -> s.bs.nodeService.move( MoveNodeParams.create().nodeId( s.treeId ).newParentPath( target ).build() ) ) );
     }
 
@@ -186,9 +263,9 @@ public class NodeTreeOperationsBenchmark
         }
 
         @Setup( Level.Invocation )
-        public void settle()
+        public void settleForInvocation()
         {
-            bs.refresh();
+            settle( bs );
         }
 
         @TearDown( Level.Trial )
@@ -201,10 +278,10 @@ public class NodeTreeOperationsBenchmark
     /** One duplication of the whole tree - every invocation leaves a new copy behind, so the corpus grows as it would in production. */
     @Benchmark
     @Measurement( iterations = 3 )
-    public DuplicateNodeResult duplicate( final DuplicateState s, final Allocation alloc )
+    public DuplicateNodeResult duplicate( final DuplicateState s, final Measured measured )
         throws Exception
     {
-        return alloc.measure( () -> s.bs.callInDraftContext(
+        return measured.measure( TREE_NODES, () -> s.bs.callInDraftContext(
             () -> s.bs.nodeService.duplicate( DuplicateNodeParams.create().nodeId( s.treeId ).includeChildren( true ).build() ) ) );
     }
 
@@ -238,9 +315,9 @@ public class NodeTreeOperationsBenchmark
         }
 
         @Setup( Level.Invocation )
-        public void settle()
+        public void settleForInvocation()
         {
-            bs.refresh();
+            settle( bs );
         }
 
         AccessControlList nextPermissions()
@@ -258,11 +335,11 @@ public class NodeTreeOperationsBenchmark
 
     /** One permission change over the whole tree, alternating between two lists so every invocation writes a real change. */
     @Benchmark
-    public ApplyNodePermissionsResult applyPermissions( final ApplyPermissionsState s, final Allocation alloc )
+    public ApplyNodePermissionsResult applyPermissions( final ApplyPermissionsState s, final Measured measured )
         throws Exception
     {
         final AccessControlList permissions = s.nextPermissions();
-        return alloc.measure( () -> s.bs.callInDraftContext( () -> s.bs.nodeService.applyPermissions(
+        return measured.measure( TREE_NODES, () -> s.bs.callInDraftContext( () -> s.bs.nodeService.applyPermissions(
             ApplyNodePermissionsParams.create()
                 .nodeId( s.treeId )
                 .permissions( permissions )
@@ -292,6 +369,7 @@ public class NodeTreeOperationsBenchmark
         public void rebuildTree()
         {
             treeId = buildTree( bs, "tree-" + rebuild++ ).id();
+            settle( bs );
         }
 
         @TearDown( Level.Trial )
@@ -304,10 +382,10 @@ public class NodeTreeOperationsBenchmark
     /** One deletion of the whole tree. */
     @Benchmark
     @Measurement( iterations = 3 )
-    public DeleteNodeResult delete( final DeleteState s, final Allocation alloc )
+    public DeleteNodeResult delete( final DeleteState s, final Measured measured )
         throws Exception
     {
-        return alloc.measure(
+        return measured.measure( TREE_NODES,
             () -> s.bs.callInDraftContext( () -> s.bs.nodeService.delete( DeleteNodeParams.create().nodeId( s.treeId ).build() ) ) );
     }
 }

--- a/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/NodeTreeOperationsBenchmark.java
+++ b/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/NodeTreeOperationsBenchmark.java
@@ -1,0 +1,267 @@
+package com.enonic.xp.perftest.content;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import com.enonic.xp.content.ContentConstants;
+import com.enonic.xp.data.PropertyTree;
+import com.enonic.xp.node.ApplyNodePermissionsParams;
+import com.enonic.xp.node.ApplyNodePermissionsResult;
+import com.enonic.xp.node.ApplyPermissionsScope;
+import com.enonic.xp.node.CreateNodeParams;
+import com.enonic.xp.node.DeleteNodeParams;
+import com.enonic.xp.node.DeleteNodeResult;
+import com.enonic.xp.node.DuplicateNodeParams;
+import com.enonic.xp.node.DuplicateNodeResult;
+import com.enonic.xp.node.MoveNodeParams;
+import com.enonic.xp.node.MoveNodeResult;
+import com.enonic.xp.node.Node;
+import com.enonic.xp.node.NodeId;
+import com.enonic.xp.node.NodePath;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.acl.AccessControlEntry;
+import com.enonic.xp.security.acl.AccessControlList;
+import com.enonic.xp.security.acl.Permission;
+
+/**
+ * Whole-tree node operations on the simplest big shape: one parent with {@value #CHILDREN} direct children, one branch.
+ * <p>
+ * Every operation is a single shot over the whole tree, so each benchmark is one full walk. The index is settled - untimed - before
+ * every invocation, so a measurement covers the operation alone, never the ground the previous one left behind.
+ */
+@BenchmarkMode( Mode.SingleShotTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Warmup( iterations = 1 )
+@Measurement( iterations = 5 )
+@Fork( 1 )
+public class NodeTreeOperationsBenchmark
+{
+    private static final int CHILDREN = Integer.getInteger( "ptest.tree.children", 10_000 );
+
+    /** Builds one parent with {@link #CHILDREN} children under the content root, refresh disabled for speed, settled at the end. */
+    private static Node buildTree( final Bootstrap bs, final String name )
+    {
+        bs.setRefreshInterval( "-1" );
+        final Node tree = bs.callInDraftContext( () -> {
+            final Node parent = bs.nodeService.create(
+                CreateNodeParams.create().data( new PropertyTree() ).name( name ).parent( ContentConstants.CONTENT_ROOT_PATH ).build() );
+            for ( int i = 0; i < CHILDREN; i++ )
+            {
+                bs.nodeService.create(
+                    CreateNodeParams.create().data( new PropertyTree() ).name( "child-" + i ).parent( parent.path() ).build() );
+            }
+            return parent;
+        } );
+        bs.refresh();
+        bs.setRefreshInterval( "1s" );
+        bs.setStoreThrottleType( "merge" );
+        return tree;
+    }
+
+    @State( Scope.Benchmark )
+    public static class MoveState
+    {
+        Bootstrap bs;
+
+        NodeId treeId;
+
+        NodePath targetA;
+
+        NodePath targetB;
+
+        boolean atA = true;
+
+        @Setup( Level.Trial )
+        public void setUp()
+            throws Exception
+        {
+            bs = new Bootstrap();
+            bs.start();
+            targetA = bs.callInDraftContext( () -> bs.nodeService.create(
+                CreateNodeParams.create().data( new PropertyTree() ).name( "target-a" ).parent( ContentConstants.CONTENT_ROOT_PATH ).build() ) ).path();
+            targetB = bs.callInDraftContext( () -> bs.nodeService.create(
+                CreateNodeParams.create().data( new PropertyTree() ).name( "target-b" ).parent( ContentConstants.CONTENT_ROOT_PATH ).build() ) ).path();
+            final Node tree = buildTree( bs, "tree" );
+            treeId = tree.id();
+            bs.callInDraftContext( () -> bs.nodeService.move(
+                MoveNodeParams.create().nodeId( treeId ).newParentPath( targetA ).build() ) );
+            bs.refresh();
+        }
+
+        @Setup( Level.Invocation )
+        public void settle()
+        {
+            bs.refresh();
+        }
+
+        NodePath nextTarget()
+        {
+            atA = !atA;
+            return atA ? targetA : targetB;
+        }
+
+        @TearDown( Level.Trial )
+        public void tearDown()
+        {
+            bs.stop();
+        }
+    }
+
+    /** One move of the tree parent, back and forth between two targets - every child follows. */
+    @Benchmark
+    public MoveNodeResult move( final MoveState s )
+    {
+        final NodePath target = s.nextTarget();
+        return s.bs.callInDraftContext(
+            () -> s.bs.nodeService.move( MoveNodeParams.create().nodeId( s.treeId ).newParentPath( target ).build() ) );
+    }
+
+    @State( Scope.Benchmark )
+    public static class DuplicateState
+    {
+        Bootstrap bs;
+
+        NodeId treeId;
+
+        @Setup( Level.Trial )
+        public void setUp()
+            throws Exception
+        {
+            bs = new Bootstrap();
+            bs.start();
+            treeId = buildTree( bs, "tree" ).id();
+        }
+
+        @Setup( Level.Invocation )
+        public void settle()
+        {
+            bs.refresh();
+        }
+
+        @TearDown( Level.Trial )
+        public void tearDown()
+        {
+            bs.stop();
+        }
+    }
+
+    /** One duplication of the whole tree - every invocation leaves a new copy behind, so the corpus grows as it would in production. */
+    @Benchmark
+    @Measurement( iterations = 3 )
+    public DuplicateNodeResult duplicate( final DuplicateState s )
+    {
+        return s.bs.callInDraftContext(
+            () -> s.bs.nodeService.duplicate( DuplicateNodeParams.create().nodeId( s.treeId ).includeChildren( true ).build() ) );
+    }
+
+    @State( Scope.Benchmark )
+    public static class ApplyPermissionsState
+    {
+        Bootstrap bs;
+
+        NodeId treeId;
+
+        AccessControlList aclA;
+
+        AccessControlList aclB;
+
+        boolean atA;
+
+        @Setup( Level.Trial )
+        public void setUp()
+            throws Exception
+        {
+            bs = new Bootstrap();
+            bs.start();
+            treeId = buildTree( bs, "tree" ).id();
+            // the operating role keeps full access in both variants, so every invocation stays permitted
+            aclA = AccessControlList.of(
+                AccessControlEntry.create().principal( RoleKeys.CONTENT_MANAGER_ADMIN ).allowAll().build(),
+                AccessControlEntry.create().principal( RoleKeys.AUTHENTICATED ).allow( Permission.READ ).build() );
+            aclB = AccessControlList.of(
+                AccessControlEntry.create().principal( RoleKeys.CONTENT_MANAGER_ADMIN ).allowAll().build(),
+                AccessControlEntry.create().principal( RoleKeys.AUTHENTICATED ).allow( Permission.READ, Permission.MODIFY ).build() );
+        }
+
+        @Setup( Level.Invocation )
+        public void settle()
+        {
+            bs.refresh();
+        }
+
+        AccessControlList nextPermissions()
+        {
+            atA = !atA;
+            return atA ? aclA : aclB;
+        }
+
+        @TearDown( Level.Trial )
+        public void tearDown()
+        {
+            bs.stop();
+        }
+    }
+
+    /** One permission change over the whole tree, alternating between two lists so every invocation writes a real change. */
+    @Benchmark
+    public ApplyNodePermissionsResult applyPermissions( final ApplyPermissionsState s )
+    {
+        final AccessControlList permissions = s.nextPermissions();
+        return s.bs.callInDraftContext( () -> s.bs.nodeService.applyPermissions( ApplyNodePermissionsParams.create()
+                                                                                     .nodeId( s.treeId )
+                                                                                     .permissions( permissions )
+                                                                                     .scope( ApplyPermissionsScope.TREE )
+                                                                                     .build() ) );
+    }
+
+    @State( Scope.Benchmark )
+    public static class DeleteState
+    {
+        Bootstrap bs;
+
+        NodeId treeId;
+
+        int rebuild;
+
+        @Setup( Level.Trial )
+        public void setUp()
+            throws Exception
+        {
+            bs = new Bootstrap();
+            bs.start();
+        }
+
+        /** A deletion consumes its tree, so every invocation gets a fresh one - built and settled outside the measurement. */
+        @Setup( Level.Invocation )
+        public void rebuildTree()
+        {
+            treeId = buildTree( bs, "tree-" + rebuild++ ).id();
+        }
+
+        @TearDown( Level.Trial )
+        public void tearDown()
+        {
+            bs.stop();
+        }
+    }
+
+    /** One deletion of the whole tree. */
+    @Benchmark
+    @Measurement( iterations = 3 )
+    public DeleteNodeResult delete( final DeleteState s )
+    {
+        return s.bs.callInDraftContext( () -> s.bs.nodeService.delete( DeleteNodeParams.create().nodeId( s.treeId ).build() ) );
+    }
+}

--- a/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/NodeTreeOperationsBenchmark.java
+++ b/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/NodeTreeOperationsBenchmark.java
@@ -1,7 +1,10 @@
 package com.enonic.xp.perftest.content;
 
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import org.openjdk.jmh.annotations.AuxCounters;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -49,6 +52,43 @@ import com.enonic.xp.security.acl.Permission;
 public class NodeTreeOperationsBenchmark
 {
     private static final int CHILDREN = Integer.getInteger( "ptest.tree.children", 10_000 );
+
+    private static final com.sun.management.ThreadMXBean THREADS =
+        (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    /**
+     * What one operation allocates on the thread that runs it, reported next to the time.
+     * <p>
+     * The whole-process figure a GC profiler reports is of no use here: the embedded search server allocates on its own threads
+     * throughout, and the corpus a benchmark rebuilds between invocations allocates too, both of which drown out the operation. The
+     * operation runs on the calling thread, so that thread's own counter isolates it.
+     */
+    @State( Scope.Thread )
+    @AuxCounters( AuxCounters.Type.EVENTS )
+    public static class Allocation
+    {
+        public long allocKiB;
+
+        @Setup( Level.Iteration )
+        public void reset()
+        {
+            allocKiB = 0;
+        }
+
+        <T> T measure( final Callable<T> operation )
+            throws Exception
+        {
+            final long before = THREADS.getCurrentThreadAllocatedBytes();
+            try
+            {
+                return operation.call();
+            }
+            finally
+            {
+                allocKiB += ( THREADS.getCurrentThreadAllocatedBytes() - before ) / 1024;
+            }
+        }
+    }
 
     /** Builds one parent with {@link #CHILDREN} children under the content root, refresh disabled for speed, settled at the end. */
     private static Node buildTree( final Bootstrap bs, final String name )
@@ -121,11 +161,12 @@ public class NodeTreeOperationsBenchmark
 
     /** One move of the tree parent, back and forth between two targets - every child follows. */
     @Benchmark
-    public MoveNodeResult move( final MoveState s )
+    public MoveNodeResult move( final MoveState s, final Allocation alloc )
+        throws Exception
     {
         final NodePath target = s.nextTarget();
-        return s.bs.callInDraftContext(
-            () -> s.bs.nodeService.move( MoveNodeParams.create().nodeId( s.treeId ).newParentPath( target ).build() ) );
+        return alloc.measure( () -> s.bs.callInDraftContext(
+            () -> s.bs.nodeService.move( MoveNodeParams.create().nodeId( s.treeId ).newParentPath( target ).build() ) ) );
     }
 
     @State( Scope.Benchmark )
@@ -160,10 +201,11 @@ public class NodeTreeOperationsBenchmark
     /** One duplication of the whole tree - every invocation leaves a new copy behind, so the corpus grows as it would in production. */
     @Benchmark
     @Measurement( iterations = 3 )
-    public DuplicateNodeResult duplicate( final DuplicateState s )
+    public DuplicateNodeResult duplicate( final DuplicateState s, final Allocation alloc )
+        throws Exception
     {
-        return s.bs.callInDraftContext(
-            () -> s.bs.nodeService.duplicate( DuplicateNodeParams.create().nodeId( s.treeId ).includeChildren( true ).build() ) );
+        return alloc.measure( () -> s.bs.callInDraftContext(
+            () -> s.bs.nodeService.duplicate( DuplicateNodeParams.create().nodeId( s.treeId ).includeChildren( true ).build() ) ) );
     }
 
     @State( Scope.Benchmark )
@@ -216,14 +258,16 @@ public class NodeTreeOperationsBenchmark
 
     /** One permission change over the whole tree, alternating between two lists so every invocation writes a real change. */
     @Benchmark
-    public ApplyNodePermissionsResult applyPermissions( final ApplyPermissionsState s )
+    public ApplyNodePermissionsResult applyPermissions( final ApplyPermissionsState s, final Allocation alloc )
+        throws Exception
     {
         final AccessControlList permissions = s.nextPermissions();
-        return s.bs.callInDraftContext( () -> s.bs.nodeService.applyPermissions( ApplyNodePermissionsParams.create()
-                                                                                     .nodeId( s.treeId )
-                                                                                     .permissions( permissions )
-                                                                                     .scope( ApplyPermissionsScope.TREE )
-                                                                                     .build() ) );
+        return alloc.measure( () -> s.bs.callInDraftContext( () -> s.bs.nodeService.applyPermissions(
+            ApplyNodePermissionsParams.create()
+                .nodeId( s.treeId )
+                .permissions( permissions )
+                .scope( ApplyPermissionsScope.TREE )
+                .build() ) ) );
     }
 
     @State( Scope.Benchmark )
@@ -260,8 +304,10 @@ public class NodeTreeOperationsBenchmark
     /** One deletion of the whole tree. */
     @Benchmark
     @Measurement( iterations = 3 )
-    public DeleteNodeResult delete( final DeleteState s )
+    public DeleteNodeResult delete( final DeleteState s, final Allocation alloc )
+        throws Exception
     {
-        return s.bs.callInDraftContext( () -> s.bs.nodeService.delete( DeleteNodeParams.create().nodeId( s.treeId ).build() ) );
+        return alloc.measure(
+            () -> s.bs.callInDraftContext( () -> s.bs.nodeService.delete( DeleteNodeParams.create().nodeId( s.treeId ).build() ) ) );
     }
 }

--- a/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/ReportWriter.java
+++ b/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/ReportWriter.java
@@ -63,10 +63,7 @@ final class ReportWriter
             final JsonNode metric = item.path( "primaryMetric" );
             final double score = metric.path( "score" ).asDouble();
             final String unit = metric.path( "scoreUnit" ).asText();
-            // reported by the benchmark itself, as the thread that ran the operation counted it
             final JsonNode secondary = item.path( "secondaryMetrics" );
-            // every counter is a total over the run - JMH sums an event counter rather than averaging it - so each is divided by the
-            // operations counted beside it
             final double ops = count( secondary, "ops" );
             rows.add( new Row( benchmark, mode, score, unit, kiB( secondary, "allocKiB" ) / ops, kiB( secondary, "peakLiveKiB" ) / ops,
                                count( secondary, "nodes" ) / ops ) );
@@ -74,7 +71,6 @@ final class ReportWriter
         return rows;
     }
 
-    /** A counter the benchmark reported in KiB per operation, as bytes, or NaN where this benchmark does not count it. */
     private static double kiB( final JsonNode secondaryMetrics, final String counter )
     {
         final JsonNode counted = secondaryMetrics.path( counter );
@@ -106,7 +102,6 @@ final class ReportWriter
 
     private static String shorten( final String fqn )
     {
-        // com.enonic.xp.perftest.content.ContentCreateBenchmark.create -> ContentCreateBenchmark.create
         final int dot = fqn.lastIndexOf( '.', fqn.lastIndexOf( '.' ) - 1 );
         return dot >= 0 ? fqn.substring( dot + 1 ) : fqn;
     }
@@ -144,10 +139,6 @@ final class ReportWriter
             return Double.isNaN( nodesPerOp ) || nodesPerOp <= 0 ? Double.NaN : bytesPerOp / nodesPerOp;
         }
 
-        /**
-         * Nodes per second where the benchmark says how many nodes one operation covers, operations per second otherwise. The reciprocal
-         * of a whole-tree operation says nothing: it is one operation however many nodes it rewrote.
-         */
         String throughput()
         {
             final double seconds = secondsPerOp();

--- a/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/ReportWriter.java
+++ b/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/ReportWriter.java
@@ -24,14 +24,15 @@ final class ReportWriter
         final StringBuilder md = new StringBuilder( 1024 );
         md.append( "## ContentService benchmarks\n\n" );
         md.append( "Run: " ).append( Instant.now() ).append( "\n\n" );
-        md.append( "| Benchmark | Mode | Score | Unit | Throughput |\n" );
-        md.append( "|---|---|---:|---|---:|\n" );
+        md.append( "| Benchmark | Mode | Score | Unit | Throughput | Alloc/op |\n" );
+        md.append( "|---|---|---:|---|---:|---:|\n" );
         for ( final Row r : rows )
         {
             md.append( "| " ).append( r.benchmark ).append( " | " ).append( r.mode ).append( " | " );
             md.append( String.format( Locale.ROOT, "%.2f", r.score ) ).append( " | " );
             md.append( r.unit ).append( " | " );
-            md.append( String.format( Locale.ROOT, "%.0f ops/s", r.opsPerSec() ) ).append( " |\n" );
+            md.append( String.format( Locale.ROOT, "%.0f ops/s", r.opsPerSec() ) ).append( " | " );
+            md.append( r.allocPerOp() ).append( " |\n" );
         }
         md.append( "\n### Environment\n\n" );
         md.append( "- **CPU**: " ).append( info.cpuModel ).append( "\n" );
@@ -56,7 +57,10 @@ final class ReportWriter
             final JsonNode metric = item.path( "primaryMetric" );
             final double score = metric.path( "score" ).asDouble();
             final String unit = metric.path( "scoreUnit" ).asText();
-            rows.add( new Row( benchmark, mode, score, unit ) );
+            // reported by the benchmark itself, as the thread that ran the operation counted it
+            final JsonNode allocated = item.path( "secondaryMetrics" ).path( "allocKiB" );
+            final double bytesPerOp = allocated.isMissingNode() ? Double.NaN : allocated.path( "score" ).asDouble() * 1024.0;
+            rows.add( new Row( benchmark, mode, score, unit, bytesPerOp ) );
         }
         return rows;
     }
@@ -78,12 +82,33 @@ final class ReportWriter
 
         final String unit;
 
-        Row( final String benchmark, final String mode, final double score, final String unit )
+        final double bytesPerOp;
+
+        Row( final String benchmark, final String mode, final double score, final String unit, final double bytesPerOp )
         {
             this.benchmark = benchmark;
             this.mode = mode;
             this.score = score;
             this.unit = unit;
+            this.bytesPerOp = bytesPerOp;
+        }
+
+        /** What one operation allocates on the thread that runs it, or a dash where the benchmark does not count it. */
+        String allocPerOp()
+        {
+            if ( Double.isNaN( bytesPerOp ) )
+            {
+                return "-";
+            }
+            if ( bytesPerOp >= 1024.0 * 1024.0 )
+            {
+                return String.format( Locale.ROOT, "%.1f MiB", bytesPerOp / ( 1024.0 * 1024.0 ) );
+            }
+            if ( bytesPerOp >= 1024.0 )
+            {
+                return String.format( Locale.ROOT, "%.1f KiB", bytesPerOp / 1024.0 );
+            }
+            return String.format( Locale.ROOT, "%.0f B", bytesPerOp );
         }
 
         double opsPerSec()

--- a/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/ReportWriter.java
+++ b/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/ReportWriter.java
@@ -24,16 +24,22 @@ final class ReportWriter
         final StringBuilder md = new StringBuilder( 1024 );
         md.append( "## ContentService benchmarks\n\n" );
         md.append( "Run: " ).append( Instant.now() ).append( "\n\n" );
-        md.append( "| Benchmark | Mode | Score | Unit | Throughput | Alloc/op |\n" );
-        md.append( "|---|---|---:|---|---:|---:|\n" );
+        md.append( "| Benchmark | Mode | Score | Unit | Throughput | Time/node | Alloc/op | Alloc/node | Peak live/op |\n" );
+        md.append( "|---|---|---:|---|---:|---:|---:|---:|---:|\n" );
         for ( final Row r : rows )
         {
             md.append( "| " ).append( r.benchmark ).append( " | " ).append( r.mode ).append( " | " );
             md.append( String.format( Locale.ROOT, "%.2f", r.score ) ).append( " | " );
             md.append( r.unit ).append( " | " );
-            md.append( String.format( Locale.ROOT, "%.0f ops/s", r.opsPerSec() ) ).append( " | " );
-            md.append( r.allocPerOp() ).append( " |\n" );
+            md.append( r.throughput() ).append( " | " );
+            md.append( r.timePerNode() ).append( " | " );
+            md.append( bytes( r.bytesPerOp ) ).append( " | " );
+            md.append( bytes( r.bytesPerNode() ) ).append( " | " );
+            md.append( bytes( r.peakLiveBytesPerOp ) ).append( " |\n" );
         }
+        md.append( "\nA whole-tree operation is one operation over many nodes, so its throughput is counted in nodes rather than in\n" );
+        md.append( "operations. **Alloc** is what the operation churns - every node it rewrites is read, rebuilt and re-indexed, whatever\n" );
+        md.append( "the shape of the walk. **Peak live** is what it holds: how far the surviving heap grows while it runs.\n" );
         md.append( "\n### Environment\n\n" );
         md.append( "- **CPU**: " ).append( info.cpuModel ).append( "\n" );
         md.append( "- **Logical cores**: " ).append( info.cores ).append( "\n" );
@@ -58,11 +64,41 @@ final class ReportWriter
             final double score = metric.path( "score" ).asDouble();
             final String unit = metric.path( "scoreUnit" ).asText();
             // reported by the benchmark itself, as the thread that ran the operation counted it
-            final JsonNode allocated = item.path( "secondaryMetrics" ).path( "allocKiB" );
-            final double bytesPerOp = allocated.isMissingNode() ? Double.NaN : allocated.path( "score" ).asDouble() * 1024.0;
-            rows.add( new Row( benchmark, mode, score, unit, bytesPerOp ) );
+            final JsonNode secondary = item.path( "secondaryMetrics" );
+            rows.add( new Row( benchmark, mode, score, unit, kiB( secondary, "allocKiB" ), kiB( secondary, "peakLiveKiB" ),
+                               count( secondary, "nodes" ) ) );
         }
         return rows;
+    }
+
+    /** A counter the benchmark reported in KiB per operation, as bytes, or NaN where this benchmark does not count it. */
+    private static double kiB( final JsonNode secondaryMetrics, final String counter )
+    {
+        final JsonNode counted = secondaryMetrics.path( counter );
+        return counted.isMissingNode() ? Double.NaN : counted.path( "score" ).asDouble() * 1024.0;
+    }
+
+    private static double count( final JsonNode secondaryMetrics, final String counter )
+    {
+        final JsonNode counted = secondaryMetrics.path( counter );
+        return counted.isMissingNode() ? Double.NaN : counted.path( "score" ).asDouble();
+    }
+
+    private static String bytes( final double value )
+    {
+        if ( Double.isNaN( value ) )
+        {
+            return "-";
+        }
+        if ( value >= 1024.0 * 1024.0 )
+        {
+            return String.format( Locale.ROOT, "%.1f MiB", value / ( 1024.0 * 1024.0 ) );
+        }
+        if ( value >= 1024.0 )
+        {
+            return String.format( Locale.ROOT, "%.1f KiB", value / 1024.0 );
+        }
+        return String.format( Locale.ROOT, "%.0f B", value );
     }
 
     private static String shorten( final String fqn )
@@ -84,47 +120,65 @@ final class ReportWriter
 
         final double bytesPerOp;
 
-        Row( final String benchmark, final String mode, final double score, final String unit, final double bytesPerOp )
+        final double peakLiveBytesPerOp;
+
+        final double nodesPerOp;
+
+        Row( final String benchmark, final String mode, final double score, final String unit, final double bytesPerOp,
+             final double peakLiveBytesPerOp, final double nodesPerOp )
         {
             this.benchmark = benchmark;
             this.mode = mode;
             this.score = score;
             this.unit = unit;
             this.bytesPerOp = bytesPerOp;
+            this.peakLiveBytesPerOp = peakLiveBytesPerOp;
+            this.nodesPerOp = nodesPerOp;
         }
 
-        /** What one operation allocates on the thread that runs it, or a dash where the benchmark does not count it. */
-        String allocPerOp()
+        double bytesPerNode()
         {
-            if ( Double.isNaN( bytesPerOp ) )
+            return Double.isNaN( nodesPerOp ) || nodesPerOp <= 0 ? Double.NaN : bytesPerOp / nodesPerOp;
+        }
+
+        /**
+         * Nodes per second where the benchmark says how many nodes one operation covers, operations per second otherwise. The reciprocal
+         * of a whole-tree operation says nothing: it is one operation however many nodes it rewrote.
+         */
+        String throughput()
+        {
+            final double seconds = secondsPerOp();
+            if ( Double.isNaN( seconds ) || seconds <= 0 )
             {
                 return "-";
             }
-            if ( bytesPerOp >= 1024.0 * 1024.0 )
-            {
-                return String.format( Locale.ROOT, "%.1f MiB", bytesPerOp / ( 1024.0 * 1024.0 ) );
-            }
-            if ( bytesPerOp >= 1024.0 )
-            {
-                return String.format( Locale.ROOT, "%.1f KiB", bytesPerOp / 1024.0 );
-            }
-            return String.format( Locale.ROOT, "%.0f B", bytesPerOp );
+            return Double.isNaN( nodesPerOp )
+                ? String.format( Locale.ROOT, "%,.0f ops/s", 1.0 / seconds )
+                : String.format( Locale.ROOT, "%,.0f nodes/s", nodesPerOp / seconds );
         }
 
-        double opsPerSec()
+        String timePerNode()
         {
-            // JMH avgt with us/op: ops/s = 1_000_000 / us-per-op
-            // Other modes/units would need different math; treat as best-effort.
+            final double seconds = secondsPerOp();
+            if ( Double.isNaN( seconds ) || Double.isNaN( nodesPerOp ) || nodesPerOp <= 0 )
+            {
+                return "-";
+            }
+            return String.format( Locale.ROOT, "%.1f us", seconds / nodesPerOp * 1_000_000.0 );
+        }
+
+        private double secondsPerOp()
+        {
             switch ( unit )
             {
-                case "us/op":
-                    return 1_000_000.0 / score;
-                case "ms/op":
-                    return 1_000.0 / score;
                 case "ns/op":
-                    return 1_000_000_000.0 / score;
+                    return score / 1_000_000_000.0;
+                case "us/op":
+                    return score / 1_000_000.0;
+                case "ms/op":
+                    return score / 1_000.0;
                 case "s/op":
-                    return 1.0 / score;
+                    return score;
                 default:
                     return Double.NaN;
             }

--- a/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/ReportWriter.java
+++ b/modules/ptest/ptest-content/src/main/java/com/enonic/xp/perftest/content/ReportWriter.java
@@ -65,8 +65,11 @@ final class ReportWriter
             final String unit = metric.path( "scoreUnit" ).asText();
             // reported by the benchmark itself, as the thread that ran the operation counted it
             final JsonNode secondary = item.path( "secondaryMetrics" );
-            rows.add( new Row( benchmark, mode, score, unit, kiB( secondary, "allocKiB" ), kiB( secondary, "peakLiveKiB" ),
-                               count( secondary, "nodes" ) ) );
+            // every counter is a total over the run - JMH sums an event counter rather than averaging it - so each is divided by the
+            // operations counted beside it
+            final double ops = count( secondary, "ops" );
+            rows.add( new Row( benchmark, mode, score, unit, kiB( secondary, "allocKiB" ) / ops, kiB( secondary, "peakLiveKiB" ) / ops,
+                               count( secondary, "nodes" ) / ops ) );
         }
         return rows;
     }


### PR DESCRIPTION
Adds `NodeTreeOperationsBenchmark` to `ptest-content`: `node.move`, `node.duplicate`, `node.applyPermissions` and `node.delete`, each as a single shot over the simplest big shape — one parent with 10 000 direct children, one branch, no cross-branch work.

The same benchmark (byte-identical files) sits on #12281's branch, so a Performance Test workflow run on `master` and one on `claude/xp-issue-12065-alternative-pur3l4` measure the difference the walker rework makes on these four operations.

## What is measured

Time alone would not show what the rework did, so each operation is measured three ways:

| Benchmark | Mode | Score | Unit | Throughput | Time/node | Alloc/op | Alloc/node | Peak live/op |
|---|---|---:|---|---:|---:|---:|---:|---:|
| NodeTreeOperationsBenchmark.applyPermissions | ss | 2436.01 | ms/op | 821 nodes/s | 1217.4 us | 235.2 MiB | 120.4 KiB | 7.2 MiB |

(one local run at `-Dptest.tree.children=2000`, to show the shape of the report — not a result)

- **Throughput in nodes, not operations.** One operation rewrites the whole tree, so its reciprocal says nothing: it is one operation however many nodes it covered. Each measurement reports the nodes it touched, and the report divides by that.
- **Allocation** is churn — every node an operation rewrites is read, rebuilt and re-indexed, and that traffic is the same however the walk is organized. Expect this column to match between the two runs.
- **Peak live** is what the operation *holds*: how far the surviving heap grows while it runs. This is the column the rework should move, since it replaced whole-subtree collections with bounded strides.

Both memory figures are measured close to the operation rather than through JMH's GC profiler: the embedded search server allocates on its own threads throughout, and the corpus a benchmark rebuilds between invocations allocates too. The whole-process figure came out at ~800 MiB for every operation alike, drowning out the differences between them. Allocation is read from the counter of the thread that runs the operation; the live set is sampled from the heap pools' post-collection usage while it runs.

**On reading the counters:** JMH sums an auxiliary event counter over the iterations of a run rather than averaging it, so every counter here is a total. Each measurement therefore counts its own operations, and the report divides by that — without it, a five-iteration run reads as one operation that allocated five times as much and covered five times as many nodes.

## Design notes

- **Single shot, milliseconds.** Every operation is one full walk of the tree, so `Mode.SingleShotTime` with 1 warmup and 5 measurement iterations (3 for the corpus-consuming pair).
- **Only the operation is timed.** The index is settled with an untimed refresh before every invocation, so a measurement never pays for the ground the previous one left behind.
- **Move** alternates the tree parent between two targets — every child follows on each shot.
- **Duplicate** copies the whole tree; each invocation leaves its copy behind, as production would.
- **applyPermissions** alternates between two permission lists over the whole tree (`scope=TREE`), so every invocation writes a real change; the operating role keeps full access in both variants.
- **Delete** consumes its tree, so each invocation gets a fresh one, built and settled outside the measurement.
- The child count bends to `-Dptest.tree.children`, and a single benchmark can be run with `-Pptest.include=...`, for quick local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PT3t5hDXj91Sk6idKRQwBs