### PR TITLE
Honour Forwarded headers per connector and only from trusted proxies

### DIFF
--- a/modules/runtime/src/home/config/com.enonic.xp.web.jetty.cfg
+++ b/modules/runtime/src/home/config/com.enonic.xp.web.jetty.cfg
@@ -12,6 +12,13 @@
 # http.requestHeaderSize = 32768
 # http.responseHeaderSize = 32768
 
+# Forwarded and X-Forwarded-* headers are honoured only on the connectors enabled here,
+# and only from the listed proxies when trustedProxies is set (addresses or CIDR ranges).
+# http.web.forwarded.enabled = true
+# http.management.forwarded.enabled = false
+# http.statistics.forwarded.enabled = false
+# http.forwarded.trustedProxies =
+
 # session.timeout = 60
 # session.cookieName = JSESSIONID
 # session.cookieSameSite = Lax

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/JettyConfig.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/JettyConfig.java
@@ -90,6 +90,26 @@ public @interface JettyConfig
     int http_responseHeaderSize() default 32 * 1024;
 
     /**
+     * Honour Forwarded and X-Forwarded-* headers on the web connector.
+     */
+    boolean http_web_forwarded_enabled() default true;
+
+    /**
+     * Honour Forwarded and X-Forwarded-* headers on the management connector.
+     */
+    boolean http_management_forwarded_enabled() default false;
+
+    /**
+     * Honour Forwarded and X-Forwarded-* headers on the statistics connector.
+     */
+    boolean http_statistics_forwarded_enabled() default false;
+
+    /**
+     * Comma-separated addresses or CIDR ranges of the proxies whose Forwarded headers are trusted. Empty trusts every peer.
+     */
+    String http_forwarded_trustedProxies() default "";
+
+    /**
      * Session cookie name.
      */
     String session_cookieName() default "JSESSIONID";

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/configurator/ConnectorConfigurator.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/configurator/ConnectorConfigurator.java
@@ -5,7 +5,6 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
 
-import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
@@ -35,11 +34,15 @@ public abstract class ConnectorConfigurator
         }
     }
 
-    protected final void doConfigure( final HttpConnectionFactory factory )
+    protected final HttpConnectionFactory newConnectionFactory( final boolean forwarded )
     {
-        factory.getHttpConfiguration().addCustomizer( new ForwardedRequestCustomizer() );
-
+        final HttpConnectionFactory factory = new HttpConnectionFactory();
         final HttpConfiguration config = factory.getHttpConfiguration();
+
+        if ( forwarded )
+        {
+            config.addCustomizer( TrustedProxyForwardedCustomizer.from( this.config.http_forwarded_trustedProxies() ) );
+        }
 
         // HTTP/1.1 requires Date header if possible
         config.setSendDateHeader( true );
@@ -47,6 +50,7 @@ public abstract class ConnectorConfigurator
         config.setSendXPoweredBy( this.config.sendServerHeader() );
         config.setRequestHeaderSize( this.config.http_requestHeaderSize() );
         config.setResponseHeaderSize( this.config.http_responseHeaderSize() );
+        return factory;
     }
 
     private List<String> resolveHosts( final String connectorHost )

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/configurator/HttpConfigurator.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/configurator/HttpConfigurator.java
@@ -20,22 +20,19 @@ public final class HttpConfigurator
         {
             return;
         }
-        //OldMetrics.removeAll( InstrumentedConnectionFactory.class );
-        final HttpConnectionFactory factory = new HttpConnectionFactory();
-        //new InstrumentedConnectionFactory( factory, Metrics.registry() );
-        doConfigure( factory );
-
         final int webPort =
             effectivePort( this.config.http_web_port(), this.config.http_xp_port(), "http.web.port", "http.xp.port", 8080 );
-        addConnectors( factory, DispatchConstants.WEB_CONNECTOR, webPort, this.config.http_web_host() );
+        addConnectors( newConnectionFactory( this.config.http_web_forwarded_enabled() ), DispatchConstants.WEB_CONNECTOR, webPort,
+                       this.config.http_web_host() );
 
-        addConnectors( factory, DispatchConstants.MANAGEMENT_CONNECTOR, this.config.http_management_port(),
-                       this.config.http_management_host() );
+        addConnectors( newConnectionFactory( this.config.http_management_forwarded_enabled() ), DispatchConstants.MANAGEMENT_CONNECTOR,
+                       this.config.http_management_port(), this.config.http_management_host() );
 
         final int statisticsPort =
             effectivePort( this.config.http_statistics_port(), this.config.http_monitor_port(), "http.statistics.port",
                            "http.monitor.port", 2609 );
-        addConnectors( factory, DispatchConstants.STATISTICS_CONNECTOR, statisticsPort, this.config.http_statistics_host() );
+        addConnectors( newConnectionFactory( this.config.http_statistics_forwarded_enabled() ), DispatchConstants.STATISTICS_CONNECTOR,
+                       statisticsPort, this.config.http_statistics_host() );
     }
 
     private static int effectivePort( final int port, final int deprecatedPort, final String name, final String deprecatedName,

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/configurator/TrustedProxyForwardedCustomizer.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/configurator/TrustedProxyForwardedCustomizer.java
@@ -1,0 +1,46 @@
+package com.enonic.xp.web.jetty.impl.configurator;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.server.ForwardedRequestCustomizer;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.util.InetAddressSet;
+
+import com.google.common.base.Splitter;
+
+final class TrustedProxyForwardedCustomizer
+    implements HttpConfiguration.Customizer
+{
+    private final HttpConfiguration.Customizer delegate;
+
+    private final InetAddressSet trustedProxies;
+
+    TrustedProxyForwardedCustomizer( final HttpConfiguration.Customizer delegate, final InetAddressSet trustedProxies )
+    {
+        this.delegate = delegate;
+        this.trustedProxies = trustedProxies;
+    }
+
+    static HttpConfiguration.Customizer from( final String trustedProxies )
+    {
+        final InetAddressSet addresses = new InetAddressSet();
+        Splitter.on( ',' ).trimResults().omitEmptyStrings().split( trustedProxies == null ? "" : trustedProxies ).forEach( addresses::add );
+        return addresses.isEmpty()
+            ? new ForwardedRequestCustomizer()
+            : new TrustedProxyForwardedCustomizer( new ForwardedRequestCustomizer(), addresses );
+    }
+
+    @Override
+    public Request customize( final Request request, final HttpFields.Mutable responseHeaders )
+    {
+        return isTrusted( request ) ? delegate.customize( request, responseHeaders ) : request;
+    }
+
+    private boolean isTrusted( final Request request )
+    {
+        return request.getConnectionMetaData().getRemoteSocketAddress() instanceof InetSocketAddress address &&
+            address.getAddress() != null && trustedProxies.test( address.getAddress() );
+    }
+}

--- a/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/configurator/HttpConfiguratorTest.java
+++ b/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/configurator/HttpConfiguratorTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.when;
 
@@ -63,6 +64,42 @@ class HttpConfiguratorTest
         assertNotNull( configuration.getCustomizer( ForwardedRequestCustomizer.class ) );
         assertEquals( 32 * 1024, configuration.getRequestHeaderSize() );
         assertEquals( 32 * 1024, configuration.getResponseHeaderSize() );
+
+        assertTrue( getHttpConfiguration( DispatchConstants.MANAGEMENT_CONNECTOR ).getCustomizers().isEmpty() );
+        assertTrue( getHttpConfiguration( DispatchConstants.STATISTICS_CONNECTOR ).getCustomizers().isEmpty() );
+    }
+
+    @Test
+    void forwardedPerConnector()
+    {
+        RunModeSupport.set( RunMode.PROD );
+        when( this.config.http_web_forwarded_enabled() ).thenReturn( false );
+        when( this.config.http_management_forwarded_enabled() ).thenReturn( true );
+        when( this.config.http_statistics_forwarded_enabled() ).thenReturn( true );
+
+        configure();
+
+        assertTrue( getHttpConfiguration( DispatchConstants.WEB_CONNECTOR ).getCustomizers().isEmpty() );
+        assertNotNull( getHttpConfiguration( DispatchConstants.MANAGEMENT_CONNECTOR ).getCustomizer( ForwardedRequestCustomizer.class ) );
+        assertNotNull( getHttpConfiguration( DispatchConstants.STATISTICS_CONNECTOR ).getCustomizer( ForwardedRequestCustomizer.class ) );
+    }
+
+    @Test
+    void forwardedTrustedProxies()
+    {
+        RunModeSupport.set( RunMode.PROD );
+        when( this.config.http_forwarded_trustedProxies() ).thenReturn( "10.0.0.0/8, 127.0.0.1" );
+
+        configure();
+
+        final HttpConfiguration configuration = getHttpConfiguration( DispatchConstants.WEB_CONNECTOR );
+        assertNotNull( configuration.getCustomizer( TrustedProxyForwardedCustomizer.class ) );
+        assertNull( configuration.getCustomizer( ForwardedRequestCustomizer.class ) );
+    }
+
+    private HttpConfiguration getHttpConfiguration( final String name )
+    {
+        return getConnector( name ).getConnectionFactory( HttpConnectionFactory.class ).getHttpConfiguration();
     }
 
     @Test

--- a/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/configurator/TrustedProxyForwardedCustomizerTest.java
+++ b/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/configurator/TrustedProxyForwardedCustomizerTest.java
@@ -1,0 +1,98 @@
+package com.enonic.xp.web.jetty.impl.configurator;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.server.ConnectionMetaData;
+import org.eclipse.jetty.server.ForwardedRequestCustomizer;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.util.InetAddressSet;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TrustedProxyForwardedCustomizerTest
+{
+    private final HttpConfiguration.Customizer delegate = mock( HttpConfiguration.Customizer.class );
+
+    private final Request request = mock( Request.class );
+
+    private final Request customized = mock( Request.class );
+
+    private final HttpFields.Mutable responseHeaders = HttpFields.build();
+
+    private TrustedProxyForwardedCustomizer newCustomizer( final String... trustedProxies )
+    {
+        final InetAddressSet addresses = new InetAddressSet();
+        for ( final String proxy : trustedProxies )
+        {
+            addresses.add( proxy );
+        }
+        when( delegate.customize( same( request ), any() ) ).thenReturn( customized );
+        return new TrustedProxyForwardedCustomizer( delegate, addresses );
+    }
+
+    private void remoteAddress( final SocketAddress address )
+    {
+        final ConnectionMetaData connectionMetaData = mock( ConnectionMetaData.class );
+        when( connectionMetaData.getRemoteSocketAddress() ).thenReturn( address );
+        when( request.getConnectionMetaData() ).thenReturn( connectionMetaData );
+    }
+
+    @Test
+    void trustedPeerIsForwarded()
+    {
+        remoteAddress( new InetSocketAddress( "10.20.30.40", 41234 ) );
+
+        assertSame( customized, newCustomizer( "10.0.0.0/8" ).customize( request, responseHeaders ) );
+    }
+
+    @Test
+    void untrustedPeerIsNotForwarded()
+    {
+        remoteAddress( new InetSocketAddress( "203.0.113.9", 41234 ) );
+
+        assertSame( request, newCustomizer( "10.0.0.0/8", "127.0.0.1" ).customize( request, responseHeaders ) );
+        verify( delegate, never() ).customize( any(), any() );
+    }
+
+    @Test
+    void unresolvedPeerIsNotForwarded()
+    {
+        remoteAddress( InetSocketAddress.createUnresolved( "proxy.invalid", 41234 ) );
+
+        assertSame( request, newCustomizer( "10.0.0.0/8" ).customize( request, responseHeaders ) );
+    }
+
+    @Test
+    void nonInetPeerIsNotForwarded()
+    {
+        remoteAddress( mock( SocketAddress.class ) );
+
+        assertSame( request, newCustomizer( "10.0.0.0/8" ).customize( request, responseHeaders ) );
+    }
+
+    @Test
+    void emptyTrustedProxiesTrustsEveryPeer()
+    {
+        assertInstanceOf( ForwardedRequestCustomizer.class, TrustedProxyForwardedCustomizer.from( "" ) );
+        assertInstanceOf( ForwardedRequestCustomizer.class, TrustedProxyForwardedCustomizer.from( null ) );
+        assertInstanceOf( TrustedProxyForwardedCustomizer.class, TrustedProxyForwardedCustomizer.from( "10.0.0.0/8" ) );
+    }
+
+    @Test
+    void invalidTrustedProxyIsRejected()
+    {
+        assertThrows( IllegalArgumentException.class, () -> TrustedProxyForwardedCustomizer.from( "not an address" ) );
+    }
+}


### PR DESCRIPTION
## Summary

Security audit finding M3. `ForwardedRequestCustomizer` was added to the one `HttpConfiguration` shared by the web, management and statistics connectors, with no notion of a trusted proxy. Any client could therefore set the remote address, scheme, host and port the application sees through `Forwarded` or `X-Forwarded-*` headers. That spoofs `request.remoteAddress` in every controller and in audit and request logs, defeats the DoS filter's per-IP tracking and allow list, and lets `X-Forwarded-Host` pick the vhost mapping. The management and statistics connectors normally sit behind no proxy at all.

## Changes

- Each connector now gets its own `HttpConnectionFactory` and `HttpConfiguration` from `ConnectorConfigurator.newConnectionFactory`.
- Forwarded headers are honoured per connector: `http.web.forwarded.enabled` defaults to `true`, so existing proxied deployments behave exactly as before; `http.management.forwarded.enabled` and `http.statistics.forwarded.enabled` default to `false`.
- New `http.forwarded.trustedProxies` takes a comma-separated list of addresses or CIDR ranges. When set, `TrustedProxyForwardedCustomizer` applies Jetty's `ForwardedRequestCustomizer` only to connections from those peers and leaves every other request untouched. Empty keeps today's behaviour of trusting every peer. An unparseable entry fails at startup rather than silently trusting everyone.
- The new keys are documented in `com.enonic.xp.web.jetty.cfg`.

## Tests

- `HttpConfiguratorTest`: default config leaves the management and statistics connectors without customizers; per-connector toggles; trusted proxies install the gating customizer.
- New `TrustedProxyForwardedCustomizerTest`: trusted peer delegates, untrusted, unresolved and non-inet peers do not, empty list yields the plain customizer, invalid entries are rejected.

Full `:web:web-jetty:test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_