### PR TITLE
Only system.admin must be able to list exports  #12303

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/export/ExportService.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/export/ExportService.java
@@ -6,5 +6,11 @@ public interface ExportService
 
     NodeImportResult importNodes( ImportNodesParams params );
 
+    /**
+     * Lists the node-exports available in the exports directory.
+     *
+     * @return names of the available node-exports.
+     * @throws com.enonic.xp.exception.ForbiddenAccessException if the caller does not have the {@code system.admin} role.
+     */
     ListExportsResult list();
 }

--- a/modules/core/core-export/src/main/java/com/enonic/xp/core/impl/export/ExportServiceImpl.java
+++ b/modules/core/core-export/src/main/java/com/enonic/xp/core/impl/export/ExportServiceImpl.java
@@ -13,11 +13,13 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.core.impl.export.reader.ZipVirtualFile;
 import com.enonic.xp.core.impl.export.writer.ExportWriter;
 import com.enonic.xp.core.impl.export.writer.ZipExportWriter;
 import com.enonic.xp.core.internal.FileNames;
 import com.enonic.xp.core.internal.FilePredicates;
+import com.enonic.xp.exception.ForbiddenAccessException;
 import com.enonic.xp.export.ExportInfo;
 import com.enonic.xp.export.ExportNodesParams;
 import com.enonic.xp.export.ExportService;
@@ -26,6 +28,8 @@ import com.enonic.xp.export.ListExportsResult;
 import com.enonic.xp.export.NodeExportResult;
 import com.enonic.xp.export.NodeImportResult;
 import com.enonic.xp.node.NodeService;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.server.VersionInfo;
 import com.enonic.xp.vfs.VirtualFile;
 
@@ -107,6 +111,8 @@ public class ExportServiceImpl
     @Override
     public ListExportsResult list()
     {
+        requireAdminRole();
+
         final Path exportsDir = exportConfiguration.getExportsDir();
 
         final ListExportsResult.Builder builder = ListExportsResult.create();
@@ -134,6 +140,15 @@ public class ExportServiceImpl
         }
 
         return builder.build();
+    }
+
+    private static void requireAdminRole()
+    {
+        final AuthenticationInfo authInfo = ContextAccessor.current().getAuthInfo();
+        if ( !authInfo.hasRole( RoleKeys.ADMIN ) )
+        {
+            throw new ForbiddenAccessException( authInfo.getUser() );
+        }
     }
 
     private static final class TimedExport

--- a/modules/core/core-export/src/test/java/com/enonic/xp/core/impl/export/ExportServiceImplTest.java
+++ b/modules/core/core-export/src/test/java/com/enonic/xp/core/impl/export/ExportServiceImplTest.java
@@ -8,16 +8,27 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.enonic.xp.context.Context;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.exception.ForbiddenAccessException;
 import com.enonic.xp.export.ExportInfo;
 import com.enonic.xp.export.ListExportsResult;
 import com.enonic.xp.node.NodeService;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.User;
+import com.enonic.xp.security.auth.AuthenticationInfo;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class ExportServiceImplTest
 {
+    private static final Context ADMIN_CONTEXT = ContextBuilder.create()
+        .authInfo( AuthenticationInfo.create().principals( RoleKeys.ADMIN ).user( User.anonymous() ).build() )
+        .build();
+
     @TempDir
     Path tempDir;
 
@@ -39,7 +50,7 @@ class ExportServiceImplTest
     @Test
     void list_returnsEmpty_whenExportsDirDoesNotExist()
     {
-        final ListExportsResult result = exportService.list();
+        final ListExportsResult result = listAsAdmin();
 
         assertThat( result.isEmpty() ).isTrue();
         assertThat( result.getSize() ).isZero();
@@ -51,7 +62,7 @@ class ExportServiceImplTest
     {
         Files.createDirectories( exportsDir );
 
-        assertThat( exportService.list().isEmpty() ).isTrue();
+        assertThat( listAsAdmin().isEmpty() ).isTrue();
     }
 
     @Test
@@ -61,7 +72,7 @@ class ExportServiceImplTest
         Files.createDirectories( exportsDir );
         Files.createFile( exportsDir.resolve( "site-backup.zip" ) );
 
-        assertThat( exportService.list().getList() ).extracting( ExportInfo::name ).containsExactly( "site-backup" );
+        assertThat( listAsAdmin().getList() ).extracting( ExportInfo::name ).containsExactly( "site-backup" );
     }
 
     @Test
@@ -73,7 +84,7 @@ class ExportServiceImplTest
         Files.createFile( exportsDir.resolve( "notes.txt" ) );
         Files.createFile( exportsDir.resolve( "archive.tar" ) );
 
-        assertThat( exportService.list().getList() ).extracting( ExportInfo::name ).containsExactly( "real" );
+        assertThat( listAsAdmin().getList() ).extracting( ExportInfo::name ).containsExactly( "real" );
     }
 
     @Test
@@ -84,7 +95,7 @@ class ExportServiceImplTest
         Files.createDirectories( exportsDir.resolve( "nested.zip" ) );
         Files.createFile( exportsDir.resolve( "actual.zip" ) );
 
-        assertThat( exportService.list().getList() ).extracting( ExportInfo::name ).containsExactly( "actual" );
+        assertThat( listAsAdmin().getList() ).extracting( ExportInfo::name ).containsExactly( "actual" );
     }
 
     @Test
@@ -95,7 +106,7 @@ class ExportServiceImplTest
         Files.createFile( exportsDir.resolve( ".hidden.zip" ) );
         Files.createFile( exportsDir.resolve( "visible.zip" ) );
 
-        assertThat( exportService.list().getList() ).extracting( ExportInfo::name ).containsExactly( "visible" );
+        assertThat( listAsAdmin().getList() ).extracting( ExportInfo::name ).containsExactly( "visible" );
     }
 
     @Test
@@ -106,7 +117,28 @@ class ExportServiceImplTest
         Files.createFile( exportsDir.resolve( "one.zip" ) );
         Files.createFile( exportsDir.resolve( "two.zip" ) );
 
-        final long count = exportService.list().stream().count();
+        final long count = listAsAdmin().stream().count();
         assertThat( count ).isEqualTo( 2L );
+    }
+
+    @Test
+    void list_requires_the_administrator_role()
+    {
+        assertThrows( ForbiddenAccessException.class, () -> exportService.list() );
+    }
+
+    @Test
+    void list_requires_the_administrator_role_for_authenticated_user()
+    {
+        final Context context = ContextBuilder.create()
+            .authInfo( AuthenticationInfo.create().principals( RoleKeys.AUTHENTICATED ).user( User.anonymous() ).build() )
+            .build();
+
+        assertThrows( ForbiddenAccessException.class, () -> context.callWith( () -> exportService.list() ) );
+    }
+
+    private ListExportsResult listAsAdmin()
+    {
+        return ADMIN_CONTEXT.callWith( () -> exportService.list() );
     }
 }

--- a/modules/lib/lib-export/src/main/resources/lib/xp/export.ts
+++ b/modules/lib/lib-export/src/main/resources/lib/xp/export.ts
@@ -209,6 +209,8 @@ interface ListExportsHandler {
 /**
  * List the available node-exports stored in the exports directory.
  *
+ * Requires the `system.admin` role.
+ *
  * @example-ref examples/export/listExports.js
  *
  * @returns {ListExportsResult} Names of all available exports.


### PR DESCRIPTION
## Summary
This change adds authorization checks to the `ExportService.list()` method to ensure only users with the administrator role can list available node exports.

## Key Changes
- **ExportServiceImpl**: Added `requireAdminRole()` method that checks if the current user has the `system.admin` role and throws `ForbiddenAccessException` if not
- **ExportService interface**: Added JavaDoc documenting that the `list()` method requires the `system.admin` role and can throw `ForbiddenAccessException`
- **ExportServiceImplTest**: 
  - Introduced `ADMIN_CONTEXT` static field to provide an admin-authenticated context for test execution
  - Created `listAsAdmin()` helper method to wrap all `exportService.list()` calls with admin context
  - Updated all existing test cases to use `listAsAdmin()` instead of direct calls
  - Added two new test cases to verify the authorization requirement:
    - `list_requires_the_administrator_role()` - verifies exception when called without authentication
    - `list_requires_the_administrator_role_for_authenticated_user()` - verifies exception when called with non-admin role
- **export.ts**: Updated JSDoc to document the `system.admin` role requirement

## Implementation Details
The authorization check uses `ContextAccessor.current().getAuthInfo()` to retrieve the current authentication context and validates that the user has the `ADMIN` role before allowing the operation. This follows the existing security pattern in the codebase.

https://claude.ai/code/session_01LHqacRZ9V5qnpc35sP8YUF