### PR TITLE
Validate redirects, bound size and set timeouts when downloading an application

### DIFF
--- a/modules/runtime/src/home/config/com.enonic.xp.server.management.app.cfg
+++ b/modules/runtime/src/home/config/com.enonic.xp.server.management.app.cfg
@@ -1,2 +1,6 @@
 # pull.allowedUrls = https://*
 # pull.checksumRequired = true
+# pull.maxSize = 1gb
+# pull.maxRedirects = 5
+# pull.connectTimeout = PT10S
+# pull.readTimeout = PT60S

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/AppManagementConfig.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/AppManagementConfig.java
@@ -15,6 +15,26 @@ public @interface AppManagementConfig
     String pull_checksumRequired() default "";
 
     /**
+     * Maximum size of the pulled application, using size units (for example {@code 512mb}, {@code 1gb}).
+     */
+    String pull_maxSize() default "1gb";
+
+    /**
+     * Maximum number of redirect hops allowed while pulling an application.
+     */
+    int pull_maxRedirects() default 5;
+
+    /**
+     * Connection timeout while pulling an application, as ISO-8601 duration.
+     */
+    String pull_connectTimeout() default "PT10S";
+
+    /**
+     * Read timeout while pulling an application, as ISO-8601 duration.
+     */
+    String pull_readTimeout() default "PT60S";
+
+    /**
      * Legacy alias of {@link #pull_allowedUrls()}.
      */
     String installUrl_allowedUrls() default "https://*";

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/ApplicationLoader.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/ApplicationLoader.java
@@ -29,17 +29,23 @@ public class ApplicationLoader
 {
     private static final long DEFAULT_MAX_SIZE = 1L << 30;
 
-    private static final int MAX_REDIRECTS = 5;
+    private static final int DEFAULT_MAX_REDIRECTS = 5;
 
-    private static final int CONNECT_TIMEOUT_MILLIS = 10_000;
+    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 10_000;
 
-    private static final int READ_TIMEOUT_MILLIS = 60_000;
+    private static final int DEFAULT_READ_TIMEOUT_MILLIS = 60_000;
 
     private final UrlAllowList allowList;
 
     private final boolean requireChecksum;
 
     private final long maxSize;
+
+    private final int maxRedirects;
+
+    private final int connectTimeoutMillis;
+
+    private final int readTimeoutMillis;
 
     public ApplicationLoader()
     {
@@ -48,26 +54,40 @@ public class ApplicationLoader
 
     public ApplicationLoader( final String allowedUrls, final boolean requireChecksum )
     {
-        this( allowedUrls, requireChecksum, DEFAULT_MAX_SIZE );
+        this( allowedUrls, requireChecksum, DEFAULT_MAX_SIZE, DEFAULT_MAX_REDIRECTS, DEFAULT_CONNECT_TIMEOUT_MILLIS,
+              DEFAULT_READ_TIMEOUT_MILLIS );
     }
 
     ApplicationLoader( final String allowedUrls, final boolean requireChecksum, final long maxSize )
     {
+        this( allowedUrls, requireChecksum, maxSize, DEFAULT_MAX_REDIRECTS, DEFAULT_CONNECT_TIMEOUT_MILLIS,
+              DEFAULT_READ_TIMEOUT_MILLIS );
+    }
+
+    ApplicationLoader( final String allowedUrls, final boolean requireChecksum, final long maxSize, final int maxRedirects,
+                       final int connectTimeoutMillis, final int readTimeoutMillis )
+    {
         Preconditions.checkArgument( maxSize > 0 && maxSize < Long.MAX_VALUE, "maxSize out of range: %s", maxSize );
+        Preconditions.checkArgument( maxRedirects >= 0, "maxRedirects out of range: %s", maxRedirects );
+        Preconditions.checkArgument( connectTimeoutMillis > 0, "connectTimeoutMillis out of range: %s", connectTimeoutMillis );
+        Preconditions.checkArgument( readTimeoutMillis > 0, "readTimeoutMillis out of range: %s", readTimeoutMillis );
         this.allowList = new UrlAllowList( allowedUrls );
         this.requireChecksum = requireChecksum;
         this.maxSize = maxSize;
+        this.maxRedirects = maxRedirects;
+        this.connectTimeoutMillis = connectTimeoutMillis;
+        this.readTimeoutMillis = readTimeoutMillis;
     }
 
     public ByteSource load( final String urlString, final String sha512Hex, final Consumer<Event> eventConsumer )
     {
         if ( !allowList.matches( urlString ) )
         {
-            throw new WebException( HttpStatus.CONFLICT, "URL is not in the installUrl allowlist" );
+            throw new WebException( HttpStatus.CONFLICT, "URL is not in the pull allowlist" );
         }
         if ( requireChecksum && ( sha512Hex == null || sha512Hex.isBlank() ) )
         {
-            throw new WebException( HttpStatus.CONFLICT, "SHA512 checksum is required for installUrl" );
+            throw new WebException( HttpStatus.CONFLICT, "SHA512 checksum is required for pull" );
         }
         final byte[] sha512;
         try
@@ -134,8 +154,8 @@ public class ApplicationLoader
         for ( int redirects = 0; ; redirects++ )
         {
             final URLConnection connection = url.openConnection();
-            connection.setConnectTimeout( CONNECT_TIMEOUT_MILLIS );
-            connection.setReadTimeout( READ_TIMEOUT_MILLIS );
+            connection.setConnectTimeout( connectTimeoutMillis );
+            connection.setReadTimeout( readTimeoutMillis );
 
             if ( !( connection instanceof HttpURLConnection http ) )
             {
@@ -150,7 +170,7 @@ public class ApplicationLoader
             }
 
             http.disconnect();
-            if ( redirects >= MAX_REDIRECTS )
+            if ( redirects >= maxRedirects )
             {
                 throw WebException.badRequest( "Too many redirects from " + start );
             }
@@ -158,7 +178,7 @@ public class ApplicationLoader
             url = resolveRedirect( url, location );
             if ( !allowList.matches( url.toString() ) )
             {
-                throw new WebException( HttpStatus.CONFLICT, "Redirect target is not in the installUrl allowlist" );
+                throw new WebException( HttpStatus.CONFLICT, "Redirect target is not in the pull allowlist" );
             }
         }
     }

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/ApplicationLoader.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/ApplicationLoader.java
@@ -16,6 +16,7 @@ import java.util.HexFormat;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import com.google.common.base.Preconditions;
 import com.google.common.io.ByteSource;
 import com.google.common.io.ByteStreams;
 
@@ -52,6 +53,7 @@ public class ApplicationLoader
 
     ApplicationLoader( final String allowedUrls, final boolean requireChecksum, final long maxSize )
     {
+        Preconditions.checkArgument( maxSize > 0 && maxSize < Long.MAX_VALUE, "maxSize out of range: %s", maxSize );
         this.allowList = new UrlAllowList( allowedUrls );
         this.requireChecksum = requireChecksum;
         this.maxSize = maxSize;
@@ -88,7 +90,7 @@ public class ApplicationLoader
         return load( url, sha512, eventConsumer );
     }
 
-    public ByteSource load( final URL url, final byte[] sha512Checksum, final Consumer<Event> eventConsumer )
+    private ByteSource load( final URL url, final byte[] sha512Checksum, final Consumer<Event> eventConsumer )
     {
         try
         {

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/ApplicationLoader.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/ApplicationLoader.java
@@ -27,14 +27,6 @@ import com.enonic.xp.web.WebException;
 
 public class ApplicationLoader
 {
-    private static final long DEFAULT_MAX_SIZE = 1L << 30;
-
-    private static final int DEFAULT_MAX_REDIRECTS = 5;
-
-    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 10_000;
-
-    private static final int DEFAULT_READ_TIMEOUT_MILLIS = 60_000;
-
     private final UrlAllowList allowList;
 
     private final boolean requireChecksum;
@@ -46,23 +38,6 @@ public class ApplicationLoader
     private final int connectTimeoutMillis;
 
     private final int readTimeoutMillis;
-
-    public ApplicationLoader()
-    {
-        this( "", true );
-    }
-
-    public ApplicationLoader( final String allowedUrls, final boolean requireChecksum )
-    {
-        this( allowedUrls, requireChecksum, DEFAULT_MAX_SIZE, DEFAULT_MAX_REDIRECTS, DEFAULT_CONNECT_TIMEOUT_MILLIS,
-              DEFAULT_READ_TIMEOUT_MILLIS );
-    }
-
-    ApplicationLoader( final String allowedUrls, final boolean requireChecksum, final long maxSize )
-    {
-        this( allowedUrls, requireChecksum, maxSize, DEFAULT_MAX_REDIRECTS, DEFAULT_CONNECT_TIMEOUT_MILLIS,
-              DEFAULT_READ_TIMEOUT_MILLIS );
-    }
 
     ApplicationLoader( final String allowedUrls, final boolean requireChecksum, final long maxSize, final int maxRedirects,
                        final int connectTimeoutMillis, final int readTimeoutMillis )

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/ApplicationLoader.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/ApplicationLoader.java
@@ -4,8 +4,10 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.security.DigestInputStream;
@@ -15,6 +17,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import com.google.common.io.ByteSource;
+import com.google.common.io.ByteStreams;
 
 import com.enonic.xp.core.internal.security.MessageDigests;
 import com.enonic.xp.event.Event;
@@ -23,9 +26,19 @@ import com.enonic.xp.web.WebException;
 
 public class ApplicationLoader
 {
+    private static final long DEFAULT_MAX_SIZE = 1L << 30;
+
+    private static final int MAX_REDIRECTS = 5;
+
+    private static final int CONNECT_TIMEOUT_MILLIS = 10_000;
+
+    private static final int READ_TIMEOUT_MILLIS = 60_000;
+
     private final UrlAllowList allowList;
 
     private final boolean requireChecksum;
+
+    private final long maxSize;
 
     public ApplicationLoader()
     {
@@ -34,8 +47,14 @@ public class ApplicationLoader
 
     public ApplicationLoader( final String allowedUrls, final boolean requireChecksum )
     {
+        this( allowedUrls, requireChecksum, DEFAULT_MAX_SIZE );
+    }
+
+    ApplicationLoader( final String allowedUrls, final boolean requireChecksum, final long maxSize )
+    {
         this.allowList = new UrlAllowList( allowedUrls );
         this.requireChecksum = requireChecksum;
+        this.maxSize = maxSize;
     }
 
     public ByteSource load( final String urlString, final String sha512Hex, final Consumer<Event> eventConsumer )
@@ -73,15 +92,25 @@ public class ApplicationLoader
     {
         try
         {
-            final URLConnection connection = url.openConnection();
+            final URLConnection connection = connect( url );
 
-            final InputStream inputStream = connection.getInputStream();
+            if ( connection.getContentLengthLong() > maxSize )
+            {
+                throw tooLarge();
+            }
+
+            final InputStream inputStream = ByteStreams.limit( connection.getInputStream(), maxSize + 1 );
             final DigestInputStream digestInputStream = new DigestInputStream( inputStream, MessageDigests.sha512() );
             final ProgressInputStream progressInputStream =
                 new ProgressInputStream( digestInputStream, connection.getContentLengthLong(), url.toString(), eventConsumer );
             try (inputStream; digestInputStream; progressInputStream)
             {
                 final byte[] bytes = progressInputStream.readAllBytes();
+
+                if ( bytes.length > maxSize )
+                {
+                    throw tooLarge();
+                }
 
                 if ( sha512Checksum != null && !MessageDigest.isEqual( sha512Checksum, digestInputStream.getMessageDigest().digest() ) )
                 {
@@ -94,6 +123,65 @@ public class ApplicationLoader
         {
             throw new UncheckedIOException( "Failed to load application from " + url, e );
         }
+    }
+
+    private URLConnection connect( final URL start )
+        throws IOException
+    {
+        URL url = start;
+        for ( int redirects = 0; ; redirects++ )
+        {
+            final URLConnection connection = url.openConnection();
+            connection.setConnectTimeout( CONNECT_TIMEOUT_MILLIS );
+            connection.setReadTimeout( READ_TIMEOUT_MILLIS );
+
+            if ( !( connection instanceof HttpURLConnection http ) )
+            {
+                return connection;
+            }
+
+            http.setInstanceFollowRedirects( false );
+            final String location = isRedirect( http.getResponseCode() ) ? http.getHeaderField( "Location" ) : null;
+            if ( location == null )
+            {
+                return http;
+            }
+
+            http.disconnect();
+            if ( redirects >= MAX_REDIRECTS )
+            {
+                throw WebException.badRequest( "Too many redirects from " + start );
+            }
+
+            url = resolveRedirect( url, location );
+            if ( !allowList.matches( url.toString() ) )
+            {
+                throw new WebException( HttpStatus.CONFLICT, "Redirect target is not in the installUrl allowlist" );
+            }
+        }
+    }
+
+    private static boolean isRedirect( final int status )
+    {
+        return status == HttpURLConnection.HTTP_MOVED_PERM || status == HttpURLConnection.HTTP_MOVED_TEMP ||
+            status == HttpURLConnection.HTTP_SEE_OTHER || status == 307 || status == 308;
+    }
+
+    private static URL resolveRedirect( final URL from, final String location )
+    {
+        try
+        {
+            return from.toURI().resolve( location ).toURL();
+        }
+        catch ( URISyntaxException | IllegalArgumentException | MalformedURLException e )
+        {
+            throw WebException.badRequest( "Invalid redirect location: " + location, e );
+        }
+    }
+
+    private WebException tooLarge()
+    {
+        return WebException.badRequest( String.format( "Application exceeds the maximum size of %d bytes", maxSize ) );
     }
 
     private static class ProgressInputStream

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/ApplicationResourceService.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/ApplicationResourceService.java
@@ -1,5 +1,6 @@
 package com.enonic.xp.impl.server.rest;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,6 +22,7 @@ import com.enonic.xp.impl.server.rest.model.ApplicationActionResultJson;
 import com.enonic.xp.impl.server.rest.model.ApplicationInstallParams;
 import com.enonic.xp.impl.server.rest.model.ApplicationInfoJson;
 import com.enonic.xp.impl.server.rest.model.ApplicationParams;
+import com.enonic.xp.util.ByteSizeParser;
 import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.multipart.MultipartForm;
 import com.enonic.xp.web.multipart.MultipartItem;
@@ -52,7 +54,9 @@ public class ApplicationResourceService
     @Modified
     public void activate( final AppManagementConfig config )
     {
-        this.applicationLoader = new ApplicationLoader( allowedUrls( config ), checksumRequired( config ) );
+        this.applicationLoader = new ApplicationLoader( allowedUrls( config ), checksumRequired( config ), maxSize( config ),
+                                                        maxRedirects( config ), connectTimeoutMillis( config ),
+                                                        readTimeoutMillis( config ) );
     }
 
     static String allowedUrls( final AppManagementConfig config )
@@ -65,6 +69,31 @@ public class ApplicationResourceService
     {
         final String pull = config.pull_checksumRequired();
         return pull.isBlank() ? config.installUrl_checksumRequired() : Boolean.parseBoolean( pull.strip() );
+    }
+
+    static long maxSize( final AppManagementConfig config )
+    {
+        return ByteSizeParser.parse( config.pull_maxSize().strip() );
+    }
+
+    static int maxRedirects( final AppManagementConfig config )
+    {
+        return config.pull_maxRedirects();
+    }
+
+    static int connectTimeoutMillis( final AppManagementConfig config )
+    {
+        return parseTimeoutMillis( config.pull_connectTimeout() );
+    }
+
+    static int readTimeoutMillis( final AppManagementConfig config )
+    {
+        return parseTimeoutMillis( config.pull_readTimeout() );
+    }
+
+    private static int parseTimeoutMillis( final String duration )
+    {
+        return Math.toIntExact( Duration.parse( duration.strip() ).toMillis() );
     }
 
     public ApplicationInfoJson install( final MultipartForm form )

--- a/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/AppManagementConfigTest.java
+++ b/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/AppManagementConfigTest.java
@@ -2,6 +2,8 @@ package com.enonic.xp.impl.server.rest;
 
 import org.junit.jupiter.api.Test;
 
+import com.enonic.xp.util.ByteSizeParser;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,6 +23,10 @@ class AppManagementConfigTest
         final AppManagementConfig config = config();
         assertEquals( "https://*", ApplicationResourceService.allowedUrls( config ) );
         assertTrue( ApplicationResourceService.checksumRequired( config ) );
+        assertEquals( ByteSizeParser.parse( "1gb" ), ApplicationResourceService.maxSize( config ) );
+        assertEquals( 5, ApplicationResourceService.maxRedirects( config ) );
+        assertEquals( 10_000, ApplicationResourceService.connectTimeoutMillis( config ) );
+        assertEquals( 60_000, ApplicationResourceService.readTimeoutMillis( config ) );
     }
 
     @Test
@@ -52,5 +58,20 @@ class AppManagementConfigTest
         when( config.pull_allowedUrls() ).thenReturn( "" );
         when( config.installUrl_allowedUrls() ).thenReturn( "https://legacy/*" );
         assertEquals( "", ApplicationResourceService.allowedUrls( config ) );
+    }
+
+    @Test
+    void pullLimitsAreConfigurable()
+    {
+        final AppManagementConfig config = config();
+        when( config.pull_maxSize() ).thenReturn( "512mb" );
+        when( config.pull_maxRedirects() ).thenReturn( 9 );
+        when( config.pull_connectTimeout() ).thenReturn( "PT3S" );
+        when( config.pull_readTimeout() ).thenReturn( "PT45S" );
+
+        assertEquals( ByteSizeParser.parse( "512mb" ), ApplicationResourceService.maxSize( config ) );
+        assertEquals( 9, ApplicationResourceService.maxRedirects( config ) );
+        assertEquals( 3_000, ApplicationResourceService.connectTimeoutMillis( config ) );
+        assertEquals( 45_000, ApplicationResourceService.readTimeoutMillis( config ) );
     }
 }

--- a/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/ApplicationLoaderTest.java
+++ b/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/ApplicationLoaderTest.java
@@ -2,15 +2,18 @@ package com.enonic.xp.impl.server.rest;
 
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.HexFormat;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -25,7 +28,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -68,7 +73,7 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ByteSource byteSource = new ApplicationLoader().load( URI.create( appUrl ).toURL(), null, eventListener );
+        final ByteSource byteSource = new ApplicationLoader( appUrl + "*", false ).load( appUrl, null, eventListener );
 
         verify( eventListener ).accept( notNull() );
         assertTrue( byteSource.contentEquals( ByteSource.wrap( bytes ) ) );
@@ -79,9 +84,6 @@ class ApplicationLoaderTest
         throws Exception
     {
         final byte[] bytes = "this is a test".getBytes( StandardCharsets.UTF_8 );
-        final byte[] sha512 = HexFormat.of()
-            .parseHex(
-                "7d0a8468ed220400c0b8e6f335baa7e070ce880a37e2ac5995b9a97b809026de626da636ac7365249bb974c719edf543b52ed286646f437dc7f810cc2068375c" );
 
         this.server.createContext( "/", exchange -> {
 
@@ -91,7 +93,7 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ByteSource byteSource = new ApplicationLoader().load( URI.create( appUrl ).toURL(), sha512, eventListener );
+        final ByteSource byteSource = new ApplicationLoader( appUrl + "*", true ).load( appUrl, "7d0a8468ed220400c0b8e6f335baa7e070ce880a37e2ac5995b9a97b809026de626da636ac7365249bb974c719edf543b52ed286646f437dc7f810cc2068375c", eventListener );
 
         verify( eventListener ).accept( notNull() );
         assertTrue( byteSource.contentEquals( ByteSource.wrap( bytes ) ) );
@@ -101,9 +103,6 @@ class ApplicationLoaderTest
     void load_with_sha512_wrong()
     {
         final byte[] bytes = "this is a test".getBytes( StandardCharsets.UTF_8 );
-        final byte[] sha512 = HexFormat.of()
-            .parseHex(
-                "0d0a8468ed220400c0b8e6f335baa7e070ce880a37e2ac5995b9a97b809026de626da636ac7365249bb974c719edf543b52ed286646f437dc7f810cc2068375c" );
 
         this.server.createContext( "/", exchange -> {
 
@@ -113,18 +112,21 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        assertThrows( WebException.class, () -> new ApplicationLoader().load( URI.create( appUrl ).toURL(), sha512, eventListener ) );
+        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", true );
+
+        assertThrows( WebException.class, () -> loader.load( appUrl, "0d0a8468ed220400c0b8e6f335baa7e070ce880a37e2ac5995b9a97b809026de626da636ac7365249bb974c719edf543b52ed286646f437dc7f810cc2068375c", eventListener ) );
     }
 
-    @Test
-    void load_follows_redirect_within_allowlist()
+    @ParameterizedTest
+    @ValueSource(ints = {301, 302, 303, 307, 308})
+    void load_follows_redirect_within_allowlist( final int status )
         throws Exception
     {
         final byte[] bytes = "this is a test".getBytes( StandardCharsets.UTF_8 );
 
         this.server.createContext( "/old", exchange -> {
             exchange.getResponseHeaders().add( "Location", "/new/app.jar" );
-            exchange.sendResponseHeaders( 302, -1 );
+            exchange.sendResponseHeaders( status, -1 );
             exchange.close();
         } );
         this.server.createContext( "/new", exchange -> {
@@ -133,10 +135,49 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ByteSource byteSource =
-            new ApplicationLoader( appUrl + "*", false ).load( URI.create( appUrl + "/old" ).toURL(), null, eventListener );
+        final ByteSource byteSource = new ApplicationLoader( appUrl + "*", false ).load( appUrl + "/old", null, eventListener );
 
         assertTrue( byteSource.contentEquals( ByteSource.wrap( bytes ) ) );
+        verify( eventListener, atLeastOnce() ).accept(
+            argThat( event -> ( appUrl + "/old" ).equals( event.getValue( "applicationUrl" ).orElse( null ) ) ) );
+    }
+
+    @Test
+    void load_rejects_invalid_redirect_location()
+    {
+        this.server.createContext( "/old", exchange -> {
+            exchange.getResponseHeaders().add( "Location", "http://exa mple.com/app.jar" );
+            exchange.sendResponseHeaders( 302, -1 );
+            exchange.close();
+        } );
+
+        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false );
+
+        assertThatThrownBy( () -> loader.load( appUrl + "/old", null, eventListener ) ).isInstanceOfSatisfying( WebException.class,
+                                                                                                                e -> assertThat(
+                                                                                                                    e.getStatus() ).isEqualTo(
+                                                                                                                    HttpStatus.BAD_REQUEST ) );
+        verifyNoInteractions( eventListener );
+    }
+
+    @Test
+    void load_from_file_url( @TempDir final Path tempDir )
+        throws Exception
+    {
+        final byte[] bytes = "this is a test".getBytes( StandardCharsets.UTF_8 );
+        final Path file = Files.write( tempDir.resolve( "app.jar" ), bytes );
+
+        final ByteSource byteSource = new ApplicationLoader( "file:*", false ).load( file.toUri().toString(), null, eventListener );
+
+        verify( eventListener ).accept( notNull() );
+        assertTrue( byteSource.contentEquals( ByteSource.wrap( bytes ) ) );
+    }
+
+    @Test
+    void rejects_max_size_out_of_range()
+    {
+        assertThrows( IllegalArgumentException.class, () -> new ApplicationLoader( "", false, 0 ) );
+        assertThrows( IllegalArgumentException.class, () -> new ApplicationLoader( "", false, Long.MAX_VALUE ) );
     }
 
     @Test
@@ -150,7 +191,7 @@ class ApplicationLoaderTest
 
         final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false );
 
-        assertThatThrownBy( () -> loader.load( URI.create( appUrl + "/old" ).toURL(), null, eventListener ) ).isInstanceOfSatisfying(
+        assertThatThrownBy( () -> loader.load( appUrl + "/old", null, eventListener ) ).isInstanceOfSatisfying(
             WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.CONFLICT ) );
         verifyNoInteractions( eventListener );
     }
@@ -166,7 +207,7 @@ class ApplicationLoaderTest
 
         final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false );
 
-        assertThatThrownBy( () -> loader.load( URI.create( appUrl + "/loop" ).toURL(), null, eventListener ) ).isInstanceOfSatisfying(
+        assertThatThrownBy( () -> loader.load( appUrl + "/loop", null, eventListener ) ).isInstanceOfSatisfying(
             WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.BAD_REQUEST ) );
         verifyNoInteractions( eventListener );
     }
@@ -184,7 +225,7 @@ class ApplicationLoaderTest
 
         final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false, bytes.length - 1 );
 
-        assertThatThrownBy( () -> loader.load( URI.create( appUrl ).toURL(), null, eventListener ) ).isInstanceOfSatisfying(
+        assertThatThrownBy( () -> loader.load( appUrl, null, eventListener ) ).isInstanceOfSatisfying(
             WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.BAD_REQUEST ) );
     }
 
@@ -201,7 +242,7 @@ class ApplicationLoaderTest
 
         final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false, bytes.length - 1 );
 
-        assertThatThrownBy( () -> loader.load( URI.create( appUrl ).toURL(), null, eventListener ) ).isInstanceOfSatisfying(
+        assertThatThrownBy( () -> loader.load( appUrl, null, eventListener ) ).isInstanceOfSatisfying(
             WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.BAD_REQUEST ) );
         verifyNoInteractions( eventListener );
     }

--- a/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/ApplicationLoaderTest.java
+++ b/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/ApplicationLoaderTest.java
@@ -117,6 +117,96 @@ class ApplicationLoaderTest
     }
 
     @Test
+    void load_follows_redirect_within_allowlist()
+        throws Exception
+    {
+        final byte[] bytes = "this is a test".getBytes( StandardCharsets.UTF_8 );
+
+        this.server.createContext( "/old", exchange -> {
+            exchange.getResponseHeaders().add( "Location", "/new/app.jar" );
+            exchange.sendResponseHeaders( 302, -1 );
+            exchange.close();
+        } );
+        this.server.createContext( "/new", exchange -> {
+            exchange.sendResponseHeaders( 200, 0 );
+            exchange.getResponseBody().write( bytes );
+            exchange.close();
+        } );
+
+        final ByteSource byteSource =
+            new ApplicationLoader( appUrl + "*", false ).load( URI.create( appUrl + "/old" ).toURL(), null, eventListener );
+
+        assertTrue( byteSource.contentEquals( ByteSource.wrap( bytes ) ) );
+    }
+
+    @Test
+    void load_rejects_redirect_outside_allowlist()
+    {
+        this.server.createContext( "/old", exchange -> {
+            exchange.getResponseHeaders().add( "Location", "http://other.invalid/app.jar" );
+            exchange.sendResponseHeaders( 302, -1 );
+            exchange.close();
+        } );
+
+        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false );
+
+        assertThatThrownBy( () -> loader.load( URI.create( appUrl + "/old" ).toURL(), null, eventListener ) ).isInstanceOfSatisfying(
+            WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.CONFLICT ) );
+        verifyNoInteractions( eventListener );
+    }
+
+    @Test
+    void load_rejects_too_many_redirects()
+    {
+        this.server.createContext( "/loop", exchange -> {
+            exchange.getResponseHeaders().add( "Location", "/loop" );
+            exchange.sendResponseHeaders( 302, -1 );
+            exchange.close();
+        } );
+
+        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false );
+
+        assertThatThrownBy( () -> loader.load( URI.create( appUrl + "/loop" ).toURL(), null, eventListener ) ).isInstanceOfSatisfying(
+            WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.BAD_REQUEST ) );
+        verifyNoInteractions( eventListener );
+    }
+
+    @Test
+    void load_rejects_oversized_application()
+    {
+        final byte[] bytes = "this is a test".getBytes( StandardCharsets.UTF_8 );
+
+        this.server.createContext( "/", exchange -> {
+            exchange.sendResponseHeaders( 200, 0 );
+            exchange.getResponseBody().write( bytes );
+            exchange.close();
+        } );
+
+        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false, bytes.length - 1 );
+
+        assertThatThrownBy( () -> loader.load( URI.create( appUrl ).toURL(), null, eventListener ) ).isInstanceOfSatisfying(
+            WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.BAD_REQUEST ) );
+    }
+
+    @Test
+    void load_rejects_oversized_content_length()
+    {
+        final byte[] bytes = "this is a test".getBytes( StandardCharsets.UTF_8 );
+
+        this.server.createContext( "/", exchange -> {
+            exchange.sendResponseHeaders( 200, bytes.length );
+            exchange.getResponseBody().write( bytes );
+            exchange.close();
+        } );
+
+        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false, bytes.length - 1 );
+
+        assertThatThrownBy( () -> loader.load( URI.create( appUrl ).toURL(), null, eventListener ) ).isInstanceOfSatisfying(
+            WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.BAD_REQUEST ) );
+        verifyNoInteractions( eventListener );
+    }
+
+    @Test
     void load_rejects_url_outside_allowlist()
     {
         final ApplicationLoader loader = new ApplicationLoader( "https://allowed.example/*", false );

--- a/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/ApplicationLoaderTest.java
+++ b/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/ApplicationLoaderTest.java
@@ -37,6 +37,14 @@ import static org.mockito.Mockito.verifyNoInteractions;
 @ExtendWith(MockitoExtension.class)
 class ApplicationLoaderTest
 {
+    private static final long DEFAULT_MAX_SIZE = 1L << 30;
+
+    private static final int DEFAULT_MAX_REDIRECTS = 5;
+
+    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 10_000;
+
+    private static final int DEFAULT_READ_TIMEOUT_MILLIS = 60_000;
+
     private HttpServer server;
 
     private String appUrl;
@@ -73,7 +81,7 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ByteSource byteSource = new ApplicationLoader( appUrl + "*", false ).load( appUrl, null, eventListener );
+        final ByteSource byteSource = loader( appUrl + "*", false ).load( appUrl, null, eventListener );
 
         verify( eventListener ).accept( notNull() );
         assertTrue( byteSource.contentEquals( ByteSource.wrap( bytes ) ) );
@@ -93,7 +101,7 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ByteSource byteSource = new ApplicationLoader( appUrl + "*", true ).load( appUrl, "7d0a8468ed220400c0b8e6f335baa7e070ce880a37e2ac5995b9a97b809026de626da636ac7365249bb974c719edf543b52ed286646f437dc7f810cc2068375c", eventListener );
+        final ByteSource byteSource = loader( appUrl + "*", true ).load( appUrl, "7d0a8468ed220400c0b8e6f335baa7e070ce880a37e2ac5995b9a97b809026de626da636ac7365249bb974c719edf543b52ed286646f437dc7f810cc2068375c", eventListener );
 
         verify( eventListener ).accept( notNull() );
         assertTrue( byteSource.contentEquals( ByteSource.wrap( bytes ) ) );
@@ -112,7 +120,7 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", true );
+        final ApplicationLoader loader = loader( appUrl + "*", true );
 
         assertThrows( WebException.class, () -> loader.load( appUrl, "0d0a8468ed220400c0b8e6f335baa7e070ce880a37e2ac5995b9a97b809026de626da636ac7365249bb974c719edf543b52ed286646f437dc7f810cc2068375c", eventListener ) );
     }
@@ -135,7 +143,7 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ByteSource byteSource = new ApplicationLoader( appUrl + "*", false ).load( appUrl + "/old", null, eventListener );
+        final ByteSource byteSource = loader( appUrl + "*", false ).load( appUrl + "/old", null, eventListener );
 
         assertTrue( byteSource.contentEquals( ByteSource.wrap( bytes ) ) );
         verify( eventListener, atLeastOnce() ).accept(
@@ -151,7 +159,7 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false );
+        final ApplicationLoader loader = loader( appUrl + "*", false );
 
         assertThatThrownBy( () -> loader.load( appUrl + "/old", null, eventListener ) ).isInstanceOfSatisfying( WebException.class,
                                                                                                                 e -> assertThat(
@@ -167,7 +175,7 @@ class ApplicationLoaderTest
         final byte[] bytes = "this is a test".getBytes( StandardCharsets.UTF_8 );
         final Path file = Files.write( tempDir.resolve( "app.jar" ), bytes );
 
-        final ByteSource byteSource = new ApplicationLoader( "file:*", false ).load( file.toUri().toString(), null, eventListener );
+        final ByteSource byteSource = loader( "file:*", false ).load( file.toUri().toString(), null, eventListener );
 
         verify( eventListener ).accept( notNull() );
         assertTrue( byteSource.contentEquals( ByteSource.wrap( bytes ) ) );
@@ -176,8 +184,12 @@ class ApplicationLoaderTest
     @Test
     void rejects_max_size_out_of_range()
     {
-        assertThrows( IllegalArgumentException.class, () -> new ApplicationLoader( "", false, 0 ) );
-        assertThrows( IllegalArgumentException.class, () -> new ApplicationLoader( "", false, Long.MAX_VALUE ) );
+        assertThrows( IllegalArgumentException.class,
+                      () -> new ApplicationLoader( "", false, 0, DEFAULT_MAX_REDIRECTS, DEFAULT_CONNECT_TIMEOUT_MILLIS,
+                                                   DEFAULT_READ_TIMEOUT_MILLIS ) );
+        assertThrows( IllegalArgumentException.class,
+                      () -> new ApplicationLoader( "", false, Long.MAX_VALUE, DEFAULT_MAX_REDIRECTS,
+                                                   DEFAULT_CONNECT_TIMEOUT_MILLIS, DEFAULT_READ_TIMEOUT_MILLIS ) );
         assertThrows( IllegalArgumentException.class, () -> new ApplicationLoader( "", false, 1, -1, 1, 1 ) );
         assertThrows( IllegalArgumentException.class, () -> new ApplicationLoader( "", false, 1, 1, 0, 1 ) );
         assertThrows( IllegalArgumentException.class, () -> new ApplicationLoader( "", false, 1, 1, 1, 0 ) );
@@ -192,7 +204,7 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false );
+        final ApplicationLoader loader = loader( appUrl + "*", false );
 
         assertThatThrownBy( () -> loader.load( appUrl + "/old", null, eventListener ) ).isInstanceOfSatisfying(
             WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.CONFLICT ) );
@@ -208,7 +220,7 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false );
+        final ApplicationLoader loader = loader( appUrl + "*", false );
 
         assertThatThrownBy( () -> loader.load( appUrl + "/loop", null, eventListener ) ).isInstanceOfSatisfying(
             WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.BAD_REQUEST ) );
@@ -226,7 +238,7 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false, bytes.length - 1 );
+        final ApplicationLoader loader = loader( appUrl + "*", false, bytes.length - 1 );
 
         assertThatThrownBy( () -> loader.load( appUrl, null, eventListener ) ).isInstanceOfSatisfying(
             WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.BAD_REQUEST ) );
@@ -243,7 +255,7 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false, bytes.length - 1 );
+        final ApplicationLoader loader = loader( appUrl + "*", false, bytes.length - 1 );
 
         assertThatThrownBy( () -> loader.load( appUrl, null, eventListener ) ).isInstanceOfSatisfying(
             WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.BAD_REQUEST ) );
@@ -253,7 +265,7 @@ class ApplicationLoaderTest
     @Test
     void load_rejects_url_outside_allowlist()
     {
-        final ApplicationLoader loader = new ApplicationLoader( "https://allowed.example/*", false );
+        final ApplicationLoader loader = loader( "https://allowed.example/*", false );
 
         assertThatThrownBy( () -> loader.load( appUrl, null, eventListener ) ).isInstanceOfSatisfying( WebException.class,
                                                                                                        e -> assertThat( e.getStatus() ).isEqualTo(
@@ -264,7 +276,7 @@ class ApplicationLoaderTest
     @Test
     void load_rejects_when_empty_allowlist()
     {
-        final ApplicationLoader loader = new ApplicationLoader( "", false );
+        final ApplicationLoader loader = loader( "", false );
 
         assertThatThrownBy( () -> loader.load( appUrl, null, eventListener ) ).isInstanceOfSatisfying( WebException.class,
                                                                                                        e -> assertThat( e.getStatus() ).isEqualTo(
@@ -275,7 +287,7 @@ class ApplicationLoaderTest
     @Test
     void load_rejects_when_checksum_required_but_missing()
     {
-        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", true );
+        final ApplicationLoader loader = loader( appUrl + "*", true );
 
         assertThatThrownBy( () -> loader.load( appUrl, null, eventListener ) ).isInstanceOfSatisfying( WebException.class,
                                                                                                        e -> assertThat( e.getStatus() ).isEqualTo(
@@ -286,7 +298,7 @@ class ApplicationLoaderTest
     @Test
     void load_rejects_when_checksum_required_but_blank()
     {
-        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", true );
+        final ApplicationLoader loader = loader( appUrl + "*", true );
 
         assertThatThrownBy( () -> loader.load( appUrl, "   ", eventListener ) ).isInstanceOfSatisfying( WebException.class,
                                                                                                         e -> assertThat( e.getStatus() ).isEqualTo(
@@ -297,7 +309,7 @@ class ApplicationLoaderTest
     @Test
     void load_rejects_invalid_sha512_hex_with_400()
     {
-        final ApplicationLoader loader = new ApplicationLoader( "https://*", true );
+        final ApplicationLoader loader = loader( "https://*", true );
 
         assertThatThrownBy( () -> loader.load( "https://example.com/foo", "not-a-hex-string", eventListener ) ).isInstanceOfSatisfying(
             WebException.class, e -> assertThat( e.getStatus() ).isEqualTo( HttpStatus.BAD_REQUEST ) );
@@ -306,7 +318,7 @@ class ApplicationLoaderTest
     @Test
     void load_rejects_malformed_url_with_400()
     {
-        final ApplicationLoader loader = new ApplicationLoader( "xyz://*", false );
+        final ApplicationLoader loader = loader( "xyz://*", false );
 
         assertThatThrownBy( () -> loader.load( "xyz://example.com/foo", null, eventListener ) ).isInstanceOfSatisfying( WebException.class,
                                                                                                                        e -> assertThat(
@@ -317,7 +329,7 @@ class ApplicationLoaderTest
     @Test
     void load_rejects_unparseable_uri_with_400()
     {
-        final ApplicationLoader loader = new ApplicationLoader( "https://*", false );
+        final ApplicationLoader loader = loader( "https://*", false );
 
         assertThatThrownBy( () -> loader.load( "https://exa mple.com", null, eventListener ) ).isInstanceOfSatisfying( WebException.class,
                                                                                                                       e -> assertThat(
@@ -337,9 +349,21 @@ class ApplicationLoaderTest
             exchange.close();
         } );
 
-        final ApplicationLoader loader = new ApplicationLoader( appUrl + "*", false );
+        final ApplicationLoader loader = loader( appUrl + "*", false );
         final ByteSource result = loader.load( appUrl, null, eventListener );
 
         assertTrue( result.contentEquals( ByteSource.wrap( bytes ) ) );
+    }
+
+    private static ApplicationLoader loader( final String allowedUrls, final boolean requireChecksum )
+    {
+        return new ApplicationLoader( allowedUrls, requireChecksum, DEFAULT_MAX_SIZE, DEFAULT_MAX_REDIRECTS,
+                                      DEFAULT_CONNECT_TIMEOUT_MILLIS, DEFAULT_READ_TIMEOUT_MILLIS );
+    }
+
+    private static ApplicationLoader loader( final String allowedUrls, final boolean requireChecksum, final long maxSize )
+    {
+        return new ApplicationLoader( allowedUrls, requireChecksum, maxSize, DEFAULT_MAX_REDIRECTS, DEFAULT_CONNECT_TIMEOUT_MILLIS,
+                                      DEFAULT_READ_TIMEOUT_MILLIS );
     }
 }

--- a/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/ApplicationLoaderTest.java
+++ b/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/ApplicationLoaderTest.java
@@ -178,6 +178,9 @@ class ApplicationLoaderTest
     {
         assertThrows( IllegalArgumentException.class, () -> new ApplicationLoader( "", false, 0 ) );
         assertThrows( IllegalArgumentException.class, () -> new ApplicationLoader( "", false, Long.MAX_VALUE ) );
+        assertThrows( IllegalArgumentException.class, () -> new ApplicationLoader( "", false, 1, -1, 1, 1 ) );
+        assertThrows( IllegalArgumentException.class, () -> new ApplicationLoader( "", false, 1, 1, 0, 1 ) );
+        assertThrows( IllegalArgumentException.class, () -> new ApplicationLoader( "", false, 1, 1, 1, 0 ) );
     }
 
     @Test


### PR DESCRIPTION
## Summary

Security audit finding L10, in `ApplicationLoader` behind the management API's `pull`. `HttpURLConnection` followed redirects transparently, so the URL allow list was checked against the first URL only and a `302` from an allowed host could fetch the application from anywhere. The connection had no connect or read timeout, and the body was read in full with no cap.

## Changes

- Redirects are followed manually with `setInstanceFollowRedirects(false)`: each `Location` is resolved against the current URL and checked against the allow list, answered with the existing 409 when it falls outside; more than five hops is a 400. `301`, `302`, `303`, `307` and `308` are treated as redirects.
- Connect timeout of 10 seconds and read timeout of 60 seconds on every connection.
- A download larger than 1 GiB is rejected with 400, both up front from `Content-Length` and while streaming, so the body is never buffered past the cap.

The shipped `https://*` default of the allow list is left alone; that is being evaluated separately.

## Tests

`ApplicationLoaderTest`: redirect within the allow list is followed (relative `Location`), redirect outside it is rejected, a redirect loop stops after five hops, and oversized downloads are rejected both from `Content-Length` and from the stream. Full `:server:server-rest:test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_