### PR TITLE
Honour api.index.enabled for the /api/ path as well #12345

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/api/ApiIndexHandler.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/api/ApiIndexHandler.java
@@ -67,9 +67,9 @@ public class ApiIndexHandler
     @Override
     protected boolean canHandle( final WebRequest webRequest )
     {
-        boolean isIndexEnabled = apiIndexMode == ApiIndexMode.ON || apiIndexMode == ApiIndexMode.AUTO && RunMode.isDev();
-        return isIndexEnabled && PathMatchers.API_BASE.equals( webRequest.getBasePath() ) ||
-            PathMatchers.API_PREFIX.equals( webRequest.getBasePath() );
+        final boolean isIndexEnabled = apiIndexMode == ApiIndexMode.ON || ( apiIndexMode == ApiIndexMode.AUTO && RunMode.isDev() );
+        final String basePath = webRequest.getBasePath();
+        return isIndexEnabled && ( PathMatchers.API_BASE.equals( basePath ) || PathMatchers.API_PREFIX.equals( basePath ) );
     }
 
     @Override

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/api/ApiIndexHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/api/ApiIndexHandlerTest.java
@@ -104,17 +104,33 @@ class ApiIndexHandlerTest
     {
         RunModeSupport.set( RunMode.PROD );
 
-        RunModeSupport.set( RunMode.PROD );
-
         final WebRequest webRequest7 = new WebRequest();
         webRequest7.setRawPath( "/api" );
         assertFalse( this.handler.canHandle( webRequest7 ) );
+
+        final WebRequest webRequest7a = new WebRequest();
+        webRequest7a.setRawPath( "/api/" );
+        assertFalse( this.handler.canHandle( webRequest7a ) );
 
         when( apiConfig.api_index_enabled() ).thenReturn( "off" );
         this.handler.activate( apiConfig );
         final WebRequest webRequest8 = new WebRequest();
         webRequest8.setRawPath( "/api" );
         assertFalse( this.handler.canHandle( webRequest8 ) );
+
+        final WebRequest webRequest8a = new WebRequest();
+        webRequest8a.setRawPath( "/api/" );
+        assertFalse( this.handler.canHandle( webRequest8a ) );
+
+        when( apiConfig.api_index_enabled() ).thenReturn( "on" );
+        this.handler.activate( apiConfig );
+        final WebRequest webRequest9 = new WebRequest();
+        webRequest9.setRawPath( "/api" );
+        assertTrue( this.handler.canHandle( webRequest9 ) );
+
+        final WebRequest webRequest9a = new WebRequest();
+        webRequest9a.setRawPath( "/api/" );
+        assertTrue( this.handler.canHandle( webRequest9a ) );
     }
 
     @Test


### PR DESCRIPTION
## Summary

`ApiIndexHandler.canHandle` combined the mode check and the two accepted base paths as `enabled && "/api" || "/api/"`. Because `&&` binds tighter than `||`, a request to **`/api/`** (trailing slash) was handled in prod and with `api.index.enabled = off`, while `/api` correctly followed the mode.

The index lists every installed application's API descriptors with their allowed principals and mounts. The intended behaviour is: discoverable by default in dev mode (`auto`), off in prod, and `api.index.enabled` overrides in either direction. This change makes the trailing-slash form follow the same rule; no behaviour changes for `/api` or for dev mode.

## Changes

- `ApiIndexHandler.canHandle`: parenthesise the path alternatives so both `/api` and `/api/` are gated by the resolved mode.
- `ApiIndexHandlerTest.testCanHandle_prod`: assert `/api/` is not handled in prod with the default (`auto`) and with `off`; assert both forms are handled in prod with `on` to cover the config override. Also drops a duplicated `RunModeSupport.set` line.

## Testing

`./gradlew :portal:portal-impl:test --tests com.enonic.xp.portal.impl.handler.api.ApiIndexHandlerTest` — 5 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_