### PR TITLE
Speed up root access on the node read and create paths

### DIFF
--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/branch/storage/BranchServiceImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/branch/storage/BranchServiceImpl.java
@@ -180,10 +180,6 @@ public class BranchServiceImpl
         return builder.build();
     }
 
-    /**
-     * Resolving a path to a node asks the index which node holds it, except for the root path: the root node keeps the one node id that
-     * is known without asking, and it can be neither moved nor deleted, so the id it always has answers the path directly.
-     */
     @Override
     public NodeBranchEntry get( final NodePath nodePath, final InternalContext context )
     {

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/branch/storage/BranchServiceImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/branch/storage/BranchServiceImpl.java
@@ -180,9 +180,18 @@ public class BranchServiceImpl
         return builder.build();
     }
 
+    /**
+     * Resolving a path to a node asks the index which node holds it, except for the root path: the root node keeps the one node id that
+     * is known without asking, and it can be neither moved nor deleted, so the id it always has answers the path directly.
+     */
     @Override
     public NodeBranchEntry get( final NodePath nodePath, final InternalContext context )
     {
+        if ( nodePath.isRoot() )
+        {
+            return doGetById( NodeId.ROOT, context );
+        }
+
         final RepositoryId repositoryId = context.getRepositoryId();
         final Branch branch = context.getBranch();
         final BranchPath cacheKey = new BranchPath( repositoryId, branch, nodePath );

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CreateNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CreateNodeCommand.java
@@ -134,11 +134,6 @@ public final class CreateNodeCommand
         return params.getPermissions().isEmpty() ? NodeDefaultAclFactory.create( getCurrentPrincipalKey() ) : params.getPermissions();
     }
 
-    /**
-     * Verification and parent resolution are the storage a create reads before it writes anything, so a repository that does not exist
-     * surfaces here. It is reported as a missing repository rather than as the index error underneath, the way every other node command
-     * reports it.
-     */
     private Node verifyAndResolveParent()
     {
         try
@@ -155,10 +150,6 @@ public final class CreateNodeCommand
         }
     }
 
-    /**
-     * A parent that is not found is either genuinely absent or absent along with the branch that would hold it, and only the root node
-     * tells those apart, so it is consulted once the parent is known to be missing and never on the way to a node that is created.
-     */
     private Node getParentNode()
     {
         final Node parentNode = doGetByPath( params.getParent() );

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CreateNodeCommand.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/CreateNodeCommand.java
@@ -2,6 +2,9 @@ package com.enonic.xp.repo.impl.node;
 
 import java.util.List;
 
+import org.elasticsearch.index.IndexNotFoundException;
+
+import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.core.internal.Millis;
 import com.enonic.xp.data.Property;
@@ -25,6 +28,7 @@ import com.enonic.xp.repo.impl.InternalContext;
 import com.enonic.xp.repo.impl.binary.BinaryService;
 import com.enonic.xp.repo.impl.storage.StoreNodeParams;
 import com.enonic.xp.repository.RepositoryId;
+import com.enonic.xp.repository.RepositoryNotFoundException;
 import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.security.acl.Permission;
 
@@ -62,11 +66,7 @@ public final class CreateNodeCommand
 
     public Node execute()
     {
-        if ( !skipVerification )
-        {
-            NodeHelper.runAsAdmin( this::verifyNotExistsAlready );
-        }
-        final Node parentNode = knownParentNode != null ? knownParentNode : NodeHelper.runAsAdmin( this::getParentNode );
+        final Node parentNode = verifyAndResolveParent();
 
         NodePermissionsResolver.requireContextUserPermissionOrAdmin( Permission.CREATE, parentNode );
 
@@ -134,12 +134,40 @@ public final class CreateNodeCommand
         return params.getPermissions().isEmpty() ? NodeDefaultAclFactory.create( getCurrentPrincipalKey() ) : params.getPermissions();
     }
 
+    /**
+     * Verification and parent resolution are the storage a create reads before it writes anything, so a repository that does not exist
+     * surfaces here. It is reported as a missing repository rather than as the index error underneath, the way every other node command
+     * reports it.
+     */
+    private Node verifyAndResolveParent()
+    {
+        try
+        {
+            if ( !skipVerification )
+            {
+                NodeHelper.runAsAdmin( this::verifyNotExistsAlready );
+            }
+            return knownParentNode != null ? knownParentNode : NodeHelper.runAsAdmin( this::getParentNode );
+        }
+        catch ( IndexNotFoundException e )
+        {
+            throw new RepositoryNotFoundException( ContextAccessor.current().getRepositoryId() );
+        }
+    }
+
+    /**
+     * A parent that is not found is either genuinely absent or absent along with the branch that would hold it, and only the root node
+     * tells those apart, so it is consulted once the parent is known to be missing and never on the way to a node that is created.
+     */
     private Node getParentNode()
     {
         final Node parentNode = doGetByPath( params.getParent() );
 
         if ( parentNode == null )
         {
+            final Context context = ContextAccessor.current();
+            NodeHelper.verifyBranchExists( this.nodeStorageService, context.getRepositoryId(), context.getBranch() );
+
             throw new NodeNotFoundException(
                 "Cannot create node with name " + params.getName() + ", parent '" + params.getParent() + "' not found" );
         }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/NodeHelper.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/NodeHelper.java
@@ -32,11 +32,6 @@ public class NodeHelper
             callWith( callable );
     }
 
-    /**
-     * A branch holds the root node from the moment it is created, so the root node is what makes the branch exist and its absence is
-     * reported as a missing branch. The lookup asks for no field of the entry, which lets the storage answer without reading the
-     * document.
-     */
     static void verifyBranchExists( final NodeStorageService nodeStorageService, final RepositoryId repositoryId, final Branch branch )
     {
         final boolean rootExists;

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/NodeHelper.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/NodeHelper.java
@@ -2,8 +2,17 @@ package com.enonic.xp.repo.impl.node;
 
 import java.util.concurrent.Callable;
 
+import org.elasticsearch.index.IndexNotFoundException;
+
+import com.enonic.xp.branch.Branch;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.node.NodeId;
+import com.enonic.xp.repo.impl.InternalContext;
+import com.enonic.xp.repo.impl.storage.NodeStorageService;
+import com.enonic.xp.repository.BranchNotFoundException;
+import com.enonic.xp.repository.RepositoryId;
+import com.enonic.xp.repository.RepositoryNotFoundException;
 
 public class NodeHelper
 {
@@ -21,5 +30,30 @@ public class NodeHelper
             authInfo( NodeConstants.NODE_SU_AUTH_INFO ).
             build().
             callWith( callable );
+    }
+
+    /**
+     * A branch holds the root node from the moment it is created, so the root node is what makes the branch exist and its absence is
+     * reported as a missing branch. The lookup asks for no field of the entry, which lets the storage answer without reading the
+     * document.
+     */
+    static void verifyBranchExists( final NodeStorageService nodeStorageService, final RepositoryId repositoryId, final Branch branch )
+    {
+        final boolean rootExists;
+        try
+        {
+            rootExists = nodeStorageService.exists( NodeId.ROOT, InternalContext.create( ContextAccessor.current() )
+                .repositoryId( repositoryId )
+                .branch( branch )
+                .build() );
+        }
+        catch ( IndexNotFoundException e )
+        {
+            throw new RepositoryNotFoundException( repositoryId );
+        }
+        if ( !rootExists )
+        {
+            throw new BranchNotFoundException( branch );
+        }
     }
 }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/NodeServiceImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/node/NodeServiceImpl.java
@@ -524,7 +524,6 @@ public class NodeServiceImpl
     @Override
     public Node create( final CreateNodeParams params )
     {
-        verifyContext();
         return doCreate( params );
     }
 
@@ -1079,22 +1078,7 @@ public class NodeServiceImpl
 
     private void verifyBranchExists( final RepositoryId repositoryId, final Branch branch )
     {
-        final boolean rootExists;
-        try
-        {
-            rootExists = this.nodeStorageService.exists( NodeId.ROOT, InternalContext.create( ContextAccessor.current() )
-                .repositoryId( repositoryId )
-                .branch( branch )
-                .build() );
-        }
-        catch ( IndexNotFoundException e )
-        {
-            throw new RepositoryNotFoundException( repositoryId );
-        }
-        if ( !rootExists )
-        {
-            throw new BranchNotFoundException( branch );
-        }
+        NodeHelper.verifyBranchExists( this.nodeStorageService, repositoryId, branch );
     }
 
     private PatchNodeParams convertUpdateParams( final UpdateNodeParams params )

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/NodeServiceImplTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/node/NodeServiceImplTest.java
@@ -435,6 +435,28 @@ class NodeServiceImplTest
     }
 
     @Test
+    void create_repo_non_existing()
+    {
+        final CreateNodeParams params = CreateNodeParams.create().name( "my-node" ).parent( NodePath.ROOT ).build();
+
+        assertThrows( RepositoryNotFoundException.class, () -> ContextBuilder.from( ContextAccessor.current() )
+            .repositoryId( "missing-repo" )
+            .build()
+            .callWith( () -> this.nodeService.create( params ) ) );
+    }
+
+    @Test
+    void create_branch_non_existing()
+    {
+        final CreateNodeParams params = CreateNodeParams.create().name( "my-node" ).parent( NodePath.ROOT ).build();
+
+        assertThrows( BranchNotFoundException.class, () -> ContextBuilder.from( ContextAccessor.current() )
+            .branch( "missing-branch" )
+            .build()
+            .callWith( () -> this.nodeService.create( params ) ) );
+    }
+
+    @Test
     void test_duplicate_binary()
     {
         final PropertyTree data = new PropertyTree();


### PR DESCRIPTION
Performance of the two hottest root-node touches, plus a behaviour pin. Four commits:

1. **Pin node create behaviour for missing repository and branch** — `NodeServiceImplTest` covered `getById` against a missing repository and branch but not `create`, leaving the exception it reports unspecified. The pin comes first so the next commit demonstrably changes nothing observable.
2. **Verify the branch on the node create path only when it fails** — every node service method verified branch existence up front, which for create meant a storage lookup of the root node on top of the parent it reads anyway. The lookup now happens only once a parent turns out to be missing, where it tells a missing branch from a missing parent; a missing repository keeps being reported as such rather than as the index error underneath. The guard moves to `NodeHelper` so the service and the create command share one copy.
3. **Answer the root path from the node id it always has** — resolving a path asks the branch index which node holds it, and caches the answer; the root path needs neither, since the root node keeps the one id known without lookup and can be neither moved nor deleted. Previously an uncached root path refreshed the storage index and searched it, and a cached one resolved inside the path cache's atomic block — serializing every concurrent lookup of the busiest path in the repository across a storage round trip.
4. **Drop javadoc from internal node and branch methods** — cleanup on the internals the two changes touched.

An earlier revision also fixed `resolvePotentialManualOrderValue` ignoring a manually ordered root; that fix is deliberately dropped from this PR — legacy manual ordering under root stays as it was, and root ordering is handled by the order-key work in #12285 instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANkY5TN9xn2cFKHk1sfX4B