### PR TITLE
Prototype: dense order key codec for manual ordering

### DIFF
--- a/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/orderkey/OrderKeyCodec.java
+++ b/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/orderkey/OrderKeyCodec.java
@@ -1,0 +1,320 @@
+package com.enonic.xp.core.internal.orderkey;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Random;
+import java.util.random.RandomGenerator;
+
+/**
+ * Mints and manipulates dense order keys. A key is {@code position '.' discriminator}: the position is a base-62 fraction
+ * whose digits sort lexicographically in value order, and the discriminator - the id of the node holding the key - makes
+ * two live keys unequal by construction, so independently minted keys never collide when sibling sets from different
+ * branches or layers merge. The separator sorts below every digit, which keeps a position that extends another sorting
+ * after it, the way the longer fraction is the larger number.
+ * <p>
+ * A birth position encodes the inverted creation instant, so a fresh key sorts before every older one under ascending
+ * order: creation and move-to-first are the same operation and need no reads. The relative operations take the anchor
+ * keys the caller already holds and never look at the rest of the sibling set; a position between two others always
+ * exists, so no operation renumbers existing keys.
+ * <p>
+ * Instances are as thread-safe as the generator they are given.
+ */
+public final class OrderKeyCodec
+{
+    static final String ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    static final char SEPARATOR = '.';
+
+    static final int MAX_POSITION_LENGTH = 512;
+
+    static final int MAX_DISCRIMINATOR_LENGTH = 64;
+
+    private static final int RADIX = 62;
+
+    private static final BigInteger RADIX_BIG = BigInteger.valueOf( RADIX );
+
+    private static final int INSTANT_DIGITS = 6;
+
+    private static final int JITTER_DIGITS = 3;
+
+    /**
+     * 62^6 - 1. Instants up to this many epoch seconds (year 3769) fit the instant digits.
+     */
+    private static final long MAX_SECONDS = 56_800_235_583L;
+
+    private static final int JITTER_BOUND = RADIX * RADIX * RADIX;
+
+    /**
+     * Steps and picks never work at a scale coarser than a birth position, whatever length canonical stripping left the
+     * anchor with: a digit of scale is precision, not magnitude, and a step taken at the length of a stripped position
+     * would be coarser than the space it moves in.
+     */
+    private static final int MIN_SCALE = INSTANT_DIGITS + JITTER_DIGITS;
+
+    /**
+     * A relative step stays within this many units of the last digit of the anchor, so a run of steps in one direction
+     * consumes the space linearly instead of halving it.
+     */
+    private static final int STEP_BOUND = 8;
+
+    private static final int[] DIGIT_VALUES = new int[128];
+
+    static
+    {
+        java.util.Arrays.fill( DIGIT_VALUES, -1 );
+        for ( int i = 0; i < ALPHABET.length(); i++ )
+        {
+            DIGIT_VALUES[ALPHABET.charAt( i )] = i;
+        }
+    }
+
+    private final RandomGenerator random;
+
+    private final Random randomAdapter;
+
+    public OrderKeyCodec( final RandomGenerator random )
+    {
+        this.random = random;
+        this.randomAdapter = Random.from( random );
+    }
+
+    public String initial( final Instant instant, final String discriminator )
+    {
+        requireValidDiscriminator( discriminator );
+        final long seconds = instant.getEpochSecond();
+        if ( seconds < 0 || seconds >= MAX_SECONDS )
+        {
+            throw new IllegalArgumentException( "Instant out of order key range: " + instant );
+        }
+
+        final StringBuilder position = new StringBuilder( INSTANT_DIGITS + JITTER_DIGITS );
+        appendDigits( position, MAX_SECONDS - seconds, INSTANT_DIGITS );
+        appendDigits( position, random.nextInt( JITTER_BOUND ), JITTER_DIGITS );
+
+        return key( canonical( position.toString() ), discriminator );
+    }
+
+    public String between( final String keyA, final String keyB, final String discriminator )
+    {
+        requireValidDiscriminator( discriminator );
+        final String positionA = positionOf( keyA );
+        final String positionB = positionOf( keyB );
+        if ( keyA.compareTo( keyB ) >= 0 )
+        {
+            throw new IllegalArgumentException( "Anchors out of order" );
+        }
+
+        if ( positionA.equals( positionB ) )
+        {
+            // Two keys share a position only when they differ by discriminator alone, and no third discriminator can be
+            // chosen to land between them. The new key extends the shared position instead, which places it directly
+            // after both anchors - adjacent to where it was asked to go.
+            return key( canonical( positionA + ALPHABET.charAt( 1 + random.nextInt( RADIX - 1 ) ) ), discriminator );
+        }
+
+        final int full = Math.max( positionA.length(), positionB.length() ) + 1;
+        final BigInteger valueA = valueAt( positionA, full );
+        final BigInteger valueB = valueAt( positionB, full );
+
+        // The pick is made at the coarsest scale whose floors already leave room, so a wide gap yields a short position
+        // and the length of a key reflects how contended its spot is, not how deep its anchors happened to be.
+        int scale = commonPrefixLength( positionA, positionB ) + 1;
+        BigInteger floorA;
+        BigInteger floorB;
+        while ( true )
+        {
+            final BigInteger unit = RADIX_BIG.pow( full - scale );
+            floorA = valueA.divide( unit );
+            floorB = valueB.divide( unit );
+            if ( floorB.subtract( floorA ).compareTo( BigInteger.TWO ) >= 0 )
+            {
+                break;
+            }
+            scale++;
+        }
+
+        final BigInteger gap = floorB.subtract( floorA ).subtract( BigInteger.ONE );
+        final BigInteger picked = floorA.add( BigInteger.ONE ).add( uniform( gap ) );
+
+        return key( canonical( render( picked, scale ) ), discriminator );
+    }
+
+    public String after( final String key, final String discriminator )
+    {
+        requireValidDiscriminator( discriminator );
+        final String position = positionOf( key );
+
+        int scale = Math.max( position.length(), MIN_SCALE );
+        BigInteger value = valueAt( position, scale );
+        final BigInteger step = BigInteger.valueOf( 1 + random.nextInt( STEP_BOUND ) );
+
+        BigInteger stepped = value.add( step );
+        while ( stepped.compareTo( RADIX_BIG.pow( scale ) ) >= 0 )
+        {
+            scale++;
+            value = value.multiply( RADIX_BIG );
+            stepped = value.add( step );
+        }
+
+        return key( canonical( render( stepped, scale ) ), discriminator );
+    }
+
+    public String before( final String key, final String discriminator )
+    {
+        requireValidDiscriminator( discriminator );
+        final String position = positionOf( key );
+
+        int scale = Math.max( position.length(), MIN_SCALE );
+        BigInteger value = valueAt( position, scale );
+        final BigInteger step = BigInteger.valueOf( 1 + random.nextInt( STEP_BOUND ) );
+
+        while ( value.compareTo( step ) <= 0 )
+        {
+            scale++;
+            value = value.multiply( RADIX_BIG );
+        }
+
+        return key( canonical( render( value.subtract( step ), scale ) ), discriminator );
+    }
+
+    /**
+     * Validates a key of unknown origin, returning it unchanged. The position must be canonical - no trailing zero
+     * digit, so that the space directly after it stays mintable - and both parts must fit the size caps that keep a
+     * hostile key from growing the index.
+     */
+    public static String requireValidKey( final String key )
+    {
+        final int separator = key.indexOf( SEPARATOR );
+        if ( separator < 1 )
+        {
+            throw new IllegalArgumentException( "Order key without position" );
+        }
+        positionOf( key );
+        requireValidDiscriminator( key.substring( separator + 1 ) );
+        return key;
+    }
+
+    private static String positionOf( final String key )
+    {
+        final int separator = key.indexOf( SEPARATOR );
+        if ( separator < 1 )
+        {
+            throw new IllegalArgumentException( "Order key without position" );
+        }
+        final String position = key.substring( 0, separator );
+        if ( position.length() > MAX_POSITION_LENGTH )
+        {
+            throw new IllegalArgumentException( "Order key position too long: " + position.length() );
+        }
+        for ( int i = 0; i < position.length(); i++ )
+        {
+            final char c = position.charAt( i );
+            if ( c >= DIGIT_VALUES.length || DIGIT_VALUES[c] < 0 )
+            {
+                throw new IllegalArgumentException( "Invalid order key digit: " + c );
+            }
+        }
+        if ( position.charAt( position.length() - 1 ) == ALPHABET.charAt( 0 ) )
+        {
+            throw new IllegalArgumentException( "Order key position not canonical" );
+        }
+        return position;
+    }
+
+    private static void requireValidDiscriminator( final String discriminator )
+    {
+        if ( discriminator == null || discriminator.isEmpty() || discriminator.length() > MAX_DISCRIMINATOR_LENGTH )
+        {
+            throw new IllegalArgumentException( "Invalid order key discriminator" );
+        }
+    }
+
+    private static String key( final String position, final String discriminator )
+    {
+        return position + SEPARATOR + discriminator;
+    }
+
+    private static String canonical( final String position )
+    {
+        int end = position.length();
+        while ( end > 0 && position.charAt( end - 1 ) == ALPHABET.charAt( 0 ) )
+        {
+            end--;
+        }
+        if ( end == 0 )
+        {
+            throw new IllegalArgumentException( "Order key position collapsed to zero" );
+        }
+        if ( end > MAX_POSITION_LENGTH )
+        {
+            throw new IllegalStateException( "Order key space exhausted at this spot" );
+        }
+        return position.substring( 0, end );
+    }
+
+    private static BigInteger valueAt( final String position, final int scale )
+    {
+        BigInteger value = BigInteger.ZERO;
+        for ( int i = 0; i < position.length(); i++ )
+        {
+            value = value.multiply( RADIX_BIG ).add( BigInteger.valueOf( DIGIT_VALUES[position.charAt( i )] ) );
+        }
+        return value.multiply( RADIX_BIG.pow( scale - position.length() ) );
+    }
+
+    private static String render( final BigInteger value, final int scale )
+    {
+        final char[] digits = new char[scale];
+        BigInteger remaining = value;
+        for ( int i = scale - 1; i >= 0; i-- )
+        {
+            final BigInteger[] divmod = remaining.divideAndRemainder( RADIX_BIG );
+            digits[i] = ALPHABET.charAt( divmod[1].intValue() );
+            remaining = divmod[0];
+        }
+        if ( remaining.signum() != 0 )
+        {
+            throw new IllegalStateException( "Order key position overflow" );
+        }
+        return new String( digits );
+    }
+
+    private BigInteger uniform( final BigInteger bound )
+    {
+        if ( bound.signum() <= 0 )
+        {
+            return BigInteger.ZERO;
+        }
+        final int bits = bound.bitLength();
+        BigInteger picked;
+        do
+        {
+            picked = new BigInteger( bits, randomAdapter );
+        }
+        while ( picked.compareTo( bound ) >= 0 );
+        return picked;
+    }
+
+    private static int commonPrefixLength( final String positionA, final String positionB )
+    {
+        final int limit = Math.min( positionA.length(), positionB.length() );
+        int i = 0;
+        while ( i < limit && positionA.charAt( i ) == positionB.charAt( i ) )
+        {
+            i++;
+        }
+        return i;
+    }
+
+    private static void appendDigits( final StringBuilder builder, final long value, final int count )
+    {
+        long remaining = value;
+        final int offset = builder.length();
+        builder.setLength( offset + count );
+        for ( int i = count - 1; i >= 0; i-- )
+        {
+            builder.setCharAt( offset + i, ALPHABET.charAt( (int) ( remaining % RADIX ) ) );
+            remaining /= RADIX;
+        }
+    }
+}

--- a/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/orderkey/OrderKeyTokenCodec.java
+++ b/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/orderkey/OrderKeyTokenCodec.java
@@ -1,0 +1,127 @@
+package com.enonic.xp.core.internal.orderkey;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.HexFormat;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Wraps order keys into the tokens that leave the server and verifies the tokens that come back. The key itself is
+ * stored and indexed plain; only the wire form carries a tag, so a client can replay positions it was handed - anchors
+ * for a reorder - but cannot mint one, which keeps exact placement values out of reach of standard means. The tag binds
+ * the scope the token was issued under, so a token cannot wander to another parent, and the leading version character
+ * lets the scheme change without anything stored to migrate.
+ * <p>
+ * The tag is a truncated HMAC-SHA512 under a subkey derived once from a master key, the same construction the redirect
+ * checksums use; the master key is never spent per token, and the derivation separates this use of it from theirs.
+ */
+public final class OrderKeyTokenCodec
+{
+    private static final char VERSION = '1';
+
+    private static final char TAG_SEPARATOR = '~';
+
+    private static final int TAG_HEX_LENGTH = 16;
+
+    private static final int TAG_BYTES = TAG_HEX_LENGTH / 2;
+
+    private static final String ALGORITHM = "HmacSHA512";
+
+    private static final int MAX_TOKEN_LENGTH =
+        2 + OrderKeyCodec.MAX_POSITION_LENGTH + 1 + OrderKeyCodec.MAX_DISCRIMINATOR_LENGTH + 1 + TAG_HEX_LENGTH;
+
+    private final SecretKeySpec subkey;
+
+    public OrderKeyTokenCodec( final byte[] subkey )
+    {
+        if ( subkey == null || subkey.length != 16 )
+        {
+            throw new IllegalArgumentException( "Order key token subkey must be 16 bytes" );
+        }
+        this.subkey = new SecretKeySpec( subkey, ALGORITHM );
+    }
+
+    /**
+     * Derives the token subkey from a master key, so the master key itself is used once per JVM rather than once per
+     * token, and a derived key cannot be walked back to it.
+     */
+    public static byte[] deriveSubkey( final byte[] masterKey, final String context )
+    {
+        try
+        {
+            final Mac mac = Mac.getInstance( ALGORITHM );
+            mac.init( new SecretKeySpec( masterKey, ALGORITHM ) );
+            final byte[] derived = mac.doFinal( context.getBytes( StandardCharsets.UTF_8 ) );
+            final byte[] subkey = new byte[16];
+            System.arraycopy( derived, 0, subkey, 0, 16 );
+            return subkey;
+        }
+        catch ( NoSuchAlgorithmException | InvalidKeyException e )
+        {
+            throw new IllegalStateException( e );
+        }
+    }
+
+    public String mint( final String key, final String scope )
+    {
+        OrderKeyCodec.requireValidKey( key );
+        return VERSION + key + TAG_SEPARATOR + HexFormat.of().formatHex( tag( key, scope ) );
+    }
+
+    /**
+     * Verifies a token and returns the key it carries. Rejection reports what failed structurally but never which tag
+     * was expected.
+     */
+    public String parse( final String token, final String scope )
+    {
+        if ( token == null || token.length() > MAX_TOKEN_LENGTH )
+        {
+            throw new IllegalArgumentException( "Invalid order key token" );
+        }
+        if ( token.length() < 1 + 1 + 1 + 1 + TAG_HEX_LENGTH || token.charAt( 0 ) != VERSION )
+        {
+            throw new IllegalArgumentException( "Invalid order key token" );
+        }
+        final int tagStart = token.length() - TAG_HEX_LENGTH;
+        if ( token.charAt( tagStart - 1 ) != TAG_SEPARATOR )
+        {
+            throw new IllegalArgumentException( "Invalid order key token" );
+        }
+
+        final String key = token.substring( 1, tagStart - 1 );
+        OrderKeyCodec.requireValidKey( key );
+
+        final byte[] expected = HexFormat.of().formatHex( tag( key, scope ) ).getBytes( StandardCharsets.ISO_8859_1 );
+        final byte[] presented = token.substring( tagStart ).toLowerCase().getBytes( StandardCharsets.ISO_8859_1 );
+        if ( !MessageDigest.isEqual( expected, presented ) )
+        {
+            throw new IllegalArgumentException( "Order key token rejected" );
+        }
+        return key;
+    }
+
+    private byte[] tag( final String key, final String scope )
+    {
+        final byte[] scopeBytes = scope.getBytes( StandardCharsets.UTF_8 );
+        final byte[] keyBytes = key.getBytes( StandardCharsets.UTF_8 );
+        final byte[] message = new byte[1 + scopeBytes.length + 1 + keyBytes.length];
+        message[0] = VERSION;
+        System.arraycopy( scopeBytes, 0, message, 1, scopeBytes.length );
+        System.arraycopy( keyBytes, 0, message, 1 + scopeBytes.length + 1, keyBytes.length );
+        try
+        {
+            final Mac mac = Mac.getInstance( ALGORITHM );
+            mac.init( subkey );
+            return Arrays.copyOf( mac.doFinal( message ), TAG_BYTES );
+        }
+        catch ( NoSuchAlgorithmException | InvalidKeyException e )
+        {
+            throw new IllegalStateException( e );
+        }
+    }
+}

--- a/modules/core/core-internal/src/test/java/com/enonic/xp/core/internal/orderkey/OrderKeyCodecTest.java
+++ b/modules/core/core-internal/src/test/java/com/enonic/xp/core/internal/orderkey/OrderKeyCodecTest.java
@@ -1,0 +1,195 @@
+package com.enonic.xp.core.internal.orderkey;
+
+import java.time.Instant;
+import java.util.SplittableRandom;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OrderKeyCodecTest
+{
+    private static final Instant T0 = Instant.parse( "2026-08-23T12:00:00Z" );
+
+    private final OrderKeyCodec codec = new OrderKeyCodec( new SplittableRandom( 42 ) );
+
+    @Test
+    void alphabet_matches_string_order()
+    {
+        for ( int i = 1; i < OrderKeyCodec.ALPHABET.length(); i++ )
+        {
+            assertTrue( OrderKeyCodec.ALPHABET.charAt( i - 1 ) < OrderKeyCodec.ALPHABET.charAt( i ) );
+        }
+        assertTrue( OrderKeyCodec.SEPARATOR < OrderKeyCodec.ALPHABET.charAt( 0 ) );
+    }
+
+    @Test
+    void initial_sorts_newest_first()
+    {
+        String previous = codec.initial( T0, "a" );
+        for ( int i = 1; i <= 1000; i++ )
+        {
+            final String next = codec.initial( T0.plusSeconds( i ), "a" );
+            assertTrue( next.compareTo( previous ) < 0, "later instant must sort first" );
+            previous = next;
+        }
+    }
+
+    @Test
+    void same_instant_same_jitter_still_distinct_keys()
+    {
+        final String keyA = new OrderKeyCodec( new SplittableRandom( 7 ) ).initial( T0, "node-a" );
+        final String keyB = new OrderKeyCodec( new SplittableRandom( 7 ) ).initial( T0, "node-b" );
+        assertEquals( positionOf( keyA ), positionOf( keyB ), "identical seed and instant collide on position" );
+        assertNotEquals( keyA, keyB, "discriminator keeps full keys distinct" );
+    }
+
+    @Test
+    void between_stays_strictly_between_under_random_nesting()
+    {
+        String lo = codec.initial( T0.plusSeconds( 3600 ), "lo" );
+        String hi = codec.initial( T0, "hi" );
+        final SplittableRandom sides = new SplittableRandom( 1 );
+        for ( int i = 0; i < 1500; i++ )
+        {
+            final String picked = codec.between( lo, hi, "n" + i );
+            assertTrue( lo.compareTo( picked ) < 0, "not above lower anchor at step " + i );
+            assertTrue( picked.compareTo( hi ) < 0, "not below upper anchor at step " + i );
+            assertDoesNotThrow( () -> OrderKeyCodec.requireValidKey( picked ) );
+            if ( sides.nextBoolean() )
+            {
+                lo = picked;
+            }
+            else
+            {
+                hi = picked;
+            }
+        }
+    }
+
+    @Test
+    void adversarial_nesting_survives_hundreds_of_levels_then_fails_clean()
+    {
+        String lo = codec.initial( T0.plusSeconds( 3600 ), "lo" );
+        String hi = codec.initial( T0, "hi" );
+        int depth = 0;
+        try
+        {
+            for ( ; depth < 4000; depth++ )
+            {
+                hi = codec.between( lo, hi, "n" + depth );
+            }
+        }
+        catch ( IllegalStateException e )
+        {
+            // the clean refusal once the capped position length is exhausted at one spot
+        }
+        assertTrue( depth >= 1000, "expected at least 1000 nested inserts into one gap, got " + depth );
+    }
+
+    @Test
+    void after_run_keeps_length_stable()
+    {
+        String key = codec.initial( T0, "n" );
+        final int initialLength = positionOf( key ).length();
+        for ( int i = 0; i < 10_000; i++ )
+        {
+            final String next = codec.after( key, "n" );
+            assertTrue( next.compareTo( key ) > 0, "after must sort after, step " + i );
+            key = next;
+        }
+        assertTrue( positionOf( key ).length() <= initialLength + 1,
+                    "a run in one direction must consume space linearly, not by length" );
+    }
+
+    @Test
+    void before_run_keeps_length_stable()
+    {
+        String key = codec.initial( T0, "n" );
+        final int initialLength = positionOf( key ).length();
+        for ( int i = 0; i < 10_000; i++ )
+        {
+            final String next = codec.before( key, "n" );
+            assertTrue( next.compareTo( key ) < 0, "before must sort before, step " + i );
+            key = next;
+        }
+        assertTrue( positionOf( key ).length() <= initialLength + 1 );
+    }
+
+    @Test
+    void before_near_zero_scales_instead_of_underflowing()
+    {
+        String key = "1.n";
+        for ( int i = 0; i < 100; i++ )
+        {
+            final String next = codec.before( key, "n" );
+            assertTrue( next.compareTo( key ) < 0 );
+            assertDoesNotThrow( () -> OrderKeyCodec.requireValidKey( next ) );
+            key = next;
+        }
+    }
+
+    @Test
+    void between_equal_positions_lands_directly_after_the_anchors()
+    {
+        final String keyA = "AB3.node-1";
+        final String keyB = "AB3.node-2";
+        final String picked = codec.between( keyA, keyB, "node-3" );
+        assertTrue( picked.compareTo( keyB ) > 0, "no key fits between equal positions; adjacency is the contract" );
+        assertDoesNotThrow( () -> OrderKeyCodec.requireValidKey( picked ) );
+    }
+
+    @Test
+    void independent_writers_never_collide_on_the_same_anchors()
+    {
+        final String lo = codec.initial( T0.plusSeconds( 60 ), "lo" );
+        final String hi = codec.initial( T0, "hi" );
+        final OrderKeyCodec writerA = new OrderKeyCodec( new SplittableRandom( 5 ) );
+        final OrderKeyCodec writerB = new OrderKeyCodec( new SplittableRandom( 5 ) );
+        final String keyA = writerA.between( lo, hi, "node-a" );
+        final String keyB = writerB.between( lo, hi, "node-b" );
+        assertEquals( positionOf( keyA ), positionOf( keyB ), "identical seeds collide on position" );
+        assertNotEquals( keyA, keyB );
+        assertTrue( lo.compareTo( keyA ) < 0 && keyA.compareTo( hi ) < 0 );
+        assertTrue( lo.compareTo( keyB ) < 0 && keyB.compareTo( hi ) < 0 );
+    }
+
+    @Test
+    void anchors_out_of_order_are_rejected()
+    {
+        final String newer = codec.initial( T0.plusSeconds( 60 ), "a" );
+        final String older = codec.initial( T0, "b" );
+        assertThrows( IllegalArgumentException.class, () -> codec.between( older, newer, "c" ) );
+    }
+
+    @Test
+    void validation_rejects_malformed_keys()
+    {
+        assertThrows( IllegalArgumentException.class, () -> OrderKeyCodec.requireValidKey( "A0.x" ) );
+        assertThrows( IllegalArgumentException.class, () -> OrderKeyCodec.requireValidKey( "A" ) );
+        assertThrows( IllegalArgumentException.class, () -> OrderKeyCodec.requireValidKey( ".x" ) );
+        assertThrows( IllegalArgumentException.class, () -> OrderKeyCodec.requireValidKey( "A!.x" ) );
+        assertThrows( IllegalArgumentException.class, () -> OrderKeyCodec.requireValidKey( "A." ) );
+        assertThrows( IllegalArgumentException.class,
+                      () -> OrderKeyCodec.requireValidKey( "A".repeat( 512 ) + "1.x" ) );
+        assertThrows( IllegalArgumentException.class, () -> OrderKeyCodec.requireValidKey( "A1." + "x".repeat( 65 ) ) );
+        assertDoesNotThrow( () -> OrderKeyCodec.requireValidKey( "A1.x" ) );
+        assertDoesNotThrow( () -> OrderKeyCodec.requireValidKey( codec.initial( T0, "node-id" ) ) );
+    }
+
+    @Test
+    void instants_outside_the_encodable_range_are_rejected()
+    {
+        assertThrows( IllegalArgumentException.class, () -> codec.initial( Instant.ofEpochSecond( -1 ), "a" ) );
+        assertThrows( IllegalArgumentException.class, () -> codec.initial( Instant.parse( "4000-01-01T00:00:00Z" ), "a" ) );
+    }
+
+    private static String positionOf( final String key )
+    {
+        return key.substring( 0, key.indexOf( OrderKeyCodec.SEPARATOR ) );
+    }
+}

--- a/modules/core/core-internal/src/test/java/com/enonic/xp/core/internal/orderkey/OrderKeyTokenCodecTest.java
+++ b/modules/core/core-internal/src/test/java/com/enonic/xp/core/internal/orderkey/OrderKeyTokenCodecTest.java
@@ -1,0 +1,105 @@
+package com.enonic.xp.core.internal.orderkey;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OrderKeyTokenCodecTest
+{
+    private static final byte[] REFERENCE_SUBKEY =
+        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+
+    private final OrderKeyTokenCodec codec = new OrderKeyTokenCodec(
+        OrderKeyTokenCodec.deriveSubkey( "master-key".getBytes( StandardCharsets.UTF_8 ), "orderkey-token-v1" ) );
+
+    @Test
+    void golden_token_matches_independent_reference_implementation()
+    {
+        final OrderKeyTokenCodec reference = new OrderKeyTokenCodec( REFERENCE_SUBKEY );
+        assertEquals( "1A1b2C3.node-id~9222f4974cff8fae", reference.mint( "A1b2C3.node-id", "parent" ) );
+    }
+
+    @Test
+    void roundtrip()
+    {
+        final String key = "A1b2C3.node-id";
+        assertEquals( key, codec.parse( codec.mint( key, "parent-id" ), "parent-id" ) );
+    }
+
+    @Test
+    void tag_verification_is_case_insensitive()
+    {
+        final String token = codec.mint( "A1b2C3.node-id", "parent-id" );
+        final int tail = token.length() - 16;
+        final String upper = token.substring( 0, tail ) + token.substring( tail ).toUpperCase();
+        assertEquals( "A1b2C3.node-id", codec.parse( upper, "parent-id" ) );
+    }
+
+    @Test
+    void rejects_wrong_scope()
+    {
+        final String token = codec.mint( "A1b2C3.node-id", "parent-id" );
+        assertThrows( IllegalArgumentException.class, () -> codec.parse( token, "other-parent" ) );
+    }
+
+    @Test
+    void rejects_tampered_key()
+    {
+        final String token = codec.mint( "A1b2C3.node-id", "parent-id" );
+        final String tampered = token.replace( "A1b2C3", "B1b2C3" );
+        assertThrows( IllegalArgumentException.class, () -> codec.parse( tampered, "parent-id" ) );
+    }
+
+    @Test
+    void rejects_tampered_tag()
+    {
+        final String token = codec.mint( "A1b2C3.node-id", "parent-id" );
+        final char last = token.charAt( token.length() - 1 );
+        final String tampered = token.substring( 0, token.length() - 1 ) + ( last == '0' ? '1' : '0' );
+        assertThrows( IllegalArgumentException.class, () -> codec.parse( tampered, "parent-id" ) );
+    }
+
+    @Test
+    void rejects_structural_garbage()
+    {
+        assertThrows( IllegalArgumentException.class, () -> codec.parse( null, "p" ) );
+        assertThrows( IllegalArgumentException.class, () -> codec.parse( "", "p" ) );
+        assertThrows( IllegalArgumentException.class, () -> codec.parse( "garbage", "p" ) );
+        final String token = codec.mint( "A1b2C3.node-id", "p" );
+        assertThrows( IllegalArgumentException.class, () -> codec.parse( token.substring( 0, token.length() - 1 ), "p" ) );
+        assertThrows( IllegalArgumentException.class, () -> codec.parse( '2' + token.substring( 1 ), "p" ) );
+        assertThrows( IllegalArgumentException.class, () -> codec.parse( "1" + "A".repeat( 600 ) + "~0011223344556677", "p" ) );
+    }
+
+    @Test
+    void rejects_token_from_a_different_subkey()
+    {
+        final OrderKeyTokenCodec other = new OrderKeyTokenCodec(
+            OrderKeyTokenCodec.deriveSubkey( "other-master".getBytes( StandardCharsets.UTF_8 ), "orderkey-token-v1" ) );
+        final String token = other.mint( "A1b2C3.node-id", "parent-id" );
+        assertThrows( IllegalArgumentException.class, () -> codec.parse( token, "parent-id" ) );
+    }
+
+    @Test
+    void subkey_derivation_is_deterministic_and_context_separated()
+    {
+        final byte[] master = "master-key".getBytes( StandardCharsets.UTF_8 );
+        final byte[] first = OrderKeyTokenCodec.deriveSubkey( master, "orderkey-token-v1" );
+        final byte[] again = OrderKeyTokenCodec.deriveSubkey( master, "orderkey-token-v1" );
+        final byte[] other = OrderKeyTokenCodec.deriveSubkey( master, "other-context" );
+        assertEquals( 16, first.length );
+        assertEquals( java.util.Arrays.toString( first ), java.util.Arrays.toString( again ) );
+        assertFalse( java.util.Arrays.equals( first, other ) );
+    }
+
+    @Test
+    void mint_refuses_invalid_keys()
+    {
+        assertThrows( IllegalArgumentException.class, () -> codec.mint( "A0.x", "p" ) );
+        assertThrows( IllegalArgumentException.class, () -> codec.mint( "no-separator", "p" ) );
+    }
+}


### PR DESCRIPTION
Prototype of the core primitive for a new manual-ordering scheme, developed in design discussion with @sry-enonic. Self-contained in `core-internal`, nothing wired to storage or API — the point of this PR is the algorithm and its properties, reviewable in isolation.

## What it replaces, eventually

`_manualordervalue` resolves each value against the sibling set and splits fixed gaps:

- assigning a value queries neighbors (refresh + search on the create path);
- `between()` halves a `2^31` gap — **30 targeted inserts into one slot, then it silently mints an exact duplicate of the lower neighbor**;
- the allocator is deterministic, so two branches performing the same insertion mint the **identical value by construction** and collide when sibling sets merge (observed in production);
- switching a parent to manual order rewrites every child to seed values.

## The primitive

An order key is `position '.' discriminator`, stored plain, sorted lexicographically (ES `not_analyzed` string semantics):

- **position** — base-62 fraction, digits sort in value order; the separator sorts below every digit so a longer fraction sorts after its prefix, matching numeric order;
- **discriminator** — the id of the node holding the key: two live keys are unequal *by construction*, whatever branch, layer or server minted them — collision-freedom without coordination or a site registry (Logoot with site = the node itself);
- **birth key** encodes the inverted creation instant: creation and move-to-first are the same zero-read operation, and un-reordered siblings keep today's newest-first order;
- **between/before/after** need only the anchor keys the caller already holds — no sibling load, no rebalancing ever (dense keys), no renumbering of untouched nodes;
- a directional run consumes space **linearly** (boundary steps), not by halving: 10 000 inserts in one direction leave the position length unchanged (test);
- targeted hammering of one gap survives **1000+ levels** and then fails with a clean exception at the position-length cap instead of corrupting (test) — versus 30-then-silent-duplicate today.

## The token layer

Keys leave the server wrapped: `'1' + key + '~' + 16 hex chars of truncated HMAC-SHA512` under a subkey derived once from a master key, bound to the scope (parent) the token was issued under — the same construction `RedirectChecksumService` already uses, with a derivation step separating the two uses of the master key. Clients can replay positions they were handed — anchors for a reorder — but cannot mint one, so exact placement stays out of reach of standard means. Wrong scope, wrong version, truncation, tampering and oversize are each rejected; the stored key never carries the tag.

The golden-token test pins the exact wire format against an independently computed reference value, so the tag implementation can change without ambiguity about compatibility. (Earlier revisions of this branch used a hand-written SipHash-2-4 for per-item speed; with token minting scoped to reorder-capable listings only, the standard platform MAC costs the same in practice and the hand-written primitive was dropped.)

## Not in this PR

Storage wiring, `_orderkey` mapping/field, `ChildOrder` integration (the stored childOrder expression is the intended per-parent migration flag), API surface, key-node lookup for the master key (`/keys/generic-hmac-sha512`), migration of existing manually-ordered parents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANkY5TN9xn2cFKHk1sfX4B