### PR TITLE
Say what the JS URL functions resolve against

### DIFF
--- a/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
+++ b/modules/lib/lib-portal/src/main/resources/lib/xp/portal.ts
@@ -345,6 +345,9 @@ interface PageUrlHandler {
 /**
  * This function generates a URL pointing to a page.
  *
+ * The URL starts with the base URL of the site - or project - the page belongs to, followed by the
+ * path of the page below that site. See {@link baseUrl} for how that base URL is resolved.
+ *
  * @example-ref examples/portal/pageUrl.js
  *
  * @param {object} params Input parameters as JSON.
@@ -600,6 +603,9 @@ interface ProcessHtmlHandler {
 
 /**
  * This function replaces abstract internal links contained in an HTML text by generated URLs.
+ *
+ * Links to content are generated the same way {@link pageUrl} generates them, and links to media
+ * the same way {@link attachmentUrl} and {@link imageUrl} do.
  *
  * When outputting processed HTML in Thymeleaf, use attribute `data-th-utext="${processedHtml}"`.
  *
@@ -926,7 +932,15 @@ interface BaseUrlHandler {
 }
 
 /**
- * This function generates a baseURL.
+ * This function generates the base URL of the site - or project - a content belongs to: the
+ * nearest site at or above it, and the project when no site is above it.
+ *
+ * The result is the Base URL configured for that site or project. With none configured, it is the
+ * address the site engine serves it at, `/site/<project>/<branch>/<site path>`. On a site request
+ * it is the address of whatever the matched virtual host mapping points at.
+ *
+ * Content paths are relative to the same site or project, so the full URL of a content is this
+ * base URL followed by its path below that site.
  *
  * Never returns an error URL: raises an error when the content does not exist.
  *


### PR DESCRIPTION
Follow-up to #12369. Doc only — no code, no parameters, no behaviour.

## Why

#12369 gave `baseUrl()` a precise meaning and changed two of its results, but its JSDoc still said only:

```
This function generates a baseURL.
```

The lib-portal tests mock `PortalUrlService`, so they cover the bean wiring and never the resolution — nothing there records what the function now returns either.

## What changed for JS callers in #12369

Worth stating, since none of it is visible from the JS surface:

- `baseUrl()` with no configured Base URL returns `/site/<project>/<branch>/<site path>`, previously `/site/<project>/<branch>`
- `baseUrl()` on a site request behind a virtual host mounted on a site returns the host's own address, where it previously produced an error
- `pageUrl()` output is unchanged in every case
- `processHtml()` is unchanged from JS

The parameters of `pageUrl`, `processHtml` and `baseUrl` are untouched. `PageUrlParams.base` and `ProcessHtmlParams.pageBase` stay Java-only, the same rule `apiBaseUrl` follows, and `pageUrlParts` is not part of the JS API — so the base and path of one URL cannot be assembled from JS, which is where #12367 went wrong.

## The docs

**`baseUrl`** now names what it resolves and all three sources:

> This function generates the base URL of the site - or project - a content belongs to: the nearest site at or above it, and the project when no site is above it.
>
> The result is the Base URL configured for that site or project. With none configured, it is the address the site engine serves it at, `/site/<project>/<branch>/<site path>`. On a site request it is the address of whatever the matched virtual host mapping points at.
>
> Content paths are relative to the same site or project, so the full URL of a content is this base URL followed by its path below that site.

**`pageUrl`** gets one sentence pointing at it, since it is that base URL plus the page's path below the site.

**`processHtml`** gets one sentence saying its content links are generated as `pageUrl` generates them, and its media links as `attachmentUrl` and `imageUrl` do.

`:lib:typescript` and `:lib:lib-portal:test` pass.

## Not in this PR

JS `pageUrl` still cannot select a site — no equivalent of guillotine's `siteKey`. On a site request the virtual host now decides, which covers site rendering; a caller passing explicit `project`/`branch` from a task gets the content's own nearest site with no way to say otherwise. Whether the JS API should grow that is a separate question, and it would need a nested object since `BaseUrlParams` is a builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8TCeZWgJjKTDhmntR9JtB


---
_Generated by [Claude Code](https://claude.ai/code/session_01L8TCeZWgJjKTDhmntR9JtB)_