### PR TITLE
Answer malformed image, component and id provider input with 400 instead of 500

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/AbstractAttachmentHandlerWorker.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/AbstractAttachmentHandlerWorker.java
@@ -69,7 +69,7 @@ public abstract class AbstractAttachmentHandlerWorker<T extends Content>
 
         final boolean isSvgz = "svgz".equals( attachment.getExtension() );
 
-        final MediaType attachmentMimeType = isSvgz ? SVG_MEDIA_TYPE : MediaType.parse( attachment.getMimeType() );
+        final MediaType attachmentMimeType = isSvgz ? SVG_MEDIA_TYPE : parseMimeType( attachment.getMimeType() );
 
         final MediaType contentType;
         final ByteSource body;
@@ -200,5 +200,17 @@ public abstract class AbstractAttachmentHandlerWorker<T extends Content>
         }
 
         return binary;
+    }
+
+    private static MediaType parseMimeType( final String mimeType )
+    {
+        try
+        {
+            return MediaType.parse( mimeType );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            return MediaType.OCTET_STREAM;
+        }
     }
 }

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/ComponentHandler.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/ComponentHandler.java
@@ -116,7 +116,7 @@ public class ComponentHandler
         final PageResolverResult resolvedPage = pageResolver.resolve( content, site.getPath() );
         Page effectivePage = resolvedPage.getEffectivePageOrElseThrow( portalRequest.getMode() );
         com.enonic.xp.region.Component component = null;
-        final ComponentPath componentPath = ComponentPath.from( HandlerHelper.findEndpointPath( portalRequest, "component" ) );
+        final ComponentPath componentPath = parseComponentPath( HandlerHelper.findEndpointPath( portalRequest, "component" ) );
 
         if ( content.getType().isFragment() )
         {
@@ -151,6 +151,18 @@ public class ComponentHandler
         portalRequest.setApplicationKey( resolvedPage.getApplicationKey() );
 
         return portalRequest;
+    }
+
+    private static ComponentPath parseComponentPath( final String path )
+    {
+        try
+        {
+            return ComponentPath.from( path );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw WebException.badRequest( String.format( "Invalid component path [%s]", path ), e );
+        }
     }
 
     private Page inlineFragments( Page page, final ComponentPath componentPath )

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/IdentityHandler.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/IdentityHandler.java
@@ -64,7 +64,7 @@ public class IdentityHandler
             return HandlerHelper.handleDefaultOptions( HttpMethod.standard() );
         }
 
-        final IdProviderKey idProviderKey = IdProviderKey.from( matcher.group( "idp" ) );
+        final IdProviderKey idProviderKey = parseIdProviderKey( matcher.group( "idp" ) );
 
         final VirtualHost virtualHost = VirtualHostHelper.getVirtualHost( webRequest.getRawRequest() );
 
@@ -153,6 +153,18 @@ public class IdentityHandler
             }
 
             req.setValidTicket( redirectChecksumService.verifyChecksum( redirect, ticket ) );
+        }
+    }
+
+    private static IdProviderKey parseIdProviderKey( final String value )
+    {
+        try
+        {
+            return IdProviderKey.from( value );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw WebException.badRequest( String.format( "Invalid id provider key [%s]", value ), e );
         }
     }
 }

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/ServiceHandler.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/ServiceHandler.java
@@ -101,8 +101,10 @@ public class ServiceHandler
 
     private PortalRequest createPortalRequest( final WebRequest webRequest, final String servicePath, final DescriptorKey descriptorKey )
     {
-        final PortalRequest portalRequest =
-            webRequest instanceof PortalRequest ? (PortalRequest) webRequest : new PortalRequest( webRequest );
+        if ( !( webRequest instanceof PortalRequest portalRequest ) || portalRequest.getBaseUri() == null )
+        {
+            throw WebException.notFound( "Not a valid request" );
+        }
         portalRequest.setContextPath( portalRequest.getBasePath() + "/_/service/" + servicePath );
 
         //Retrieves the ServiceDescriptor

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/ServiceHandler.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/ServiceHandler.java
@@ -69,10 +69,10 @@ public class ServiceHandler
             return HandlerHelper.handleDefaultOptions( HttpMethod.standard() );
         }
 
-        final ApplicationKey applicationKey = ApplicationKey.from( matcher.group( 1 ) );
-        final String name = matcher.group( 2 );
+        final DescriptorKey descriptorKey = parseDescriptorKey( matcher.group( 1 ), matcher.group( 2 ) );
+        final ApplicationKey applicationKey = descriptorKey.getApplicationKey();
+        final String name = descriptorKey.getName();
         final String servicePath = matcher.group( 0 );
-        final DescriptorKey descriptorKey = DescriptorKey.from( applicationKey, name );
 
         final PortalRequest portalRequest = createPortalRequest( webRequest, servicePath, descriptorKey );
 
@@ -97,6 +97,18 @@ public class ServiceHandler
         }
 
         return portalResponse;
+    }
+
+    private static DescriptorKey parseDescriptorKey( final String applicationKey, final String name )
+    {
+        try
+        {
+            return DescriptorKey.from( ApplicationKey.from( applicationKey ), name );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw WebException.badRequest( String.format( "Invalid service [%s/%s]", applicationKey, name ), e );
+        }
     }
 
     private PortalRequest createPortalRequest( final WebRequest webRequest, final String servicePath, final DescriptorKey descriptorKey )

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/image/ImageHandlerWorker.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/image/ImageHandlerWorker.java
@@ -109,13 +109,16 @@ public final class ImageHandlerWorker
         final ImageOrientation imageOrientation = requireNonNullElse(
             MediaUtils.readOrientation( mediaData ), ImageOrientation.TopLeft );
 
-        final int imageQuality = nullToEmpty( this.qualityParam ).isEmpty() ? DEFAULT_QUALITY : Integer.parseInt( this.qualityParam );
-
-        final int backgroundColor = nullToEmpty( this.backgroundParam ).isEmpty()
-            ? DEFAULT_BACKGROUND
-            : Integer.parseInt( this.backgroundParam.startsWith( "0x" ) ? this.backgroundParam.substring( 2 ) : this.backgroundParam, 16 );
         try
         {
+            final int imageQuality =
+                nullToEmpty( this.qualityParam ).isEmpty() ? DEFAULT_QUALITY : Integer.parseInt( this.qualityParam );
+
+            final int backgroundColor = nullToEmpty( this.backgroundParam ).isEmpty()
+                ? DEFAULT_BACKGROUND
+                : Integer.parseInt( this.backgroundParam.startsWith( "0x" ) ? this.backgroundParam.substring( 2 ) : this.backgroundParam,
+                                    16 );
+
             final Attachment attachment =
                 requireNonNull( content.getAttachments().byLabel( "source" ), "Media content must have an attachment" );
 

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/AttachmentHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/AttachmentHandlerTest.java
@@ -191,6 +191,22 @@ class AttachmentHandlerTest
     }
 
     @Test
+    void malformedMimeTypeServedAsOctetStream()
+        throws Exception
+    {
+        final Attachment attachment = Attachment.create().name( "logo.png" ).mimeType( "png" ).label( "small" ).build();
+        final Media content = createMedia( "123456", "path/to/content", attachment );
+        when( this.contentService.getById( eq( content.getId() ) ) ).thenReturn( content );
+
+        this.request.setRawPath( "/_/attachment/download/123456/logo.png" );
+
+        final PortalResponse res = this.handler.handle( this.request );
+        assertEquals( HttpStatus.OK, res.getStatus() );
+        assertEquals( MediaType.OCTET_STREAM, res.getContentType() );
+        assertSame( this.mediaBytes, res.getBody() );
+    }
+
+    @Test
     void idNotFound()
         throws Exception
     {

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/ComponentHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/ComponentHandlerTest.java
@@ -140,6 +140,20 @@ class ComponentHandlerTest
     }
 
     @Test
+    void invalidComponentPath()
+    {
+        setupSite();
+        setupContent();
+        setupTemplates();
+
+        this.request.setRawPath( "/_/component/main-region/first" );
+
+        final WebException e = assertThrows( WebException.class, () -> this.handler.handle( this.request ) );
+        assertEquals( HttpStatus.BAD_REQUEST, e.getStatus() );
+        assertEquals( "Invalid component path [main-region/first]", e.getMessage() );
+    }
+
+    @Test
     void getContentNotFound()
     {
         this.request.setRawPath( "/_/component/main-region/666" );

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/IdentityHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/IdentityHandlerTest.java
@@ -121,6 +121,16 @@ class IdentityHandlerTest
     }
 
     @Test
+    void testInvalidIdProviderKey()
+    {
+        this.request.setRawPath( "/site/project/branch/_/idprovider/roles" );
+
+        final WebException e = assertThrows( WebException.class, () -> this.handler.handle( this.request ) );
+        assertEquals( HttpStatus.BAD_REQUEST, e.getStatus() );
+        assertEquals( "Invalid id provider key [roles]", e.getMessage() );
+    }
+
+    @Test
     void testHandle()
         throws Exception
     {

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/ImageHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/ImageHandlerTest.java
@@ -328,6 +328,32 @@ class ImageHandlerTest
     }
 
     @Test
+    void invalidQualityFormat()
+        throws Exception
+    {
+        setupContent();
+
+        this.request.setRawPath( "/_/image/123456/scale-100-100/image-name.jpg" );
+        this.request.getParams().put( "quality", "high" );
+
+        final WebException webException = assertThrows( WebException.class, () -> this.handler.handle( this.request ) );
+        assertEquals( HttpStatus.BAD_REQUEST, webException.getStatus() );
+    }
+
+    @Test
+    void invalidBackground()
+        throws Exception
+    {
+        setupContent();
+
+        this.request.setRawPath( "/_/image/123456/scale-100-100/image-name.jpg" );
+        this.request.getParams().put( "background", "0xzz" );
+
+        final WebException webException = assertThrows( WebException.class, () -> this.handler.handle( this.request ) );
+        assertEquals( HttpStatus.BAD_REQUEST, webException.getStatus() );
+    }
+
+    @Test
     void nameMissmatch()
         throws Exception
     {

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/ImageHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/ImageHandlerTest.java
@@ -354,6 +354,19 @@ class ImageHandlerTest
     }
 
     @Test
+    void backgroundWithoutPrefix()
+        throws Exception
+    {
+        setupContent();
+
+        this.request.setRawPath( "/_/image/123456/scale-100-100/image-name.jpg" );
+        this.request.getParams().put( "background", "ffffff" );
+
+        final WebResponse res = this.handler.handle( this.request );
+        assertEquals( HttpStatus.OK, res.getStatus() );
+    }
+
+    @Test
     void nameMissmatch()
         throws Exception
     {

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/ServiceHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/ServiceHandlerTest.java
@@ -43,6 +43,7 @@ import com.enonic.xp.trace.Tracer;
 import com.enonic.xp.web.HttpMethod;
 import com.enonic.xp.web.HttpStatus;
 import com.enonic.xp.web.WebException;
+import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
 import com.enonic.xp.web.websocket.WebSocketConfig;
 import com.enonic.xp.web.websocket.WebSocketContext;
@@ -133,6 +134,18 @@ class ServiceHandlerTest
             assertEquals( HttpStatus.NOT_FOUND, e.getStatus() );
             assertEquals( "Not a valid service url pattern", e.getMessage() );
         }
+    }
+
+    @Test
+    void testHandleNotSiteBase()
+    {
+        final WebRequest webRequest = new WebRequest();
+        webRequest.setMethod( HttpMethod.GET );
+        webRequest.setRawPath( "/_/service/demo/test" );
+
+        final WebException e = assertThrows( WebException.class, () -> this.handler.handle( webRequest ) );
+        assertEquals( HttpStatus.NOT_FOUND, e.getStatus() );
+        assertEquals( "Not a valid request", e.getMessage() );
     }
 
     @Test

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/ServiceHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/ServiceHandlerTest.java
@@ -159,6 +159,18 @@ class ServiceHandlerTest
     }
 
     @Test
+    void testHandlePortalRequestWithoutBaseUri()
+    {
+        final PortalRequest portalRequest = new PortalRequest();
+        portalRequest.setMethod( HttpMethod.GET );
+        portalRequest.setRawPath( "/_/service/demo/test" );
+
+        final WebException e = assertThrows( WebException.class, () -> this.handler.handle( portalRequest ) );
+        assertEquals( HttpStatus.NOT_FOUND, e.getStatus() );
+        assertEquals( "Not a valid request", e.getMessage() );
+    }
+
+    @Test
     void testForbiddenService()
         throws Exception
     {

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/ServiceHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/ServiceHandlerTest.java
@@ -137,6 +137,16 @@ class ServiceHandlerTest
     }
 
     @Test
+    void testInvalidServiceKey()
+    {
+        this.request.setRawPath( "/site/draft/site/somepath/content/_/service/invalid!/test" );
+
+        final WebException e = assertThrows( WebException.class, () -> this.handler.handle( this.request ) );
+        assertEquals( HttpStatus.BAD_REQUEST, e.getStatus() );
+        assertEquals( "Invalid service [invalid!/test]", e.getMessage() );
+    }
+
+    @Test
     void testHandleNotSiteBase()
     {
         final WebRequest webRequest = new WebRequest();


### PR DESCRIPTION
## Summary

Security audit finding L13: several endpoint handlers converted request input outside their exception handling. The resulting `IllegalArgumentException` fell through to the exception mapper, which renders it as 500 and logs a stack trace on every hit. All of these are reachable anonymously, so each is a cheap way to flood the error log.

## Changes

- `ImageHandlerWorker`: the `quality` and `background` parameters are parsed inside the existing `try`, so `quality=high` or `background=0xzz` gets the same 400 as an out-of-range value already did.
- `ComponentHandler`: an unparseable component path such as `main-region/first` is answered with 400 `Invalid component path [...]`.
- `IdentityHandler`: an invalid id provider key in the URL is answered with 400 `Invalid id provider key [...]`.
- `ServiceHandler`: a request without a portal base (root-level `/_/service/app/name`) dereferenced a null base URI. It is now rejected with 404 `Not a valid request`, matching the other endpoint handlers. This was never a working path, only a 500.
- `AbstractAttachmentHandlerWorker`: an attachment whose stored mime type cannot be parsed is served as `application/octet-stream` instead of failing. This one is stored data rather than request input, so no client error status fits.

## Tests

- `ImageHandlerTest.invalidQualityFormat`, `invalidBackground`
- `ComponentHandlerTest.invalidComponentPath`
- `IdentityHandlerTest.testInvalidIdProviderKey`
- `ServiceHandlerTest.testHandleNotSiteBase`
- `AttachmentHandlerTest.malformedMimeTypeServedAsOctetStream`

Full `:portal:portal-impl:test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_