### PR TITLE
rich-text sanitizer is not thread safe  #12362

### DIFF
--- a/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/processor/InternalHtmlSanitizer.java
+++ b/modules/core/core-internal/src/main/java/com/enonic/xp/core/internal/processor/InternalHtmlSanitizer.java
@@ -1,13 +1,15 @@
 package com.enonic.xp.core.internal.processor;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
 
 import org.owasp.html.ElementPolicy;
 import org.owasp.html.HtmlPolicyBuilder;
-import org.owasp.html.HtmlStreamEventProcessor;
-import org.owasp.html.HtmlStreamEventReceiver;
-import org.owasp.html.HtmlStreamEventReceiverWrapper;
+import org.owasp.html.HtmlSanitizer;
+import org.owasp.html.PolicyFactory;
 
 public final class InternalHtmlSanitizer
 {
@@ -16,30 +18,7 @@ public final class InternalHtmlSanitizer
             "h1", "h2", "h3", "h4", "h5", "h6", "div", "pre", "strong", "a", "img", "figure", "figcaption", "table", "caption", "tbody",
             "thead", "tfoot"};
 
-    private static final HtmlPolicyBuilder RICH_TEXT_POLICY = new HtmlPolicyBuilder().allowElements( ALLOWED_ELEMENTS )
-        .allowElements( getImgElementPolicy(), "img" )
-        .allowAttributes( "class" )
-        .globally()//classes to everyone
-        .allowAttributes( "start" )
-        .onElements( "ol" )
-        .allowAttributes( "value" )
-        .onElements( "li" )
-        .allowAttributes( "colspan", "rowspan" )
-        .onElements( "td", "th" )
-        .allowAttributes( "alt", "width", "height", "src" )
-        .onElements( "img" )
-        .allowAttributes( "accesskey", "charset", "dir", "download", "href", "id", "lang", "name", "onclick", "rel", "tabindex", "target",
-                          "title", "type" )
-        .onElements( "a" )
-        .allowAttributes( "align", "border", "cellpadding", "cellspacing", "summary" )
-        .onElements( "table" )
-        .allowAttributes( "scope" )
-        .onElements( "td", "th", "tr" )
-        .allowStandardUrlProtocols()
-        .allowUrlProtocols( "content", "media", "image" )
-        .allowStyling();
-
-    private static final HtmlPolicyBuilder STRICT_POLICY = new HtmlPolicyBuilder().allowCommonBlockElements()
+    private static final PolicyFactory STRICT_POLICY = new HtmlPolicyBuilder().allowCommonBlockElements()
         .allowCommonInlineFormattingElements()
         .allowElements( "a", "img", "pre" )
         .allowElements( "table", "caption", "thead", "tbody", "tfoot", "tr", "th", "td", "col", "colgroup" )
@@ -53,60 +32,111 @@ public final class InternalHtmlSanitizer
         .allowAttributes( "scope" )
         .onElements( "td", "th" )
         .allowStandardUrlProtocols()
-        .allowStyling();
+        .allowStyling()
+        .toFactory();
 
-    private static final Sanitizer STRICT_SANITIZER = new Sanitizer( STRICT_POLICY, true );
+    private static final Sanitizer STRICT_SANITIZER = new Sanitizer( html -> STRICT_POLICY, true );
 
-    private static final Sanitizer RICH_TEXT_SANITIZER =
-        new Sanitizer( RICH_TEXT_POLICY, ( HtmlStreamEventReceiver r ) -> new HtmlStreamEventReceiverWrapper( r )
-        {
-            @Override
-            public void openTag( String elementName, List<String> attrs )
-            {
-                attrs.stream()
-                    .filter( attr -> attr.startsWith( "data-" ) )
-                    .forEach( attr -> RICH_TEXT_POLICY.allowAttributes( attr ).globally() );
-
-                super.openTag( elementName, attrs );
-            }
-        }, false );
+    private static final Sanitizer RICH_TEXT_SANITIZER = new Sanitizer( InternalHtmlSanitizer::richTextPolicy, false );
 
     private InternalHtmlSanitizer()
     {
     }
 
+    private static HtmlPolicyBuilder richTextPolicyBuilder()
+    {
+        return new HtmlPolicyBuilder().allowElements( ALLOWED_ELEMENTS )
+            .allowElements( getImgElementPolicy(), "img" )
+            .allowAttributes( "class" )
+            .globally()//classes to everyone
+            .allowAttributes( "start" )
+            .onElements( "ol" )
+            .allowAttributes( "value" )
+            .onElements( "li" )
+            .allowAttributes( "colspan", "rowspan" )
+            .onElements( "td", "th" )
+            .allowAttributes( "alt", "width", "height", "src" )
+            .onElements( "img" )
+            .allowAttributes( "accesskey", "charset", "dir", "download", "href", "id", "lang", "name", "onclick", "rel", "tabindex",
+                              "target", "title", "type" )
+            .onElements( "a" )
+            .allowAttributes( "align", "border", "cellpadding", "cellspacing", "summary" )
+            .onElements( "table" )
+            .allowAttributes( "scope" )
+            .onElements( "td", "th", "tr" )
+            .allowStandardUrlProtocols()
+            .allowUrlProtocols( "content", "media", "image" )
+            .allowStyling();
+    }
+
+    private static PolicyFactory richTextPolicy( final String html )
+    {
+        final HtmlPolicyBuilder policy = richTextPolicyBuilder();
+        final Set<String> dataAttributes = dataAttributes( html );
+        if ( !dataAttributes.isEmpty() )
+        {
+            policy.allowAttributes( dataAttributes.toArray( String[]::new ) ).globally();
+        }
+        return policy.toFactory();
+    }
+
+    private static Set<String> dataAttributes( final String html )
+    {
+        final Set<String> result = new HashSet<>();
+        HtmlSanitizer.sanitize( html, new HtmlSanitizer.Policy()
+        {
+            @Override
+            public void openDocument()
+            {
+            }
+
+            @Override
+            public void closeDocument()
+            {
+            }
+
+            @Override
+            public void openTag( final String elementName, final List<String> attrs )
+            {
+                for ( int i = 0; i < attrs.size(); i += 2 )
+                {
+                    if ( attrs.get( i ).startsWith( "data-" ) )
+                    {
+                        result.add( attrs.get( i ) );
+                    }
+                }
+            }
+
+            @Override
+            public void closeTag( final String elementName )
+            {
+            }
+
+            @Override
+            public void text( final String text )
+            {
+            }
+        } );
+        return result;
+    }
+
     public static final class Sanitizer
     {
-        private final HtmlPolicyBuilder policy;
-
-        private final HtmlStreamEventProcessor processor;
+        private final Function<String, PolicyFactory> policy;
 
         private final boolean nbspReplace;
 
-        private Sanitizer( final HtmlPolicyBuilder policy, final boolean nbspReplace )
+        private Sanitizer( final Function<String, PolicyFactory> policy, final boolean nbspReplace )
         {
             this.policy = policy;
-            this.processor = null;
-            this.nbspReplace = nbspReplace;
-        }
-
-        private Sanitizer( final HtmlPolicyBuilder policy, HtmlStreamEventProcessor processor, final boolean nbspReplace )
-        {
-            this.policy = policy;
-            this.processor = processor;
             this.nbspReplace = nbspReplace;
         }
 
         public String sanitize( final String value )
         {
-            if ( processor != null )
-            {
-                policy.withPreprocessor( processor ).toFactory().sanitize( value );
-            }
-
-            return policy.toFactory().sanitize( nbspReplace ? value.replace( "\u00A0", "&nbsp;" ) : value );
+            final String html = nbspReplace ? value.replace( "\u00A0", "&nbsp;" ) : value;
+            return policy.apply( html ).sanitize( html );
         }
-
     }
 
     public static Sanitizer richText()

--- a/modules/core/core-internal/src/test/java/com/enonic/xp/core/internal/processor/HtmlSanitizerTest.java
+++ b/modules/core/core-internal/src/test/java/com/enonic/xp/core/internal/processor/HtmlSanitizerTest.java
@@ -1,8 +1,16 @@
 package com.enonic.xp.core.internal.processor;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HtmlSanitizerTest
 {
@@ -32,6 +40,50 @@ class HtmlSanitizerTest
         final String sanitized = InternalHtmlSanitizer.richText().sanitize( html );
 
         assertEquals( "<table><tbody><tr><td data-widget=\"altValue\"></td></tr></tbody></table>", sanitized );
+    }
+
+    @Test
+    void testDataAttributesAreCollectedFromAttributeNamesOnly()
+    {
+        final String html = "<p data-first=\"1\" class=\"data-second\">text</p><p data-second=\"2\">more</p>";
+        final String sanitized = InternalHtmlSanitizer.richText().sanitize( html );
+
+        assertEquals( "<p data-first=\"1\" class=\"data-second\">text</p><p data-second=\"2\">more</p>", sanitized );
+    }
+
+    @Test
+    void testStrictDropsDataAttributes()
+    {
+        final String sanitized = InternalHtmlSanitizer.strict().sanitize( "<p data-widget=\"1\">text</p>" );
+
+        assertEquals( "<p>text</p>", sanitized );
+    }
+
+    @Test
+    void testConcurrentSanitizeKeepsDataAttributes()
+        throws Exception
+    {
+        final ExecutorService executor = Executors.newFixedThreadPool( 8 );
+        try
+        {
+            final List<Future<Boolean>> results = new ArrayList<>();
+            for ( int i = 0; i < 400; i++ )
+            {
+                final String attribute = "data-attr" + i;
+                results.add( executor.submit( () -> {
+                    final String html = "<p " + attribute + "=\"v\">t</p>";
+                    return html.equals( InternalHtmlSanitizer.richText().sanitize( html ) );
+                } ) );
+            }
+            for ( final Future<Boolean> result : results )
+            {
+                assertTrue( result.get( 30, TimeUnit.SECONDS ) );
+            }
+        }
+        finally
+        {
+            executor.shutdownNow();
+        }
     }
 
     @Test

--- a/modules/core/core-internal/src/test/java/com/enonic/xp/core/internal/processor/HtmlSanitizerTest.java
+++ b/modules/core/core-internal/src/test/java/com/enonic/xp/core/internal/processor/HtmlSanitizerTest.java
@@ -82,7 +82,11 @@ class HtmlSanitizerTest
         }
         finally
         {
-            executor.shutdownNow();
+            executor.shutdown();
+            if ( !executor.awaitTermination( 30, TimeUnit.SECONDS ) )
+            {
+                executor.shutdownNow();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Security audit finding M11, thread-safety part only. The rich-text sanitizer ran a preprocessor that called `RICH_TEXT_POLICY.allowAttributes( attr ).globally()` for every `data-*` attribute it met, during sanitization, on a static `HtmlPolicyBuilder` shared by all threads. `HtmlPolicyBuilder` is not thread-safe, and every attribute name ever seen stayed allowed for all later documents. The `onclick` attribute on links is kept: the sanitizer targets attacks that need no user interaction, and interactive attributes removal would break creditor.

## Changes

- `InternalHtmlSanitizer` no longer holds a mutable shared builder. The rich-text policy is assembled per document: a read-only pass over the parsed HTML collects the `data-*` attribute names (attribute names only, not values, which the old stream filter also matched), a fresh builder gets them added, and the resulting `PolicyFactory` sanitizes that document.
- The strict policy has no per-document state and is built once as an immutable `PolicyFactory`.
- The `Sanitizer` type keeps its public `sanitize( String )` contract, so `HtmlAreaContentProcessor` and `HtmlSanitizerImpl` are unchanged.

## Tests

- `testDataAttributesAreCollectedFromAttributeNamesOnly`, `testStrictDropsDataAttributes`
- `testConcurrentSanitizeKeepsDataAttributes`: 400 documents with distinct `data-*` names sanitized on 8 threads, each output checked.
- Existing sanitizer tests unchanged and passing; the content processor tests in `core-content` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_