### PR TITLE
Fix suffix byte ranges and cap the number of ranges in an attachment request

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/attachment/RangeRequestHelper.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/attachment/RangeRequestHelper.java
@@ -25,6 +25,8 @@ public final class RangeRequestHelper
 
     private static final String MULTIPART_BOUNDARY = "__BOUNDARY__";
 
+    private static final int MAX_RANGES = 10;
+
     public void handleRangeRequest( final WebRequest request, final WebResponse.Builder response, final ByteSource body,
                                     final MediaType contentType )
         throws IOException
@@ -39,9 +41,15 @@ public final class RangeRequestHelper
 
         final String rangeHeader = request.getHeaders().getOrDefault( HttpHeaders.RANGE, "" ).trim();
         final String rangeValue = rangeHeader.length() > "bytes=".length() ? rangeHeader.substring( "bytes=".length() ) : "";
+        final String[] rangeValues = rangeValue.split( "," );
+        if ( rangeValues.length > MAX_RANGES )
+        {
+            response.body( body );
+            return;
+        }
 
         long fileLength = body.size();
-        final List<Range> ranges = parseRangeBytesHeader( rangeValue, fileLength );
+        final List<Range> ranges = parseRangeBytesHeader( rangeValues, fileLength );
         if ( ranges.isEmpty() )
         {
             response.status( HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE );
@@ -64,13 +72,12 @@ public final class RangeRequestHelper
         }
     }
 
-    private List<Range> parseRangeBytesHeader( final String rangeHeaderValue, final long fileLength )
+    private List<Range> parseRangeBytesHeader( final String[] rangeValues, final long fileLength )
     {
-        final String[] rangeValues = rangeHeaderValue.split( "," );
         try
         {
             return Arrays.stream( rangeValues ).
-                map( ( rangeValue ) -> parseRangeBytes( rangeValue, fileLength ) ).
+                map( ( rangeValue ) -> parseRangeBytes( rangeValue.trim(), fileLength ) ).
                 filter( Objects::nonNull ).
                 collect( Collectors.toList() );
         }
@@ -87,7 +94,7 @@ public final class RangeRequestHelper
         if ( rangeValue.startsWith( "-" ) )
         {
             end = fileLength - 1;
-            start = fileLength - 1 - Long.parseLong( rangeValue.substring( "-".length() ) );
+            start = Math.max( 0, fileLength - Long.parseLong( rangeValue.substring( "-".length() ) ) );
         }
         else
         {

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/attachment/RangeRequestHelper.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/attachment/RangeRequestHelper.java
@@ -27,6 +27,8 @@ public final class RangeRequestHelper
 
     private static final int MAX_RANGES = 10;
 
+    private static final String BYTES_UNIT = "bytes=";
+
     public void handleRangeRequest( final WebRequest request, final WebResponse.Builder response, final ByteSource body,
                                     final MediaType contentType )
         throws IOException
@@ -40,8 +42,13 @@ public final class RangeRequestHelper
         }
 
         final String rangeHeader = request.getHeaders().getOrDefault( HttpHeaders.RANGE, "" ).trim();
-        final String rangeValue = rangeHeader.length() > "bytes=".length() ? rangeHeader.substring( "bytes=".length() ) : "";
-        final String[] rangeValues = rangeValue.split( ",", MAX_RANGES + 1 );
+        if ( !rangeHeader.regionMatches( true, 0, BYTES_UNIT, 0, BYTES_UNIT.length() ) )
+        {
+            response.body( body );
+            return;
+        }
+
+        final String[] rangeValues = rangeHeader.substring( BYTES_UNIT.length() ).split( ",", MAX_RANGES + 1 );
         if ( rangeValues.length > MAX_RANGES )
         {
             response.status( HttpStatus.OK );
@@ -51,6 +58,13 @@ public final class RangeRequestHelper
 
         long fileLength = body.size();
         final List<Range> ranges = parseRangeBytesHeader( rangeValues, fileLength );
+        if ( ranges.stream().mapToLong( range -> range.length ).sum() > fileLength )
+        {
+            response.status( HttpStatus.OK );
+            response.body( body );
+            return;
+        }
+
         if ( ranges.isEmpty() )
         {
             response.status( HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE );

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/attachment/RangeRequestHelper.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/attachment/RangeRequestHelper.java
@@ -41,9 +41,10 @@ public final class RangeRequestHelper
 
         final String rangeHeader = request.getHeaders().getOrDefault( HttpHeaders.RANGE, "" ).trim();
         final String rangeValue = rangeHeader.length() > "bytes=".length() ? rangeHeader.substring( "bytes=".length() ) : "";
-        final String[] rangeValues = rangeValue.split( "," );
+        final String[] rangeValues = rangeValue.split( ",", MAX_RANGES + 1 );
         if ( rangeValues.length > MAX_RANGES )
         {
+            response.status( HttpStatus.OK );
             response.body( body );
             return;
         }

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/AttachmentHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/AttachmentHandlerTest.java
@@ -266,8 +266,48 @@ class AttachmentHandlerTest
         final byte[] responseBody = ( (ByteSource) res.getBody() ).read();
         final byte[] mediaBytesData = mediaBytes.read();
 
-        assertEquals( 4, responseBody.length );
-        assertArrayEquals( new byte[]{mediaBytesData[3], mediaBytesData[4], mediaBytesData[5], mediaBytesData[6]}, responseBody );
+        assertEquals( 3, responseBody.length );
+        assertArrayEquals( new byte[]{mediaBytesData[4], mediaBytesData[5], mediaBytesData[6]}, responseBody );
+        assertEquals( "bytes 4-6/7", res.getHeaders().get( "Content-Range" ) );
+    }
+
+    @Test
+    void byteServingSuffixLongerThanFile()
+        throws Exception
+    {
+        this.request.setRawPath( "/_/attachment/inline/123456/logo.png" );
+        this.request.getHeaders().put( "Range", "bytes=-100" );
+
+        final PortalResponse res = this.handler.handle( this.request );
+        assertEquals( HttpStatus.PARTIAL_CONTENT, res.getStatus() );
+        assertEquals( "bytes 0-6/7", res.getHeaders().get( "Content-Range" ) );
+        assertArrayEquals( mediaBytes.read(), ( (ByteSource) res.getBody() ).read() );
+    }
+
+    @Test
+    void byteServingSuffixZero()
+        throws Exception
+    {
+        this.request.setRawPath( "/_/attachment/inline/123456/logo.png" );
+        this.request.getHeaders().put( "Range", "bytes=-0" );
+
+        final PortalResponse res = this.handler.handle( this.request );
+        assertEquals( HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE, res.getStatus() );
+        assertEquals( "bytes */7", res.getHeaders().get( "Content-Range" ) );
+        assertNull( res.getBody() );
+    }
+
+    @Test
+    void byteServingTooManyRangesServesWholeBody()
+        throws Exception
+    {
+        this.request.setRawPath( "/_/attachment/inline/123456/logo.png" );
+        this.request.getHeaders().put( "Range", "bytes=" + "0-,".repeat( 10 ) + "0-" );
+
+        final PortalResponse res = this.handler.handle( this.request );
+        assertEquals( HttpStatus.OK, res.getStatus() );
+        assertNull( res.getHeaders().get( "Content-Range" ) );
+        assertSame( this.mediaBytes, res.getBody() );
     }
 
     @Test

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/AttachmentHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/AttachmentHandlerTest.java
@@ -311,6 +311,32 @@ class AttachmentHandlerTest
     }
 
     @Test
+    void byteServingUnknownUnitServesWholeBody()
+        throws Exception
+    {
+        this.request.setRawPath( "/_/attachment/inline/123456/logo.png" );
+        this.request.getHeaders().put( "Range", "items=0-1" );
+
+        final PortalResponse res = this.handler.handle( this.request );
+        assertEquals( HttpStatus.OK, res.getStatus() );
+        assertNull( res.getHeaders().get( "Content-Range" ) );
+        assertArrayEquals( mediaBytes.read(), ( (ByteSource) res.getBody() ).read() );
+    }
+
+    @Test
+    void byteServingOverlappingRangesServeWholeBody()
+        throws Exception
+    {
+        this.request.setRawPath( "/_/attachment/inline/123456/logo.png" );
+        this.request.getHeaders().put( "Range", "bytes=0-,0-" );
+
+        final PortalResponse res = this.handler.handle( this.request );
+        assertEquals( HttpStatus.OK, res.getStatus() );
+        assertEquals( MediaType.PNG, res.getContentType() );
+        assertArrayEquals( mediaBytes.read(), ( (ByteSource) res.getBody() ).read() );
+    }
+
+    @Test
     void byteServingSuffixFrom()
         throws Exception
     {


### PR DESCRIPTION
## Summary

Security audit finding L12, in `RangeRequestHelper` used by the attachment and image handlers.

- **Negative start.** `Range: bytes=-100` on a 10-byte attachment computed a negative start, `ByteSource.slice` threw, and the anonymous request became a 500 logged at ERROR. The suffix start is now clamped to 0, so a suffix longer than the file returns the whole file as `206` with `Content-Range: bytes 0-N/N+1`, which is what RFC 9110 specifies.
- **Off by one.** `bytes=-N` returned N+1 bytes. It now returns the last N bytes. The existing `byteServingSuffixLength` test encoded the old behaviour (`bytes=-3` on 7 bytes returned 4) and has been corrected to 3 bytes with `Content-Range: bytes 4-6/7`.
- **Unbounded range count.** `bytes=0-,0-,...` repeated a thousand times multiplied the response body. A header with more than ten ranges is now ignored and the whole body served once with 200, which RFC 9110 §14.2 explicitly allows for sets of many ranges.
- Whitespace after the comma separator is tolerated, as the RFC grammar permits.

`bytes=-0` continues to be answered with 416, as before.

## Tests

New in `AttachmentHandlerTest`: `byteServingSuffixLongerThanFile`, `byteServingSuffixZero`, `byteServingTooManyRangesServesWholeBody`; `byteServingSuffixLength` corrected. Full `:portal:portal-impl:test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_