### PR TITLE
Return only the reason phrase for 5xx responses outside dev mode

### DIFF
--- a/modules/jaxrs/jaxrs-impl/build.gradle
+++ b/modules/jaxrs/jaxrs-impl/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testFixturesImplementation project( ':core:core-internal' )
 
     testImplementation( testFixtures( project(":web:web-jetty") ) )
+    testImplementation( testFixtures( project( ':core:core-api' ) ) )
 }
 
 jar {

--- a/modules/jaxrs/jaxrs-impl/src/main/java/com/enonic/xp/jaxrs/impl/exception/JsonExceptionMapper.java
+++ b/modules/jaxrs/jaxrs-impl/src/main/java/com/enonic/xp/jaxrs/impl/exception/JsonExceptionMapper.java
@@ -17,9 +17,11 @@ import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.exception.NotFoundException;
 import com.enonic.xp.security.PrincipalKey;
+import com.enonic.xp.server.RunMode;
 import com.enonic.xp.security.auth.AuthenticationInfo;
 import com.enonic.xp.web.WebException;
 
+import static java.util.Objects.requireNonNullElse;
 import static java.util.Objects.requireNonNullElseGet;
 
 @Provider
@@ -53,9 +55,14 @@ public final class JsonExceptionMapper
     {
         final ObjectNode node = JsonNodeFactory.instance.objectNode();
         node.put( "status", status );
-        node.put( "message", cause.getMessage() );
+        node.put( "message", status >= 500 && !RunMode.isDev() ? reasonPhrase( status ) : cause.getMessage() );
         node.set( "context", createContextJson() );
         return node;
+    }
+
+    private static String reasonPhrase( final int status )
+    {
+        return requireNonNullElse( Response.Status.fromStatusCode( status ), Response.Status.INTERNAL_SERVER_ERROR ).getReasonPhrase();
     }
 
     private static ObjectNode createContextJson()

--- a/modules/jaxrs/jaxrs-impl/src/test/java/com/enonic/xp/jaxrs/impl/exception/JsonExceptionMapperTest.java
+++ b/modules/jaxrs/jaxrs-impl/src/test/java/com/enonic/xp/jaxrs/impl/exception/JsonExceptionMapperTest.java
@@ -2,6 +2,7 @@ package com.enonic.xp.jaxrs.impl.exception;
 
 import java.io.IOException;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
+
+import com.enonic.xp.server.RunMode;
+import com.enonic.xp.server.RunModeSupport;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -23,12 +27,45 @@ class JsonExceptionMapperTest
         this.mapper = new JsonExceptionMapper();
     }
 
+    @AfterEach
+    void resetRunMode()
+    {
+        RunModeSupport.set( RunMode.PROD );
+    }
+
     @Test
     void testCreateErrorJson()
     {
         final IOException cause = new IOException();
         final ObjectNode json = JsonExceptionMapper.createErrorJson( cause, 500 );
         assertNotNull( json );
+    }
+
+    @Test
+    void testCreateErrorJson_serverErrorHidesDetailsInProd()
+    {
+        RunModeSupport.set( RunMode.PROD );
+
+        final ObjectNode json = JsonExceptionMapper.createErrorJson( new IOException( "/opt/xp/home/repo/blob is not writable" ), 500 );
+        assertEquals( "Internal Server Error", json.get( "message" ).asText() );
+    }
+
+    @Test
+    void testCreateErrorJson_serverErrorKeepsDetailsInDev()
+    {
+        RunModeSupport.set( RunMode.DEV );
+
+        final ObjectNode json = JsonExceptionMapper.createErrorJson( new IOException( "details" ), 500 );
+        assertEquals( "details", json.get( "message" ).asText() );
+    }
+
+    @Test
+    void testCreateErrorJson_clientErrorKeepsMessage()
+    {
+        RunModeSupport.set( RunMode.PROD );
+
+        final ObjectNode json = JsonExceptionMapper.createErrorJson( new IllegalArgumentException( "bad input" ), 400 );
+        assertEquals( "bad input", json.get( "message" ).asText() );
     }
 
     @Test

--- a/modules/jaxrs/jaxrs-impl/src/test/java/com/enonic/xp/jaxrs/impl/exception/JsonExceptionMapperTest.java
+++ b/modules/jaxrs/jaxrs-impl/src/test/java/com/enonic/xp/jaxrs/impl/exception/JsonExceptionMapperTest.java
@@ -21,16 +21,19 @@ class JsonExceptionMapperTest
 {
     private JsonExceptionMapper mapper;
 
+    private RunMode previousRunMode;
+
     @BeforeEach
     void setup()
     {
         this.mapper = new JsonExceptionMapper();
+        this.previousRunMode = RunMode.get();
     }
 
     @AfterEach
-    void resetRunMode()
+    void restoreRunMode()
     {
-        RunModeSupport.set( RunMode.PROD );
+        RunModeSupport.set( previousRunMode );
     }
 
     @Test

--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/exception/ExceptionInfo.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/exception/ExceptionInfo.java
@@ -38,6 +38,11 @@ final class ExceptionInfo
 
     public String getDescription()
     {
+        if ( this.status.is5xxServerError() && !this.withDebugInfo )
+        {
+            return this.status.getReasonPhrase();
+        }
+
         String str = this.getMessage();
         final Throwable innerCause = this.cause != null ? this.cause.getCause() : null;
         if ( innerCause != null )

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/exception/ExceptionRendererImplTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/exception/ExceptionRendererImplTest.java
@@ -276,6 +276,20 @@ class ExceptionRendererImplTest
     }
 
     @Test
+    void render_internal_server_error_prod_hides_details()
+    {
+        RunModeSupport.set( RunMode.PROD );
+        this.renderer =
+            new ExceptionRendererImpl( resourceService, errorHandlerScriptFactory, null, postProcessor, new ExceptionMapperImpl() );
+
+        final RuntimeException cause = new RuntimeException( "/opt/xp/home/repo/blob is not writable" );
+        final PortalResponse res = this.renderer.render( this.request, cause );
+
+        assertThat( res.getStatus() ).isEqualTo( HttpStatus.INTERNAL_SERVER_ERROR );
+        assertThat( res.getBody().toString() ).isEqualTo( "{\"status\":500,\"message\":\"Internal Server Error\"}" );
+    }
+
+    @Test
     void render_internal_server_error()
     {
         this.request.getHeaders().put( HttpHeaders.ACCEPT, "text/html,text/*" );


### PR DESCRIPTION
## Summary

Security audit finding L7. An uncaught exception was rendered as `{"status":500,"message":"<cause message> (<cause class>)"}` by the portal exception renderer, and as `{"status":500,"message":"<cause message>"}` by the JAX-RS mapper used on the management and admin REST endpoints. Those messages carry file system paths under `$XP_HOME`, Elasticsearch messages, download URLs and internal class names, and reach anonymous clients on the portal.

## Changes

- `ExceptionInfo.getDescription()` returns the status reason phrase for a 5xx status unless the renderer is running with debug info, which is dev mode. 4xx responses and the dev-mode error page with its stack trace are unchanged. The ERROR log entry still carries the full message and stack trace.
- `JsonExceptionMapper.createErrorJson()` applies the same rule for status codes of 500 and above, keyed on `RunMode.isDev()`.
- `jaxrs-impl` gets the `core-api` test fixtures on its test classpath so the mapper test can switch run mode.

## Tests

- `ExceptionRendererImplTest.render_internal_server_error_prod_hides_details`
- `JsonExceptionMapperTest.testCreateErrorJson_serverErrorHidesDetailsInProd`, `testCreateErrorJson_serverErrorKeepsDetailsInDev`, `testCreateErrorJson_clientErrorKeepsMessage`

Full `:portal:portal-impl:test` and `:jaxrs:jaxrs-impl:test` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_