### PR TITLE
content mapping handler does not respect content permissions  #12356

### DIFF
--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentContentHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentContentHandler.java
@@ -1,10 +1,12 @@
 package com.enonic.xp.lib.portal.current;
 
 import com.enonic.xp.content.Content;
+import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.lib.content.mapper.ContentMapper;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
+import com.enonic.xp.security.acl.Permission;
 
 import static java.util.Objects.requireNonNull;
 
@@ -16,7 +18,12 @@ public final class GetCurrentContentHandler
     public ContentMapper execute()
     {
         final Content content = this.request.getContent();
-        return content != null ? new ContentMapper( content ) : null;
+        return content != null && isReadable( content ) ? new ContentMapper( content ) : null;
+    }
+
+    private static boolean isReadable( final Content content )
+    {
+        return content.getPermissions().isAllowedFor( ContextAccessor.current().getAuthInfo().getPrincipals(), Permission.READ );
     }
 
     @Override

--- a/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentContentHandler.java
+++ b/modules/lib/lib-portal/src/main/java/com/enonic/xp/lib/portal/current/GetCurrentContentHandler.java
@@ -23,7 +23,8 @@ public final class GetCurrentContentHandler
 
     private static boolean isReadable( final Content content )
     {
-        return content.getPermissions().isAllowedFor( ContextAccessor.current().getAuthInfo().getPrincipals(), Permission.READ );
+        return !content.getPath().isRoot() &&
+            content.getPermissions().isAllowedFor( ContextAccessor.current().getAuthInfo().getPrincipals(), Permission.READ );
     }
 
     @Override

--- a/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/TestDataFixtures.java
+++ b/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/TestDataFixtures.java
@@ -56,6 +56,8 @@ public final class TestDataFixtures
                             .add( new Mixin( MixinName.from( "com.enonic.myapplication:myschema" ), newTinyPropertyTree() ) )
                             .build() );
         builder.page( newPage() );
+        builder.permissions(
+            AccessControlList.of( AccessControlEntry.create().principal( RoleKeys.EVERYONE ).allow( Permission.READ ).build() ) );
 
         return builder.build();
     }
@@ -73,6 +75,8 @@ public final class TestDataFixtures
         builder.createdTime( Instant.ofEpochSecond( 0 ) );
         builder.language( Locale.ENGLISH );
         builder.data( newTinyPropertyTree() );
+        builder.permissions(
+            AccessControlList.of( AccessControlEntry.create().principal( RoleKeys.EVERYONE ).allow( Permission.READ ).build() ) );
         return builder.build();
     }
 

--- a/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/current/GetCurrentContentScriptTest.java
+++ b/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/current/GetCurrentContentScriptTest.java
@@ -34,6 +34,15 @@ class GetCurrentContentScriptTest
     }
 
     @Test
+    void currentContentIsRoot()
+    {
+        final Content content = Content.create( TestDataFixtures.newContent() ).root().build();
+        this.portalRequest.setContent( content );
+
+        runFunction( "/test/getCurrentContent-test.js", "noCurrentContent" );
+    }
+
+    @Test
     void noCurrentContent()
     {
         this.portalRequest.setContent( null );

--- a/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/current/GetCurrentContentScriptTest.java
+++ b/modules/lib/lib-portal/src/test/java/com/enonic/xp/lib/portal/current/GetCurrentContentScriptTest.java
@@ -4,6 +4,10 @@ import org.junit.jupiter.api.Test;
 
 import com.enonic.xp.content.Content;
 import com.enonic.xp.lib.portal.TestDataFixtures;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.acl.AccessControlEntry;
+import com.enonic.xp.security.acl.AccessControlList;
+import com.enonic.xp.security.acl.Permission;
 import com.enonic.xp.testing.ScriptTestSupport;
 
 class GetCurrentContentScriptTest
@@ -16,6 +20,17 @@ class GetCurrentContentScriptTest
         this.portalRequest.setContent( content );
 
         runFunction( "/test/getCurrentContent-test.js", "currentContent" );
+    }
+
+    @Test
+    void currentContentNotReadable()
+    {
+        final Content content = Content.create( TestDataFixtures.newContent() )
+            .permissions( AccessControlList.of( AccessControlEntry.create().principal( RoleKeys.ADMIN ).allow( Permission.READ ).build() ) )
+            .build();
+        this.portalRequest.setContent( content );
+
+        runFunction( "/test/getCurrentContent-test.js", "noCurrentContent" );
     }
 
     @Test

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/PortalRequestHelper.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/PortalRequestHelper.java
@@ -57,8 +57,7 @@ public final class PortalRequestHelper
         final Content content = portalRequest.getContent();
         if ( content != null )
         {
-            if ( content.getPath().isRoot() ||
-                !content.getPermissions().isAllowedFor( ContextAccessor.current().getAuthInfo().getPrincipals(), Permission.READ ) )
+            if ( !isReadable( content ) )
             {
                 throw WebException.forbidden( String.format( "You don't have permission to access [%s]", portalRequest.getContentPath() ) );
             }
@@ -68,6 +67,12 @@ public final class PortalRequestHelper
         {
             throw WebException.notFound( String.format( "Page [%s] not found", portalRequest.getContentPath() ) );
         }
+    }
+
+    public static boolean isReadable( final Content content )
+    {
+        return !content.getPath().isRoot() &&
+            content.getPermissions().isAllowedFor( ContextAccessor.current().getAuthInfo().getPrincipals(), Permission.READ );
     }
 
     public static Site getSiteOrElseThrow( final PortalRequest portalRequest )

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/mapping/MappingHandlerHelper.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/mapping/MappingHandlerHelper.java
@@ -91,6 +91,10 @@ class MappingHandlerHelper
         }
 
         final Content content = request.getContent() == null ? null : PortalRequestHelper.getContentOrElseThrow( request );
+        if ( content == null && site != null && !PortalRequestHelper.isReadable( site ) )
+        {
+            throw WebException.forbidden( String.format( "You don't have permission to access [%s]", request.getContentPath() ) );
+        }
 
         final List<ControllerMappingDescriptor> matchingMappings =
             controllerMappingsResolver.resolveAll( PortalRequestHelper.getSiteRelativePath( request ), request.getParams(), content,

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/mapping/MappingHandlerHelper.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/mapping/MappingHandlerHelper.java
@@ -90,7 +90,7 @@ class MappingHandlerHelper
             return webHandlerChain.handle( webRequest, webResponse );
         }
 
-        final Content content = request.getContent();
+        final Content content = request.getContent() == null ? null : PortalRequestHelper.getContentOrElseThrow( request );
 
         final List<ControllerMappingDescriptor> matchingMappings =
             controllerMappingsResolver.resolveAll( PortalRequestHelper.getSiteRelativePath( request ), request.getParams(), content,

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/mapping/ComponentServiceMappingHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/mapping/ComponentServiceMappingHandlerTest.java
@@ -25,6 +25,10 @@ import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceService;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.acl.AccessControlEntry;
+import com.enonic.xp.security.acl.AccessControlList;
+import com.enonic.xp.security.acl.Permission;
 import com.enonic.xp.site.Site;
 import com.enonic.xp.site.SiteConfig;
 import com.enonic.xp.site.SiteConfigs;
@@ -111,7 +115,11 @@ class ComponentServiceMappingHandlerTest
         SiteConfigsDataSerializer.toData( siteConfigs, siteData.getRoot() );
 
         final Site site = Site.create().name( "my-site" ).parentPath( ContentPath.ROOT ).data( siteData ).build();
-        final Content content = Content.create().name( "my-content" ).parentPath( site.getPath() ).build();
+        final Content content = Content.create()
+            .name( "my-content" )
+            .parentPath( site.getPath() )
+            .permissions( AccessControlList.of( AccessControlEntry.create().principal( RoleKeys.EVERYONE ).allow( Permission.READ ).build() ) )
+            .build();
 
         this.request.setContent( content );
         this.request.setContentPath( content.getPath() );

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/mapping/ImageServiceMappingHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/mapping/ImageServiceMappingHandlerTest.java
@@ -22,6 +22,10 @@ import com.enonic.xp.repository.RepositoryId;
 import com.enonic.xp.resource.Resource;
 import com.enonic.xp.resource.ResourceKey;
 import com.enonic.xp.resource.ResourceService;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.acl.AccessControlEntry;
+import com.enonic.xp.security.acl.AccessControlList;
+import com.enonic.xp.security.acl.Permission;
 import com.enonic.xp.site.Site;
 import com.enonic.xp.site.SiteConfig;
 import com.enonic.xp.site.SiteConfigs;
@@ -100,7 +104,11 @@ class ImageServiceMappingHandlerTest
         SiteConfigsDataSerializer.toData( siteConfigs, siteData.getRoot() );
 
         final Site site = Site.create().name( "my-site" ).parentPath( ContentPath.ROOT ).data( siteData ).build();
-        final Content content = Content.create().name( "my-content" ).parentPath( site.getPath() ).build();
+        final Content content = Content.create()
+            .name( "my-content" )
+            .parentPath( site.getPath() )
+            .permissions( AccessControlList.of( AccessControlEntry.create().principal( RoleKeys.EVERYONE ).allow( Permission.READ ).build() ) )
+            .build();
 
         this.request.setContent( content );
         this.request.setContentPath( content.getPath() );

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/mapping/MappingHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/mapping/MappingHandlerTest.java
@@ -243,6 +243,29 @@ class MappingHandlerTest
     }
 
     @Test
+    void executeScript_noContent()
+        throws Exception
+    {
+        final ResourceKey controller = ResourceKey.from( "demo:/services/test" );
+        final ControllerMappingDescriptor mapping =
+            ControllerMappingDescriptor.create().controller( controller ).pattern( "/.*" ).build();
+
+        setupContentAndSite( mapping, false );
+        this.request.setContent( null );
+
+        this.request.setBaseUri( "/site" );
+        this.request.setContentPath( ContentPath.from( "/site/somesite/missing" ) );
+
+        when( rendererDelegate.render( isA( ControllerMappingDescriptor.class ), same( request ) ) ).thenReturn(
+            PortalResponse.create().body( "Ok body" ).build() );
+
+        final WebResponse response = this.handler.handle( this.request, PortalResponse.create().build(), null );
+        assertEquals( HttpStatus.OK, response.getStatus() );
+        assertEquals( "Ok body", response.getBody() );
+        assertNull( this.request.getContent() );
+    }
+
+    @Test
     void executeScript_contentNotReadable_unauthorized()
         throws Exception
     {

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/mapping/MappingHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/mapping/MappingHandlerTest.java
@@ -292,6 +292,33 @@ class MappingHandlerTest
     }
 
     @Test
+    void executeScript_noContent_siteNotReadable_unauthorized()
+        throws Exception
+    {
+        final ResourceKey controller = ResourceKey.from( "demo:/services/test" );
+        final ControllerMappingDescriptor mapping =
+            ControllerMappingDescriptor.create().controller( controller ).pattern( "/.*" ).build();
+
+        setupContentAndSite( mapping, false );
+
+        final Site restrictedSite = Site.create( this.request.getSite() )
+            .permissions( AccessControlList.create()
+                              .add( AccessControlEntry.create().allow( Permission.READ ).principal( RoleKeys.ADMIN ).build() )
+                              .build() )
+            .build();
+        this.request.setSite( restrictedSite );
+        this.request.setContent( null );
+
+        this.request.setBaseUri( "/site" );
+        this.request.setContentPath( ContentPath.from( "/site/somesite/missing" ) );
+
+        final WebException e =
+            assertThrows( WebException.class, () -> this.handler.handle( this.request, PortalResponse.create().build(), null ) );
+        assertEquals( HttpStatus.UNAUTHORIZED, e.getStatus() );
+        verifyNoInteractions( rendererDelegate );
+    }
+
+    @Test
     void executeScript_recordsTraceAttributes()
         throws Exception
     {
@@ -846,6 +873,9 @@ class MappingHandlerTest
             .modifier( PrincipalKey.from( "user:system:admin" ) )
             .type( ContentTypeName.from( contentTypeName ) )
             .page( page )
+            .permissions( AccessControlList.create()
+                              .add( AccessControlEntry.create().allow( Permission.READ ).principal( RoleKeys.EVERYONE ).build() )
+                              .build() )
             .build();
     }
 

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/mapping/MappingHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/mapping/MappingHandlerTest.java
@@ -243,6 +243,32 @@ class MappingHandlerTest
     }
 
     @Test
+    void executeScript_contentNotReadable_unauthorized()
+        throws Exception
+    {
+        final ResourceKey controller = ResourceKey.from( "demo:/services/test" );
+        final ControllerMappingDescriptor mapping =
+            ControllerMappingDescriptor.create().controller( controller ).pattern( "/.*" ).build();
+
+        setupContentAndSite( mapping, false );
+
+        final Content restrictedContent = Content.create( this.request.getContent() )
+            .permissions( AccessControlList.create()
+                              .add( AccessControlEntry.create().allow( Permission.READ ).principal( RoleKeys.ADMIN ).build() )
+                              .build() )
+            .build();
+        this.request.setContent( restrictedContent );
+
+        this.request.setBaseUri( "/site" );
+        this.request.setContentPath( ContentPath.from( "/site/somesite/content" ) );
+
+        final WebException e =
+            assertThrows( WebException.class, () -> this.handler.handle( this.request, PortalResponse.create().build(), null ) );
+        assertEquals( HttpStatus.UNAUTHORIZED, e.getStatus() );
+        verifyNoInteractions( rendererDelegate );
+    }
+
+    @Test
     void executeScript_recordsTraceAttributes()
         throws Exception
     {


### PR DESCRIPTION
## Summary

`SiteHandler` and `PortalRequestRerouter` resolve the requested content as **content admin** so that the site and id provider can be found even when the caller may not read the content. The caller's READ check lives in `PortalRequestHelper.getContentOrElseThrow`, which `PageHandlerWorker` and `ComponentHandler` call, but `MappingHandlerHelper` did not.

Consequence: a site with a controller mapping (for example the catch-all `<pattern>/.*</pattern>` used by headless front ends) rendered content whose ACL grants READ only to a restricted role to anonymous visitors, on both `master` and `draft`, and `portal.getContent()` returned the full content to the controller. A `match` constraint on the mapping could also be used to probe the existence and type of restricted content, because it was evaluated on the admin-resolved content.

## Changes

- **`MappingHandlerHelper`**: apply `getContentOrElseThrow` before the content can influence mapping selection or reach a controller or filter, exactly as `PageHandlerWorker` does for pages. Anonymous callers get **401** so the id provider login flow can start; authenticated callers without READ get **403**.
- **`MappingHandlerHelper`**, paths without content: when the URL resolves to no content but lies under a site, the site itself must be readable before its mappings run. Before the admin-context resolution an unreadable site was simply not found for the caller and no mapping ran; this restores that rule, so a restricted site's catch-all controller no longer executes for visitors who may not read the site.
- **`PortalRequestHelper.isReadable`**: the READ rule shared by both checks.
- **`GetCurrentContentHandler`** (`portal.getContent()`): return `null` when the current context may not read the request content. Defence in depth for services, filters and error handlers that run under a content path; an elevated `context.run` still sees the content.
- **Tests**: `MappingHandlerTest.executeScript_contentNotReadable_unauthorized`, `executeScript_noContent_siteNotReadable_unauthorized`, `executeScript_noContent` and `GetCurrentContentScriptTest.currentContentNotReadable`. The test fixtures previously had no ACL at all; they now carry an everyone-READ ACL like real content.

No changes to `SiteHandler` or `PortalRequestRerouter`: the admin-context lookup is still needed there for site and id provider resolution.

## Testing

`./gradlew :portal:portal-impl:test --tests com.enonic.xp.portal.impl.handler.mapping.MappingHandlerTest :lib:lib-portal:test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV