### PR TITLE
Parse multipart bodies on demand and answer multipart parse failures with 413 or 400

### DIFF
--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/multipart/MultipartServiceImpl.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/multipart/MultipartServiceImpl.java
@@ -1,7 +1,9 @@
 package com.enonic.xp.web.impl.multipart;
 
+import java.io.IOException;
 import java.util.Collections;
 
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.Part;
 
@@ -10,6 +12,8 @@ import org.osgi.service.component.annotations.Component;
 import com.google.common.net.MediaType;
 
 import com.enonic.xp.util.Exceptions;
+import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.multipart.MultipartForm;
 import com.enonic.xp.web.multipart.MultipartService;
 
@@ -19,31 +23,56 @@ public final class MultipartServiceImpl
 {
     private static final MediaType MULTIPART_FORM = MediaType.create( "multipart", "form-data" );
 
+    private static final String BOUNDARY = "boundary";
+
     @Override
     public MultipartForm parse( final HttpServletRequest req )
     {
         return new MultipartFormImpl( getParts( req ) );
     }
 
-    private MediaType getMediaType( final HttpServletRequest req )
+    private static MediaType getMediaType( final HttpServletRequest req )
     {
         final String value = req.getContentType();
-        return value != null ? MediaType.parse( value ) : MediaType.OCTET_STREAM;
+        if ( value == null )
+        {
+            return MediaType.OCTET_STREAM;
+        }
+        try
+        {
+            return MediaType.parse( value );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            return MediaType.OCTET_STREAM;
+        }
     }
 
-    private Iterable<Part> getParts( final HttpServletRequest req )
+    private static Iterable<Part> getParts( final HttpServletRequest req )
     {
-        final MediaType type = getMediaType( req ).withoutParameters();
-        if ( !type.is( MULTIPART_FORM ) )
+        final MediaType type = getMediaType( req );
+        if ( !type.withoutParameters().is( MULTIPART_FORM ) )
         {
             return Collections.emptyList();
+        }
+        if ( !type.parameters().containsKey( BOUNDARY ) )
+        {
+            throw WebException.badRequest( "Missing multipart boundary" );
         }
 
         try
         {
             return req.getParts();
         }
-        catch ( final Exception e )
+        catch ( IllegalStateException e )
+        {
+            throw new WebException( HttpStatus.PAYLOAD_TOO_LARGE, "Multipart request exceeds the configured limits", e );
+        }
+        catch ( IOException | IllegalArgumentException e )
+        {
+            throw WebException.badRequest( "Malformed multipart request", e );
+        }
+        catch ( ServletException e )
         {
             throw Exceptions.unchecked( e );
         }

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
@@ -1,8 +1,12 @@
 package com.enonic.xp.web.impl.serializer;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+
+import com.google.common.base.Splitter;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,8 +17,12 @@ import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.servlet.ServletRequestUrlHelper;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 public final class RequestSerializer
 {
+    private static final String MULTIPART_FORM_DATA = "multipart/form-data";
+
     private final WebRequest webRequest;
 
     public RequestSerializer( final WebRequest webRequest )
@@ -76,9 +84,44 @@ public final class RequestSerializer
 
     private void setParameters( final HttpServletRequest from, final WebRequest to )
     {
+        if ( isMultipartFormData( from.getContentType() ) )
+        {
+            addQueryParameters( from.getQueryString(), to );
+            return;
+        }
+
         for ( final Map.Entry<String, String[]> entry : from.getParameterMap().entrySet() )
         {
             to.getParams().putAll( entry.getKey(), Arrays.asList( entry.getValue() ) );
+        }
+    }
+
+    static boolean isMultipartFormData( final String contentType )
+    {
+        return contentType != null && contentType.regionMatches( true, 0, MULTIPART_FORM_DATA, 0, MULTIPART_FORM_DATA.length() );
+    }
+
+    static void addQueryParameters( final String queryString, final WebRequest to )
+    {
+        if ( isNullOrEmpty( queryString ) )
+        {
+            return;
+        }
+
+        try
+        {
+            for ( final String pair : Splitter.on( '&' ).omitEmptyStrings().split( queryString ) )
+            {
+                final int separator = pair.indexOf( '=' );
+                final String name = separator < 0 ? pair : pair.substring( 0, separator );
+                final String value = separator < 0 ? "" : pair.substring( separator + 1 );
+                to.getParams()
+                    .put( URLDecoder.decode( name, StandardCharsets.UTF_8 ), URLDecoder.decode( value, StandardCharsets.UTF_8 ) );
+            }
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw WebException.badRequest( "Malformed query string", e );
         }
     }
 }

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 public final class RequestSerializer
 {
-    private static final String MULTIPART_FORM_DATA = "multipart/form-data";
+    private static final String MULTIPART_PREFIX = "multipart/";
 
     private final WebRequest webRequest;
 
@@ -84,7 +84,7 @@ public final class RequestSerializer
 
     private void setParameters( final HttpServletRequest from, final WebRequest to )
     {
-        if ( isMultipartFormData( from.getContentType() ) )
+        if ( isMultipart( from.getContentType() ) )
         {
             addQueryParameters( from.getQueryString(), to );
             return;
@@ -96,15 +96,15 @@ public final class RequestSerializer
         }
     }
 
-    static boolean isMultipartFormData( final String contentType )
+    static boolean isMultipart( final String contentType )
     {
         if ( contentType == null )
         {
             return false;
         }
         final int parameters = contentType.indexOf( ';' );
-        final String mediaType = parameters < 0 ? contentType : contentType.substring( 0, parameters );
-        return MULTIPART_FORM_DATA.equalsIgnoreCase( mediaType.trim() );
+        final String mediaType = ( parameters < 0 ? contentType : contentType.substring( 0, parameters ) ).trim();
+        return mediaType.regionMatches( true, 0, MULTIPART_PREFIX, 0, MULTIPART_PREFIX.length() );
     }
 
     static void addQueryParameters( final String queryString, final WebRequest to )

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
@@ -103,8 +103,20 @@ public final class RequestSerializer
             return false;
         }
         final int parameters = contentType.indexOf( ';' );
-        final String mediaType = ( parameters < 0 ? contentType : contentType.substring( 0, parameters ) ).trim();
-        return mediaType.regionMatches( true, 0, MULTIPART_PREFIX, 0, MULTIPART_PREFIX.length() );
+        int end = parameters < 0 ? contentType.length() : parameters;
+        int start = 0;
+
+        while ( start < end && Character.isWhitespace( contentType.charAt( start ) ) )
+        {
+            start++;
+        }
+        while ( end > start && Character.isWhitespace( contentType.charAt( end - 1 ) ) )
+        {
+            end--;
+        }
+
+        return end - start >= MULTIPART_PREFIX.length() &&
+            contentType.regionMatches( true, start, MULTIPART_PREFIX, 0, MULTIPART_PREFIX.length() );
     }
 
     static void addQueryParameters( final String queryString, final WebRequest to )

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
@@ -98,7 +98,13 @@ public final class RequestSerializer
 
     static boolean isMultipartFormData( final String contentType )
     {
-        return contentType != null && contentType.regionMatches( true, 0, MULTIPART_FORM_DATA, 0, MULTIPART_FORM_DATA.length() );
+        if ( contentType == null )
+        {
+            return false;
+        }
+        final int parameters = contentType.indexOf( ';' );
+        final String mediaType = parameters < 0 ? contentType : contentType.substring( 0, parameters );
+        return MULTIPART_FORM_DATA.equalsIgnoreCase( mediaType.trim() );
     }
 
     static void addQueryParameters( final String queryString, final WebRequest to )

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import com.google.common.base.Splitter;
+import com.google.common.net.MediaType;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,7 +22,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 public final class RequestSerializer
 {
-    private static final String MULTIPART_PREFIX = "multipart/";
+    private static final MediaType ANY_MULTIPART_TYPE = MediaType.create( "multipart", "*" );
 
     private final WebRequest webRequest;
 
@@ -102,21 +103,14 @@ public final class RequestSerializer
         {
             return false;
         }
-        final int parameters = contentType.indexOf( ';' );
-        int end = parameters < 0 ? contentType.length() : parameters;
-        int start = 0;
-
-        while ( start < end && Character.isWhitespace( contentType.charAt( start ) ) )
+        try
         {
-            start++;
+            return MediaType.parse( contentType ).is( ANY_MULTIPART_TYPE );
         }
-        while ( end > start && Character.isWhitespace( contentType.charAt( end - 1 ) ) )
+        catch ( IllegalArgumentException e )
         {
-            end--;
+            return false;
         }
-
-        return end - start >= MULTIPART_PREFIX.length() &&
-            contentType.regionMatches( true, start, MULTIPART_PREFIX, 0, MULTIPART_PREFIX.length() );
     }
 
     static void addQueryParameters( final String queryString, final WebRequest to )

--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/multipart/MultipartServiceImplTest.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/multipart/MultipartServiceImplTest.java
@@ -1,19 +1,24 @@
 package com.enonic.xp.web.impl.multipart;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.Part;
 
+import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.multipart.MultipartForm;
 import com.enonic.xp.web.multipart.MultipartService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MultipartServiceImplTest
 {
@@ -46,11 +51,65 @@ class MultipartServiceImplTest
         final Part part = Mockito.mock( Part.class );
         Mockito.when( part.getName() ).thenReturn( "part" );
         Mockito.when( this.req.getParts() ).thenReturn( List.of( part ) );
-        Mockito.when( this.req.getContentType() ).thenReturn( "multipart/form-data" );
+        Mockito.when( this.req.getContentType() ).thenReturn( "multipart/form-data; boundary=----xp" );
 
         final MultipartForm form = this.service.parse( this.req );
         assertNotNull( form );
         assertEquals( false, form.isEmpty() );
         assertEquals( 1, form.getSize() );
+    }
+
+    @Test
+    void testParse_malformedContentType()
+        throws Exception
+    {
+        Mockito.when( this.req.getContentType() ).thenReturn( "multipart" );
+
+        final MultipartForm form = this.service.parse( this.req );
+        assertEquals( true, form.isEmpty() );
+        Mockito.verify( this.req, Mockito.never() ).getParts();
+    }
+
+    @Test
+    void testParse_missingBoundary()
+        throws Exception
+    {
+        Mockito.when( this.req.getContentType() ).thenReturn( "multipart/form-data" );
+
+        final WebException e = assertThrows( WebException.class, () -> this.service.parse( this.req ) );
+        assertEquals( HttpStatus.BAD_REQUEST, e.getStatus() );
+        Mockito.verify( this.req, Mockito.never() ).getParts();
+    }
+
+    @Test
+    void testParse_limitExceeded()
+        throws Exception
+    {
+        Mockito.when( this.req.getContentType() ).thenReturn( "multipart/form-data; boundary=x" );
+        Mockito.when( this.req.getParts() ).thenThrow( new IllegalStateException( "max file size exceeded: 1024" ) );
+
+        final WebException e = assertThrows( WebException.class, () -> this.service.parse( this.req ) );
+        assertEquals( HttpStatus.PAYLOAD_TOO_LARGE, e.getStatus() );
+    }
+
+    @Test
+    void testParse_malformedBody()
+        throws Exception
+    {
+        Mockito.when( this.req.getContentType() ).thenReturn( "multipart/form-data; boundary=x" );
+        Mockito.when( this.req.getParts() ).thenThrow( new IOException( "unexpected end of stream" ) );
+
+        final WebException e = assertThrows( WebException.class, () -> this.service.parse( this.req ) );
+        assertEquals( HttpStatus.BAD_REQUEST, e.getStatus() );
+    }
+
+    @Test
+    void testParse_servletException()
+        throws Exception
+    {
+        Mockito.when( this.req.getContentType() ).thenReturn( "multipart/form-data; boundary=x" );
+        Mockito.when( this.req.getParts() ).thenThrow( new ServletException( "boom" ) );
+
+        assertThrows( ServletException.class, () -> this.service.parse( this.req ) );
     }
 }

--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/RequestSerializerMultipartTest.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/RequestSerializerMultipartTest.java
@@ -1,0 +1,97 @@
+package com.enonic.xp.web.impl.serializer;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
+import com.enonic.xp.web.WebRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RequestSerializerMultipartTest
+{
+    private HttpServletRequest request;
+
+    @BeforeEach
+    void setUp()
+    {
+        request = mock( HttpServletRequest.class );
+        when( request.getMethod() ).thenReturn( "POST" );
+        when( request.getScheme() ).thenReturn( "http" );
+        when( request.getServerName() ).thenReturn( "localhost" );
+        when( request.getServerPort() ).thenReturn( 8080 );
+        when( request.getRequestURI() ).thenReturn( "/site/master/a" );
+        when( request.getPathInfo() ).thenReturn( "/site/master/a" );
+        when( request.getLocales() ).thenReturn( Collections.emptyEnumeration() );
+        when( request.getHeaderNames() ).thenReturn( Collections.emptyEnumeration() );
+    }
+
+    @Test
+    void multipartRequestTakesParametersFromQueryStringOnly()
+        throws Exception
+    {
+        when( request.getContentType() ).thenReturn( "multipart/form-data; boundary=----boundary" );
+        when( request.getQueryString() ).thenReturn( "a=1&a=2&b=x+y&c=%C3%A6&d" );
+
+        final WebRequest webRequest = new WebRequest();
+        new RequestSerializer( webRequest ).serialize( request );
+
+        assertEquals( List.of( "1", "2" ), webRequest.getParams().get( "a" ) );
+        assertEquals( List.of( "x y" ), webRequest.getParams().get( "b" ) );
+        assertEquals( List.of( "\u00e6" ), webRequest.getParams().get( "c" ) );
+        assertEquals( List.of( "" ), webRequest.getParams().get( "d" ) );
+        verify( request, never() ).getParameterMap();
+        verify( request, never() ).getParts();
+    }
+
+    @Test
+    void multipartRequestWithoutQueryString()
+    {
+        when( request.getContentType() ).thenReturn( "Multipart/Form-Data; boundary=x" );
+        when( request.getQueryString() ).thenReturn( null );
+
+        final WebRequest webRequest = new WebRequest();
+        new RequestSerializer( webRequest ).serialize( request );
+
+        assertTrue( webRequest.getParams().isEmpty() );
+        verify( request, never() ).getParameterMap();
+    }
+
+    @Test
+    void multipartRequestWithMalformedQueryString()
+    {
+        when( request.getContentType() ).thenReturn( "multipart/form-data; boundary=x" );
+        when( request.getQueryString() ).thenReturn( "a=%zz" );
+
+        final WebException e = assertThrows( WebException.class, () -> new RequestSerializer( new WebRequest() ).serialize( request ) );
+        assertEquals( HttpStatus.BAD_REQUEST, e.getStatus() );
+    }
+
+    @Test
+    void formRequestUsesParameterMap()
+    {
+        when( request.getContentType() ).thenReturn( "application/x-www-form-urlencoded" );
+        when( request.getParameterMap() ).thenReturn( Map.of( "field", new String[]{"value"} ) );
+
+        final WebRequest webRequest = new WebRequest();
+        new RequestSerializer( webRequest ).serialize( request );
+
+        assertEquals( List.of( "value" ), webRequest.getParams().get( "field" ) );
+        assertFalse( RequestSerializer.isMultipartFormData( "application/x-www-form-urlencoded" ) );
+        assertFalse( RequestSerializer.isMultipartFormData( null ) );
+    }
+}

--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/RequestSerializerMultipartTest.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/RequestSerializerMultipartTest.java
@@ -94,14 +94,33 @@ class RequestSerializerMultipartTest
     }
 
     @Test
-    void isMultipartFormData()
+    void multipartMixedRequestTakesParametersFromQueryStringOnly()
+        throws Exception
     {
-        assertTrue( RequestSerializer.isMultipartFormData( "multipart/form-data" ) );
-        assertTrue( RequestSerializer.isMultipartFormData( "multipart/form-data; boundary=x" ) );
-        assertTrue( RequestSerializer.isMultipartFormData( "MULTIPART/FORM-DATA ; boundary=x" ) );
-        assertFalse( RequestSerializer.isMultipartFormData( "multipart/form-data2" ) );
-        assertFalse( RequestSerializer.isMultipartFormData( "multipart/mixed; boundary=x" ) );
-        assertFalse( RequestSerializer.isMultipartFormData( "application/x-www-form-urlencoded" ) );
-        assertFalse( RequestSerializer.isMultipartFormData( null ) );
+        when( request.getContentType() ).thenReturn( "multipart/mixed; boundary=x" );
+        when( request.getQueryString() ).thenReturn( "a=1" );
+
+        final WebRequest webRequest = new WebRequest();
+        new RequestSerializer( webRequest ).serialize( request );
+
+        assertEquals( List.of( "1" ), webRequest.getParams().get( "a" ) );
+        verify( request, never() ).getParameterMap();
+        verify( request, never() ).getParts();
+    }
+
+    @Test
+    void isMultipart()
+    {
+        assertTrue( RequestSerializer.isMultipart( "multipart/form-data" ) );
+        assertTrue( RequestSerializer.isMultipart( "multipart/form-data; boundary=x" ) );
+        assertTrue( RequestSerializer.isMultipart( "MULTIPART/FORM-DATA ; boundary=x" ) );
+        assertTrue( RequestSerializer.isMultipart( "multipart/mixed; boundary=x" ) );
+        assertTrue( RequestSerializer.isMultipart( "multipart/related; type=application/xop+xml" ) );
+        assertTrue( RequestSerializer.isMultipart( " Multipart/Byteranges" ) );
+        assertFalse( RequestSerializer.isMultipart( "multipartx/form-data" ) );
+        assertFalse( RequestSerializer.isMultipart( "application/x-www-form-urlencoded" ) );
+        assertFalse( RequestSerializer.isMultipart( "text/plain" ) );
+        assertFalse( RequestSerializer.isMultipart( "" ) );
+        assertFalse( RequestSerializer.isMultipart( null ) );
     }
 }

--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/RequestSerializerMultipartTest.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/RequestSerializerMultipartTest.java
@@ -91,6 +91,16 @@ class RequestSerializerMultipartTest
         new RequestSerializer( webRequest ).serialize( request );
 
         assertEquals( List.of( "value" ), webRequest.getParams().get( "field" ) );
+    }
+
+    @Test
+    void isMultipartFormData()
+    {
+        assertTrue( RequestSerializer.isMultipartFormData( "multipart/form-data" ) );
+        assertTrue( RequestSerializer.isMultipartFormData( "multipart/form-data; boundary=x" ) );
+        assertTrue( RequestSerializer.isMultipartFormData( "MULTIPART/FORM-DATA ; boundary=x" ) );
+        assertFalse( RequestSerializer.isMultipartFormData( "multipart/form-data2" ) );
+        assertFalse( RequestSerializer.isMultipartFormData( "multipart/mixed; boundary=x" ) );
         assertFalse( RequestSerializer.isMultipartFormData( "application/x-www-form-urlencoded" ) );
         assertFalse( RequestSerializer.isMultipartFormData( null ) );
     }

--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/RequestSerializerMultipartTest.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/RequestSerializerMultipartTest.java
@@ -115,12 +115,13 @@ class RequestSerializerMultipartTest
         assertTrue( RequestSerializer.isMultipart( "multipart/form-data; boundary=x" ) );
         assertTrue( RequestSerializer.isMultipart( "MULTIPART/FORM-DATA ; boundary=x" ) );
         assertTrue( RequestSerializer.isMultipart( "multipart/mixed; boundary=x" ) );
-        assertTrue( RequestSerializer.isMultipart( "multipart/related; type=application/xop+xml" ) );
-        assertTrue( RequestSerializer.isMultipart( " Multipart/Byteranges" ) );
+        assertTrue( RequestSerializer.isMultipart( "multipart/related; type=\"application/xop+xml\"" ) );
+        assertTrue( RequestSerializer.isMultipart( "Multipart/Byteranges" ) );
         assertFalse( RequestSerializer.isMultipart( "multipartx/form-data" ) );
         assertFalse( RequestSerializer.isMultipart( "application/x-www-form-urlencoded" ) );
         assertFalse( RequestSerializer.isMultipart( "text/plain" ) );
         assertFalse( RequestSerializer.isMultipart( "" ) );
+        assertFalse( RequestSerializer.isMultipart( "multipart" ) );
         assertFalse( RequestSerializer.isMultipart( null ) );
     }
 }


### PR DESCRIPTION
## Summary

The dispatch servlet carries the multipart configuration and `RequestSerializer` called `getParameterMap()` for every request. For a `multipart/form-data` body that call makes Jetty parse the whole body up front, spooling parts above 10 KiB to the temp directory with 15 GiB limits, before any handler has decided it needs the parts. An anonymous client can keep the disk busy on any URL.

## Changes

- `RequestSerializer` no longer asks the container for parameters when the request carries any `multipart/*` body, detected with Guava's `MediaType`. Parameters then come from the query string only. Multipart bodies are parsed on demand by `MultipartService`, which is what `portal.getMultipartForm()` and the admin REST readers already use.
- `MultipartServiceImpl` answers parse problems with client errors instead of 500. A malformed `Content-Type` is treated as not multipart, a missing `boundary` parameter is a 400, the Servlet API's `IllegalStateException` for exceeded `maxFileSize`/`maxRequestSize` becomes 413, and a malformed body becomes 400.

## Behaviour change to be aware of

Text fields of a `multipart/form-data` POST used to show up in `req.params` because Jetty merged them into the parameter map. After this change `req.params` for multipart requests holds query parameters only. Controllers read form fields through `portal.getMultipartForm()`.

## Not changed

- `multipart.maxFileSize` and `multipart.maxRequestSize` keep their 15 GiB defaults. Lowering them is a product decision.
- `multipart.store` still defaults to `java.io.tmpdir`. The launcher points that at `$XP_HOME/work`, so the spool directory is not the shared system temp directory.

## Tests

- `RequestSerializerMultipartTest`: query-only parameters for `multipart/form-data` and `multipart/mixed`, malformed query string, form-urlencoded still using the parameter map, media type detection for form-data, mixed, related, byteranges, malformed and non-multipart types.
- `MultipartServiceImplTest`: malformed content type, missing boundary, limit exceeded, malformed body, servlet exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV