### PR TITLE
app.config conversion and read-only app on GraalJS #12304 #12306

### DIFF
--- a/modules/lib/core/index.d.ts
+++ b/modules/lib/core/index.d.ts
@@ -16,19 +16,21 @@ declare global {
     type XpMixin = Record<string, Record<string, Record<string, unknown>>>;
 }
 
+export type AppConfig = Readonly<Record<string, string | undefined>>;
+
 export interface App {
     /**
      * The name of the application.
      *
      * @type string
      */
-    name: string;
+    readonly name: string;
     /**
      * Version of the application.
      *
      * @type string
      */
-    version: string;
+    readonly version: string;
     /**
      * Values from the application’s configuration file.
      * This can be set using $XP_HOME/config/<app.name>.cfg.
@@ -36,7 +38,7 @@ export interface App {
      *
      * @type Object
      */
-    config: Record<string, string | undefined>;
+    readonly config: AppConfig;
 }
 
 export interface DoubleUnderscore {

--- a/modules/lib/jsdoc/global.js
+++ b/modules/lib/jsdoc/global.js
@@ -54,6 +54,7 @@ var app = {
      * Name of application.
      *
      * @type string
+     * @readonly
      */
     name: '',
 
@@ -61,6 +62,7 @@ var app = {
      * Application version.
      *
      * @type string
+     * @readonly
      */
     version: '',
 
@@ -69,7 +71,9 @@ var app = {
      * $XP_HOME/config/<app-name>.cfg.
      *
      * @type Object
+     * @readonly
      */
+    config: {}
 };
 
 /**

--- a/modules/lib/test/App.test-d.ts
+++ b/modules/lib/test/App.test-d.ts
@@ -1,0 +1,21 @@
+import type {App} from '../core/index';
+
+import {
+    expectError,
+    expectType,
+} from 'tsd';
+
+declare global {
+    // Ignore this error in code editor, it's needed when running the tests.
+    const app: App;
+}
+
+// The reads come first: assigning to app.config['someKey'] below narrows it to string.
+expectType<string>(app.name);
+expectType<string>(app.version);
+expectType<string | undefined>(app.config['someKey']);
+
+expectError(app.name = 'com.enonic.app.name');
+expectError(app.version = '1.0.0');
+expectError(app.config = {});
+expectError(app.config['someKey'] = 'someValue');

--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/graal/executor/GraalScriptExecutor.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/graal/executor/GraalScriptExecutor.java
@@ -59,6 +59,26 @@ public class GraalScriptExecutor
 
     private static final long SLOT_WAIT_SECONDS = 300;
 
+    private static final Source READ_ONLY_APP_SCRIPT = Source.newBuilder( "js", "(function() {" +
+        "const readOnly = function( target, label ) {" +
+        "const deny = function( property ) {" +
+        "throw new TypeError( \"Cannot assign to read only property '\" + String( property ) + \"' of \" + label );" +
+        "};" +
+        "return new Proxy( Object.freeze( target ), {" +
+        "set: function( target, property ) { deny( property ); }," +
+        "defineProperty: function( target, property ) { deny( property ); }," +
+        "deleteProperty: function( target, property ) { deny( property ); } } );" +
+        "};" +
+        "const source = globalThis.app;" +
+        "source.config = readOnly( source.config, 'app.config' );" +
+        "const app = readOnly( source, 'app' );" +
+        "Object.defineProperty( globalThis, 'app', {" +
+        "get: function() { return app; }," +
+        "set: function() { throw new TypeError( \"Cannot assign to read only property 'app' of global\" ); }," +
+        "enumerable: true," +
+        "configurable: false } );" +
+        "})();", "read-only-app" ).buildLiteral();
+
     private final ScriptSettings scriptSettings;
 
     private final ClassLoader classLoader;
@@ -872,7 +892,7 @@ public class GraalScriptExecutor
             final Map<String, Object> globalVariables = new HashMap<>( scriptSettings.getGlobalVariables() );
             globalVariables.put( "app", this.javascriptHelper.objectConverter().toJs( application.buildMap( HashMap::new ) ) );
             globalVariables.forEach( ( key, value ) -> this.context.getBindings( "js" ).putMember( key, value ) );
-            this.context.eval( "js", "Object.defineProperty( globalThis, 'app', { writable: false, configurable: false } );" );
+            this.context.eval( READ_ONLY_APP_SCRIPT );
         }
     }
 }

--- a/modules/script/script-impl/src/main/java/com/enonic/xp/script/graal/executor/GraalScriptExecutor.java
+++ b/modules/script/script-impl/src/main/java/com/enonic/xp/script/graal/executor/GraalScriptExecutor.java
@@ -23,7 +23,6 @@ import javax.script.SimpleBindings;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
-import org.graalvm.polyglot.proxy.ProxyObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -871,8 +870,9 @@ public class GraalScriptExecutor
             this.exportsCache = new ScriptExportsCache<>( resourceService::getResource, GraalScriptExecutor.this::onCacheExpired );
 
             final Map<String, Object> globalVariables = new HashMap<>( scriptSettings.getGlobalVariables() );
-            globalVariables.put( "app", ProxyObject.fromMap( application.buildMap( HashMap::new ) ) );
+            globalVariables.put( "app", this.javascriptHelper.objectConverter().toJs( application.buildMap( HashMap::new ) ) );
             globalVariables.forEach( ( key, value ) -> this.context.getBindings( "js" ).putMember( key, value ) );
+            this.context.eval( "js", "Object.defineProperty( globalThis, 'app', { writable: false, configurable: false } );" );
         }
     }
 }

--- a/modules/script/script-impl/src/test/java/com/enonic/xp/script/impl/AbstractScriptTest.java
+++ b/modules/script/script-impl/src/test/java/com/enonic/xp/script/impl/AbstractScriptTest.java
@@ -44,7 +44,8 @@ public abstract class AbstractScriptTest
         Mockito.when( application.getVersion() ).thenReturn( Version.parseVersion( "1.0.0" ) );
         Mockito.when( application.getClassLoader() ).thenReturn( getClass().getClassLoader() );
         Mockito.when( application.isStarted() ).thenReturn( true );
-        Mockito.when( application.getConfig() ).thenReturn( ConfigBuilder.create().build() );
+        Mockito.when( application.getConfig() )
+            .thenReturn( ConfigBuilder.create().add( "key", "value" ).add( "dotted.key", "dotted value" ).build() );
 
         final ResourceService resourceService = Mockito.mock( ResourceService.class );
         Mockito.when( resourceService.getResource( Mockito.any() ) ).thenAnswer( invocation -> {

--- a/modules/script/script-impl/src/test/resources/myapplication/application-test.js
+++ b/modules/script/script-impl/src/test/resources/myapplication/application-test.js
@@ -13,4 +13,16 @@ assert.assertEquals('2', module.exports.val);
 
 assert.assertEquals('myapplication', app.name);
 assert.assertEquals('1.0.0', app.version);
-assert.assertEquals('{}', JSON.stringify(app.config));
+assert.assertEquals('dotted.key,key', Object.keys(app.config).sort().join(','));
+assert.assertEquals(true, Object.prototype.hasOwnProperty.call(app.config, 'key'));
+assert.assertEquals('value', app.config['key']);
+assert.assertEquals('dotted value', app.config['dotted.key']);
+
+var rebindFailed = false;
+try {
+    app = 'replaced';
+} catch (e) {
+    rebindFailed = true;
+}
+assert.assertEquals(true, rebindFailed);
+assert.assertEquals('myapplication', app.name);

--- a/modules/script/script-impl/src/test/resources/myapplication/application-test.js
+++ b/modules/script/script-impl/src/test/resources/myapplication/application-test.js
@@ -26,3 +26,52 @@ try {
 }
 assert.assertEquals(true, rebindFailed);
 assert.assertEquals('myapplication', app.name);
+
+// GraalJS enforces the read-only contract at runtime; on Nashorn the types are the only guard
+if (typeof Graal !== 'undefined') {
+    var messageOf = function (action) {
+        try {
+            action();
+        } catch (e) {
+            return e.message;
+        }
+        return 'nothing thrown';
+    };
+
+    var nameOf = function (action) {
+        try {
+            action();
+        } catch (e) {
+            return e.name;
+        }
+        return 'nothing thrown';
+    };
+
+    assert.assertEquals(true, Object.isFrozen(app));
+    assert.assertEquals(true, Object.isFrozen(app.config));
+
+    // the message must not serialize the object: app.config carries the deployment's secrets
+    assert.assertEquals("Cannot assign to read only property 'app' of global", messageOf(function () {
+        app = 'replaced';
+    }));
+    assert.assertEquals("Cannot assign to read only property 'name' of app", messageOf(function () {
+        app.name = 'replaced';
+    }));
+    assert.assertEquals("Cannot assign to read only property 'key' of app.config", messageOf(function () {
+        app.config['key'] = 'replaced';
+    }));
+
+    assert.assertEquals('TypeError', nameOf(function () {
+        app.config['brandNew'] = 'added';
+    }));
+    assert.assertEquals('TypeError', nameOf(function () {
+        delete app.config['key'];
+    }));
+    assert.assertEquals('TypeError', nameOf(function () {
+        Object.defineProperty(app, 'name', {value: 'replaced'});
+    }));
+
+    assert.assertEquals('myapplication', app.name);
+    assert.assertEquals('value', app.config['key']);
+    assert.assertEquals('undefined', typeof app.config['brandNew']);
+}

--- a/modules/tools/testing/src/main/java/com/enonic/xp/testing/ScriptTestSupport.java
+++ b/modules/tools/testing/src/main/java/com/enonic/xp/testing/ScriptTestSupport.java
@@ -18,6 +18,7 @@ import com.enonic.xp.app.Application;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.config.ConfigBuilder;
+import com.enonic.xp.config.Configuration;
 import com.enonic.xp.content.Content;
 import com.enonic.xp.content.ContentConstants;
 import com.enonic.xp.content.ContentId;
@@ -278,8 +279,18 @@ public abstract class ScriptTestSupport
         }
         final ApplicationImpl application = new ApplicationImpl( bundle, new ClassLoaderApplicationUrlResolver(
             new URLClassLoader( resourcesPath, ClassLoader.getPlatformClassLoader() ), appKey ), getClass().getClassLoader() );
-        application.setConfig( ConfigBuilder.create().build() );
+        application.setConfig( createAppConfig() );
         return application;
+    }
+
+    /**
+     * Supplies the configuration the scripts under test see as {@code app.config}. Override to seed
+     * values; it is consulted once, while the script runtime is being built, so it cannot depend on
+     * anything an overridden {@link #initialize()} sets up after {@code super.initialize()}.
+     */
+    protected Configuration createAppConfig()
+    {
+        return ConfigBuilder.create().build();
     }
 
     private Bundle createBundle()

--- a/modules/tools/testing/src/test/java/com/enonic/xp/testing/usage/AppConfigScriptTest.java
+++ b/modules/tools/testing/src/test/java/com/enonic/xp/testing/usage/AppConfigScriptTest.java
@@ -1,0 +1,21 @@
+package com.enonic.xp.testing.usage;
+
+import com.enonic.xp.config.ConfigBuilder;
+import com.enonic.xp.config.Configuration;
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+class AppConfigScriptTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "test/usage/app-config-test.js";
+    }
+
+    @Override
+    protected Configuration createAppConfig()
+    {
+        return ConfigBuilder.create().add( "key", "value" ).add( "dotted.key", "dotted value" ).build();
+    }
+}

--- a/modules/tools/testing/src/test/resources/test/usage/app-config-test.js
+++ b/modules/tools/testing/src/test/resources/test/usage/app-config-test.js
@@ -1,0 +1,7 @@
+/* global app*/
+var t = require('/lib/xp/testing');
+
+exports.testAppConfig = function () {
+    t.assertEquals('value', app.config['key']);
+    t.assertEquals('dotted value', app.config['dotted.key']);
+};


### PR DESCRIPTION
Two defects on the same GraalJS binding, one commit each.

`ProxyObject.fromMap` wraps only the map it is given, so the nested `config` map reached scripts as a host `java.util.HashMap` — `app` behaved as a JavaScript object and `app.config` did not. `GraalObjectConverter.toJs` already recurses into nested maps and already backs callback-result conversion, so routing the same map through it introduces no new conversion logic.

`app` was also writable, at both levels. `putMember` cannot express property attributes and the object behind it was never sealed, so a stray write stayed visible to every later request on the same pooled context. Nashorn already rejects `app = ...` because its binding lives in `GLOBAL_SCOPE` and is not assignable; making the GraalJS binding read-only closes that divergence rather than creating one.

## Changes

- `GraalScriptExecutor` binds `app` through `objectConverter().toJs(...)` instead of `ProxyObject.fromMap(...)`
- `GraalScriptExecutor` freezes `app` and `app.config`, wraps both in a `Proxy` whose `set`, `defineProperty` and `deleteProperty` traps throw, and redefines the global as a non-configurable accessor whose setter throws
- `App` declares `name`, `version` and `config` `readonly`, with `config` typed as a new exported `AppConfig`; the jsdoc `app` namespace gains the missing `config` member and `@readonly` on all three
- `ScriptTestSupport` gains `createAppConfig()`, replacing the `app.config` write that test scripts used to seed configuration
- `application-test.js` pins the config contract on both engines and the immutability contract on GraalJS; `App.test-d.ts` pins the type contract; `AppConfigScriptTest` pins the harness hook

Nashorn is untouched.

## Error messages

GraalJS serialises the target object into its own `TypeError`, and `.cfg` files hold credentials. Measured with a two-key config:

| write | before | after |
| --- | --- | --- |
| `app = 1` | 1783 chars, the entire global object | `Cannot assign to read only property 'app' of global` |
| `app.name = 'x'` | 139 chars, inlining every config value | `Cannot assign to read only property 'name' of app` |
| `app.config['key'] = 'x'` | `... of {key: "value", dotted.key: "dotted value"}` | `Cannot assign to read only property 'key' of app.config` |

The global is an accessor rather than a non-writable data property because `js.strict` does not reach `Function`-constructed code: under a data property, `Function("app = 1")()` fails silently. Cost is about 5ns per read of `app` (20M reads: 1047.6ms against 947.2ms).

## Breaking

On GraalJS, applications calling Java `Map` methods on `app.config` — `config.get('x')`, `config.containsKey('x')` — now get a `TypeError`, as do applications writing to `app` or `app.config`. GraalJS is opt-in per application and was not encouraged before 8.1, which is still in beta.

## Verified

`:script:script-impl:test` and `:testGraalJs` (180 each), `:tools:testing:test` and `:testGraalJs`, `testGraalJs` for portal-impl, core-task, app-system and all 25 `lib-*`, `:lib:typescript`, `:lib:jsdoc` and `tsd`. Each new assertion was mutation-checked by removing the code it guards and confirming it fails. Verification is unit-level; no XP instance was started.

Closes #12304
Closes #12306
