### PR TITLE
Answer unknown HTTP methods with 405 #12365

### DIFF
--- a/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiFilter.java
+++ b/modules/portal/portal-impl/src/main/java/com/enonic/xp/portal/impl/handler/SlashApiFilter.java
@@ -68,18 +68,24 @@ public final class SlashApiFilter
             return;
         }
 
-        final WebRequest webRequest = webSerializerService.request( req );
-        webRequest.setBody( readBody( req ) );
-        final WebSocketContext webSocketContext = this.webSocketContextFactory.newContext( req, res );
-        webRequest.setWebSocketContext( webSocketContext );
-
+        WebRequest webRequest = null;
         WebResponse webResponse;
         try
         {
+            webRequest = webSerializerService.request( req );
+            webRequest.setBody( readBody( req ) );
+            final WebSocketContext webSocketContext = this.webSocketContextFactory.newContext( req, res );
+            webRequest.setWebSocketContext( webSocketContext );
+
             webResponse = slashApiHandler.handle( webRequest );
         }
         catch ( Exception e )
         {
+            if ( webRequest == null )
+            {
+                webRequest = new WebRequest();
+                webRequest.setRawRequest( req );
+            }
             webResponse = exceptionRenderer.render( webRequest, e );
         }
 
@@ -94,14 +100,25 @@ public final class SlashApiFilter
     private static String readBody( final HttpServletRequest req )
         throws IOException
     {
-        final String contentType = req.getContentType();
+        final MediaType mediaType = parseMediaType( req.getContentType() );
+        return mediaType != null && ( mediaType.is( MediaType.ANY_TEXT_TYPE ) || mediaType.is( MediaType.JSON_UTF_8.withoutParameters() ) )
+            ? CharStreams.toString( req.getReader() )
+            : null;
+    }
+
+    private static MediaType parseMediaType( final String contentType )
+    {
         if ( contentType == null )
         {
             return null;
         }
-        final MediaType mediaType = MediaType.parse( contentType );
-        return mediaType.is( MediaType.ANY_TEXT_TYPE ) || mediaType.is( MediaType.JSON_UTF_8.withoutParameters() )
-            ? CharStreams.toString( req.getReader() )
-            : null;
+        try
+        {
+            return MediaType.parse( contentType );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            return null;
+        }
     }
 }

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiFilterTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiFilterTest.java
@@ -1,5 +1,8 @@
 package com.enonic.xp.portal.impl.handler;
 
+import java.io.BufferedReader;
+import java.io.StringReader;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -8,14 +11,19 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
+import com.enonic.xp.web.exception.ExceptionRenderer;
 import com.enonic.xp.web.serializer.WebSerializerService;
 import com.enonic.xp.web.websocket.WebSocketConfig;
 import com.enonic.xp.web.websocket.WebSocketContext;
 import com.enonic.xp.web.websocket.WebSocketContextFactory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -33,14 +41,17 @@ class SlashApiFilterTest
 
     WebSocketContextFactory webSocketContextFactory;
 
+    private ExceptionRenderer exceptionRenderer;
+
     @BeforeEach
     void setUp()
     {
         slashApiHandler = mock( SlashApiHandler.class );
         webSerializerService = mock( WebSerializerService.class );
         webSocketContextFactory = mock();
+        exceptionRenderer = mock( ExceptionRenderer.class );
 
-        filter = new SlashApiFilter( slashApiHandler, webSerializerService, webSocketContextFactory, mock() );
+        filter = new SlashApiFilter( slashApiHandler, webSerializerService, webSocketContextFactory, exceptionRenderer );
     }
 
     @Test
@@ -86,6 +97,73 @@ class SlashApiFilterTest
 
         verify( slashApiHandler ).handle( webRequest );
         verifyNoInteractions( chain );
+    }
+
+    @Test
+    void readsTextBody()
+        throws Exception
+    {
+        final HttpServletRequest req = mock( HttpServletRequest.class );
+        final HttpServletResponse res = mock( HttpServletResponse.class );
+        final FilterChain chain = mock( FilterChain.class );
+
+        when( req.getPathInfo() ).thenReturn( "/com.enonic.app.myapp:myapi" );
+        when( req.getContentType() ).thenReturn( "application/json" );
+        when( req.getReader() ).thenReturn( new BufferedReader( new StringReader( "{}" ) ) );
+
+        final WebRequest webRequest = new WebRequest();
+        when( webSerializerService.request( req ) ).thenReturn( webRequest );
+        when( slashApiHandler.handle( any( WebRequest.class ) ) ).thenReturn( WebResponse.create().status( HttpStatus.OK ).build() );
+
+        filter.doFilter( req, res, chain );
+
+        verify( slashApiHandler ).handle( webRequest );
+        assertEquals( "{}", webRequest.getBody() );
+    }
+
+    @Test
+    void skipsBodyForMalformedContentType()
+        throws Exception
+    {
+        final HttpServletRequest req = mock( HttpServletRequest.class );
+        final HttpServletResponse res = mock( HttpServletResponse.class );
+        final FilterChain chain = mock( FilterChain.class );
+
+        when( req.getPathInfo() ).thenReturn( "/com.enonic.app.myapp:myapi" );
+        when( req.getContentType() ).thenReturn( "foo" );
+
+        final WebRequest webRequest = new WebRequest();
+        when( webSerializerService.request( req ) ).thenReturn( webRequest );
+        when( slashApiHandler.handle( any( WebRequest.class ) ) ).thenReturn( WebResponse.create().status( HttpStatus.OK ).build() );
+
+        filter.doFilter( req, res, chain );
+
+        verify( slashApiHandler ).handle( webRequest );
+        assertNull( webRequest.getBody() );
+        verify( req, never() ).getReader();
+    }
+
+    @Test
+    void rendersRequestSerializationFailure()
+        throws Exception
+    {
+        final HttpServletRequest req = mock( HttpServletRequest.class );
+        final HttpServletResponse res = mock( HttpServletResponse.class );
+        final FilterChain chain = mock( FilterChain.class );
+
+        when( req.getPathInfo() ).thenReturn( "/com.enonic.app.myapp:myapi" );
+
+        final WebException cause = new WebException( HttpStatus.METHOD_NOT_ALLOWED, "Method BREW not allowed" );
+        when( webSerializerService.request( req ) ).thenThrow( cause );
+
+        final WebResponse errorResponse = WebResponse.create().status( HttpStatus.METHOD_NOT_ALLOWED ).build();
+        when( exceptionRenderer.render( any( WebRequest.class ), eq( cause ) ) ).thenReturn( errorResponse );
+
+        filter.doFilter( req, res, chain );
+
+        verify( exceptionRenderer ).render( argThat( webRequest -> webRequest.getRawRequest() == req ), eq( cause ) );
+        verify( webSerializerService ).response( argThat( webRequest -> webRequest.getRawRequest() == req ), eq( errorResponse ), eq( res ) );
+        verifyNoInteractions( slashApiHandler, chain );
     }
 
     @Test

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiFilterTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/handler/SlashApiFilterTest.java
@@ -122,6 +122,53 @@ class SlashApiFilterTest
     }
 
     @Test
+    void readsPlainTextBody()
+        throws Exception
+    {
+        final HttpServletRequest req = mock( HttpServletRequest.class );
+        final HttpServletResponse res = mock( HttpServletResponse.class );
+        final FilterChain chain = mock( FilterChain.class );
+
+        when( req.getPathInfo() ).thenReturn( "/com.enonic.app.myapp:myapi" );
+        when( req.getContentType() ).thenReturn( "text/plain; charset=utf-8" );
+        when( req.getReader() ).thenReturn( new BufferedReader( new StringReader( "Hello World" ) ) );
+
+        final WebRequest webRequest = new WebRequest();
+        when( webSerializerService.request( req ) ).thenReturn( webRequest );
+        when( slashApiHandler.handle( any( WebRequest.class ) ) ).thenReturn( WebResponse.create().status( HttpStatus.OK ).build() );
+
+        filter.doFilter( req, res, chain );
+
+        verify( slashApiHandler ).handle( webRequest );
+        assertEquals( "Hello World", webRequest.getBody() );
+    }
+
+    @Test
+    void rendersHandlerFailure()
+        throws Exception
+    {
+        final HttpServletRequest req = mock( HttpServletRequest.class );
+        final HttpServletResponse res = mock( HttpServletResponse.class );
+        final FilterChain chain = mock( FilterChain.class );
+
+        when( req.getPathInfo() ).thenReturn( "/com.enonic.app.myapp:myapi" );
+
+        final WebRequest webRequest = new WebRequest();
+        when( webSerializerService.request( req ) ).thenReturn( webRequest );
+
+        final WebException cause = new WebException( HttpStatus.NOT_FOUND, "API not found" );
+        when( slashApiHandler.handle( webRequest ) ).thenThrow( cause );
+
+        final WebResponse errorResponse = WebResponse.create().status( HttpStatus.NOT_FOUND ).build();
+        when( exceptionRenderer.render( webRequest, cause ) ).thenReturn( errorResponse );
+
+        filter.doFilter( req, res, chain );
+
+        verify( exceptionRenderer ).render( webRequest, cause );
+        verify( webSerializerService ).response( webRequest, errorResponse, res );
+    }
+
+    @Test
     void skipsBodyForMalformedContentType()
         throws Exception
     {

--- a/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/serializer/RequestBodyReaderTest.java
+++ b/modules/portal/portal-impl/src/test/java/com/enonic/xp/portal/impl/serializer/RequestBodyReaderTest.java
@@ -63,6 +63,15 @@ class RequestBodyReaderTest
     }
 
     @Test
+    void readMalformedContentType()
+        throws Exception
+    {
+        setText( "foo", "Hello World" );
+
+        assertNull( RequestBodyReader.readBody( this.req ) );
+    }
+
+    @Test
     void readText()
         throws Exception
     {

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/handler/WebDispatcherServlet.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/handler/WebDispatcherServlet.java
@@ -55,12 +55,26 @@ public final class WebDispatcherServlet
     protected void service( final HttpServletRequest req, final HttpServletResponse res )
         throws ServletException, IOException
     {
-        final WebRequest webRequest = webSerializerService.request( req );
-        final WebSocketContext webSocketContext = this.webSocketContextFactory.newContext( req, res );
-        webRequest.setWebSocketContext( webSocketContext );
-        webRequest.setBody( RequestBodyReader.readBody( req ) );
+        WebRequest webRequest = null;
+        WebResponse webResponse;
+        try
+        {
+            webRequest = webSerializerService.request( req );
+            final WebSocketContext webSocketContext = this.webSocketContextFactory.newContext( req, res );
+            webRequest.setWebSocketContext( webSocketContext );
+            webRequest.setBody( RequestBodyReader.readBody( req ) );
 
-        final WebResponse webResponse = doHandle( webRequest );
+            webResponse = exceptionRenderer.maybeThrow( webRequest, webDispatcher.dispatch( webRequest, WebResponse.create().build() ) );
+        }
+        catch ( Exception e )
+        {
+            if ( webRequest == null )
+            {
+                webRequest = new WebRequest();
+                webRequest.setRawRequest( req );
+            }
+            webResponse = exceptionRenderer.render( webRequest, e );
+        }
 
         if ( webRequest.getWebSocketContext() != null && webResponse.getWebSocket() != null )
         {
@@ -74,18 +88,6 @@ public final class WebDispatcherServlet
         }
 
         webSerializerService.response( webRequest, webResponse, res );
-    }
-
-    private WebResponse doHandle( final WebRequest webRequest )
-    {
-        try
-        {
-            return exceptionRenderer.maybeThrow( webRequest, webDispatcher.dispatch( webRequest, WebResponse.create().build() ) );
-        }
-        catch ( Exception e )
-        {
-            return exceptionRenderer.render( webRequest, e );
-        }
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestBodyReader.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestBodyReader.java
@@ -22,11 +22,24 @@ public final class RequestBodyReader
             return null;
         }
 
-        return isText( MediaType.parse( type ) ) ? CharStreams.toString( req.getReader() ) : null;
+        final MediaType mediaType = parseOrNull( type );
+        return mediaType != null && isText( mediaType ) ? CharStreams.toString( req.getReader() ) : null;
     }
 
     public static boolean isText( final MediaType type )
     {
         return TEXT_CONTENT_TYPES.stream().anyMatch( type::is );
+    }
+
+    private static MediaType parseOrNull( final String type )
+    {
+        try
+        {
+            return MediaType.parse( type );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            return null;
+        }
     }
 }

--- a/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
+++ b/modules/web/web-impl/src/main/java/com/enonic/xp/web/impl/serializer/RequestSerializer.java
@@ -8,6 +8,8 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 
 import com.enonic.xp.web.HttpMethod;
+import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.servlet.ServletRequestUrlHelper;
 
@@ -23,7 +25,7 @@ public final class RequestSerializer
     public void serialize( final HttpServletRequest request )
     {
         webRequest.setRawRequest( request );
-        webRequest.setMethod( HttpMethod.valueOf( request.getMethod() ) );
+        webRequest.setMethod( parseMethod( request.getMethod() ) );
         webRequest.setScheme( request.getScheme() );
         webRequest.setHost( request.getServerName() );
         webRequest.setPort( request.getServerPort() );
@@ -36,6 +38,18 @@ public final class RequestSerializer
         setParameters( request, webRequest );
         setHeaders( request, webRequest );
         setCookies( request, webRequest );
+    }
+
+    private static HttpMethod parseMethod( final String method )
+    {
+        try
+        {
+            return HttpMethod.valueOf( method );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw new WebException( HttpStatus.METHOD_NOT_ALLOWED, String.format( "Method %s not allowed", method ) );
+        }
     }
 
     private void setHeaders( final HttpServletRequest from, final WebRequest to )

--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/handler/WebDispatcherServletTest.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/handler/WebDispatcherServletTest.java
@@ -4,6 +4,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,7 @@ import com.google.common.net.MediaType;
 
 import com.enonic.xp.web.HttpMethod;
 import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
 import com.enonic.xp.web.WebResponse;
 import com.enonic.xp.web.exception.ExceptionRenderer;
 import com.enonic.xp.web.impl.serializer.WebSerializerServiceImpl;
@@ -21,8 +23,12 @@ import com.enonic.xp.web.sse.SseConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class WebDispatcherServletTest
@@ -187,6 +193,43 @@ class WebDispatcherServletTest
 
         final HttpResponse<String> response = callRequest( request );
         assertEquals( 200, response.statusCode() );
+    }
+
+    @Test
+    void testPost_malformedContentType()
+        throws Exception
+    {
+        final HttpRequest request = newRequest( "/site/master/a/b" ).header( "content-type", "foo" )
+            .POST( HttpRequest.BodyPublishers.ofString( "Hello World" ) )
+            .build();
+
+        this.handler.verifier = req -> {
+            assertEquals( "foo", req.getContentType() );
+            assertNull( req.getBody() );
+        };
+
+        final HttpResponse<String> response = callRequest( request );
+        assertEquals( 200, response.statusCode() );
+    }
+
+    @Test
+    void testUnknownMethod_methodNotAllowed()
+        throws Exception
+    {
+        when( exceptionRenderer.render( any(), any() ) ).thenAnswer( invocation -> {
+            final WebException cause = invocation.getArgument( 1 );
+            return WebResponse.create().status( cause.getStatus() ).build();
+        } );
+
+        final AtomicBoolean handled = new AtomicBoolean();
+        this.handler.verifier = req -> handled.set( true );
+
+        final HttpRequest request = newRequest( "/site/master/a/b" ).method( "BREW", HttpRequest.BodyPublishers.noBody() ).build();
+
+        final HttpResponse<String> response = callRequest( request );
+        assertEquals( 405, response.statusCode() );
+        assertFalse( handled.get() );
+        verify( exceptionRenderer ).render( argThat( req -> req.getRawRequest() != null ), any( WebException.class ) );
     }
 
     @Test

--- a/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/RequestSerializerTest.java
+++ b/modules/web/web-impl/src/test/java/com/enonic/xp/web/impl/serializer/RequestSerializerTest.java
@@ -1,0 +1,27 @@
+package com.enonic.xp.web.impl.serializer;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import com.enonic.xp.web.HttpStatus;
+import com.enonic.xp.web.WebException;
+import com.enonic.xp.web.WebRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RequestSerializerTest
+{
+    @Test
+    void unknownMethod()
+    {
+        final HttpServletRequest request = mock( HttpServletRequest.class );
+        when( request.getMethod() ).thenReturn( "BREW" );
+
+        final WebException e = assertThrows( WebException.class, () -> new RequestSerializer( new WebRequest() ).serialize( request ) );
+        assertEquals( HttpStatus.METHOD_NOT_ALLOWED, e.getStatus() );
+    }
+}


### PR DESCRIPTION
## Summary

Security audit finding L8, brought to `master` directly. #12325 carried the same change but was merged into the H2 branch (#12322), which needs rework before it can land, so this PR takes the original master-based commits, rebased onto current `master`. Once it merges, #12322 gets rebased and drops its copy.

Two pieces of request input were parsed before the dispatcher servlet and the universal API filter entered their exception-rendering path:

- `RequestSerializer` resolved the method with `HttpMethod.valueOf`, so a request line such as `BREW / HTTP/1.1` threw `IllegalArgumentException` straight into Jetty.
- `RequestBodyReader` and `SlashApiFilter.readBody` parsed the `Content-Type` header with `MediaType.parse`, so `Content-Type: foo` did the same.

Both cases produced a 500 with a stack trace logged per request, reachable anonymously.

## Changes

- `RequestSerializer` rejects an unknown method with a 405 `WebException`, matching how the mapping handler already answers non-standard methods.
- `RequestBodyReader` and `SlashApiFilter` treat a `Content-Type` that cannot be parsed as a non-text body instead of throwing.
- `WebDispatcherServlet` and `SlashApiFilter` serialize the request inside the rendered path. If serialization itself fails, the exception renderer is given a `WebRequest` carrying only the raw servlet request, which is all it needs to produce the error response.

## Tests

- `RequestSerializerTest.unknownMethod`
- `WebDispatcherServletTest.testUnknownMethod_methodNotAllowed` (real Jetty, method `BREW`) and `testPost_malformedContentType`
- `RequestBodyReaderTest.readMalformedContentType`
- `SlashApiFilterTest.rendersRequestSerializationFailure`, `rendersHandlerFailure`, `readsTextBody`, `readsPlainTextBody`, `skipsBodyForMalformedContentType`

The affected `web-impl` and `portal-impl` suites pass locally on current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NF5h4qbEHLSwEBTxQKSoMV)_