### PR TITLE
Answer unknown HTTP methods with 405  #12365

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiFilter.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiFilter.java
@@ -65,17 +65,23 @@ public final class SlashApiFilter
             return;
         }
 
-        final WebRequest webRequest = webSerializerService.request( req );
-        final WebSocketContext webSocketContext = this.webSocketContextFactory.newContext( req, res );
-        webRequest.setWebSocketContext( webSocketContext );
-
+        WebRequest webRequest = null;
         WebResponse webResponse;
         try
         {
+            webRequest = webSerializerService.request( req );
+            final WebSocketContext webSocketContext = this.webSocketContextFactory.newContext( req, res );
+            webRequest.setWebSocketContext( webSocketContext );
+
             webResponse = slashApiHandler.handle( webRequest );
         }
         catch ( Exception e )
         {
+            if ( webRequest == null )
+            {
+                webRequest = new WebRequest();
+                webRequest.setRawRequest( req );
+            }
             webResponse = exceptionRenderer.render( webRequest, e );
         }
 

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiFilterTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiFilterTest.java
@@ -19,7 +19,6 @@ import com.enonic.xp.web.websocket.WebSocketContext;
 import com.enonic.xp.web.websocket.WebSocketContextFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -95,6 +94,31 @@ class SlashApiFilterTest
 
         verify( slashApiHandler ).handle( webRequest );
         verifyNoInteractions( chain );
+    }
+
+    @Test
+    void rendersHandlerFailure()
+        throws Exception
+    {
+        final HttpServletRequest req = mock( HttpServletRequest.class );
+        final HttpServletResponse res = mock( HttpServletResponse.class );
+        final FilterChain chain = mock( FilterChain.class );
+
+        when( req.getPathInfo() ).thenReturn( "/com.enonic.app.myapp:myapi" );
+
+        final WebRequest webRequest = new WebRequest();
+        when( webSerializerService.request( req ) ).thenReturn( webRequest );
+
+        final WebException cause = new WebException( HttpStatus.NOT_FOUND, "API not found" );
+        when( slashApiHandler.handle( webRequest ) ).thenThrow( cause );
+
+        final WebResponse errorResponse = WebResponse.create().status( HttpStatus.NOT_FOUND ).build();
+        when( exceptionRenderer.render( webRequest, cause ) ).thenReturn( errorResponse );
+
+        filter.doFilter( req, res, chain );
+
+        verify( exceptionRenderer ).render( webRequest, cause );
+        verify( webSerializerService ).response( webRequest, errorResponse, res );
     }
 
     @Test

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiFilterTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiFilterTest.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.portal.impl.handler;
 
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -8,14 +9,19 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
+import com.enonic.xp.web.exception.ExceptionRenderer;
 import com.enonic.xp.web.serializer.WebSerializerService;
 import com.enonic.xp.web.websocket.WebSocketConfig;
 import com.enonic.xp.web.websocket.WebSocketContext;
 import com.enonic.xp.web.websocket.WebSocketContextFactory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -33,14 +39,17 @@ class SlashApiFilterTest
 
     WebSocketContextFactory webSocketContextFactory;
 
+    private ExceptionRenderer exceptionRenderer;
+
     @BeforeEach
     void setUp()
     {
         slashApiHandler = mock( SlashApiHandler.class );
         webSerializerService = mock( WebSerializerService.class );
         webSocketContextFactory = mock();
+        exceptionRenderer = mock( ExceptionRenderer.class );
 
-        filter = new SlashApiFilter( slashApiHandler, webSerializerService, webSocketContextFactory, mock() );
+        filter = new SlashApiFilter( slashApiHandler, webSerializerService, webSocketContextFactory, exceptionRenderer );
     }
 
     @Test
@@ -86,6 +95,29 @@ class SlashApiFilterTest
 
         verify( slashApiHandler ).handle( webRequest );
         verifyNoInteractions( chain );
+    }
+
+    @Test
+    void rendersRequestSerializationFailure()
+        throws Exception
+    {
+        final HttpServletRequest req = mock( HttpServletRequest.class );
+        final HttpServletResponse res = mock( HttpServletResponse.class );
+        final FilterChain chain = mock( FilterChain.class );
+
+        when( req.getPathInfo() ).thenReturn( "/com.enonic.app.myapp:myapi" );
+
+        final WebException cause = new WebException( HttpStatus.METHOD_NOT_ALLOWED, "Method BREW not allowed" );
+        when( webSerializerService.request( req ) ).thenThrow( cause );
+
+        final WebResponse errorResponse = WebResponse.create().status( HttpStatus.METHOD_NOT_ALLOWED ).build();
+        when( exceptionRenderer.render( any( WebRequest.class ), eq( cause ) ) ).thenReturn( errorResponse );
+
+        filter.doFilter( req, res, chain );
+
+        verify( exceptionRenderer ).render( argThat( webRequest -> webRequest.getRawRequest() == req ), eq( cause ) );
+        verify( webSerializerService ).response( argThat( webRequest -> webRequest.getRawRequest() == req ), eq( errorResponse ), eq( res ) );
+        verifyNoInteractions( slashApiHandler, chain );
     }
 
     @Test

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiFilterTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiFilterTest.java
@@ -18,7 +18,6 @@ import com.enonic.xp.web.websocket.WebSocketConfig;
 import com.enonic.xp.web.websocket.WebSocketContext;
 import com.enonic.xp.web.websocket.WebSocketContextFactory;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/handler/WebDispatcherServlet.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/handler/WebDispatcherServlet.java
@@ -54,11 +54,26 @@ public final class WebDispatcherServlet
     protected void service( final HttpServletRequest req, final HttpServletResponse res )
         throws ServletException, IOException
     {
-        final WebRequest webRequest = webSerializerService.request( req );
-        final WebSocketContext webSocketContext = this.webSocketContextFactory.newContext( req, res );
-        webRequest.setWebSocketContext( webSocketContext );
+        WebRequest webRequest = null;
+        WebResponse webResponse;
+        try
+        {
+            webRequest = webSerializerService.request( req );
+            final WebSocketContext webSocketContext = this.webSocketContextFactory.newContext( req, res );
+            webRequest.setWebSocketContext( webSocketContext );
+            webRequest.setBody( webSerializerService.readBody( req ) );
 
-        final WebResponse webResponse = doHandle( req, webRequest );
+            webResponse = exceptionRenderer.maybeThrow( webRequest, webDispatcher.dispatch( webRequest, WebResponse.create().build() ) );
+        }
+        catch ( Exception e )
+        {
+            if ( webRequest == null )
+            {
+                webRequest = new WebRequest();
+                webRequest.setRawRequest( req );
+            }
+            webResponse = exceptionRenderer.render( webRequest, e );
+        }
 
         if ( webRequest.getWebSocketContext() != null && webResponse.getWebSocket() != null )
         {
@@ -72,19 +87,6 @@ public final class WebDispatcherServlet
         }
 
         webSerializerService.response( webRequest, webResponse, res );
-    }
-
-    private WebResponse doHandle( final HttpServletRequest req, final WebRequest webRequest )
-    {
-        try
-        {
-            webRequest.setBody( webSerializerService.readBody( req ) );
-            return exceptionRenderer.maybeThrow( webRequest, webDispatcher.dispatch( webRequest, WebResponse.create().build() ) );
-        }
-        catch ( Exception e )
-        {
-            return exceptionRenderer.render( webRequest, e );
-        }
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
@@ -8,6 +8,8 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 
 import com.enonic.xp.web.HttpMethod;
+import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.servlet.ServletRequestUrlHelper;
 
@@ -23,7 +25,7 @@ public final class RequestSerializer
     public void serialize( final HttpServletRequest request )
     {
         webRequest.setRawRequest( request );
-        webRequest.setMethod( HttpMethod.valueOf( request.getMethod() ) );
+        webRequest.setMethod( parseMethod( request.getMethod() ) );
         webRequest.setScheme( request.getScheme() );
         webRequest.setHost( request.getServerName() );
         webRequest.setPort( request.getServerPort() );
@@ -36,6 +38,18 @@ public final class RequestSerializer
         setParameters( request, webRequest );
         setHeaders( request, webRequest );
         setCookies( request, webRequest );
+    }
+
+    private static HttpMethod parseMethod( final String method )
+    {
+        try
+        {
+            return HttpMethod.valueOf( method );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw new WebException( HttpStatus.METHOD_NOT_ALLOWED, String.format( "Method %s not allowed", method ) );
+        }
     }
 
     private void setHeaders( final HttpServletRequest from, final WebRequest to )

--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/handler/WebDispatcherServletTest.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/handler/WebDispatcherServletTest.java
@@ -4,6 +4,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class WebDispatcherServletTest
@@ -216,6 +221,43 @@ class WebDispatcherServletTest
 
         final HttpResponse<String> response = callRequest( request );
         assertEquals( 413, response.statusCode() );
+    }
+
+    @Test
+    void testPost_malformedContentType()
+        throws Exception
+    {
+        final HttpRequest request = newRequest( "/site/master/a/b" ).header( "content-type", "foo" )
+            .POST( HttpRequest.BodyPublishers.ofString( "Hello World" ) )
+            .build();
+
+        this.handler.verifier = req -> {
+            assertEquals( "foo", req.getContentType() );
+            assertNull( req.getBody() );
+        };
+
+        final HttpResponse<String> response = callRequest( request );
+        assertEquals( 200, response.statusCode() );
+    }
+
+    @Test
+    void testUnknownMethod_methodNotAllowed()
+        throws Exception
+    {
+        when( exceptionRenderer.render( any(), any() ) ).thenAnswer( invocation -> {
+            final WebException cause = invocation.getArgument( 1 );
+            return WebResponse.create().status( cause.getStatus() ).build();
+        } );
+
+        final AtomicBoolean handled = new AtomicBoolean();
+        this.handler.verifier = req -> handled.set( true );
+
+        final HttpRequest request = newRequest( "/site/master/a/b" ).method( "BREW", HttpRequest.BodyPublishers.noBody() ).build();
+
+        final HttpResponse<String> response = callRequest( request );
+        assertEquals( 405, response.statusCode() );
+        assertFalse( handled.get() );
+        verify( exceptionRenderer ).render( argThat( req -> req.getRawRequest() != null ), any( WebException.class ) );
     }
 
     @Test

--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/RequestSerializerTest.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/RequestSerializerTest.java
@@ -1,0 +1,27 @@
+package com.enonic.xp.web.impl.serializer;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
+import com.enonic.xp.web.WebRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RequestSerializerTest
+{
+    @Test
+    void unknownMethod()
+    {
+        final HttpServletRequest request = mock( HttpServletRequest.class );
+        when( request.getMethod() ).thenReturn( "BREW" );
+
+        final WebException e = assertThrows( WebException.class, () -> new RequestSerializer( new WebRequest() ).serialize( request ) );
+        assertEquals( HttpStatus.METHOD_NOT_ALLOWED, e.getStatus() );
+    }
+}


### PR DESCRIPTION
## Summary

Security audit finding L8. Stacked on #12322 (H2), which owns the request body reading; this PR contains only the changes on top of it.

`RequestSerializer` resolved the method with `HttpMethod.valueOf`, so a request line such as `BREW / HTTP/1.1` threw `IllegalArgumentException` straight into Jetty, before the dispatcher servlet or the universal API filter reached their exception-rendering path. The result was a 500 with a stack trace logged per request, reachable anonymously.

## Changes

- `RequestSerializer` rejects an unknown method with a 405 `WebException`, matching how the mapping handler already answers non-standard methods.
- `WebDispatcherServlet` and `SlashApiFilter` serialize the request inside the rendered path. If serialization itself fails, the exception renderer is given a `WebRequest` carrying only the raw servlet request, which is all it needs to produce the error response.

A malformed `Content-Type` is handled by the bounded body reader from #12322, which treats it as a body that is not read.

## Tests

- `RequestSerializerTest.unknownMethod`
- `WebDispatcherServletTest.testUnknownMethod_methodNotAllowed` (real Jetty, method `BREW`) and `testPost_malformedContentType`
- `SlashApiFilterTest.rendersRequestSerializationFailure` and `rendersHandlerFailure`

`:web:web-impl:test` and the `portal-impl` handler and serializer suites pass locally on this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV