### PR TITLE
Bound the size arguments of the blur, block, border and rounded image filters

### DIFF
--- a/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/effect/ImageFilters.java
+++ b/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/effect/ImageFilters.java
@@ -41,6 +41,7 @@ public class ImageFilters
 
     public ImageFunction block( Object... args )
     {
+        Preconditions.checkArgument( args.length <= 1, "Too many arguments %s", args.length );
         final int blockSize = CommandArgumentParser.getIntArg( args, 0, 2 );
         Preconditions.checkArgument( blockSize > 0 && blockSize <= MAX_SIZE, "block size must be between 1 and %s : %s", MAX_SIZE,
                                      blockSize );
@@ -49,6 +50,7 @@ public class ImageFilters
 
     public ImageFunction blur( Object... args )
     {
+        Preconditions.checkArgument( args.length <= 1, "Too many arguments %s", args.length );
         final int radius = CommandArgumentParser.getIntArg( args, 0, 2 );
         Preconditions.checkArgument( radius >= 0 && radius <= MAX_BLUR_RADIUS, "blur radius must be between 0 and %s : %s",
                                      MAX_BLUR_RADIUS, radius );
@@ -57,6 +59,7 @@ public class ImageFilters
 
     public ImageFunction border( Object... args )
     {
+        Preconditions.checkArgument( args.length <= 2, "Too many arguments %s", args.length );
         final int size = CommandArgumentParser.getIntArg( args, 0, 2 );
         final int color = CommandArgumentParser.getIntArg( args, 1, 0x000000 );
         Preconditions.checkArgument( size >= 0 && size <= MAX_SIZE, "border size must be between 0 and %s : %s", MAX_SIZE, size );
@@ -156,6 +159,7 @@ public class ImageFilters
 
     public ImageFunction rounded( Object... args )
     {
+        Preconditions.checkArgument( args.length <= 3, "Too many arguments %s", args.length );
         final int radius = CommandArgumentParser.getIntArg( args, 0, 10 );
         final int borderSize = CommandArgumentParser.getIntArg( args, 1, 0 );
         final int borderColor = CommandArgumentParser.getIntArg( args, 2, 0x000000 );

--- a/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/effect/ImageFilters.java
+++ b/modules/core/core-image/src/main/java/com/enonic/xp/core/impl/image/effect/ImageFilters.java
@@ -14,6 +14,8 @@ import java.awt.image.ImageFilter;
 import java.awt.image.ImageProducer;
 import java.util.function.Consumer;
 
+import com.google.common.base.Preconditions;
+
 import com.jhlabs.image.BlockFilter;
 import com.jhlabs.image.BumpFilter;
 import com.jhlabs.image.EdgeFilter;
@@ -33,15 +35,23 @@ import com.enonic.xp.image.ImageHelper;
 
 public class ImageFilters
 {
+    private static final int MAX_BLUR_RADIUS = 100;
+
+    private static final int MAX_SIZE = 1000;
+
     public ImageFunction block( Object... args )
     {
         final int blockSize = CommandArgumentParser.getIntArg( args, 0, 2 );
+        Preconditions.checkArgument( blockSize > 0 && blockSize <= MAX_SIZE, "block size must be between 1 and %s : %s", MAX_SIZE,
+                                     blockSize );
         return adaptOperation( new BlockFilter( blockSize ) );
     }
 
     public ImageFunction blur( Object... args )
     {
         final int radius = CommandArgumentParser.getIntArg( args, 0, 2 );
+        Preconditions.checkArgument( radius >= 0 && radius <= MAX_BLUR_RADIUS, "blur radius must be between 0 and %s : %s",
+                                     MAX_BLUR_RADIUS, radius );
         return adaptOperation( new GaussianFilter( radius ) );
     }
 
@@ -49,6 +59,7 @@ public class ImageFilters
     {
         final int size = CommandArgumentParser.getIntArg( args, 0, 2 );
         final int color = CommandArgumentParser.getIntArg( args, 1, 0x000000 );
+        Preconditions.checkArgument( size >= 0 && size <= MAX_SIZE, "border size must be between 0 and %s : %s", MAX_SIZE, size );
         return borderFunction( size, color );
     }
 
@@ -148,6 +159,9 @@ public class ImageFilters
         final int radius = CommandArgumentParser.getIntArg( args, 0, 10 );
         final int borderSize = CommandArgumentParser.getIntArg( args, 1, 0 );
         final int borderColor = CommandArgumentParser.getIntArg( args, 2, 0x000000 );
+        Preconditions.checkArgument( radius >= 0 && radius <= MAX_SIZE, "rounded radius must be between 0 and %s : %s", MAX_SIZE, radius );
+        Preconditions.checkArgument( borderSize >= 0 && borderSize <= MAX_SIZE, "rounded border size must be between 0 and %s : %s",
+                                     MAX_SIZE, borderSize );
         return roundedFunction( radius, borderSize, borderColor );
     }
 

--- a/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/ImageFilterBuilderImplTest.java
+++ b/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/ImageFilterBuilderImplTest.java
@@ -64,6 +64,16 @@ public final class ImageFilterBuilderImplTest
     }
 
     @Test
+    void testFilterArgumentOutOfBounds()
+    {
+        final ImageFilterBuilderImpl imageFilterBuilder = new ImageFilterBuilderImpl();
+        imageFilterBuilder.activate( mock( ImageConfig.class, invocation -> invocation.getMethod().getDefaultValue() ) );
+
+        assertThrows( IllegalArgumentException.class, () -> imageFilterBuilder.build( FilterSetExpr.parse( "blur(5000000)" ) ) );
+        assertThrows( IllegalArgumentException.class, () -> imageFilterBuilder.build( FilterSetExpr.parse( "block(0)" ) ) );
+    }
+
+    @Test
     void testTooManyFilters()
     {
         final ImageFilterBuilderImpl imageFilterBuilder = new ImageFilterBuilderImpl();

--- a/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/effect/ImageFiltersArgumentsTest.java
+++ b/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/effect/ImageFiltersArgumentsTest.java
@@ -1,0 +1,52 @@
+package com.enonic.xp.core.impl.image.effect;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ImageFiltersArgumentsTest
+    extends BaseImageFilterTest
+{
+    @Test
+    void blurRadiusWithinBounds()
+    {
+        assertNotNull( newFilters().blur( 0 ).apply( getOpaque() ) );
+        assertNotNull( newFilters().blur( 100 ).apply( getOpaque() ) );
+    }
+
+    @Test
+    void blurRadiusOutOfBounds()
+    {
+        assertThrows( IllegalArgumentException.class, () -> newFilters().blur( -1 ) );
+        assertThrows( IllegalArgumentException.class, () -> newFilters().blur( 101 ) );
+        assertThrows( IllegalArgumentException.class, () -> newFilters().blur( 5_000_000 ) );
+    }
+
+    @Test
+    void blockSizeOutOfBounds()
+    {
+        assertThrows( IllegalArgumentException.class, () -> newFilters().block( 0 ) );
+        assertThrows( IllegalArgumentException.class, () -> newFilters().block( -5 ) );
+        assertThrows( IllegalArgumentException.class, () -> newFilters().block( 1001 ) );
+        assertNotNull( newFilters().block( 1000 ).apply( getOpaque() ) );
+    }
+
+    @Test
+    void borderSizeOutOfBounds()
+    {
+        assertThrows( IllegalArgumentException.class, () -> newFilters().border( -1 ) );
+        assertThrows( IllegalArgumentException.class, () -> newFilters().border( 1001 ) );
+        assertNotNull( newFilters().border( 0 ).apply( getOpaque() ) );
+    }
+
+    @Test
+    void roundedArgumentsOutOfBounds()
+    {
+        assertThrows( IllegalArgumentException.class, () -> newFilters().rounded( -1 ) );
+        assertThrows( IllegalArgumentException.class, () -> newFilters().rounded( 1001 ) );
+        assertThrows( IllegalArgumentException.class, () -> newFilters().rounded( 10, -1 ) );
+        assertThrows( IllegalArgumentException.class, () -> newFilters().rounded( 10, 1001 ) );
+        assertNotNull( newFilters().rounded( 0, 0 ).apply( getOpaque() ) );
+    }
+}

--- a/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/effect/ImageFiltersArgumentsTest.java
+++ b/modules/core/core-image/src/test/java/com/enonic/xp/core/impl/image/effect/ImageFiltersArgumentsTest.java
@@ -24,6 +24,17 @@ class ImageFiltersArgumentsTest
     }
 
     @Test
+    void tooManyArguments()
+    {
+        assertThrows( IllegalArgumentException.class, () -> newFilters().blur( 2, 1 ) );
+        assertThrows( IllegalArgumentException.class, () -> newFilters().block( 2, 1 ) );
+        assertThrows( IllegalArgumentException.class, () -> newFilters().border( 2, 0, 1 ) );
+        assertThrows( IllegalArgumentException.class, () -> newFilters().rounded( 10, 0, 0, 1 ) );
+        assertNotNull( newFilters().border( 2, 0 ).apply( getOpaque() ) );
+        assertNotNull( newFilters().rounded( 10, 0, 0 ).apply( getOpaque() ) );
+    }
+
+    @Test
     void blockSizeOutOfBounds()
     {
         assertThrows( IllegalArgumentException.class, () -> newFilters().block( 0 ) );


### PR DESCRIPTION
## Summary

Security audit finding M7. `scale.maxDimension` and `filters.maxTotal` bound image dimensions and the number of filters, and the memory circuit breaker bounds heap, but no filter argument was bounded.

- `blur(radius)` builds a Gaussian kernel of `2*radius+1` taps convolved against every pixel, so `?filter=blur(5000000)` on any public image URL pinned a request thread for minutes, and every distinct argument is a new cache entry.
- `block(0)` handed JH Labs' `BlockFilter` a zero step and never terminated.
- `border` and `rounded` accepted negative and arbitrarily large sizes.

## Changes

`ImageFilters` now validates the arguments with `Preconditions.checkArgument`, in the same style as `ImageScales`:

| Filter | Argument | Allowed |
|---|---|---|
| `blur` | radius | 0 to 100 |
| `block` | block size | 1 to 1000 |
| `border` | size | 0 to 1000 |
| `rounded` | radius, border size | 0 to 1000 |

The `IllegalArgumentException` is raised while the filter chain is built inside `ImageService.readImage`, which the image handlers already translate into a 400 `Invalid parameters` response. Per-pixel colour filters (`sepia`, `gamma`, `colorize`, `hsbadjust`, `rgbadjust`) have constant cost per pixel and are left as they are.

## Tests

- New `ImageFiltersArgumentsTest` covering the boundaries of all four filters, including `blur(100)` and `block(1000)` on a real image.
- `ImageFilterBuilderImplTest.testFilterArgumentOutOfBounds` for the parsed-expression path (`blur(5000000)`, `block(0)`).

Full `:core:core-image:test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_