### PR TITLE
importNodes throws NPE when optional xslt is omitted #12315

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/export/ImportNodesParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/export/ImportNodesParams.java
@@ -154,6 +154,15 @@ public final class ImportNodesParams
             return this;
         }
 
+        /**
+         * @deprecated XSLT files in the exports directory are not supported. The value is ignored; use {@link #xslt(VirtualFile)}.
+         */
+        @Deprecated
+        public Builder xsltFileName( final String xsltFileName )
+        {
+            return this;
+        }
+
         public Builder xsltParams( final Map<String, Object> xsltParams )
         {
             this.xsltParams = xsltParams;

--- a/modules/core/core-api/src/main/java/com/enonic/xp/export/ImportNodesParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/export/ImportNodesParams.java
@@ -155,7 +155,7 @@ public final class ImportNodesParams
         }
 
         /**
-         * @deprecated XSLT files in the exports directory are not supported. The value is ignored; use {@link #xslt(VirtualFile)}.
+         * @deprecated ignored, use {@link #xslt(VirtualFile)}
          */
         @Deprecated
         public Builder xsltFileName( final String xsltFileName )

--- a/modules/core/core-api/src/main/java/com/enonic/xp/export/ImportNodesParams.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/export/ImportNodesParams.java
@@ -108,8 +108,6 @@ public final class ImportNodesParams
 
         private VirtualFile xslt;
 
-        private String xsltFileName;
-
         private Map<String, Object> xsltParams;
 
         private NodeImportListener nodeImportListener;
@@ -156,12 +154,6 @@ public final class ImportNodesParams
             return this;
         }
 
-        public Builder xsltFileName( final String xsltFileName )
-        {
-            this.xsltFileName = xsltFileName;
-            return this;
-        }
-
         public Builder xsltParams( final Map<String, Object> xsltParams )
         {
             this.xsltParams = xsltParams;
@@ -197,12 +189,6 @@ public final class ImportNodesParams
             if ( exportName != null )
             {
                 Preconditions.checkArgument( FileNames.isSafeFileName( exportName ), "Invalid export name" );
-            }
-
-            Preconditions.checkArgument( !( xsltFileName != null && xslt != null ), "xsltFileName and xslt are mutually exclusive" );
-            if ( xsltFileName != null )
-            {
-                Preconditions.checkArgument( FileNames.isSafeFileName( xsltFileName ), "Invalid xslt file name" );
             }
         }
 

--- a/modules/core/core-api/src/test/java/com/enonic/xp/export/ImportNodesParamsTest.java
+++ b/modules/core/core-api/src/test/java/com/enonic/xp/export/ImportNodesParamsTest.java
@@ -9,6 +9,7 @@ import com.enonic.xp.node.NodePath;
 import com.enonic.xp.vfs.VirtualFile;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ImportNodesParamsTest
@@ -35,5 +36,18 @@ class ImportNodesParamsTest
         assertNotNull( result.getSource() );
         assertNotNull( result.getXslt() );
         assertNotNull( result.getXsltParams() );
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void xsltFileName_isDeprecatedAndIgnored()
+    {
+        final ImportNodesParams result = ImportNodesParams.create()
+            .targetNodePath( NodePath.ROOT )
+            .exportName( "my-export" )
+            .xsltFileName( "transform.xsl" )
+            .build();
+
+        assertNull( result.getXslt() );
     }
 }

--- a/modules/core/core-export/src/test/java/com/enonic/xp/core/impl/export/ExportServiceImplTest.java
+++ b/modules/core/core-export/src/test/java/com/enonic/xp/core/impl/export/ExportServiceImplTest.java
@@ -1,22 +1,34 @@
 package com.enonic.xp.core.impl.export;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextBuilder;
 import com.enonic.xp.exception.ForbiddenAccessException;
 import com.enonic.xp.export.ExportInfo;
+import com.enonic.xp.export.ImportNodesParams;
 import com.enonic.xp.export.ListExportsResult;
+import com.enonic.xp.export.NodeImportResult;
+import com.enonic.xp.node.ImportNodeParams;
+import com.enonic.xp.node.ImportNodeResult;
+import com.enonic.xp.node.Node;
+import com.enonic.xp.node.NodePath;
 import com.enonic.xp.node.NodeService;
 import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.User;
 import com.enonic.xp.security.auth.AuthenticationInfo;
+import com.enonic.xp.vfs.VirtualFiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -29,10 +41,56 @@ class ExportServiceImplTest
         .authInfo( AuthenticationInfo.create().principals( RoleKeys.ADMIN ).user( User.anonymous() ).build() )
         .build();
 
+    private static final String NODE_XML = """
+        <node>
+          <childOrder>_name DESC</childOrder>
+          <nodeType>content</nodeType>
+          <permissions/>
+          <data>
+            <string name="controller">com.enonic.apps.genericapp:default</string>
+          </data>
+          <indexConfigs>
+            <defaultConfig>
+              <decideByType>false</decideByType>
+              <enabled>true</enabled>
+              <nGram>true</nGram>
+              <fulltext>true</fulltext>
+              <includeInAllText>true</includeInAllText>
+            </defaultConfig>
+          </indexConfigs>
+        </node>
+        """;
+
+    private static final String TRANSFORM_XSL = """
+        <?xml version="1.0"?>
+        <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+          <xsl:output method="xml" indent="yes"/>
+          <xsl:param name="applicationId"/>
+          <xsl:variable name="placeholderApp" select="'com.enonic.apps.genericapp'"/>
+
+          <xsl:template match="string[starts-with(text(),concat($placeholderApp,':'))]">
+            <string>
+              <xsl:attribute name="name">
+                <xsl:value-of select="@name"/>
+              </xsl:attribute>
+              <xsl:value-of select="concat($applicationId, substring-after(.,$placeholderApp))"/>
+            </string>
+          </xsl:template>
+
+          <xsl:template match="@*|node()">
+            <xsl:copy>
+              <xsl:apply-templates select="@*|node()"/>
+            </xsl:copy>
+          </xsl:template>
+        </xsl:stylesheet>
+        """.stripLeading();
+
     @TempDir
     Path tempDir;
 
     private Path exportsDir;
+
+    private NodeService nodeService;
 
     private ExportServiceImpl exportService;
 
@@ -44,7 +102,8 @@ class ExportServiceImplTest
         final ExportConfigurationDynamic config = mock( ExportConfigurationDynamic.class );
         when( config.getExportsDir() ).thenReturn( exportsDir );
 
-        exportService = new ExportServiceImpl( config, mock( NodeService.class ) );
+        nodeService = mock( NodeService.class );
+        exportService = new ExportServiceImpl( config, nodeService );
     }
 
     @Test
@@ -141,4 +200,72 @@ class ExportServiceImplTest
     {
         return ADMIN_CONTEXT.callWith( () -> exportService.list() );
     }
+
+    @Test
+    void importNodes_appliesXsltVirtualFile_whenGivenDirectly()
+        throws IOException
+    {
+        createExportZip( "my-export" );
+        final Path xsltPath = tempDir.resolve( "app-transform.xsl" );
+        Files.writeString( xsltPath, TRANSFORM_XSL );
+
+        final ArgumentCaptor<ImportNodeParams> captor = captureImportedNode();
+
+        final NodeImportResult result = exportService.importNodes( ImportNodesParams.create()
+                                                                       .exportName( "my-export" )
+                                                                       .targetNodePath( NodePath.ROOT )
+                                                                       .xslt( VirtualFiles.from( xsltPath ) )
+                                                                       .xsltParam( "applicationId", "com.acme.myapp" )
+                                                                       .build() );
+
+        assertThat( result.getImportErrors() ).isEmpty();
+        assertThat( captor.getValue().getNode().data().getString( "controller" ) ).isEqualTo( "com.acme.myapp:default" );
+    }
+
+    @Test
+    void importNodes_withoutXslt_importsUntransformed()
+        throws IOException
+    {
+        createExportZip( "my-export" );
+
+        final ArgumentCaptor<ImportNodeParams> captor = captureImportedNode();
+
+        final NodeImportResult result =
+            exportService.importNodes( ImportNodesParams.create().exportName( "my-export" ).targetNodePath( NodePath.ROOT ).build() );
+
+        assertThat( result.getImportErrors() ).isEmpty();
+        assertThat( result.getAddedNodes().getSize() ).isEqualTo( 1 );
+        assertThat( captor.getValue().getNode().data().getString( "controller" ) ).isEqualTo( "com.enonic.apps.genericapp:default" );
+    }
+
+    private ArgumentCaptor<ImportNodeParams> captureImportedNode()
+    {
+        final ArgumentCaptor<ImportNodeParams> captor = ArgumentCaptor.forClass( ImportNodeParams.class );
+        when( nodeService.importNode( captor.capture() ) ).thenAnswer( invocation -> {
+            final Node node = invocation.<ImportNodeParams>getArgument( 0 ).getNode();
+            return ImportNodeResult.create().node( node ).preExisting( false ).build();
+        } );
+        return captor;
+    }
+
+    private void createExportZip( final String exportName )
+        throws IOException
+    {
+        Files.createDirectories( exportsDir );
+        try (OutputStream out = Files.newOutputStream( exportsDir.resolve( exportName + ".zip" ) );
+             ZipOutputStream zip = new ZipOutputStream( out ))
+        {
+            addZipEntry( zip, exportName + "/export.properties", "xp.version=1.0" );
+            addZipEntry( zip, exportName + "/mynode/_/node.xml", NODE_XML );
+        }
+    }
+
+    private static void addZipEntry( final ZipOutputStream zip, final String name, final String content )
+        throws IOException
+    {
+        zip.putNextEntry( new ZipEntry( name ) );
+        zip.write( content.getBytes( StandardCharsets.UTF_8 ) );
+        zip.closeEntry();
+    }
+
 }

--- a/modules/lib/lib-export/src/main/java/com/enonic/xp/lib/export/ImportHandler.java
+++ b/modules/lib/lib-export/src/main/java/com/enonic/xp/lib/export/ImportHandler.java
@@ -57,13 +57,10 @@ public class ImportHandler
             paramsBuilder.exportName( source.toString() );
         }
 
+        // A plain file name (deprecated: XSLT file in the exports directory) is ignored.
         if ( xslt instanceof ResourceKey )
         {
             paramsBuilder.xslt( toVirtualFile( (ResourceKey) xslt ) );
-        }
-        else if ( xslt != null )
-        {
-            throw new IllegalArgumentException( "xslt must be an application resource key" );
         }
 
         if ( xsltParams != null )

--- a/modules/lib/lib-export/src/main/java/com/enonic/xp/lib/export/ImportHandler.java
+++ b/modules/lib/lib-export/src/main/java/com/enonic/xp/lib/export/ImportHandler.java
@@ -57,7 +57,6 @@ public class ImportHandler
             paramsBuilder.exportName( source.toString() );
         }
 
-        // A plain file name (deprecated: XSLT file in the exports directory) is ignored.
         if ( xslt instanceof ResourceKey )
         {
             paramsBuilder.xslt( toVirtualFile( (ResourceKey) xslt ) );

--- a/modules/lib/lib-export/src/main/java/com/enonic/xp/lib/export/ImportHandler.java
+++ b/modules/lib/lib-export/src/main/java/com/enonic/xp/lib/export/ImportHandler.java
@@ -61,9 +61,9 @@ public class ImportHandler
         {
             paramsBuilder.xslt( toVirtualFile( (ResourceKey) xslt ) );
         }
-        else
+        else if ( xslt != null )
         {
-            paramsBuilder.xsltFileName( xslt.toString() );
+            throw new IllegalArgumentException( "xslt must be an application resource key" );
         }
 
         if ( xsltParams != null )

--- a/modules/lib/lib-export/src/main/resources/lib/xp/examples/export/importNodes.js
+++ b/modules/lib/lib-export/src/main/resources/lib/xp/examples/export/importNodes.js
@@ -7,7 +7,7 @@ var t = require('/lib/xp/testing');
 let importNodes = exportLib.importNodes({
     source: resolve('/import'),
     targetNodePath: '/content',
-    xslt: 'transform.xslt',
+    xslt: resolve('/import/transform.xsl'),
     xsltParams: {'k': 'v'},
     includeNodeIds: true,
     includePermissions: true

--- a/modules/lib/lib-export/src/main/resources/lib/xp/export.ts
+++ b/modules/lib/lib-export/src/main/resources/lib/xp/export.ts
@@ -30,7 +30,7 @@ function checkRequired<T extends object, K extends keyof T>(
 export interface ImportNodesParams {
     source: string | object;
     targetNodePath: string;
-    xslt?: string | ResourceKey;
+    xslt?: ResourceKey;
     xsltParams?: Record<string, unknown>;
     includeNodeIds?: boolean;
     includePermissions?: boolean;
@@ -59,7 +59,7 @@ interface ImportHandler {
 
     setTargetNodePath(value: string): void;
 
-    setXslt(value: string | ResourceKey | null): void;
+    setXslt(value: ResourceKey | null): void;
 
     setXsltParams(value: ScriptValue | null): void;
 
@@ -88,7 +88,7 @@ interface ImportHandler {
  * @param {object} params JSON with the parameters.
  * @param {string|object} params.source Either name of nodes-export located in exports directory or application resource key.
  * @param {string} params.targetNodePath Target path for imported nodes.
- * @param {string|object} [params.xslt] XSLT file name in exports directory or application resource key. Used for XSLT transformation.
+ * @param {object} [params.xslt] Application resource key of an XSLT file used to transform node XML before import.
  * @param {object} [params.xsltParams] Parameters used in XSLT transformation.
  * @param {boolean} [params.includeNodeIds=false] Set to true to use node IDs from the import, false to generate new node IDs.
  * @param {boolean} [params.includePermissions=false] Set to true to use Node permissions from the import, false to use target node permissions.

--- a/modules/lib/lib-export/src/main/resources/lib/xp/export.ts
+++ b/modules/lib/lib-export/src/main/resources/lib/xp/export.ts
@@ -30,7 +30,7 @@ function checkRequired<T extends object, K extends keyof T>(
 export interface ImportNodesParams {
     source: string | object;
     targetNodePath: string;
-    xslt?: ResourceKey;
+    xslt?: string | ResourceKey;
     xsltParams?: Record<string, unknown>;
     includeNodeIds?: boolean;
     includePermissions?: boolean;
@@ -59,7 +59,7 @@ interface ImportHandler {
 
     setTargetNodePath(value: string): void;
 
-    setXslt(value: ResourceKey | null): void;
+    setXslt(value: string | ResourceKey | null): void;
 
     setXsltParams(value: ScriptValue | null): void;
 
@@ -88,7 +88,7 @@ interface ImportHandler {
  * @param {object} params JSON with the parameters.
  * @param {string|object} params.source Either name of nodes-export located in exports directory or application resource key.
  * @param {string} params.targetNodePath Target path for imported nodes.
- * @param {object} [params.xslt] Application resource key of an XSLT file used to transform node XML before import.
+ * @param {object} [params.xslt] Application resource key of an XSLT file used to transform node XML before import. A file name (string) is deprecated and ignored.
  * @param {object} [params.xsltParams] Parameters used in XSLT transformation.
  * @param {boolean} [params.includeNodeIds=false] Set to true to use node IDs from the import, false to generate new node IDs.
  * @param {boolean} [params.includePermissions=false] Set to true to use Node permissions from the import, false to use target node permissions.

--- a/modules/lib/lib-export/src/test/java/com/enonic/xp/lib/export/ImportHandlerTest.java
+++ b/modules/lib/lib-export/src/test/java/com/enonic/xp/lib/export/ImportHandlerTest.java
@@ -6,16 +6,25 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 
 import com.enonic.xp.export.ExportService;
+import com.enonic.xp.export.ImportNodesParams;
 import com.enonic.xp.export.NodeImportResult;
 import com.enonic.xp.home.HomeDirSupport;
 import com.enonic.xp.node.NodePath;
 import com.enonic.xp.testing.ScriptTestSupport;
 import com.enonic.xp.util.BinaryReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ImportHandlerTest
@@ -51,8 +60,37 @@ class ImportHandlerTest
             .addError( "error", new NoStacktraceException() )
             .build();
 
-        when( exportService.importNodes( any() ) ).thenReturn( result );
+        final ArgumentCaptor<ImportNodesParams> captor = ArgumentCaptor.forClass( ImportNodesParams.class );
+        when( exportService.importNodes( captor.capture() ) ).thenReturn( result );
         runScript( "/lib/xp/examples/export/importNodes.js" );
+
+        final ImportNodesParams params = captor.getValue();
+        assertNotNull( params.getSource() );
+        assertNotNull( params.getXslt() );
+        assertEquals( "/content", params.getTargetNodePath().toString() );
+    }
+
+    @Test
+    void importNodes_withoutXslt()
+    {
+        final ArgumentCaptor<ImportNodesParams> captor = ArgumentCaptor.forClass( ImportNodesParams.class );
+        when( exportService.importNodes( captor.capture() ) ).thenReturn( NodeImportResult.create().build() );
+
+        runScript( "/test/importNodes-without-xslt.js" );
+
+        final ImportNodesParams params = captor.getValue();
+        assertNull( params.getXslt() );
+        assertEquals( "my-export", params.getExportName() );
+        assertEquals( "/content", params.getTargetNodePath().toString() );
+    }
+
+    @Test
+    void importNodes_rejectsXsltFileName()
+    {
+        final RuntimeException e = assertThrows( RuntimeException.class, () -> runScript( "/test/importNodes-with-xslt-string.js" ) );
+
+        assertTrue( e.getMessage().contains( "xslt must be an application resource key" ), e.getMessage() );
+        verify( exportService, never() ).importNodes( any() );
     }
 
     private static class NoStacktraceException

--- a/modules/lib/lib-export/src/test/java/com/enonic/xp/lib/export/ImportHandlerTest.java
+++ b/modules/lib/lib-export/src/test/java/com/enonic/xp/lib/export/ImportHandlerTest.java
@@ -19,12 +19,7 @@ import com.enonic.xp.util.BinaryReference;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ImportHandlerTest
@@ -85,12 +80,14 @@ class ImportHandlerTest
     }
 
     @Test
-    void importNodes_rejectsXsltFileName()
+    void importNodes_ignoresDeprecatedXsltFileName()
     {
-        final RuntimeException e = assertThrows( RuntimeException.class, () -> runScript( "/test/importNodes-with-xslt-string.js" ) );
+        final ArgumentCaptor<ImportNodesParams> captor = ArgumentCaptor.forClass( ImportNodesParams.class );
+        when( exportService.importNodes( captor.capture() ) ).thenReturn( NodeImportResult.create().build() );
 
-        assertTrue( e.getMessage().contains( "xslt must be an application resource key" ), e.getMessage() );
-        verify( exportService, never() ).importNodes( any() );
+        runScript( "/test/importNodes-with-xslt-string.js" );
+
+        assertNull( captor.getValue().getXslt() );
     }
 
     private static class NoStacktraceException

--- a/modules/lib/lib-export/src/test/resources/test/importNodes-with-xslt-string.js
+++ b/modules/lib/lib-export/src/test/resources/test/importNodes-with-xslt-string.js
@@ -1,6 +1,5 @@
 var exportLib = require('/lib/xp/export');
 
-// xslt as a plain file name is deprecated and ignored; only application resource keys are supported
 exportLib.importNodes({
     source: 'my-export',
     targetNodePath: '/content',

--- a/modules/lib/lib-export/src/test/resources/test/importNodes-with-xslt-string.js
+++ b/modules/lib/lib-export/src/test/resources/test/importNodes-with-xslt-string.js
@@ -1,6 +1,6 @@
 var exportLib = require('/lib/xp/export');
 
-// xslt as a plain file name is not supported; only application resource keys are
+// xslt as a plain file name is deprecated and ignored; only application resource keys are supported
 exportLib.importNodes({
     source: 'my-export',
     targetNodePath: '/content',

--- a/modules/lib/lib-export/src/test/resources/test/importNodes-with-xslt-string.js
+++ b/modules/lib/lib-export/src/test/resources/test/importNodes-with-xslt-string.js
@@ -1,0 +1,8 @@
+var exportLib = require('/lib/xp/export');
+
+// xslt as a plain file name is not supported; only application resource keys are
+exportLib.importNodes({
+    source: 'my-export',
+    targetNodePath: '/content',
+    xslt: 'transform.xslt'
+});

--- a/modules/lib/lib-export/src/test/resources/test/importNodes-without-xslt.js
+++ b/modules/lib/lib-export/src/test/resources/test/importNodes-without-xslt.js
@@ -1,6 +1,5 @@
 var exportLib = require('/lib/xp/export');
 
-// xslt is optional and must be omittable without error (#12315)
 exportLib.importNodes({
     source: 'my-export',
     targetNodePath: '/content'

--- a/modules/lib/lib-export/src/test/resources/test/importNodes-without-xslt.js
+++ b/modules/lib/lib-export/src/test/resources/test/importNodes-without-xslt.js
@@ -1,0 +1,7 @@
+var exportLib = require('/lib/xp/export');
+
+// xslt is optional and must be omittable without error (#12315)
+exportLib.importNodes({
+    source: 'my-export',
+    targetNodePath: '/content'
+});

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/RepositoryResource.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/RepositoryResource.java
@@ -67,8 +67,6 @@ public final class RepositoryResource
             .exportName( params.getExportName() )
             .importWithIds( params.isImportWithIds() )
             .importWithPermissions( params.isImportWithPermissions() )
-            .xslSource( params.getXslSource() )
-            .xslParams( params.getXslParams() )
             .exportService( exportService )
             .build();
         final TaskId taskId = taskService.submitLocalTask(

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJson.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJson.java
@@ -1,8 +1,12 @@
 package com.enonic.xp.impl.server.rest.model;
 
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 import static java.util.Objects.requireNonNull;
 
@@ -16,10 +20,6 @@ public final class ImportNodesRequestJson
 
     private final boolean importWithPermissions;
 
-    private final String xslSource;
-
-    private final Map<String, Object> xslParams;
-
     @JsonCreator
     public ImportNodesRequestJson( @JsonProperty("exportName") final String exportName, //
                                    @JsonProperty("targetRepoPath") final String targetRepoPath, //
@@ -27,18 +27,18 @@ public final class ImportNodesRequestJson
                                    @JsonProperty("importWithPermissions") final Boolean importWithPermissions, //
                                    @JsonProperty("xslSource") final String xslSource, //
                                    @JsonProperty("xslParams") final Map<String, Object> xslParams )
-
     {
-
         requireNonNull( exportName, "exportName is required" );
         requireNonNull( targetRepoPath, "targetRepoPath is required" );
+
+        // Older clients still send these keys; XSL transformation of server-side imports is not supported.
+        Preconditions.checkArgument( Strings.isNullOrEmpty( xslSource ) && ( xslParams == null || xslParams.isEmpty() ),
+                                     "xslSource and xslParams are not supported" );
 
         this.targetRepoPath = RepoPath.from( targetRepoPath );
         this.exportName = exportName;
         this.importWithIds = importWithIds != null ? importWithIds : true;
         this.importWithPermissions = importWithPermissions != null ? importWithPermissions : true;
-        this.xslSource = xslSource;
-        this.xslParams = xslParams;
     }
 
     public RepoPath getTargetRepoPath()
@@ -59,16 +59,5 @@ public final class ImportNodesRequestJson
     public boolean isImportWithPermissions()
     {
         return importWithPermissions;
-    }
-
-
-    public String getXslSource()
-    {
-        return xslSource;
-    }
-
-    public Map<String, Object> getXslParams()
-    {
-        return xslParams;
     }
 }

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJson.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJson.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static java.util.Objects.requireNonNull;
 
-// xslSource and xslParams are deprecated and ignored: XSLT files in the exports directory are not supported.
 @JsonIgnoreProperties({"xslSource", "xslParams"})
 public final class ImportNodesRequestJson
 {

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJson.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJson.java
@@ -5,9 +5,6 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-
 import static java.util.Objects.requireNonNull;
 
 public final class ImportNodesRequestJson
@@ -20,20 +17,20 @@ public final class ImportNodesRequestJson
 
     private final boolean importWithPermissions;
 
+    /**
+     * @param xslSource deprecated, ignored. XSLT files in the exports directory are not supported.
+     * @param xslParams deprecated, ignored.
+     */
     @JsonCreator
     public ImportNodesRequestJson( @JsonProperty("exportName") final String exportName, //
                                    @JsonProperty("targetRepoPath") final String targetRepoPath, //
                                    @JsonProperty("importWithIds") final Boolean importWithIds, //
                                    @JsonProperty("importWithPermissions") final Boolean importWithPermissions, //
-                                   @JsonProperty("xslSource") final String xslSource, //
-                                   @JsonProperty("xslParams") final Map<String, Object> xslParams )
+                                   @Deprecated @JsonProperty("xslSource") final String xslSource, //
+                                   @Deprecated @JsonProperty("xslParams") final Map<String, Object> xslParams )
     {
         requireNonNull( exportName, "exportName is required" );
         requireNonNull( targetRepoPath, "targetRepoPath is required" );
-
-        // Older clients still send these keys; XSL transformation of server-side imports is not supported.
-        Preconditions.checkArgument( Strings.isNullOrEmpty( xslSource ) && ( xslParams == null || xslParams.isEmpty() ),
-                                     "xslSource and xslParams are not supported" );
 
         this.targetRepoPath = RepoPath.from( targetRepoPath );
         this.exportName = exportName;

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJson.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJson.java
@@ -1,12 +1,13 @@
 package com.enonic.xp.impl.server.rest.model;
 
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static java.util.Objects.requireNonNull;
 
+// xslSource and xslParams are deprecated and ignored: XSLT files in the exports directory are not supported.
+@JsonIgnoreProperties({"xslSource", "xslParams"})
 public final class ImportNodesRequestJson
 {
     private final RepoPath targetRepoPath;
@@ -17,17 +18,11 @@ public final class ImportNodesRequestJson
 
     private final boolean importWithPermissions;
 
-    /**
-     * @param xslSource deprecated, ignored. XSLT files in the exports directory are not supported.
-     * @param xslParams deprecated, ignored.
-     */
     @JsonCreator
     public ImportNodesRequestJson( @JsonProperty("exportName") final String exportName, //
                                    @JsonProperty("targetRepoPath") final String targetRepoPath, //
                                    @JsonProperty("importWithIds") final Boolean importWithIds, //
-                                   @JsonProperty("importWithPermissions") final Boolean importWithPermissions, //
-                                   @Deprecated @JsonProperty("xslSource") final String xslSource, //
-                                   @Deprecated @JsonProperty("xslParams") final Map<String, Object> xslParams )
+                                   @JsonProperty("importWithPermissions") final Boolean importWithPermissions )
     {
         requireNonNull( exportName, "exportName is required" );
         requireNonNull( targetRepoPath, "targetRepoPath is required" );

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/task/ImportRunnableTask.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/task/ImportRunnableTask.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.impl.server.rest.task;
 
-import java.util.Map;
-
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
@@ -18,8 +16,6 @@ import com.enonic.xp.task.ProgressReporter;
 import com.enonic.xp.task.RunnableTask;
 import com.enonic.xp.task.TaskId;
 
-import static com.google.common.base.Strings.emptyToNull;
-
 public class ImportRunnableTask
     implements RunnableTask
 {
@@ -35,10 +31,6 @@ public class ImportRunnableTask
 
     private final boolean importWithPermissions;
 
-    private final String xslSource;
-
-    private final Map<String, Object> xslParams;
-
     private final ExportService exportService;
 
     private ImportRunnableTask( Builder builder )
@@ -49,9 +41,6 @@ public class ImportRunnableTask
         this.exportName = builder.exportName;
         this.importWithIds = builder.importWithIds;
         this.importWithPermissions = builder.importWithPermissions;
-        this.xslSource = builder.xslSource;
-        this.xslParams = builder.xslParams;
-
         this.exportService = builder.exportService;
     }
 
@@ -69,8 +58,6 @@ public class ImportRunnableTask
                 .targetNodePath( nodePath )
                 .includeNodeIds( importWithIds )
                 .includePermissions( importWithPermissions )
-                .xsltFileName( emptyToNull( xslSource ) )
-                .xsltParams( xslParams )
                 .nodeImportListener( new ImportListenerImpl( progressReporter ) );
 
             return this.exportService.importNodes( builder.build() );
@@ -100,10 +87,6 @@ public class ImportRunnableTask
         private boolean importWithIds;
 
         private boolean importWithPermissions;
-
-        private String xslSource;
-
-        private Map<String, Object> xslParams;
 
         private ExportService exportService;
 
@@ -140,18 +123,6 @@ public class ImportRunnableTask
         public Builder importWithPermissions( boolean importWithPermissions )
         {
             this.importWithPermissions = importWithPermissions;
-            return this;
-        }
-
-        public Builder xslSource( String xslSource )
-        {
-            this.xslSource = xslSource;
-            return this;
-        }
-
-        public Builder xslParams( Map<String, Object> xslParams )
-        {
-            this.xslParams = xslParams;
             return this;
         }
 

--- a/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJsonTest.java
+++ b/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJsonTest.java
@@ -1,24 +1,36 @@
 package com.enonic.xp.impl.server.rest.model;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.enonic.xp.core.internal.json.ObjectMapperHelper;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ImportNodesRequestJsonTest
 {
+    private static final ObjectMapper MAPPER = ObjectMapperHelper.create();
+
     @Test
-    @SuppressWarnings("deprecation")
     void deprecatedXslFields_areAccepted_andIgnored()
+        throws Exception
     {
-        final ImportNodesRequestJson json =
-            new ImportNodesRequestJson( "export", "system-repo:master:/a", null, null, "transform.xsl", Map.of( "k", "v" ) );
+        final ImportNodesRequestJson json = MAPPER.readValue( """
+                                                                  {
+                                                                    "exportName": "export",
+                                                                    "targetRepoPath": "system-repo:master:/a",
+                                                                    "importWithIds": false,
+                                                                    "xslSource": "transform.xsl",
+                                                                    "xslParams": {"applicationId": "com.acme.app"}
+                                                                  }
+                                                                  """, ImportNodesRequestJson.class );
 
         assertEquals( "export", json.getExportName() );
         assertEquals( "system-repo", json.getTargetRepoPath().getRepositoryId().toString() );
-        assertTrue( json.isImportWithIds() );
+        assertFalse( json.isImportWithIds() );
         assertTrue( json.isImportWithPermissions() );
     }
 }

--- a/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJsonTest.java
+++ b/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJsonTest.java
@@ -5,32 +5,20 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ImportNodesRequestJsonTest
 {
     @Test
-    void emptyXslFields_areAccepted()
+    @SuppressWarnings("deprecation")
+    void deprecatedXslFields_areAccepted_andIgnored()
     {
-        final ImportNodesRequestJson json = new ImportNodesRequestJson( "export", "system-repo:master:/a", null, null, "", null );
+        final ImportNodesRequestJson json =
+            new ImportNodesRequestJson( "export", "system-repo:master:/a", null, null, "transform.xsl", Map.of( "k", "v" ) );
 
         assertEquals( "export", json.getExportName() );
+        assertEquals( "system-repo", json.getTargetRepoPath().getRepositoryId().toString() );
         assertTrue( json.isImportWithIds() );
         assertTrue( json.isImportWithPermissions() );
-    }
-
-    @Test
-    void xslSource_isRejected()
-    {
-        assertThrows( IllegalArgumentException.class,
-                      () -> new ImportNodesRequestJson( "export", "system-repo:master:/a", true, true, "transform.xsl", null ) );
-    }
-
-    @Test
-    void xslParams_areRejected()
-    {
-        assertThrows( IllegalArgumentException.class,
-                      () -> new ImportNodesRequestJson( "export", "system-repo:master:/a", true, true, null, Map.of( "k", "v" ) ) );
     }
 }

--- a/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJsonTest.java
+++ b/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/model/ImportNodesRequestJsonTest.java
@@ -1,0 +1,36 @@
+package com.enonic.xp.impl.server.rest.model;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ImportNodesRequestJsonTest
+{
+    @Test
+    void emptyXslFields_areAccepted()
+    {
+        final ImportNodesRequestJson json = new ImportNodesRequestJson( "export", "system-repo:master:/a", null, null, "", null );
+
+        assertEquals( "export", json.getExportName() );
+        assertTrue( json.isImportWithIds() );
+        assertTrue( json.isImportWithPermissions() );
+    }
+
+    @Test
+    void xslSource_isRejected()
+    {
+        assertThrows( IllegalArgumentException.class,
+                      () -> new ImportNodesRequestJson( "export", "system-repo:master:/a", true, true, "transform.xsl", null ) );
+    }
+
+    @Test
+    void xslParams_areRejected()
+    {
+        assertThrows( IllegalArgumentException.class,
+                      () -> new ImportNodesRequestJson( "export", "system-repo:master:/a", true, true, null, Map.of( "k", "v" ) ) );
+    }
+}

--- a/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/task/ImportRunnableTaskTest.java
+++ b/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/task/ImportRunnableTaskTest.java
@@ -51,8 +51,6 @@ class ImportRunnableTaskTest
             .exportName( params.getExportName() )
             .importWithIds( params.isImportWithIds() )
             .importWithPermissions( params.isImportWithPermissions() )
-            .xslSource( params.getXslSource() )
-            .xslParams( params.getXslParams() )
             .exportService( exportService )
             .build();
     }

--- a/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/task/ImportRunnableTaskTest.java
+++ b/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/task/ImportRunnableTaskTest.java
@@ -69,7 +69,7 @@ class ImportRunnableTaskTest
         final PropertyTree repoData = new PropertyTree();
         repoData.addString( "key", "value" );
 
-        final ImportRunnableTask task = createTask( new ImportNodesRequestJson( "export", "system-repo:master:a", true, true, "", null ) );
+        final ImportRunnableTask task = createTask( new ImportNodesRequestJson( "export", "system-repo:master:a", true, true ) );
 
         ProgressReporter progressReporter = mock( ProgressReporter.class );
         task.run( TaskId.from( "taskId" ), progressReporter );


### PR DESCRIPTION
Fixes #12315.

Since 15020fde44, `ImportHandler` routed `xslt` through an `if/else` where a `null` value fell into the "file name" branch and `xslt.toString()` threw. That branch fed `ImportNodesParams.Builder.xsltFileName`, which was validated but never copied into the built params or read by `ExportServiceImpl`, so the "XSLT file in the exports directory" form never did anything. Only `xslt: resolve(...)` ever worked.

The file-name form is retired rather than wired up. For security reasons an XSLT stylesheet read from disk cannot be accepted: a stylesheet dropped into the exports directory would run inside the import with no provenance. A stylesheet shipped as an application resource is part of a deployed, reviewed application and is the trustworthy source.

## Changes

* `ImportHandler`: only a `ResourceKey` sets the stylesheet. Omitted `xslt` means no transformation; a string is ignored instead of throwing.
* `ImportNodesParams.Builder.xsltFileName(String)`: `@Deprecated` no-op, kept for compatibility. Its validation is removed.
* `lib/xp/export.ts`: `xslt` documented as a resource key; the string form stays in the type and is documented as deprecated. The example uses `resolve(...)`.
* `server-rest`: `ImportRunnableTask` and `RepositoryResource` drop `xslSource`/`xslParams`. `ImportNodesRequestJson` ignores both keys via `@JsonIgnoreProperties`, so existing clients keep working.

## Tests

* `ImportHandlerTest`: omitted `xslt`, `resolve(...)`, and ignored string form.
* `ExportServiceImplTest`: import from a generated export zip with and without a stylesheet, asserting the transformed node reaches `NodeService.importNode`.
* `ImportNodesParamsTest`, `ImportNodesRequestJsonTest`: deprecated inputs are accepted and ignored.

Follow-up: enonic/cli-enonic#694 removes `--xsl-source` / `--xsl-param` from `enonic import`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKAAx35EQRaygmqUq99sib