### PR TITLE
Require the admin role for snapshot, restore, reindex, audit log cleanup and export/import tasks

### DIFF
--- a/modules/app/app-system/src/main/java/com/enonic/xp/app/system/ExportTaskHandler.java
+++ b/modules/app/app-system/src/main/java/com/enonic/xp/app/system/ExportTaskHandler.java
@@ -61,6 +61,8 @@ public class ExportTaskHandler
 
     public void execute()
     {
+        TaskUtils.requireAdmin();
+
         final ProgressReporter progressReporter = TaskProgressReporterContext.current();
 
         final ExportNodesParams.Builder params = ExportNodesParams.create()

--- a/modules/app/app-system/src/main/java/com/enonic/xp/app/system/ImportTaskHandler.java
+++ b/modules/app/app-system/src/main/java/com/enonic/xp/app/system/ImportTaskHandler.java
@@ -70,6 +70,8 @@ public class ImportTaskHandler
 
     public void execute()
     {
+        TaskUtils.requireAdmin();
+
         final ProgressReporter progressReporter = TaskProgressReporterContext.current();
 
         final NodeImportResult result = ContextBuilder.from( ContextAccessor.current() )

--- a/modules/app/app-system/src/main/java/com/enonic/xp/app/system/TaskUtils.java
+++ b/modules/app/app-system/src/main/java/com/enonic/xp/app/system/TaskUtils.java
@@ -5,6 +5,10 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.exception.ForbiddenAccessException;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.task.TaskId;
 import com.enonic.xp.task.TaskInfo;
 
@@ -12,6 +16,15 @@ public final class TaskUtils
 {
     private TaskUtils()
     {
+    }
+
+    public static void requireAdmin()
+    {
+        final AuthenticationInfo authInfo = ContextAccessor.current().getAuthInfo();
+        if ( !authInfo.hasRole( RoleKeys.ADMIN ) )
+        {
+            throw new ForbiddenAccessException( authInfo.getUser() );
+        }
     }
 
     public static void checkAlreadySubmitted( final TaskInfo currentTaskInfo, final Collection<TaskInfo> allTasks )

--- a/modules/app/app-system/src/test/java/com/enonic/xp/app/system/ExportTaskHandlerTest.java
+++ b/modules/app/app-system/src/test/java/com/enonic/xp/app/system/ExportTaskHandlerTest.java
@@ -11,10 +11,17 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.enonic.xp.export.ExportNodesParams;
+import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.context.ContextAccessorSupport;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.exception.ForbiddenAccessException;
 import com.enonic.xp.export.ExportService;
 import com.enonic.xp.export.NodeExportResult;
 import com.enonic.xp.home.HomeDirSupport;
 import com.enonic.xp.node.NodePath;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.User;
+import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.support.JsonTestHelper;
 import com.enonic.xp.task.ProgressReportParams;
 import com.enonic.xp.task.ProgressReporter;
@@ -24,7 +31,9 @@ import com.enonic.xp.testing.ScriptTestSupport;
 import com.enonic.xp.util.BinaryReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,6 +61,21 @@ class ExportTaskHandlerTest
         super.initialize();
         HomeDirSupport.set( temporaryFolder );
         addService( ExportService.class, this.exportService );
+        ContextAccessorSupport.getInstance()
+            .set( ContextBuilder.from( ContextAccessor.current() )
+                      .authInfo( AuthenticationInfo.create().principals( RoleKeys.ADMIN ).user( User.anonymous() ).build() )
+                      .build() );
+    }
+
+    @Test
+    void exportNodes_requiresAdmin()
+    {
+        ContextAccessorSupport.getInstance()
+            .set( ContextBuilder.from( ContextAccessor.current() ).authInfo( AuthenticationInfo.unAuthenticated() ).build() );
+
+        assertThrows( ForbiddenAccessException.class, () -> TaskProgressReporterContext.withContext(
+            ( id, reporter ) -> runFunction( "/test/ExportTaskHandlerTest.js", "exportNodes" ) ).run( TaskId.from( "task" ), progressReporter ) );
+        verifyNoInteractions( exportService );
     }
 
     @Test

--- a/modules/app/app-system/src/test/java/com/enonic/xp/app/system/ImportTaskHandlerTest.java
+++ b/modules/app/app-system/src/test/java/com/enonic/xp/app/system/ImportTaskHandlerTest.java
@@ -10,11 +10,18 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.context.ContextAccessorSupport;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.exception.ForbiddenAccessException;
 import com.enonic.xp.export.ExportService;
 import com.enonic.xp.export.ImportNodesParams;
 import com.enonic.xp.export.NodeImportResult;
 import com.enonic.xp.home.HomeDirSupport;
 import com.enonic.xp.node.NodePath;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.User;
+import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.support.JsonTestHelper;
 import com.enonic.xp.task.ProgressReportParams;
 import com.enonic.xp.task.ProgressReporter;
@@ -24,10 +31,12 @@ import com.enonic.xp.testing.ScriptTestSupport;
 import com.enonic.xp.util.BinaryReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,6 +64,21 @@ class ImportTaskHandlerTest
         super.initialize();
         HomeDirSupport.set( temporaryFolder );
         addService( ExportService.class, this.exportService );
+        ContextAccessorSupport.getInstance()
+            .set( ContextBuilder.from( ContextAccessor.current() )
+                      .authInfo( AuthenticationInfo.create().principals( RoleKeys.ADMIN ).user( User.anonymous() ).build() )
+                      .build() );
+    }
+
+    @Test
+    void importNodes_requiresAdmin()
+    {
+        ContextAccessorSupport.getInstance()
+            .set( ContextBuilder.from( ContextAccessor.current() ).authInfo( AuthenticationInfo.unAuthenticated() ).build() );
+
+        assertThrows( ForbiddenAccessException.class, () -> TaskProgressReporterContext.withContext(
+            ( id, reporter ) -> runFunction( "/test/ImportTaskHandlerTest.js", "importNodes" ) ).run( TaskId.from( "task" ), progressReporter ) );
+        verifyNoInteractions( exportService );
     }
 
     @Test

--- a/modules/app/app-system/src/test/java/com/enonic/xp/app/system/TaskParamsMappingTest.java
+++ b/modules/app/app-system/src/test/java/com/enonic/xp/app/system/TaskParamsMappingTest.java
@@ -10,6 +10,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.context.ContextAccessorSupport;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.User;
+import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.app.ApplicationKey;
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.data.PropertyTree;
@@ -96,6 +102,10 @@ class TaskParamsMappingTest
         addService( ExportService.class, exportService );
         addService( VacuumService.class, vacuumService );
         addService( TaskService.class, taskService );
+        ContextAccessorSupport.getInstance()
+            .set( ContextBuilder.from( ContextAccessor.current() )
+                      .authInfo( AuthenticationInfo.create().principals( RoleKeys.ADMIN ).user( User.anonymous() ).build() )
+                      .build() );
     }
 
     @Test

--- a/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/AuditLogServiceImpl.java
+++ b/modules/core/core-audit/src/main/java/com/enonic/xp/core/impl/audit/AuditLogServiceImpl.java
@@ -11,8 +11,12 @@ import com.enonic.xp.audit.CleanUpAuditLogResult;
 import com.enonic.xp.audit.FindAuditLogParams;
 import com.enonic.xp.audit.FindAuditLogResult;
 import com.enonic.xp.audit.LogAuditLogParams;
+import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.core.impl.audit.config.AuditLogConfig;
+import com.enonic.xp.exception.ForbiddenAccessException;
 import com.enonic.xp.node.NodeService;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.auth.AuthenticationInfo;
 
 public class AuditLogServiceImpl
     implements AuditLogService
@@ -87,6 +91,12 @@ public class AuditLogServiceImpl
     @Override
     public CleanUpAuditLogResult cleanUp( final CleanUpAuditLogParams params )
     {
+        final AuthenticationInfo authInfo = ContextAccessor.current().getAuthInfo();
+        if ( !authInfo.hasRole( RoleKeys.ADMIN ) )
+        {
+            throw new ForbiddenAccessException( authInfo.getUser() );
+        }
+
         return CleanUpAuditLogCommand.create().
             nodeService( nodeService ).
             ageThreshold( params.getAgeThreshold() != null ? params.getAgeThreshold() : config.ageThreshold() ).

--- a/modules/core/core-audit/src/test/java/com/enonic/xp/core/impl/audit/AuditLogServiceImplTest.java
+++ b/modules/core/core-audit/src/test/java/com/enonic/xp/core/impl/audit/AuditLogServiceImplTest.java
@@ -38,6 +38,7 @@ import com.enonic.xp.node.NodeService;
 import com.enonic.xp.node.NodeVersionId;
 import com.enonic.xp.node.Nodes;
 import com.enonic.xp.repository.internal.InternalRepositoryService;
+import com.enonic.xp.exception.ForbiddenAccessException;
 import com.enonic.xp.security.PrincipalKey;
 
 import static java.util.Objects.requireNonNullElse;
@@ -140,6 +141,12 @@ class AuditLogServiceImplTest
     }
 
     @Test
+    void cleanUpRequiresAdmin()
+    {
+        assertThrows( ForbiddenAccessException.class, () -> auditLogService.cleanUp( CleanUpAuditLogParams.create().build() ) );
+    }
+
+    @Test
     void cleanUpOneEmpty()
     {
         when( config.ageThreshold() ).thenReturn( "PT1s" );
@@ -148,7 +155,7 @@ class AuditLogServiceImplTest
 
         final CleanUpAuditLogListener listener = mock( CleanUpAuditLogListener.class );
 
-        final CleanUpAuditLogResult result = auditLogService.cleanUp( CleanUpAuditLogParams.create().listener( listener ).build() );
+        final CleanUpAuditLogResult result = AuditLogContext.createAdminContext().callWith( () -> auditLogService.cleanUp( CleanUpAuditLogParams.create().listener( listener ).build() ) );
 
         assertEquals( 0, result.getDeleted() );
         verify( listener, times( 1 ) ).resolved( 0 );
@@ -169,7 +176,7 @@ class AuditLogServiceImplTest
 
         final CleanUpAuditLogListener listener = mock( CleanUpAuditLogListener.class );
 
-        final CleanUpAuditLogResult result = auditLogService.cleanUp( CleanUpAuditLogParams.create().listener( listener ).build() );
+        final CleanUpAuditLogResult result = AuditLogContext.createAdminContext().callWith( () -> auditLogService.cleanUp( CleanUpAuditLogParams.create().listener( listener ).build() ) );
 
         assertEquals( 3, result.getDeleted() );
         verify( listener, times( 1 ) ).resolved( 3 );
@@ -191,7 +198,7 @@ class AuditLogServiceImplTest
 
         final CleanUpAuditLogListener listener = mock( CleanUpAuditLogListener.class );
 
-        final CleanUpAuditLogResult result = auditLogService.cleanUp( CleanUpAuditLogParams.create().listener( listener ).build() );
+        final CleanUpAuditLogResult result = AuditLogContext.createAdminContext().callWith( () -> auditLogService.cleanUp( CleanUpAuditLogParams.create().listener( listener ).build() ) );
 
         assertEquals( 10500, result.getDeleted() );
         verify( listener, times( 1 ) ).resolved( 10_500 );
@@ -213,7 +220,7 @@ class AuditLogServiceImplTest
         when( nodeService.enumerate( any( EnumerateNodesParams.class ) ) ).thenReturn(
             createBatch( 2, Instant.now().minus( Duration.ofHours( 2 ) ), null ) );
 
-        final CleanUpAuditLogResult result = auditLogService.cleanUp( CleanUpAuditLogParams.create().build() );
+        final CleanUpAuditLogResult result = AuditLogContext.createAdminContext().callWith( () -> auditLogService.cleanUp( CleanUpAuditLogParams.create().build() ) );
 
         assertEquals( 2, result.getDeleted() );
 

--- a/modules/core/core-audit/src/test/java/com/enonic/xp/core/impl/audit/AuditLogServiceImplTest.java
+++ b/modules/core/core-audit/src/test/java/com/enonic/xp/core/impl/audit/AuditLogServiceImplTest.java
@@ -51,6 +51,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class AuditLogServiceImplTest
@@ -144,6 +145,7 @@ class AuditLogServiceImplTest
     void cleanUpRequiresAdmin()
     {
         assertThrows( ForbiddenAccessException.class, () -> auditLogService.cleanUp( CleanUpAuditLogParams.create().build() ) );
+        verifyNoInteractions( nodeService );
     }
 
     @Test

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/SecurityHelper.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/SecurityHelper.java
@@ -1,6 +1,7 @@
 package com.enonic.xp.repo.impl;
 
 import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.exception.ForbiddenAccessException;
 import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 
@@ -11,6 +12,15 @@ public class SecurityHelper
     {
         final AuthenticationInfo authInfo = ContextAccessor.current().getAuthInfo();
         return authInfo.hasRole( RoleKeys.ADMIN );
+    }
+
+    public static void requireAdmin()
+    {
+        final AuthenticationInfo authInfo = ContextAccessor.current().getAuthInfo();
+        if ( !authInfo.hasRole( RoleKeys.ADMIN ) )
+        {
+            throw new ForbiddenAccessException( authInfo.getUser() );
+        }
     }
 
 }

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/snapshot/SnapshotServiceImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/elasticsearch/snapshot/SnapshotServiceImpl.java
@@ -40,6 +40,7 @@ import com.enonic.xp.node.SnapshotParams;
 import com.enonic.xp.node.SnapshotResult;
 import com.enonic.xp.node.SnapshotResults;
 import com.enonic.xp.repo.impl.RepositoryEvents;
+import com.enonic.xp.repo.impl.SecurityHelper;
 import com.enonic.xp.repo.impl.config.RepoConfiguration;
 import com.enonic.xp.repo.impl.index.IndexServiceInternal;
 import com.enonic.xp.repo.impl.node.NodeHelper;
@@ -82,6 +83,7 @@ public class SnapshotServiceImpl
     @Override
     public SnapshotResult snapshot( final SnapshotParams snapshotParams )
     {
+        SecurityHelper.requireAdmin();
         checkSnapshotRepository();
 
         return NodeHelper.runAsAdmin( () -> doSnapshot( snapshotParams ) );
@@ -126,6 +128,7 @@ public class SnapshotServiceImpl
     @Override
     public RestoreResult restore( final RestoreParams restoreParams )
     {
+        SecurityHelper.requireAdmin();
         checkSnapshotRepository();
 
         return NodeHelper.runAsAdmin( () -> doRestore( restoreParams ) );
@@ -209,6 +212,7 @@ public class SnapshotServiceImpl
     @Override
     public SnapshotResults list()
     {
+        SecurityHelper.requireAdmin();
         checkSnapshotRepository();
 
         return doListSnapshots();
@@ -226,6 +230,7 @@ public class SnapshotServiceImpl
     @Override
     public DeleteSnapshotsResult delete( final DeleteSnapshotParams params )
     {
+        SecurityHelper.requireAdmin();
         checkSnapshotRepository();
 
         return doDelete( params );

--- a/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/index/IndexServiceImpl.java
+++ b/modules/core/core-repo/src/main/java/com/enonic/xp/repo/impl/index/IndexServiceImpl.java
@@ -14,6 +14,7 @@ import com.enonic.xp.index.ReindexParams;
 import com.enonic.xp.index.ReindexResult;
 import com.enonic.xp.index.UpdateIndexSettingsParams;
 import com.enonic.xp.index.UpdateIndexSettingsResult;
+import com.enonic.xp.repo.impl.SecurityHelper;
 import com.enonic.xp.repo.impl.node.dao.NodeVersionService;
 import com.enonic.xp.repo.impl.repository.DefaultIndexResourceProvider;
 import com.enonic.xp.repo.impl.repository.IndexNameResolver;
@@ -57,6 +58,8 @@ public class IndexServiceImpl
     @Override
     public ReindexResult reindex( final ReindexParams params )
     {
+        SecurityHelper.requireAdmin();
+
         if ( params.isInitialize() )
         {
             doPurgeSearchIndex( params.getRepositoryId() );
@@ -77,6 +80,8 @@ public class IndexServiceImpl
     @Override
     public UpdateIndexSettingsResult updateIndexSettings( final UpdateIndexSettingsParams params )
     {
+        SecurityHelper.requireAdmin();
+
         final UpdateIndexSettingsResult.Builder result = UpdateIndexSettingsResult.create();
 
         final UpdateIndexSettings updateIndexSettings = UpdateIndexSettings.from( params.getSettings() );

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/elasticsearch/snapshot/SnapshotServiceImplTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/elasticsearch/snapshot/SnapshotServiceImplTest.java
@@ -43,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class SnapshotServiceImplTest
@@ -138,5 +139,6 @@ class SnapshotServiceImplTest
         assertThrows( ForbiddenAccessException.class, () -> instance.restore( RestoreParams.create().snapshotName( "s" ).build() ) );
         assertThrows( ForbiddenAccessException.class, () -> instance.list() );
         assertThrows( ForbiddenAccessException.class, () -> instance.delete( DeleteSnapshotParams.create().add( "s" ).build() ) );
+        verifyNoInteractions( clusterAdminClient );
     }
 }

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/elasticsearch/snapshot/SnapshotServiceImplTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/elasticsearch/snapshot/SnapshotServiceImplTest.java
@@ -22,14 +22,23 @@ import org.elasticsearch.snapshots.SnapshotState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.enonic.xp.context.Context;
+import com.enonic.xp.context.ContextBuilder;
 import com.enonic.xp.event.EventPublisher;
+import com.enonic.xp.exception.ForbiddenAccessException;
 import com.enonic.xp.node.DeleteSnapshotParams;
 import com.enonic.xp.node.DeleteSnapshotsResult;
+import com.enonic.xp.node.RestoreParams;
+import com.enonic.xp.node.SnapshotParams;
 import com.enonic.xp.repo.impl.config.RepoConfiguration;
 import com.enonic.xp.repo.impl.index.IndexServiceInternal;
 import com.enonic.xp.repo.impl.repository.RepositoryEntryService;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.User;
+import com.enonic.xp.security.auth.AuthenticationInfo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -39,6 +48,10 @@ import static org.mockito.Mockito.when;
 class SnapshotServiceImplTest
 {
     private ClusterAdminClient clusterAdminClient;
+
+    private static final Context ADMIN_CONTEXT = ContextBuilder.create()
+        .authInfo( AuthenticationInfo.create().principals( RoleKeys.ADMIN ).user( User.anonymous() ).build() )
+        .build();
 
     private SnapshotServiceImpl instance;
 
@@ -96,8 +109,8 @@ class SnapshotServiceImplTest
             argThat( request -> "snapshot2".equals( request.snapshot() ) || "snapshot4".equals( request.snapshot() ) ) ) ).thenThrow(
             new ElasticsearchException( "Failed to delete snapshot" ) );
 
-        final DeleteSnapshotsResult result = instance.delete(
-            DeleteSnapshotParams.create().add( "snapshot1" ).add( "snapshot2" ).before( now.minus( 2, ChronoUnit.HOURS ) ).build() );
+        final DeleteSnapshotsResult result = ADMIN_CONTEXT.callWith( () -> instance.delete(
+            DeleteSnapshotParams.create().add( "snapshot1" ).add( "snapshot2" ).before( now.minus( 2, ChronoUnit.HOURS ) ).build() ) );
 
         assertEquals( 2, result.getDeletedSnapshots().size() );
         assertTrue( result.getDeletedSnapshots().contains( "snapshot1" ) );
@@ -116,5 +129,14 @@ class SnapshotServiceImplTest
         when( snapshot.endTime() ).thenReturn( endTime.toEpochMilli() );
 
         return snapshot;
+    }
+
+    @Test
+    void requiresAdmin()
+    {
+        assertThrows( ForbiddenAccessException.class, () -> instance.snapshot( SnapshotParams.create().snapshotName( "s" ).build() ) );
+        assertThrows( ForbiddenAccessException.class, () -> instance.restore( RestoreParams.create().snapshotName( "s" ).build() ) );
+        assertThrows( ForbiddenAccessException.class, () -> instance.list() );
+        assertThrows( ForbiddenAccessException.class, () -> instance.delete( DeleteSnapshotParams.create().add( "s" ).build() ) );
     }
 }

--- a/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/index/IndexServiceImplUpdateSettingsTest.java
+++ b/modules/core/core-repo/src/test/java/com/enonic/xp/repo/impl/index/IndexServiceImplUpdateSettingsTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
+import com.enonic.xp.context.Context;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.exception.ForbiddenAccessException;
 import com.enonic.xp.index.IndexType;
 import com.enonic.xp.index.UpdateIndexSettingsParams;
 import com.enonic.xp.index.UpdateIndexSettingsResult;
@@ -15,8 +18,12 @@ import com.enonic.xp.repo.impl.repository.RepositoryEntryService;
 import com.enonic.xp.repo.impl.search.NodeSearchService;
 import com.enonic.xp.repo.impl.storage.IndexDataService;
 import com.enonic.xp.repository.RepositoryId;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.User;
+import com.enonic.xp.security.auth.AuthenticationInfo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -25,12 +32,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 class IndexServiceImplUpdateSettingsTest
 {
     private static final RepositoryId REPO = RepositoryId.from( "my-repo" );
 
     private static final String SETTINGS = "{\"index\":{\"number_of_replicas\":\"2\"}}";
+
+    private static final Context ADMIN_CONTEXT = ContextBuilder.create()
+        .authInfo( AuthenticationInfo.create().principals( RoleKeys.ADMIN ).user( User.anonymous() ).build() )
+        .build();
 
     private IndexServiceInternal indexServiceInternal;
 
@@ -47,8 +59,8 @@ class IndexServiceImplUpdateSettingsTest
     @Test
     void bothIndicesByDefault()
     {
-        final UpdateIndexSettingsResult result =
-            indexService.updateIndexSettings( UpdateIndexSettingsParams.create().repository( REPO ).settings( SETTINGS ).build() );
+        final UpdateIndexSettingsResult result = ADMIN_CONTEXT.callWith(
+            () -> indexService.updateIndexSettings( UpdateIndexSettingsParams.create().repository( REPO ).settings( SETTINGS ).build() ) );
 
         verify( indexServiceInternal ).updateIndex( eq( "search-my-repo" ), any() );
         verify( indexServiceInternal ).updateIndex( eq( "storage-my-repo" ), any() );
@@ -60,8 +72,8 @@ class IndexServiceImplUpdateSettingsTest
     @Test
     void searchIndexOnly()
     {
-        final UpdateIndexSettingsResult result = indexService.updateIndexSettings(
-            UpdateIndexSettingsParams.create().repository( REPO ).indexType( IndexType.SEARCH ).settings( SETTINGS ).build() );
+        final UpdateIndexSettingsResult result = ADMIN_CONTEXT.callWith( () -> indexService.updateIndexSettings(
+            UpdateIndexSettingsParams.create().repository( REPO ).indexType( IndexType.SEARCH ).settings( SETTINGS ).build() ) );
 
         verify( indexServiceInternal ).updateIndex( eq( "search-my-repo" ), any() );
         verify( indexServiceInternal, never() ).updateIndex( eq( "storage-my-repo" ), any() );
@@ -73,8 +85,8 @@ class IndexServiceImplUpdateSettingsTest
     {
         for ( final IndexType type : new IndexType[]{IndexType.VERSION, IndexType.BRANCH, IndexType.COMMIT} )
         {
-            indexService.updateIndexSettings(
-                UpdateIndexSettingsParams.create().repository( REPO ).indexType( type ).settings( SETTINGS ).build() );
+            ADMIN_CONTEXT.runWith( () -> indexService.updateIndexSettings(
+                UpdateIndexSettingsParams.create().repository( REPO ).indexType( type ).settings( SETTINGS ).build() ) );
         }
 
         verify( indexServiceInternal, times( 3 ) ).updateIndex( eq( "storage-my-repo" ), any() );
@@ -84,16 +96,25 @@ class IndexServiceImplUpdateSettingsTest
     @Test
     void requireClosedIndexClosesAndReopens()
     {
-        indexService.updateIndexSettings( UpdateIndexSettingsParams.create()
-                                              .repository( REPO )
-                                              .indexType( IndexType.SEARCH )
-                                              .settings( SETTINGS )
-                                              .requireClosedIndex( true )
-                                              .build() );
+        ADMIN_CONTEXT.runWith( () -> indexService.updateIndexSettings( UpdateIndexSettingsParams.create()
+                                                                           .repository( REPO )
+                                                                           .indexType( IndexType.SEARCH )
+                                                                           .settings( SETTINGS )
+                                                                           .requireClosedIndex( true )
+                                                                           .build() ) );
 
         final InOrder inOrder = inOrder( indexServiceInternal );
         inOrder.verify( indexServiceInternal ).closeIndices( "search-my-repo" );
         inOrder.verify( indexServiceInternal ).updateIndex( eq( "search-my-repo" ), any() );
         inOrder.verify( indexServiceInternal ).openIndices( "search-my-repo" );
+    }
+
+    @Test
+    void requiresAdmin()
+    {
+        final UpdateIndexSettingsParams params = UpdateIndexSettingsParams.create().repository( REPO ).settings( SETTINGS ).build();
+
+        assertThrows( ForbiddenAccessException.class, () -> indexService.updateIndexSettings( params ) );
+        verifyNoInteractions( indexServiceInternal );
     }
 }

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/index/IndexServiceImplTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/index/IndexServiceImplTest.java
@@ -51,11 +51,11 @@ class IndexServiceImplTest
         final Node node =
             createNode( CreateNodeParams.create().name( "myNode" ).parent( NodePath.ROOT ).refresh( RefreshMode.ALL ).build() );
 
-        final ReindexResult result = this.indexService.reindex( ReindexParams.create().
+        final ReindexResult result = ctxDefaultAdmin().callWith( () -> this.indexService.reindex( ReindexParams.create().
             addBranch( WS_DEFAULT ).
             repositoryId( testRepoId ).
             initialize( true ).
-            build() );
+            build() ) );
 
         refresh();
 
@@ -74,11 +74,11 @@ class IndexServiceImplTest
             refresh( RefreshMode.ALL ).
             build() );
 
-        final ReindexResult result = this.indexService.reindex( ReindexParams.create().
+        final ReindexResult result = ctxDefaultAdmin().callWith( () -> this.indexService.reindex( ReindexParams.create().
             addBranch( WS_DEFAULT ).
             repositoryId( testRepoId ).
             initialize( false ).
-            build() );
+            build() ) );
 
         assertEquals( 2, result.getReindexNodes().getSize() );
 
@@ -95,11 +95,11 @@ class IndexServiceImplTest
             refresh( RefreshMode.ALL ).
             build() );
 
-        final ReindexResult result = this.indexService.reindex( ReindexParams.create().
+        final ReindexResult result = ctxDefaultAdmin().callWith( () -> this.indexService.reindex( ReindexParams.create().
             addBranch( WS_DEFAULT ).
             repositoryId( testRepoId ).
             initialize( false ).
-            build() );
+            build() ) );
 
         assertEquals( 2, result.getReindexNodes().getSize() );
 
@@ -131,11 +131,11 @@ class IndexServiceImplTest
         assertNotNull( ctxOther().callWith( () -> queryForNode( node.id() ) ) );
 
 
-        this.indexService.reindex( ReindexParams.create().
+        ctxDefaultAdmin().runWith( () -> this.indexService.reindex( ReindexParams.create().
             addBranch( WS_OTHER ).
             repositoryId( testRepoId ).
             initialize( true ).
-            build() );
+            build() ) );
 
         refresh();
 
@@ -161,11 +161,11 @@ class IndexServiceImplTest
 
         assertEquals( 2, cmsRepoContext.callWith( this::findAllNodes ).getNodeHits().getSize() );
 
-        this.indexService.reindex( ReindexParams.create().
+        ctxDefaultAdmin().runWith( () -> this.indexService.reindex( ReindexParams.create().
             addBranch( cmsRepoContext.getBranch() ).
             repositoryId( cmsRepoContext.getRepositoryId() ).
             initialize( true ).
-            build() );
+            build() ) );
 
         refresh();
 
@@ -194,11 +194,11 @@ class IndexServiceImplTest
 
         final int nodesInSystemRepoCount = systemRepoContext.callWith( this::findAllNodes ).getNodeHits().getSize();
 
-        this.indexService.reindex( ReindexParams.create().
+        ctxDefaultAdmin().runWith( () -> this.indexService.reindex( ReindexParams.create().
             addBranch( systemRepoContext.getBranch() ).
             repositoryId( systemRepoContext.getRepositoryId() ).
             initialize( true ).
-            build() );
+            build() ) );
 
         refresh();
 
@@ -235,10 +235,10 @@ class IndexServiceImplTest
     @Test
     void updateIndexSettings()
     {
-        final UpdateIndexSettingsResult result = this.indexService.updateIndexSettings( UpdateIndexSettingsParams.create().
+        final UpdateIndexSettingsResult result = ctxDefaultAdmin().callWith( () -> this.indexService.updateIndexSettings( UpdateIndexSettingsParams.create().
             repository( testRepoId ).
             settings( "{\"index\": {\"number_of_replicas\": 2}}" ).
-            build() );
+            build() ) );
 
         assertEquals( 2, result.getUpdatedIndexes().size() );
     }
@@ -254,10 +254,10 @@ class IndexServiceImplTest
     @Test
     void getIndexSettings()
     {
-        this.indexService.updateIndexSettings( UpdateIndexSettingsParams.create().
+        ctxDefaultAdmin().runWith( () -> this.indexService.updateIndexSettings( UpdateIndexSettingsParams.create().
             repository( testRepoId ).
             settings( "{\"index\": {\"number_of_replicas\": 2}}" ).
-            build() );
+            build() ) );
 
         final Map<String, String> indexSettings = this.indexService.getIndexSettings( testRepoId, IndexType.SEARCH );
 

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/index/ReindexLoadTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/index/ReindexLoadTest.java
@@ -35,11 +35,11 @@ class ReindexLoadTest
 
         refresh();
 
-        final ReindexResult result = this.indexService.reindex( ReindexParams.create().
+        final ReindexResult result = ctxDefaultAdmin().callWith( () -> this.indexService.reindex( ReindexParams.create().
             addBranch( WS_DEFAULT ).
             repositoryId( testRepoId ).
             initialize( true ).
-            build() );
+            build() ) );
 
         assertEquals( loadSize + 1, result.getReindexNodes().getSize() );
     }

--- a/modules/itest/itest-core/src/test/java/com/enonic/xp/core/snapshot/SnapshotServiceImplTest.java
+++ b/modules/itest/itest-core/src/test/java/com/enonic/xp/core/snapshot/SnapshotServiceImplTest.java
@@ -318,7 +318,8 @@ class SnapshotServiceImplTest
     void restore_latest_no_snapshots()
     {
         final SnapshotException exception =
-            assertThrows( SnapshotException.class, () -> snapshotService.restore( RestoreParams.create().latest( true ).build() ) );
+            assertThrows( SnapshotException.class,
+                          () -> NodeHelper.runAsAdmin( () -> snapshotService.restore( RestoreParams.create().latest( true ).build() ) ) );
 
         assertEquals( "No snapshots found", exception.getMessage() );
     }


### PR DESCRIPTION
## Summary

Security audit finding L4: repository-wide maintenance operations elevated to admin internally without checking who called them.

- `SnapshotServiceImpl.snapshot/restore/list/delete` wrapped the work in `NodeHelper.runAsAdmin`, so any caller could snapshot or restore every repository.
- `IndexServiceImpl.reindex/updateIndexSettings` purged and rebuilt search indices for any caller.
- `AuditLogServiceImpl.cleanUp` deleted audit log entries for any caller.
- `ExportTaskHandler`/`ImportTaskHandler` ran node export/import for whoever submitted the task.

Each entry point now requires the `system.admin` role in the current context and throws `ForbiddenAccessException` otherwise. A shared `SecurityHelper.requireAdmin()` is added in `core-repo`, with the same check in `core-audit` and `app-system` `TaskUtils`, which do not depend on `core-repo`.

Existing production callers (the management REST resources and API handlers, the system task handlers, the vacuum service and `SnapshotsVacuumTask`) already run in an admin context, so behaviour for them is unchanged.

## Tests

- New `requiresAdmin` tests for `SnapshotServiceImpl` and `IndexServiceImpl.updateIndexSettings`, `cleanUpRequiresAdmin` for `AuditLogServiceImpl`, and `exportNodes_requiresAdmin`/`importNodes_requiresAdmin` for the task handlers, all asserting `ForbiddenAccessException` and no interaction with the underlying services.
- Existing unit and integration tests that exercised these operations now run them in an admin context.

Verified locally with `:core:core-repo:test`, `:core:core-audit:test`, `:app:app-system:test` and the affected `itest-core` integration test classes (`IndexServiceImplTest`, `ReindexLoadTest`, `SnapshotServiceImplTest`, `AuditLogServiceImplTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_