### PR TITLE
Serve only resources under the assets folder from the asset endpoint

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/AssetHandler.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/AssetHandler.java
@@ -86,6 +86,10 @@ public class AssetHandler
         final String assetPath = assetsKey.getPath() + path;
 
         final ResourceKey resourceKey = ResourceKey.from( applicationKey, assetPath );
+        if ( !resourceKey.getPath().startsWith( assetsKey.getPath() ) )
+        {
+            throw WebException.notFound( String.format( "Resource [%s] not found", resourceKey ) );
+        }
 
         final Resource resource = resolveResource( resourceKey );
 

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/AssetHandlerTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/AssetHandlerTest.java
@@ -150,6 +150,23 @@ class AssetHandlerTest
     }
 
     @Test
+    void testPathOutsideAssetsNotFound()
+    {
+        addResource( "demo:/site/site.xml" );
+        addResource( "demo:/assets-other/main.css" );
+
+        this.request.setRawPath( "/_/asset/demo/../site/site.xml" );
+        final WebException traversal = assertThrows( WebException.class, () -> this.handler.handle( this.request ) );
+        assertEquals( HttpStatus.NOT_FOUND, traversal.getStatus() );
+        assertEquals( "Resource [demo:/site/site.xml] not found", traversal.getMessage() );
+
+        this.request.setRawPath( "/_/asset/demo/../assets-other/main.css" );
+        final WebException sibling = assertThrows( WebException.class, () -> this.handler.handle( this.request ) );
+        assertEquals( HttpStatus.NOT_FOUND, sibling.getStatus() );
+        assertEquals( "Resource [demo:/assets-other/main.css] not found", sibling.getMessage() );
+    }
+
+    @Test
     void testNotValidUrlPattern()
         throws Exception
     {


### PR DESCRIPTION
## Summary

Security audit finding L11. `AssetHandler` builds the resource key as `/assets/` plus the requested path and `ResourceKey.from` normalises it, so a path containing `..` could resolve to a resource outside the application's assets folder, for example `demo:/site/site.xml`. The only check on the normalised key gated the cache header. Jetty's URI compliance rejects encoded traversal today, so this is defence in depth against a relaxed `UriCompliance` or another entry point rather than a live hole.

## Changes

After normalisation the handler requires the key's path to stay under `/assets/` and answers anything else with the same 404 an unknown asset gets, before touching the resource service. A sibling folder such as `/assets-other/` is rejected as well, since the check includes the trailing slash.

## Tests

`AssetHandlerTest.testPathOutsideAssetsNotFound` covers `../site/site.xml` and `../assets-other/main.css`. Full `:portal:portal-impl:test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_