### PR TITLE
Reject unmatched hosts on management and statistics connectors that have vhost mappings

### DIFF
--- a/modules/runtime/src/home/config/com.enonic.xp.web.vhost.cfg
+++ b/modules/runtime/src/home/config/com.enonic.xp.web.vhost.cfg
@@ -22,6 +22,9 @@
 # mapping.stats.idProvider.myidprovider = default&enabled=autologin
 # mapping.stats.allow = role:system.admin
 
+# Once at least one mapping exists for the management or statistics endpoint, requests to that endpoint
+# whose host matches none of its mappings are rejected with 404. Without any mapping the endpoint
+# stays reachable through an unrestricted default.
 # mapping.mgmt.host = mgmt.enonic.com
 # mapping.mgmt.source = /
 # mapping.mgmt.target = /

--- a/modules/web/web-vhost/src/main/java/com/enonic/xp/web/vhost/impl/VirtualHostFilter.java
+++ b/modules/web/web-vhost/src/main/java/com/enonic/xp/web/vhost/impl/VirtualHostFilter.java
@@ -1,5 +1,7 @@
 package com.enonic.xp.web.vhost.impl;
 
+import java.util.Objects;
+
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -57,15 +59,14 @@ public final class VirtualHostFilter
                 VirtualHostHelper.setVirtualHost( req, virtualHost );
                 chain.doFilter( new VirtualHostRequestWrapper( req, virtualHost ), res );
             }
-            else if ( DispatchConstants.WEB_CONNECTOR.equals( connector ) )
+            else if ( DispatchConstants.WEB_CONNECTOR.equals( connector ) || hasMappingsFor( connector ) )
             {
-                LOG.warn( "Virtual host mapping could not be resolved for host [{}] and path [{}]", req.getServerName(),
-                          req.getPathInfo() );
+                LOG.warn( "Virtual host mapping could not be resolved for host [{}] and path [{}] on connector [{}]", req.getServerName(),
+                          req.getPathInfo(), connector );
                 res.setStatus( HttpServletResponse.SC_NOT_FOUND );
             }
             else
             {
-                // Management and statistics ports stay reachable when no vhost mapping matches.
                 applyDefaultVirtualHost( req, res, chain, connector );
             }
         }
@@ -73,6 +74,13 @@ public final class VirtualHostFilter
         {
             applyDefaultVirtualHost( req, res, chain, connector );
         }
+    }
+
+    private boolean hasMappingsFor( final String connector )
+    {
+        return virtualHostService.getVirtualHosts()
+            .stream()
+            .anyMatch( virtualHost -> Objects.equals( connector, virtualHost.getConnector() ) );
     }
 
     private static void applyDefaultVirtualHost( final HttpServletRequest req, final HttpServletResponse res, final FilterChain chain,

--- a/modules/web/web-vhost/src/test/java/com/enonic/xp/web/vhost/impl/VirtualHostFilterTest.java
+++ b/modules/web/web-vhost/src/test/java/com/enonic/xp/web/vhost/impl/VirtualHostFilterTest.java
@@ -206,7 +206,7 @@ class VirtualHostFilterTest
         filter.doFilter( this.req, this.res, this.chain );
 
         verify( this.chain, never() ).doFilter( any(), any() );
-        verify( req, never() ).setAttribute( eq( VirtualHost.class.getName() ), notNull() );
+        verify( req, never() ).setAttribute( eq( VirtualHost.class.getName() ), any() );
         verify( res ).setStatus( 404 );
     }
 
@@ -228,7 +228,7 @@ class VirtualHostFilterTest
         filter.doFilter( this.req, this.res, this.chain );
 
         verify( this.chain, never() ).doFilter( any(), any() );
-        verify( req, never() ).setAttribute( eq( VirtualHost.class.getName() ), notNull() );
+        verify( req, never() ).setAttribute( eq( VirtualHost.class.getName() ), any() );
         verify( res ).setStatus( 404 );
     }
 

--- a/modules/web/web-vhost/src/test/java/com/enonic/xp/web/vhost/impl/VirtualHostFilterTest.java
+++ b/modules/web/web-vhost/src/test/java/com/enonic/xp/web/vhost/impl/VirtualHostFilterTest.java
@@ -189,6 +189,50 @@ class VirtualHostFilterTest
     }
 
     @Test
+    void testManagementPort_mappingExistsButNoMatch_notFound()
+        throws Exception
+    {
+        final VirtualHostMapping mapping =
+            new VirtualHostMapping( "mgmt", "admin.enonic.com", "/", "/", VirtualHostIdProvidersMapping.create().build(), 0, Map.of(),
+                                    DispatchConstants.MANAGEMENT_CONNECTOR );
+        this.virtualHosts.add( mapping );
+
+        when( this.virtualHostService.isEnabled() ).thenReturn( true );
+        when( this.req.getServerName() ).thenReturn( "10.0.0.5" );
+        when( this.req.getPathInfo() ).thenReturn( "/repo" );
+        when( this.req.getAttribute( DispatchConstants.CONNECTOR_ATTRIBUTE ) ).thenReturn( DispatchConstants.MANAGEMENT_CONNECTOR );
+
+        VirtualHostFilter filter = new VirtualHostFilter( virtualHostService, new VirtualHostResolverImpl( virtualHostService ) );
+        filter.doFilter( this.req, this.res, this.chain );
+
+        verify( this.chain, never() ).doFilter( any(), any() );
+        verify( req, never() ).setAttribute( eq( VirtualHost.class.getName() ), notNull() );
+        verify( res ).setStatus( 404 );
+    }
+
+    @Test
+    void testStatusPort_mappingExistsButNoMatch_notFound()
+        throws Exception
+    {
+        final VirtualHostMapping mapping =
+            new VirtualHostMapping( "stats", "stats.enonic.com", "/", "/", VirtualHostIdProvidersMapping.create().build(), 0, Map.of(),
+                                    DispatchConstants.STATISTICS_CONNECTOR );
+        this.virtualHosts.add( mapping );
+
+        when( this.virtualHostService.isEnabled() ).thenReturn( true );
+        when( this.req.getServerName() ).thenReturn( "10.0.0.5" );
+        when( this.req.getPathInfo() ).thenReturn( "/dump.threads" );
+        when( this.req.getAttribute( DispatchConstants.CONNECTOR_ATTRIBUTE ) ).thenReturn( DispatchConstants.STATISTICS_CONNECTOR );
+
+        VirtualHostFilter filter = new VirtualHostFilter( virtualHostService, new VirtualHostResolverImpl( virtualHostService ) );
+        filter.doFilter( this.req, this.res, this.chain );
+
+        verify( this.chain, never() ).doFilter( any(), any() );
+        verify( req, never() ).setAttribute( eq( VirtualHost.class.getName() ), notNull() );
+        verify( res ).setStatus( 404 );
+    }
+
+    @Test
     void testStatusPort_noMatch_defaultVhostUsed()
         throws Exception
     {


### PR DESCRIPTION
## Summary

When at least one vhost mapping exists for the management (`api`) or statistics (`status`) connector, a request whose host matches none of them now gets **404** instead of falling through to the unrestricted default vhost.

The fallback made the `allow`, `api.rest.enabled` and `api.<app>:<api>.verbs` settings of the mappings that do exist bypassable: a client on an IP that may reach the port could simply send a different `Host` header (for example the raw IP) and land on the default vhost with an empty allow list and no API policy. A firewall cannot enforce a Host-keyed rule, so this has to be closed in the filter.

Connectors with **no** mapping keep the previous behaviour and stay reachable through the default vhost, so existing installs without management or statistics vhosts are unaffected. The web connector already required a match and is unchanged.

## Changes

- `VirtualHostFilter`: fail closed with 404 when the connector has mappings but none match; keep the default vhost only when the connector has no mappings at all.
- `VirtualHostFilterTest`: two new cases (management and statistics) asserting 404 and no filter-chain invocation when a mapping exists but the host does not match. The existing "mapping exists only for the web connector, management still uses the default" case still passes and now documents the distinction.
- `com.enonic.xp.web.vhost.cfg`: comment explaining the rule next to the management example.

## Testing

`./gradlew :web:web-vhost:test` — 76 tests pass, including all 11 `VirtualHostFilterTest` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_