### PR TITLE
Limit the size of request bodies read into memory and read API bodies after access checks

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiFilter.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiFilter.java
@@ -16,9 +16,6 @@ import jakarta.servlet.annotation.WebFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import com.google.common.io.CharStreams;
-import com.google.common.net.MediaType;
-
 import com.enonic.xp.annotation.Order;
 import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
@@ -73,7 +70,6 @@ public final class SlashApiFilter
         try
         {
             webRequest = webSerializerService.request( req );
-            webRequest.setBody( readBody( req ) );
             final WebSocketContext webSocketContext = this.webSocketContextFactory.newContext( req, res );
             webRequest.setWebSocketContext( webSocketContext );
 
@@ -95,30 +91,5 @@ public final class SlashApiFilter
         }
 
         webSerializerService.response( webRequest, webResponse, res );
-    }
-
-    private static String readBody( final HttpServletRequest req )
-        throws IOException
-    {
-        final MediaType mediaType = parseMediaType( req.getContentType() );
-        return mediaType != null && ( mediaType.is( MediaType.ANY_TEXT_TYPE ) || mediaType.is( MediaType.JSON_UTF_8.withoutParameters() ) )
-            ? CharStreams.toString( req.getReader() )
-            : null;
-    }
-
-    private static MediaType parseMediaType( final String contentType )
-    {
-        if ( contentType == null )
-        {
-            return null;
-        }
-        try
-        {
-            return MediaType.parse( contentType );
-        }
-        catch ( IllegalArgumentException e )
-        {
-            return null;
-        }
     }
 }

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiHandler.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiHandler.java
@@ -11,6 +11,8 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import com.enonic.xp.admin.tool.AdminToolDescriptor;
 import com.enonic.xp.admin.tool.AdminToolDescriptorService;
 import com.enonic.xp.api.ApiDescriptor;
@@ -46,6 +48,7 @@ import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
 import com.enonic.xp.web.dispatch.DispatchConstants;
+import com.enonic.xp.web.serializer.WebSerializerService;
 import com.enonic.xp.web.sse.SseConfig;
 import com.enonic.xp.web.websocket.WebSocketConfig;
 import com.enonic.xp.web.websocket.WebSocketContext;
@@ -70,6 +73,8 @@ public class SlashApiHandler
 
     private final SseManager sseManager;
 
+    private final WebSerializerService webSerializerService;
+
     private volatile boolean mediaApiAutoMount = true;
 
     @Activate
@@ -78,7 +83,7 @@ public class SlashApiHandler
                             @Reference final WebappService webappService,
                             @Reference final AdminToolDescriptorService adminToolDescriptorService,
                             @Reference final DynamicUniversalApiHandlerRegistry universalApiHandlerRegistry,
-                            @Reference final SseManager sseManager )
+                            @Reference final SseManager sseManager, @Reference final WebSerializerService webSerializerService )
     {
         this.controllerScriptFactory = controllerScriptFactory;
         this.apiDescriptorService = apiDescriptorService;
@@ -87,6 +92,7 @@ public class SlashApiHandler
         this.adminToolDescriptorService = adminToolDescriptorService;
         this.universalApiHandlerRegistry = universalApiHandlerRegistry;
         this.sseManager = sseManager;
+        this.webSerializerService = webSerializerService;
     }
 
     @Activate
@@ -144,11 +150,28 @@ public class SlashApiHandler
         verifyAccessToApi( apiDescriptor, portalRequest, mountContext );
         verifyRequestMounted( apiDescriptor, portalRequest, mountContext );
 
+        if ( portalRequest.getBody() == null && portalRequest.getRawRequest() != null )
+        {
+            portalRequest.setBody( readBody( portalRequest.getRawRequest() ) );
+        }
+
         final Supplier<WebResponse> handler = dynamicApiHandler != null
             ? () -> executeDynamicApiHandler( portalRequest, dynamicApiHandler )
             : () -> executeController( portalRequest, descriptorKey );
 
         return execute( portalRequest, descriptorKey, handler );
+    }
+
+    private Object readBody( final HttpServletRequest rawRequest )
+    {
+        try
+        {
+            return webSerializerService.readBody( rawRequest );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
     }
 
     private ApiDescriptor resolveApiDescriptor( DynamicUniversalApiHandler dynamicApiHandler, final DescriptorKey descriptorKey )

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiFilterTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiFilterTest.java
@@ -1,7 +1,5 @@
 package com.enonic.xp.portal.impl.handler;
 
-import java.io.BufferedReader;
-import java.io.StringReader;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,8 +18,6 @@ import com.enonic.xp.web.websocket.WebSocketConfig;
 import com.enonic.xp.web.websocket.WebSocketContext;
 import com.enonic.xp.web.websocket.WebSocketContextFactory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -100,50 +96,6 @@ class SlashApiFilterTest
     }
 
     @Test
-    void readsTextBody()
-        throws Exception
-    {
-        final HttpServletRequest req = mock( HttpServletRequest.class );
-        final HttpServletResponse res = mock( HttpServletResponse.class );
-        final FilterChain chain = mock( FilterChain.class );
-
-        when( req.getPathInfo() ).thenReturn( "/com.enonic.app.myapp:myapi" );
-        when( req.getContentType() ).thenReturn( "application/json" );
-        when( req.getReader() ).thenReturn( new BufferedReader( new StringReader( "{}" ) ) );
-
-        final WebRequest webRequest = new WebRequest();
-        when( webSerializerService.request( req ) ).thenReturn( webRequest );
-        when( slashApiHandler.handle( any( WebRequest.class ) ) ).thenReturn( WebResponse.create().status( HttpStatus.OK ).build() );
-
-        filter.doFilter( req, res, chain );
-
-        verify( slashApiHandler ).handle( webRequest );
-        assertEquals( "{}", webRequest.getBody() );
-    }
-
-    @Test
-    void readsPlainTextBody()
-        throws Exception
-    {
-        final HttpServletRequest req = mock( HttpServletRequest.class );
-        final HttpServletResponse res = mock( HttpServletResponse.class );
-        final FilterChain chain = mock( FilterChain.class );
-
-        when( req.getPathInfo() ).thenReturn( "/com.enonic.app.myapp:myapi" );
-        when( req.getContentType() ).thenReturn( "text/plain; charset=utf-8" );
-        when( req.getReader() ).thenReturn( new BufferedReader( new StringReader( "Hello World" ) ) );
-
-        final WebRequest webRequest = new WebRequest();
-        when( webSerializerService.request( req ) ).thenReturn( webRequest );
-        when( slashApiHandler.handle( any( WebRequest.class ) ) ).thenReturn( WebResponse.create().status( HttpStatus.OK ).build() );
-
-        filter.doFilter( req, res, chain );
-
-        verify( slashApiHandler ).handle( webRequest );
-        assertEquals( "Hello World", webRequest.getBody() );
-    }
-
-    @Test
     void rendersHandlerFailure()
         throws Exception
     {
@@ -166,28 +118,6 @@ class SlashApiFilterTest
 
         verify( exceptionRenderer ).render( webRequest, cause );
         verify( webSerializerService ).response( webRequest, errorResponse, res );
-    }
-
-    @Test
-    void skipsBodyForMalformedContentType()
-        throws Exception
-    {
-        final HttpServletRequest req = mock( HttpServletRequest.class );
-        final HttpServletResponse res = mock( HttpServletResponse.class );
-        final FilterChain chain = mock( FilterChain.class );
-
-        when( req.getPathInfo() ).thenReturn( "/com.enonic.app.myapp:myapi" );
-        when( req.getContentType() ).thenReturn( "foo" );
-
-        final WebRequest webRequest = new WebRequest();
-        when( webSerializerService.request( req ) ).thenReturn( webRequest );
-        when( slashApiHandler.handle( any( WebRequest.class ) ) ).thenReturn( WebResponse.create().status( HttpStatus.OK ).build() );
-
-        filter.doFilter( req, res, chain );
-
-        verify( slashApiHandler ).handle( webRequest );
-        assertNull( webRequest.getBody() );
-        verify( req, never() ).getReader();
     }
 
     @Test

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiHandlerTest.java
@@ -1,6 +1,7 @@
 package com.enonic.xp.portal.impl.handler;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 
@@ -57,6 +58,7 @@ import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
 import com.enonic.xp.web.dispatch.DispatchConstants;
 import com.enonic.xp.web.sse.SseConfig;
+import com.enonic.xp.web.serializer.WebSerializerService;
 import com.enonic.xp.web.sse.SseEndpoint;
 import com.enonic.xp.web.websocket.WebSocketConfig;
 import com.enonic.xp.web.websocket.WebSocketContext;
@@ -76,6 +78,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -95,6 +98,8 @@ class SlashApiHandlerTest
 
     private SseManager sseManager;
 
+    private WebSerializerService webSerializerService;
+
     private ControllerScript controllerScript;
 
     private PortalRequest request;
@@ -112,9 +117,10 @@ class SlashApiHandlerTest
         adminToolDescriptorService = mock( AdminToolDescriptorService.class );
         universalApiHandlerRegistry = new DynamicUniversalApiHandlerRegistry();
         sseManager = mock( SseManager.class );
+        webSerializerService = mock( WebSerializerService.class );
 
         handler = new SlashApiHandler( controllerScriptFactory, apiDescriptorService, siteService, webappService, adminToolDescriptorService,
-                                       universalApiHandlerRegistry, sseManager );
+                                       universalApiHandlerRegistry, sseManager, webSerializerService );
 
         final WebSocketConfig webSocketConfig = mock( WebSocketConfig.class );
 
@@ -226,6 +232,84 @@ class SlashApiHandlerTest
         assertNull( request.getSite() );
         assertNull( request.getContent() );
         assertEquals( "/api/com.enonic.app.myapp:api-key", request.getContextPath() );
+    }
+
+    @Test
+    void testHandleApi_readsBodyAfterAccessGranted()
+        throws Exception
+    {
+        request.setRawPath( "/api/com.enonic.app.myapp:api-key" );
+
+        final ApiDescriptor apiDescriptor = ApiDescriptor.create()
+            .key( DescriptorKey.from( ApplicationKey.from( "com.enonic.app.myapp" ), "api-key" ) )
+            .allowedPrincipals( PrincipalKeys.from( RoleKeys.EVERYONE ) )
+            .mount( "web" )
+            .build();
+
+        when( apiDescriptorService.getByKey( any( DescriptorKey.class ) ) ).thenReturn( apiDescriptor );
+        when( webSerializerService.readBody( servletRequestMock ) ).thenReturn( "{\"a\":1}" );
+
+        final WebResponse webResponse = this.handler.handle( request );
+        assertEquals( HttpStatus.OK, webResponse.getStatus() );
+        assertEquals( "{\"a\":1}", request.getBody() );
+    }
+
+    @Test
+    void testHandleApi_bodyAlreadyReadIsKept()
+        throws Exception
+    {
+        request.setRawPath( "/api/com.enonic.app.myapp:api-key" );
+        request.setBody( "already read by the dispatcher" );
+
+        final ApiDescriptor apiDescriptor = ApiDescriptor.create()
+            .key( DescriptorKey.from( ApplicationKey.from( "com.enonic.app.myapp" ), "api-key" ) )
+            .allowedPrincipals( PrincipalKeys.from( RoleKeys.EVERYONE ) )
+            .mount( "web" )
+            .build();
+
+        when( apiDescriptorService.getByKey( any( DescriptorKey.class ) ) ).thenReturn( apiDescriptor );
+
+        this.handler.handle( request );
+
+        verify( webSerializerService, never() ).readBody( any() );
+        assertEquals( "already read by the dispatcher", request.getBody() );
+    }
+
+    @Test
+    void testHandleApiAccessDenied_doesNotReadBody()
+        throws Exception
+    {
+        request.setRawPath( "/api/com.enonic.app.myapp:api-key" );
+
+        final ApiDescriptor apiDescriptor = ApiDescriptor.create()
+            .key( DescriptorKey.from( ApplicationKey.from( "com.enonic.app.myapp" ), "api-key" ) )
+            .allowedPrincipals( PrincipalKeys.from( PrincipalKey.from( "role:principalKey" ) ) )
+            .mount( "web" )
+            .build();
+
+        when( apiDescriptorService.getByKey( any( DescriptorKey.class ) ) ).thenReturn( apiDescriptor );
+
+        final WebException ex = assertThrows( WebException.class, () -> this.handler.handle( request ) );
+        assertEquals( HttpStatus.UNAUTHORIZED, ex.getStatus() );
+        verify( webSerializerService, never() ).readBody( any() );
+    }
+
+    @Test
+    void testHandleApi_bodyReadFailureIsUnchecked()
+        throws Exception
+    {
+        request.setRawPath( "/api/com.enonic.app.myapp:api-key" );
+
+        final ApiDescriptor apiDescriptor = ApiDescriptor.create()
+            .key( DescriptorKey.from( ApplicationKey.from( "com.enonic.app.myapp" ), "api-key" ) )
+            .allowedPrincipals( PrincipalKeys.from( RoleKeys.EVERYONE ) )
+            .mount( "web" )
+            .build();
+
+        when( apiDescriptorService.getByKey( any( DescriptorKey.class ) ) ).thenReturn( apiDescriptor );
+        when( webSerializerService.readBody( servletRequestMock ) ).thenThrow( new IOException( "closed" ) );
+
+        assertThrows( UncheckedIOException.class, () -> this.handler.handle( request ) );
     }
 
     @Test

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/serializer/RequestBodyReaderTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/serializer/RequestBodyReaderTest.java
@@ -11,22 +11,28 @@ import com.google.common.net.MediaType;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.impl.serializer.RequestBodyReader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RequestBodyReaderTest
 {
+    private static final long LIMIT = 1024;
+
     private HttpServletRequest req;
 
     @BeforeEach
     void setup()
     {
         this.req = Mockito.mock( HttpServletRequest.class );
+        Mockito.when( this.req.getContentLengthLong() ).thenReturn( -1L );
     }
 
     @Test
@@ -47,18 +53,13 @@ class RequestBodyReaderTest
         Mockito.when( this.req.getReader() ).thenReturn( new BufferedReader( new StringReader( text ) ) );
     }
 
-    private void setBytes( final String type, final byte[] bytes )
-    {
-        Mockito.when( this.req.getContentType() ).thenReturn( type );
-    }
-
     @Test
     void readNonText()
         throws Exception
     {
-        setBytes( "application/octet-stream", new byte[0] );
+        Mockito.when( this.req.getContentType() ).thenReturn( "application/octet-stream" );
 
-        final Object result = RequestBodyReader.readBody( this.req );
+        final Object result = RequestBodyReader.readBody( this.req, LIMIT );
         assertNull( result );
     }
 
@@ -66,9 +67,21 @@ class RequestBodyReaderTest
     void readMalformedContentType()
         throws Exception
     {
-        setText( "foo", "Hello World" );
+        Mockito.when( this.req.getContentType() ).thenReturn( "text" );
 
-        assertNull( RequestBodyReader.readBody( this.req ) );
+        assertNull( RequestBodyReader.readBody( this.req, LIMIT ) );
+        Mockito.verify( this.req, Mockito.never() ).getReader();
+    }
+
+    @Test
+    void readNonText_ignoresLimit()
+        throws Exception
+    {
+        Mockito.when( this.req.getContentType() ).thenReturn( "application/octet-stream" );
+        Mockito.when( this.req.getContentLengthLong() ).thenReturn( LIMIT * 100 );
+
+        assertNull( RequestBodyReader.readBody( this.req, LIMIT ) );
+        Mockito.verify( this.req, Mockito.never() ).getReader();
     }
 
     @Test
@@ -77,8 +90,81 @@ class RequestBodyReaderTest
     {
         setText( "text/plain", "Hello World" );
 
-        final Object result = RequestBodyReader.readBody( this.req );
+        final Object result = RequestBodyReader.readBody( this.req, LIMIT );
         assertNotNull( result );
         assertEquals( "Hello World", result );
+    }
+
+    @Test
+    void readText_exactlyAtLimit()
+        throws Exception
+    {
+        setText( "text/plain", "Hello World" );
+
+        assertEquals( "Hello World", RequestBodyReader.readBody( this.req, "Hello World".length() ) );
+    }
+
+    @Test
+    void readText_declaredLengthOverLimit_rejectedWithoutReading()
+        throws Exception
+    {
+        Mockito.when( this.req.getContentType() ).thenReturn( "application/json" );
+        Mockito.when( this.req.getContentLengthLong() ).thenReturn( LIMIT + 1 );
+
+        final WebException e = assertThrows( WebException.class, () -> RequestBodyReader.readBody( this.req, LIMIT ) );
+        assertEquals( HttpStatus.PAYLOAD_TOO_LARGE, e.getStatus() );
+        Mockito.verify( this.req, Mockito.never() ).getReader();
+    }
+
+    @Test
+    void readText_streamedNonAscii_countsEncodedBytes()
+        throws Exception
+    {
+        final String fiveTwoByteChars = "\u00e9\u00e9\u00e9\u00e9\u00e9";
+
+        setText( "text/plain", fiveTwoByteChars );
+        assertEquals( fiveTwoByteChars, RequestBodyReader.readBody( this.req, 10 ) );
+
+        setText( "text/plain", fiveTwoByteChars );
+        final WebException e = assertThrows( WebException.class, () -> RequestBodyReader.readBody( this.req, 9 ) );
+        assertEquals( HttpStatus.PAYLOAD_TOO_LARGE, e.getStatus() );
+    }
+
+    @Test
+    void readText_streamedThreeByteChars_countsEncodedBytes()
+        throws Exception
+    {
+        final String threeEuroSigns = "\u20ac\u20ac\u20ac";
+
+        setText( "text/plain", threeEuroSigns );
+        assertEquals( threeEuroSigns, RequestBodyReader.readBody( this.req, 9 ) );
+
+        setText( "text/plain", threeEuroSigns );
+        final WebException e = assertThrows( WebException.class, () -> RequestBodyReader.readBody( this.req, 8 ) );
+        assertEquals( HttpStatus.PAYLOAD_TOO_LARGE, e.getStatus() );
+    }
+
+    @Test
+    void readText_streamedSurrogatePair_countsFourBytes()
+        throws Exception
+    {
+        final String emoji = "\uD83D\uDE00";
+
+        setText( "text/plain", emoji );
+        assertEquals( emoji, RequestBodyReader.readBody( this.req, 4 ) );
+
+        setText( "text/plain", emoji );
+        final WebException e = assertThrows( WebException.class, () -> RequestBodyReader.readBody( this.req, 3 ) );
+        assertEquals( HttpStatus.PAYLOAD_TOO_LARGE, e.getStatus() );
+    }
+
+    @Test
+    void readText_streamedOverLimit_rejected()
+        throws Exception
+    {
+        setText( "text/plain", "Hello World" );
+
+        final WebException e = assertThrows( WebException.class, () -> RequestBodyReader.readBody( this.req, "Hello World".length() - 1 ) );
+        assertEquals( HttpStatus.PAYLOAD_TOO_LARGE, e.getStatus() );
     }
 }

--- a/modules/runtime/src/home/config/com.enonic.xp.web.jetty.cfg
+++ b/modules/runtime/src/home/config/com.enonic.xp.web.jetty.cfg
@@ -11,6 +11,8 @@
 # http.statistics.host =
 # http.requestHeaderSize = 32768
 # http.responseHeaderSize = 32768
+# Maximum size in bytes of a text or JSON request body read into memory; larger bodies are rejected with 413
+# http.maxRequestBodySize = 10485760
 
 # session.timeout = 60
 # session.cookieName = JSESSIONID

--- a/modules/web/web-api/src/main/java/com/enonic/xp/web/serializer/WebSerializerService.java
+++ b/modules/web/web-api/src/main/java/com/enonic/xp/web/serializer/WebSerializerService.java
@@ -12,6 +12,12 @@ public interface WebSerializerService
 {
     WebRequest request( HttpServletRequest httpRequest );
 
+    default Object readBody( HttpServletRequest httpRequest )
+        throws IOException
+    {
+        return null;
+    }
+
     void response( WebRequest webRequest, WebResponse webResponse, HttpServletResponse httpResponse )
         throws IOException;
 }

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/handler/WebDispatcherServlet.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/handler/WebDispatcherServlet.java
@@ -20,7 +20,6 @@ import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
 import com.enonic.xp.web.exception.ExceptionRenderer;
 import com.enonic.xp.web.handler.WebHandler;
-import com.enonic.xp.web.impl.serializer.RequestBodyReader;
 import com.enonic.xp.web.serializer.WebSerializerService;
 import com.enonic.xp.web.sse.SseConfig;
 import com.enonic.xp.web.websocket.WebSocketContext;
@@ -62,7 +61,7 @@ public final class WebDispatcherServlet
             webRequest = webSerializerService.request( req );
             final WebSocketContext webSocketContext = this.webSocketContextFactory.newContext( req, res );
             webRequest.setWebSocketContext( webSocketContext );
-            webRequest.setBody( RequestBodyReader.readBody( req ) );
+            webRequest.setBody( webSerializerService.readBody( req ) );
 
             webResponse = exceptionRenderer.maybeThrow( webRequest, webDispatcher.dispatch( webRequest, WebResponse.create().build() ) );
         }

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestBodyReader.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestBodyReader.java
@@ -1,29 +1,56 @@
 package com.enonic.xp.web.impl.serializer;
 
 import java.io.IOException;
+import java.io.Reader;
 import java.util.List;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import com.google.common.io.CharStreams;
 import com.google.common.net.MediaType;
+
+import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
 
 public final class RequestBodyReader
 {
     private static final List<MediaType> TEXT_CONTENT_TYPES =
         List.of( MediaType.ANY_TEXT_TYPE, MediaType.JSON_UTF_8.withoutParameters() );
 
-    public static Object readBody( final HttpServletRequest req )
+    private static final int BUFFER_SIZE = 8192;
+
+    private RequestBodyReader()
+    {
+    }
+
+    public static Object readBody( final HttpServletRequest req, final long maxBytes )
         throws IOException
     {
-        final String type = req.getContentType();
-        if ( type == null )
+        final MediaType type = parseOrNull( req.getContentType() );
+        if ( type == null || !isText( type ) )
         {
             return null;
         }
 
-        final MediaType mediaType = parseOrNull( type );
-        return mediaType != null && isText( mediaType ) ? CharStreams.toString( req.getReader() ) : null;
+        if ( req.getContentLengthLong() > maxBytes )
+        {
+            throw tooLarge( maxBytes );
+        }
+
+        final StringBuilder body = new StringBuilder();
+        final char[] buffer = new char[BUFFER_SIZE];
+        final Reader reader = req.getReader();
+        long total = 0;
+        int read;
+        while ( ( read = reader.read( buffer ) ) != -1 )
+        {
+            total += utf8Length( buffer, read );
+            if ( total > maxBytes )
+            {
+                throw tooLarge( maxBytes );
+            }
+            body.append( buffer, 0, read );
+        }
+        return body.toString();
     }
 
     public static boolean isText( final MediaType type )
@@ -31,15 +58,46 @@ public final class RequestBodyReader
         return TEXT_CONTENT_TYPES.stream().anyMatch( type::is );
     }
 
-    private static MediaType parseOrNull( final String type )
+    private static MediaType parseOrNull( final String contentType )
     {
+        if ( contentType == null )
+        {
+            return null;
+        }
         try
         {
-            return MediaType.parse( type );
+            return MediaType.parse( contentType );
         }
         catch ( IllegalArgumentException e )
         {
             return null;
         }
+    }
+
+    private static long utf8Length( final char[] chars, final int length )
+    {
+        long bytes = 0;
+        for ( int i = 0; i < length; i++ )
+        {
+            final char c = chars[i];
+            if ( c < 0x80 )
+            {
+                bytes += 1;
+            }
+            else if ( c < 0x800 || Character.isSurrogate( c ) )
+            {
+                bytes += 2;
+            }
+            else
+            {
+                bytes += 3;
+            }
+        }
+        return bytes;
+    }
+
+    private static WebException tooLarge( final long maxBytes )
+    {
+        return new WebException( HttpStatus.PAYLOAD_TOO_LARGE, "Request body exceeds the maximum of " + maxBytes + " bytes" );
     }
 }

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/WebSerializerConfig.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/WebSerializerConfig.java
@@ -1,0 +1,11 @@
+package com.enonic.xp.web.impl.serializer;
+
+public @interface WebSerializerConfig
+{
+    long DEFAULT_MAX_REQUEST_BODY_SIZE = 10L * 1024 * 1024;
+
+    /**
+     * Maximum size in bytes of a text or JSON request body read into memory.
+     */
+    long http_maxRequestBodySize() default DEFAULT_MAX_REQUEST_BODY_SIZE;
+}

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/WebSerializerServiceImpl.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/WebSerializerServiceImpl.java
@@ -2,7 +2,9 @@ package com.enonic.xp.web.impl.serializer;
 
 import java.io.IOException;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -11,16 +13,32 @@ import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
 import com.enonic.xp.web.serializer.WebSerializerService;
 
-@Component
+@Component(configurationPid = "com.enonic.xp.web.jetty")
 public final class WebSerializerServiceImpl
     implements WebSerializerService
 {
+    private volatile long maxRequestBodySize = WebSerializerConfig.DEFAULT_MAX_REQUEST_BODY_SIZE;
+
+    @Activate
+    @Modified
+    public void activate( final WebSerializerConfig config )
+    {
+        this.maxRequestBodySize = config.http_maxRequestBodySize();
+    }
+
     @Override
     public WebRequest request( final HttpServletRequest httpRequest )
     {
         final WebRequest webRequest = new WebRequest();
         new RequestSerializer( webRequest ).serialize( httpRequest );
         return webRequest;
+    }
+
+    @Override
+    public Object readBody( final HttpServletRequest httpRequest )
+        throws IOException
+    {
+        return RequestBodyReader.readBody( httpRequest, this.maxRequestBodySize );
     }
 
     @Override

--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/handler/WebDispatcherServletTest.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/handler/WebDispatcherServletTest.java
@@ -16,6 +16,7 @@ import com.enonic.xp.web.HttpStatus;
 import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.WebResponse;
 import com.enonic.xp.web.exception.ExceptionRenderer;
+import com.enonic.xp.web.impl.serializer.WebSerializerConfig;
 import com.enonic.xp.web.impl.serializer.WebSerializerServiceImpl;
 import com.enonic.xp.web.jetty.impl.JettyTestSupport;
 import com.enonic.xp.web.sse.SseConfig;
@@ -23,6 +24,7 @@ import com.enonic.xp.web.sse.SseConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,6 +40,8 @@ class WebDispatcherServletTest
 
     private TestWebHandler handler;
 
+    private WebSerializerServiceImpl webSerializerService;
+
     final ExceptionRenderer exceptionRenderer = mock();
 
     @Override
@@ -46,8 +50,14 @@ class WebDispatcherServletTest
         this.handler = new TestWebHandler();
 
         when( exceptionRenderer.maybeThrow( any(), any() ) ).thenAnswer( invocation -> invocation.getArgument( 1 ) );
+        when( exceptionRenderer.render( any(), any() ) ).thenAnswer( invocation -> {
+            final Exception e = invocation.getArgument( 1 );
+            final HttpStatus status = e instanceof WebException webException ? webException.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
+            return WebResponse.create().status( status ).build();
+        } );
 
-        this.servlet = new WebDispatcherServlet( new WebDispatcherImpl(), exceptionRenderer, mock(), new WebSerializerServiceImpl() );
+        this.webSerializerService = new WebSerializerServiceImpl();
+        this.servlet = new WebDispatcherServlet( new WebDispatcherImpl(), exceptionRenderer, mock(), this.webSerializerService );
         this.servlet.addWebHandler( this.handler );
 
         this.handler.response = WebResponse.create().status( HttpStatus.OK ).build();
@@ -193,6 +203,24 @@ class WebDispatcherServletTest
 
         final HttpResponse<String> response = callRequest( request );
         assertEquals( 200, response.statusCode() );
+    }
+
+    @Test
+    void testPost_bodyTooLarge()
+        throws Exception
+    {
+        final WebSerializerConfig config = mock( WebSerializerConfig.class, invocation -> invocation.getMethod().getDefaultValue() );
+        when( config.http_maxRequestBodySize() ).thenReturn( 8L );
+        this.webSerializerService.activate( config );
+
+        final HttpRequest request = newRequest( "/site/master/a/b" ).header( "content-type", "text/plain; charset=utf-8" )
+            .POST( HttpRequest.BodyPublishers.ofString( "Hello World" ) )
+            .build();
+
+        this.handler.verifier = req -> fail( "handler must not be invoked for an oversized body" );
+
+        final HttpResponse<String> response = callRequest( request );
+        assertEquals( 413, response.statusCode() );
     }
 
     @Test

--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/WebSerializerServiceImplTest.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/WebSerializerServiceImplTest.java
@@ -1,0 +1,72 @@
+package com.enonic.xp.web.impl.serializer;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
+import com.enonic.xp.web.WebRequest;
+import com.enonic.xp.web.WebResponse;
+import com.enonic.xp.web.serializer.WebSerializerService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class WebSerializerServiceImplTest
+{
+    @Test
+    void readBodyUsesConfiguredLimit()
+        throws Exception
+    {
+        final WebSerializerConfig config = mock( WebSerializerConfig.class, invocation -> invocation.getMethod().getDefaultValue() );
+        when( config.http_maxRequestBodySize() ).thenReturn( 5L );
+
+        final WebSerializerServiceImpl service = new WebSerializerServiceImpl();
+        service.activate( config );
+
+        assertEquals( "Hello", service.readBody( textRequest( "Hello" ) ) );
+
+        final WebException e = assertThrows( WebException.class, () -> service.readBody( textRequest( "Hello World" ) ) );
+        assertEquals( HttpStatus.PAYLOAD_TOO_LARGE, e.getStatus() );
+    }
+
+    @Test
+    void readBodyDefaultReturnsNull()
+        throws Exception
+    {
+        final WebSerializerService service = new WebSerializerService()
+        {
+            @Override
+            public WebRequest request( final HttpServletRequest httpRequest )
+            {
+                return null;
+            }
+
+            @Override
+            public void response( final WebRequest webRequest, final WebResponse webResponse, final HttpServletResponse httpResponse )
+            {
+            }
+        };
+
+        assertNull( service.readBody( textRequest( "Hello" ) ) );
+    }
+
+    private static HttpServletRequest textRequest( final String text )
+        throws IOException
+    {
+        final HttpServletRequest req = mock( HttpServletRequest.class );
+        when( req.getContentType() ).thenReturn( "text/plain" );
+        when( req.getContentLengthLong() ).thenReturn( -1L );
+        when( req.getReader() ).thenReturn( new BufferedReader( new StringReader( text ) ) );
+        return req;
+    }
+}


### PR DESCRIPTION
## Summary

`WebDispatcherServlet` (web connector) and `SlashApiFilter` (management connector) read any `text/*` or `application/json` request body fully into memory with `CharStreams.toString`, with no size limit and before any handler, access or mount check ran. Jetty imposes no request-body limit of its own and the DoS filter ships disabled, so an anonymous client could stream an arbitrarily large chunked body to any URL on port 8080 and exhaust the heap with a handful of connections.

## Changes

- **`RequestBodyReader`** enforces a maximum: the declared `Content-Length` is checked before anything is read, and the encoded length of what is read is checked while streaming so chunked bodies are bounded too. Oversized bodies are rejected with **413 Payload Too Large**. Non-text bodies are ignored regardless of size, and a `Content-Type` that cannot be parsed is treated as a body that is not read.
- **`WebSerializerService.readBody(HttpServletRequest)`** exposes the limited read to both connectors as a default method, so foreign implementations keep compiling. `WebSerializerServiceImpl` binds to the `com.enonic.xp.web.jetty` configuration and reads the new **`http.maxRequestBodySize`** property (default 10 MiB), documented in the shipped `com.enonic.xp.web.jetty.cfg` next to the other HTTP size limits.
- **`WebDispatcherServlet`** reads the body inside its handling block, so the 413 is rendered through `ExceptionRenderer` like any other error.
- **`SlashApiFilter`** no longer reads the body. **`SlashApiHandler`** reads it once `verifyAccessToApi` and `verifyRequestMounted` have passed, so a caller without access to an API cannot make the server buffer its body. On the web connector the dispatcher has already read a text body and the handler's read is a no-op.

## Tests

- `RequestBodyReaderTest`: rejection by declared length without touching the reader, rejection while streaming, encoded-length counting for two-, three- and four-byte characters, exactly-at-limit accepted, non-text and malformed content types ignore the limit.
- `WebDispatcherServletTest.testPost_bodyTooLarge`: end-to-end 413 through Jetty with a lowered limit; handler never invoked.
- `SlashApiHandlerTest`: body read after access is granted, not read when access is denied, existing body kept when already read.
- `SlashApiFilterTest`: the filter's own body-reading tests are removed with the code they covered.

## Notes

- The default of 10 MiB bounds a single request; concurrency limits (DoS filter, proxy) still govern aggregate memory. Deployments that legitimately post larger JSON bodies to services should raise `http.maxRequestBodySize`.
- If sharing the Jetty PID from `web-impl` is unwanted, moving the property to a dedicated PID is a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV