### PR TITLE
Encode the string path of apiUrl like every other URL builder

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ApiUrlPathResolver.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/url/ApiUrlPathResolver.java
@@ -3,8 +3,8 @@ package com.enonic.xp.portal.impl.url;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static com.enonic.xp.portal.impl.url.UrlBuilderHelper.appendAndEncodePathParts;
 import static com.enonic.xp.portal.impl.url.UrlBuilderHelper.appendPathSegments;
-import static com.enonic.xp.portal.impl.url.UrlBuilderHelper.appendSubPath;
 
 final class ApiUrlPathResolver
     implements Supplier<String>
@@ -24,7 +24,7 @@ final class ApiUrlPathResolver
     {
         final StringBuilder result = new StringBuilder();
 
-        appendSubPath( result, path );
+        appendAndEncodePathParts( result, path );
         appendPathSegments( result, pathSegments );
 
         return result.toString();

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/url/PortalUrlServiceImpl_apiUrlTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/url/PortalUrlServiceImpl_apiUrlTest.java
@@ -84,6 +84,20 @@ class PortalUrlServiceImpl_apiUrlTest
     }
 
     @Test
+    void testPathIsEncoded()
+    {
+        PortalRequestAccessor.set( null );
+
+        final ApiUrlParams params = ApiUrlParams.create()
+            .setApi( DescriptorKey.from( "com.enonic.app.myapp:myapi" ) )
+            .setPath( "/a b/c?d=1#e/" )
+            .build();
+
+        final String url = this.service.apiUrl( params );
+        assertEquals( "/api/com.enonic.app.myapp:myapi/a%20b/c%3Fd=1%23e", url );
+    }
+
+    @Test
     void testNoRequestWithBaseUrl()
     {
         PortalRequestAccessor.set( null );


### PR DESCRIPTION
## Summary

Security audit finding L18. `apiUrl({path: "..."})` appended the string path through `appendSubPath`, which does no encoding, while the array form of the same parameter and the path of every other URL builder (`url`, `assetUrl`, `componentUrl`, content paths) go through `appendAndEncodePathParts`. A `?`, `#`, quote or space in a string path therefore survived into the generated URL, and the documentation never asked callers to pre-encode.

## Changes

`ApiUrlPathResolver` now uses `appendAndEncodePathParts` for the string form: the value is split on `/` and each segment is percent-encoded, exactly like `portal.url({path})`. Query parameters continue to go through the separate `params` argument, so nothing legitimate is lost. A path that was already percent-encoded by the caller is now encoded twice, which is the same contract the other builders have always had.

## Tests

`PortalUrlServiceImpl_apiUrlTest.testPathIsEncoded`: `/a b/c?d=1#e/` becomes `/a%20b/c%3Fd=1%23e`. Full `:portal:portal-impl:test` and `:lib:lib-portal:test` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_