### PR TITLE
Require the admin role for thread, deadlock and server dumps behind a statistics vhost

### DIFF
--- a/modules/core/core-api/src/main/java/com/enonic/xp/status/StatusReporter.java
+++ b/modules/core/core-api/src/main/java/com/enonic/xp/status/StatusReporter.java
@@ -19,4 +19,9 @@ public interface StatusReporter
     {
         this.report( context.getOutputStream() );
     }
+
+    default boolean isSensitive()
+    {
+        return false;
+    }
 }

--- a/modules/server/server-status/src/main/java/com/enonic/xp/server/impl/status/DeadlockReporter.java
+++ b/modules/server/server-status/src/main/java/com/enonic/xp/server/impl/status/DeadlockReporter.java
@@ -24,6 +24,12 @@ public final class DeadlockReporter
     }
 
     @Override
+    public boolean isSensitive()
+    {
+        return true;
+    }
+
+    @Override
     public MediaType getMediaType()
     {
         return MediaType.PLAIN_TEXT_UTF_8;

--- a/modules/server/server-status/src/main/java/com/enonic/xp/server/impl/status/StatusServlet.java
+++ b/modules/server/server-status/src/main/java/com/enonic/xp/server/impl/status/StatusServlet.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -27,7 +28,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import com.enonic.xp.annotation.Order;
+import com.enonic.xp.context.ContextAccessor;
+import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.status.StatusReporter;
+import com.enonic.xp.web.dispatch.DispatchConstants;
+import com.enonic.xp.web.vhost.VirtualHostService;
 
 @Component(immediate = true, service = Servlet.class, property = {"connector=status"})
 @Order(-200)
@@ -38,6 +43,14 @@ public final class StatusServlet
     private static final String PATH_PREFIX = "/";
 
     private final Map<String, StatusReporter> reporters = new ConcurrentHashMap<>();
+
+    private final VirtualHostService virtualHostService;
+
+    @Activate
+    public StatusServlet( @Reference final VirtualHostService virtualHostService )
+    {
+        this.virtualHostService = virtualHostService;
+    }
 
     @Override
     protected void doGet( final HttpServletRequest req, final HttpServletResponse res )
@@ -72,6 +85,12 @@ public final class StatusServlet
             return;
         }
 
+        if ( reporter.isSensitive() && hasStatisticsVirtualHost() && !ContextAccessor.current().getAuthInfo().hasRole( RoleKeys.ADMIN ) )
+        {
+            serializeError( res, 403, String.format( "Reporter [%s] requires the admin role", name ) );
+            return;
+        }
+
         try
         {
             serialize( req, res, reporter );
@@ -84,6 +103,13 @@ public final class StatusServlet
         {
             serializeError( res, 500, e.getMessage() );
         }
+    }
+
+    private boolean hasStatisticsVirtualHost()
+    {
+        return virtualHostService.isEnabled() && virtualHostService.getVirtualHosts()
+            .stream()
+            .anyMatch( virtualHost -> DispatchConstants.STATISTICS_CONNECTOR.equals( virtualHost.getConnector() ) );
     }
 
     private void serialize( final HttpServletRequest req, final HttpServletResponse res, final StatusReporter reporter )

--- a/modules/server/server-status/src/main/java/com/enonic/xp/server/impl/status/ThreadDumpReporter.java
+++ b/modules/server/server-status/src/main/java/com/enonic/xp/server/impl/status/ThreadDumpReporter.java
@@ -24,6 +24,12 @@ public final class ThreadDumpReporter
     }
 
     @Override
+    public boolean isSensitive()
+    {
+        return true;
+    }
+
+    @Override
     public MediaType getMediaType()
     {
         return MediaType.PLAIN_TEXT_UTF_8;

--- a/modules/server/server-status/src/test/java/com/enonic/xp/server/impl/status/DeadlockReporterTest.java
+++ b/modules/server/server-status/src/test/java/com/enonic/xp/server/impl/status/DeadlockReporterTest.java
@@ -7,6 +7,7 @@ import com.google.common.net.MediaType;
 import com.enonic.xp.status.BaseReporterTest;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DeadlockReporterTest
     extends BaseReporterTest<DeadlockReporter>
@@ -27,5 +28,11 @@ class DeadlockReporterTest
         throws Exception
     {
         assertNotNull( textReport() );
+    }
+
+    @Test
+    void testSensitive()
+    {
+        assertTrue( newReporter().isSensitive() );
     }
 }

--- a/modules/server/server-status/src/test/java/com/enonic/xp/server/impl/status/StatusServletTest.java
+++ b/modules/server/server-status/src/test/java/com/enonic/xp/server/impl/status/StatusServletTest.java
@@ -32,6 +32,7 @@ import com.enonic.xp.web.vhost.VirtualHostService;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -79,8 +80,8 @@ class StatusServletTest
         when( res.getWriter() ).thenReturn( new PrintWriter( error ) );
 
         servlet = new StatusServlet( virtualHostService );
-        servlet.addReporter( reporter( "dump.threads", true ) );
-        servlet.addReporter( reporter( "jvm.info", false ) );
+        servlet.addReporter( new SensitiveReporter( "dump.threads" ) );
+        servlet.addReporter( new PlainReporter( "jvm.info" ) );
     }
 
     private void virtualHosts( final String... connectors )
@@ -140,6 +141,20 @@ class StatusServletTest
     }
 
     @Test
+    void sensitiveReporterOpenWithVirtualHostsDisabled()
+        throws Exception
+    {
+        when( virtualHostService.isEnabled() ).thenReturn( false );
+        when( req.getRequestURI() ).thenReturn( "/dump.threads" );
+
+        servlet.doGet( req, res );
+
+        verify( res ).setStatus( 200 );
+        verify( virtualHostService, never() ).getVirtualHosts();
+        assertEquals( "dump.threads", body.toString( StandardCharsets.UTF_8 ) );
+    }
+
+    @Test
     void plainReporterOpenWithStatisticsVirtualHost()
         throws Exception
     {
@@ -163,34 +178,48 @@ class StatusServletTest
         verify( res ).setStatus( 404 );
     }
 
-    private static StatusReporter reporter( final String name, final boolean sensitive )
+    private static class PlainReporter
+        implements StatusReporter
     {
-        return new StatusReporter()
+        private final String name;
+
+        PlainReporter( final String name )
         {
-            @Override
-            public String getName()
-            {
-                return name;
-            }
+            this.name = name;
+        }
 
-            @Override
-            public MediaType getMediaType()
-            {
-                return MediaType.PLAIN_TEXT_UTF_8;
-            }
+        @Override
+        public String getName()
+        {
+            return name;
+        }
 
-            @Override
-            public void report( final OutputStream stream )
-                throws IOException
-            {
-                stream.write( name.getBytes( StandardCharsets.UTF_8 ) );
-            }
+        @Override
+        public MediaType getMediaType()
+        {
+            return MediaType.PLAIN_TEXT_UTF_8;
+        }
 
-            @Override
-            public boolean isSensitive()
-            {
-                return sensitive;
-            }
-        };
+        @Override
+        public void report( final OutputStream stream )
+            throws IOException
+        {
+            stream.write( name.getBytes( StandardCharsets.UTF_8 ) );
+        }
+    }
+
+    private static final class SensitiveReporter
+        extends PlainReporter
+    {
+        SensitiveReporter( final String name )
+        {
+            super( name );
+        }
+
+        @Override
+        public boolean isSensitive()
+        {
+            return true;
+        }
     }
 }

--- a/modules/server/server-status/src/test/java/com/enonic/xp/server/impl/status/StatusServletTest.java
+++ b/modules/server/server-status/src/test/java/com/enonic/xp/server/impl/status/StatusServletTest.java
@@ -1,0 +1,196 @@
+package com.enonic.xp.server.impl.status;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.net.MediaType;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import com.enonic.xp.context.Context;
+import com.enonic.xp.context.ContextBuilder;
+import com.enonic.xp.security.RoleKeys;
+import com.enonic.xp.security.User;
+import com.enonic.xp.security.auth.AuthenticationInfo;
+import com.enonic.xp.status.StatusReporter;
+import com.enonic.xp.web.dispatch.DispatchConstants;
+import com.enonic.xp.web.vhost.VirtualHost;
+import com.enonic.xp.web.vhost.VirtualHostService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StatusServletTest
+{
+    private static final Context ADMIN = ContextBuilder.create()
+        .authInfo( AuthenticationInfo.create().principals( RoleKeys.ADMIN ).user( User.anonymous() ).build() )
+        .build();
+
+    private final HttpServletRequest req = mock( HttpServletRequest.class );
+
+    private final HttpServletResponse res = mock( HttpServletResponse.class );
+
+    private final VirtualHostService virtualHostService = mock( VirtualHostService.class );
+
+    private final ByteArrayOutputStream body = new ByteArrayOutputStream();
+
+    private final StringWriter error = new StringWriter();
+
+    private StatusServlet servlet;
+
+    @BeforeEach
+    void setUp()
+        throws IOException
+    {
+        when( res.getOutputStream() ).thenReturn( new ServletOutputStream()
+        {
+            @Override
+            public void write( final int b )
+            {
+                body.write( b );
+            }
+
+            @Override
+            public boolean isReady()
+            {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener( final WriteListener writeListener )
+            {
+            }
+        } );
+        when( res.getWriter() ).thenReturn( new PrintWriter( error ) );
+
+        servlet = new StatusServlet( virtualHostService );
+        servlet.addReporter( reporter( "dump.threads", true ) );
+        servlet.addReporter( reporter( "jvm.info", false ) );
+    }
+
+    private void virtualHosts( final String... connectors )
+    {
+        final List<VirtualHost> virtualHosts = new ArrayList<>();
+        for ( final String connector : connectors )
+        {
+            final VirtualHost virtualHost = mock( VirtualHost.class );
+            when( virtualHost.getConnector() ).thenReturn( connector );
+            virtualHosts.add( virtualHost );
+        }
+        when( virtualHostService.isEnabled() ).thenReturn( true );
+        when( virtualHostService.getVirtualHosts() ).thenReturn( virtualHosts );
+    }
+
+    @Test
+    void sensitiveReporterOpenWithoutStatisticsVirtualHost()
+        throws Exception
+    {
+        virtualHosts( DispatchConstants.WEB_CONNECTOR, DispatchConstants.MANAGEMENT_CONNECTOR );
+        when( req.getRequestURI() ).thenReturn( "/dump.threads" );
+
+        servlet.doGet( req, res );
+
+        verify( res ).setStatus( 200 );
+        assertEquals( "dump.threads", body.toString( StandardCharsets.UTF_8 ) );
+    }
+
+    @Test
+    void sensitiveReporterRequiresAdminWithStatisticsVirtualHost()
+        throws Exception
+    {
+        virtualHosts( DispatchConstants.WEB_CONNECTOR, DispatchConstants.STATISTICS_CONNECTOR );
+        when( req.getRequestURI() ).thenReturn( "/dump.threads" );
+
+        servlet.doGet( req, res );
+
+        verify( res ).setStatus( 403 );
+        assertTrue( error.toString().contains( "Reporter [dump.threads] requires the admin role" ) );
+        assertEquals( 0, body.size() );
+    }
+
+    @Test
+    void sensitiveReporterServedToAdminWithStatisticsVirtualHost()
+        throws Exception
+    {
+        virtualHosts( DispatchConstants.STATISTICS_CONNECTOR );
+        when( req.getRequestURI() ).thenReturn( "/dump.threads" );
+
+        ADMIN.callWith( () -> {
+            servlet.doGet( req, res );
+            return null;
+        } );
+
+        verify( res ).setStatus( 200 );
+        assertEquals( "dump.threads", body.toString( StandardCharsets.UTF_8 ) );
+    }
+
+    @Test
+    void plainReporterOpenWithStatisticsVirtualHost()
+        throws Exception
+    {
+        virtualHosts( DispatchConstants.STATISTICS_CONNECTOR );
+        when( req.getRequestURI() ).thenReturn( "/jvm.info" );
+
+        servlet.doGet( req, res );
+
+        verify( res ).setStatus( 200 );
+        assertEquals( "jvm.info", body.toString( StandardCharsets.UTF_8 ) );
+    }
+
+    @Test
+    void unknownReporter()
+        throws Exception
+    {
+        when( req.getRequestURI() ).thenReturn( "/nothing" );
+
+        servlet.doGet( req, res );
+
+        verify( res ).setStatus( 404 );
+    }
+
+    private static StatusReporter reporter( final String name, final boolean sensitive )
+    {
+        return new StatusReporter()
+        {
+            @Override
+            public String getName()
+            {
+                return name;
+            }
+
+            @Override
+            public MediaType getMediaType()
+            {
+                return MediaType.PLAIN_TEXT_UTF_8;
+            }
+
+            @Override
+            public void report( final OutputStream stream )
+                throws IOException
+            {
+                stream.write( name.getBytes( StandardCharsets.UTF_8 ) );
+            }
+
+            @Override
+            public boolean isSensitive()
+            {
+                return sensitive;
+            }
+        };
+    }
+}

--- a/modules/server/server-status/src/test/java/com/enonic/xp/server/impl/status/ThreadDumpReporterTest.java
+++ b/modules/server/server-status/src/test/java/com/enonic/xp/server/impl/status/ThreadDumpReporterTest.java
@@ -7,6 +7,7 @@ import com.google.common.net.MediaType;
 import com.enonic.xp.status.BaseReporterTest;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ThreadDumpReporterTest
     extends BaseReporterTest<ThreadDumpReporter>
@@ -27,5 +28,11 @@ class ThreadDumpReporterTest
         throws Exception
     {
         assertNotNull( textReport() );
+    }
+
+    @Test
+    void testSensitive()
+    {
+        assertTrue( newReporter().isSensitive() );
     }
 }

--- a/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/JettyServerDumpReporter.java
+++ b/modules/web/web-jetty/src/main/java/com/enonic/xp/web/jetty/impl/JettyServerDumpReporter.java
@@ -32,6 +32,12 @@ public final class JettyServerDumpReporter
     }
 
     @Override
+    public boolean isSensitive()
+    {
+        return true;
+    }
+
+    @Override
     public MediaType getMediaType()
     {
         return MediaType.PLAIN_TEXT_UTF_8;

--- a/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/JettyServerDumpReporterTest.java
+++ b/modules/web/web-jetty/src/test/java/com/enonic/xp/web/jetty/impl/JettyServerDumpReporterTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.net.MediaType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -31,6 +32,14 @@ class JettyServerDumpReporterTest
 
         final JettyServerDumpReporter reporter = new JettyServerDumpReporter( server );
         assertEquals( MediaType.PLAIN_TEXT_UTF_8, reporter.getMediaType() );
+    }
+
+    @Test
+    void isSensitive()
+    {
+        final Server server = mock( Server.class, withSettings().stubOnly() );
+
+        assertTrue( new JettyServerDumpReporter( server ).isSensitive() );
     }
 
     @Test


### PR DESCRIPTION
## Summary

The statistics endpoint serves a few reporters whose output is far more revealing than health or metrics: full thread dumps with stack traces (`dump.threads`), deadlock analysis (`dump.deadlocks`) and the Jetty server dump with connector, handler and session state (`http.serverdump`). Today anyone who can reach the statistics connector can read them.

This change gates those three reporters behind the `system.admin` role, but only when the statistics connector has been exposed through at least one virtual host. When no vhost maps to the statistics connector the port is only reachable inside the network perimeter and behaviour stays exactly as before.

## Changes

- `StatusReporter` gains `default boolean isSensitive()` returning `false`.
- `ThreadDumpReporter`, `DeadlockReporter` and `JettyServerDumpReporter` override it to return `true`.
- `StatusServlet` now receives `VirtualHostService` and, for a sensitive reporter, responds `403` with a JSON error unless the caller has `system.admin` or no virtual host is mapped to the statistics connector.
- Health, ready, metrics and all other reporters are unchanged.

The host-binding side of the statistics connector is left as is, consistent with the decision to treat network exposure as a firewall concern.

## How a caller becomes an admin on the statistics connector

`ContextFilter`, `VirtualHostFilter` and `IdProviderFilter` already run on the statistics connector. The id provider configured on the statistics vhost authenticates the request, through its session cookie or its `autoLogin` handling of `Authorization` headers, and the resulting principals are what the servlet checks. A statistics vhost without an id provider therefore keeps the three dumps closed for everyone, which is the intended fail-closed default for an exposed port.

## Tests

- `StatusServletTest` covering: non-sensitive reporters always served, sensitive reporter denied for a non-admin behind a statistics vhost, allowed for an admin, allowed when vhosts are disabled, allowed when no vhost maps to the statistics connector.
- `isSensitive` assertions added to `ThreadDumpReporterTest`, `DeadlockReporterTest` and `JettyServerDumpReporterTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV