### PR TITLE
Remove scheduler mutation methods from the management API

### DIFF
--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/api/SchedulerApiHandler.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/api/SchedulerApiHandler.java
@@ -1,10 +1,6 @@
 package com.enonic.xp.impl.server.rest.api;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.Map;
-import java.util.Optional;
-import java.util.TimeZone;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -12,25 +8,19 @@ import org.osgi.service.component.annotations.Reference;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import com.enonic.xp.data.PropertyTree;
-import com.enonic.xp.descriptor.DescriptorKey;
 import com.enonic.xp.impl.server.rest.model.ScheduledJobJson;
 import com.enonic.xp.portal.universalapi.UniversalApiHandler;
-import com.enonic.xp.scheduler.CalendarService;
-import com.enonic.xp.scheduler.CreateScheduledJobParams;
-import com.enonic.xp.scheduler.ScheduleCalendar;
-import com.enonic.xp.scheduler.ScheduleCalendarType;
 import com.enonic.xp.scheduler.ScheduledJob;
 import com.enonic.xp.scheduler.ScheduledJobName;
 import com.enonic.xp.scheduler.SchedulerService;
-import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.web.HttpMethod;
 import com.enonic.xp.web.HttpStatus;
 import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
 
 /**
- * {@code server:scheduler} - scheduled jobs: list, get, create and delete.
+ * {@code server:scheduler} - scheduled jobs: list and get. Jobs are created by applications and the
+ * scheduler configuration, not through the management API.
  */
 @Component(service = UniversalApiHandler.class, property = {"key=server:scheduler", "title=Scheduler API", "mount=management",
     "allowedPrincipals=role:system.admin"})
@@ -41,19 +31,14 @@ public class SchedulerApiHandler
 
     private final SchedulerService schedulerService;
 
-    private final CalendarService calendarService;
-
     @Activate
-    public SchedulerApiHandler( @Reference final SchedulerService schedulerService, @Reference final CalendarService calendarService )
+    public SchedulerApiHandler( @Reference final SchedulerService schedulerService )
     {
         super( KEY );
         this.schedulerService = schedulerService;
-        this.calendarService = calendarService;
 
         route( HttpMethod.GET, "/", "list", this::list );
-        route( HttpMethod.POST, "/", "create", this::create );
         route( HttpMethod.GET, "/{name}", "get", this::get );
-        route( HttpMethod.DELETE, "/{name}", "delete", this::delete );
     }
 
     private WebResponse list( final WebRequest request, final Map<String, String> params )
@@ -68,84 +53,8 @@ public class SchedulerApiHandler
         final ScheduledJob job = schedulerService.get( ScheduledJobName.from( params.get( "name" ) ) );
         if ( job == null )
         {
-            return notFound( params );
+            return error( HttpStatus.NOT_FOUND, String.format( "Scheduled job [%s] not found", params.get( "name" ) ) );
         }
         return json( new ScheduledJobJson( job ) );
-    }
-
-    private WebResponse create( final WebRequest request, final Map<String, String> params )
-        throws JsonProcessingException
-    {
-        final CreateJson create = body( request, CreateJson.class );
-        if ( create.name() == null || create.name().isBlank() )
-        {
-            throw new IllegalArgumentException( "[name] is required" );
-        }
-        if ( create.descriptor() == null || create.descriptor().isBlank() )
-        {
-            throw new IllegalArgumentException( "[descriptor] is required" );
-        }
-        if ( create.schedule() == null )
-        {
-            throw new IllegalArgumentException( "[schedule] is required" );
-        }
-
-        final ScheduledJob job = schedulerService.create( CreateScheduledJobParams.create()
-                                                              .name( ScheduledJobName.from( create.name() ) )
-                                                              .descriptor( DescriptorKey.from( create.descriptor() ) )
-                                                              .calendar( calendar( create.schedule() ) )
-                                                              .description( create.description() )
-                                                              .config( PropertyTree.fromMap( create.config() == null ? Map.of() : create.config() ) )
-                                                              .enabled( create.enabled() )
-                                                              .user( Optional.ofNullable( create.user() ).map( PrincipalKey::from ).orElse( null ) )
-                                                              .build() );
-        return json( HttpStatus.CREATED, new ScheduledJobJson( job ) );
-    }
-
-    private WebResponse delete( final WebRequest request, final Map<String, String> params )
-        throws JsonProcessingException
-    {
-        if ( !schedulerService.delete( ScheduledJobName.from( params.get( "name" ) ) ) )
-        {
-            return notFound( params );
-        }
-        return json( Map.of( "name", params.get( "name" ) ) );
-    }
-
-    private WebResponse notFound( final Map<String, String> params )
-    {
-        return error( HttpStatus.NOT_FOUND, String.format( "Scheduled job [%s] not found", params.get( "name" ) ) );
-    }
-
-    private ScheduleCalendar calendar( final ScheduleJson schedule )
-    {
-        if ( schedule.type() == null )
-        {
-            throw new IllegalArgumentException( "[schedule.type] is required: CRON, ONE_TIME or FIXED_RATE" );
-        }
-        if ( schedule.value() == null )
-        {
-            throw new IllegalArgumentException( "[schedule.value] is required" );
-        }
-        return switch ( schedule.type() )
-        {
-            case CRON -> calendarService.cron( schedule.value(), TimeZone.getTimeZone(
-                Optional.ofNullable( schedule.timeZone() ).orElseThrow( () -> new IllegalArgumentException( "[schedule.timeZone] is required for CRON" ) ) ) );
-            case ONE_TIME -> calendarService.oneTime( Instant.parse( schedule.value() ), schedule.deleteAfterRun() );
-            case FIXED_RATE -> calendarService.fixedRate( Duration.parse( schedule.value() ) );
-        };
-    }
-
-    public record CreateJson(String name, String descriptor, String description, ScheduleJson schedule, Map<String, Object> config,
-                             Boolean enabled, String user)
-    {
-        public CreateJson
-        {
-            enabled = enabled == null || enabled;
-        }
-    }
-
-    public record ScheduleJson(ScheduleCalendarType type, String value, String timeZone, boolean deleteAfterRun)
-    {
     }
 }

--- a/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/api/SchedulerApiHandler.java
+++ b/modules/server/server-rest/src/main/java/com/enonic/xp/impl/server/rest/api/SchedulerApiHandler.java
@@ -19,8 +19,7 @@ import com.enonic.xp.web.WebRequest;
 import com.enonic.xp.web.WebResponse;
 
 /**
- * {@code server:scheduler} - scheduled jobs: list and get. Jobs are created by applications and the
- * scheduler configuration, not through the management API.
+ * {@code server:scheduler} - scheduled jobs: list and get.
  */
 @Component(service = UniversalApiHandler.class, property = {"key=server:scheduler", "title=Scheduler API", "mount=management",
     "allowedPrincipals=role:system.admin"})

--- a/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/api/SchedulerApiHandlerTest.java
+++ b/modules/server/server-rest/src/test/java/com/enonic/xp/impl/server/rest/api/SchedulerApiHandlerTest.java
@@ -1,27 +1,17 @@
 package com.enonic.xp.impl.server.rest.api;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.descriptor.DescriptorKey;
-import com.enonic.xp.scheduler.CalendarService;
-import com.enonic.xp.scheduler.CreateScheduledJobParams;
-import com.enonic.xp.scheduler.CronCalendar;
-import com.enonic.xp.scheduler.FixedRateCalendar;
-import com.enonic.xp.scheduler.OneTimeCalendar;
 import com.enonic.xp.scheduler.ScheduleCalendar;
 import com.enonic.xp.scheduler.ScheduledJob;
 import com.enonic.xp.scheduler.ScheduledJobName;
 import com.enonic.xp.scheduler.SchedulerService;
-import com.enonic.xp.security.PrincipalKey;
 import com.enonic.xp.web.HttpMethod;
 import com.enonic.xp.web.HttpStatus;
 import com.enonic.xp.web.WebResponse;
@@ -30,18 +20,12 @@ import static com.enonic.xp.impl.server.rest.api.ManagementApiTestSupport.reques
 import static com.enonic.xp.impl.server.rest.api.ManagementApiTestSupport.withVirtualHostContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class SchedulerApiHandlerTest
 {
     private SchedulerService schedulerService;
-
-    private CalendarService calendarService;
 
     private SchedulerApiHandler handler;
 
@@ -49,8 +33,7 @@ class SchedulerApiHandlerTest
     void setUp()
     {
         schedulerService = mock( SchedulerService.class );
-        calendarService = mock( CalendarService.class );
-        handler = new SchedulerApiHandler( schedulerService, calendarService );
+        handler = new SchedulerApiHandler( schedulerService );
     }
 
     @Test
@@ -75,79 +58,20 @@ class SchedulerApiHandlerTest
     }
 
     @Test
-    void createCron()
+    void mutationsNotExposed()
     {
-        final CronCalendar cron = mock( CronCalendar.class );
-        when( calendarService.cron( eq( "0 3 * * *" ), any( TimeZone.class ) ) ).thenReturn( cron );
-        when( schedulerService.create( any() ) ).thenReturn( job( "nightly" ) );
-
-        final WebResponse response = handler.handle( request( HttpMethod.POST, "/server:scheduler", """
-            {"name":"nightly","descriptor":"com.enonic.xp.app.system:dump","description":"Nightly dump",
-             "schedule":{"type":"CRON","value":"0 3 * * *","timeZone":"Europe/Oslo"},
-             "config":{"name":"nightly"},"user":"user:system:su"}
-            """ ) );
-
-        assertEquals( HttpStatus.CREATED, response.getStatus() );
-
-        final ArgumentCaptor<CreateScheduledJobParams> captor = ArgumentCaptor.forClass( CreateScheduledJobParams.class );
-        verify( schedulerService ).create( captor.capture() );
-        final CreateScheduledJobParams params = captor.getValue();
-        assertEquals( "nightly", params.getName().getValue() );
-        assertEquals( "com.enonic.xp.app.system:dump", params.getDescriptor().toString() );
-        assertEquals( cron, params.getCalendar() );
-        assertEquals( "nightly", params.getConfig().getString( "name" ) );
-        assertEquals( PrincipalKey.from( "user:system:su" ), params.getUser() );
-        assertTrue( params.isEnabled() );
-        verify( calendarService ).cron( "0 3 * * *", TimeZone.getTimeZone( "Europe/Oslo" ) );
-    }
-
-    @Test
-    void createOneTimeAndFixedRate()
-    {
-        when( calendarService.oneTime( any( Instant.class ), eq( true ) ) ).thenReturn( mock( OneTimeCalendar.class ) );
-        when( calendarService.fixedRate( Duration.parse( "PT1H" ) ) ).thenReturn( mock( FixedRateCalendar.class ) );
-        when( schedulerService.create( any() ) ).thenReturn( job( "once" ) );
-
-        assertEquals( HttpStatus.CREATED, handler.handle( request( HttpMethod.POST, "/server:scheduler",
-                                                                   "{\"name\":\"once\",\"descriptor\":\"a:b\",\"schedule\":{\"type\":\"ONE_TIME\",\"value\":\"2030-01-01T00:00:00Z\",\"deleteAfterRun\":true}}" ) ).getStatus() );
-        assertEquals( HttpStatus.CREATED, handler.handle( request( HttpMethod.POST, "/server:scheduler",
-                                                                   "{\"name\":\"hourly\",\"descriptor\":\"a:b\",\"enabled\":false,\"schedule\":{\"type\":\"FIXED_RATE\",\"value\":\"PT1H\"}}" ) ).getStatus() );
-
-        verify( calendarService ).oneTime( Instant.parse( "2030-01-01T00:00:00Z" ), true );
-        verify( calendarService ).fixedRate( Duration.parse( "PT1H" ) );
-    }
-
-    @Test
-    void createValidation()
-    {
-        assertEquals( HttpStatus.BAD_REQUEST, handler.handle( request( HttpMethod.POST, "/server:scheduler", "{\"descriptor\":\"a:b\"}" ) ).getStatus() );
-        assertEquals( HttpStatus.BAD_REQUEST, handler.handle( request( HttpMethod.POST, "/server:scheduler", "{\"name\":\"x\",\"descriptor\":\"a:b\"}" ) ).getStatus() );
-        assertEquals( HttpStatus.BAD_REQUEST, handler.handle( request( HttpMethod.POST, "/server:scheduler",
-                                                                       "{\"name\":\"x\",\"descriptor\":\"a:b\",\"schedule\":{\"type\":\"CRON\",\"value\":\"* * * * *\"}}" ) ).getStatus() );
-        assertEquals( HttpStatus.BAD_REQUEST, handler.handle( request( HttpMethod.POST, "/server:scheduler",
-                                                                       "{\"name\":\"x\",\"descriptor\":\"a:b\",\"schedule\":{\"type\":\"WEEKLY\",\"value\":\"x\"}}" ) ).getStatus() );
-        verify( schedulerService, never() ).create( any() );
-    }
-
-    @Test
-    void delete()
-    {
-        when( schedulerService.delete( ScheduledJobName.from( "nightly" ) ) ).thenReturn( true );
-
-        assertEquals( HttpStatus.OK, handler.handle( request( HttpMethod.DELETE, "/server:scheduler/nightly" ) ).getStatus() );
-        assertEquals( HttpStatus.NOT_FOUND, handler.handle( request( HttpMethod.DELETE, "/server:scheduler/other" ) ).getStatus() );
+        assertEquals( HttpStatus.METHOD_NOT_ALLOWED, handler.handle( request( HttpMethod.POST, "/server:scheduler", "{}" ) ).getStatus() );
+        assertEquals( HttpStatus.METHOD_NOT_ALLOWED, handler.handle( request( HttpMethod.DELETE, "/server:scheduler/nightly" ) ).getStatus() );
     }
 
     @Test
     void readOnlyVhost()
     {
-        final Map<String, String> policy = Map.of( "api.server:scheduler.verbs", "list, get" );
+        final Map<String, String> policy = Map.of( "api.server:scheduler.verbs", "list" );
         when( schedulerService.list() ).thenReturn( List.of() );
 
         assertEquals( HttpStatus.OK, withVirtualHostContext( policy, () -> handler.handle( request( HttpMethod.GET, "/server:scheduler" ) ) ).getStatus() );
-        assertEquals( HttpStatus.FORBIDDEN, withVirtualHostContext( policy, () -> handler.handle( request( HttpMethod.DELETE, "/server:scheduler/nightly" ) ) ).getStatus() );
-        assertEquals( HttpStatus.FORBIDDEN, withVirtualHostContext( policy, () -> handler.handle( request( HttpMethod.POST, "/server:scheduler", "{}" ) ) ).getStatus() );
-        verify( schedulerService, never() ).delete( any() );
+        assertEquals( HttpStatus.FORBIDDEN, withVirtualHostContext( policy, () -> handler.handle( request( HttpMethod.GET, "/server:scheduler/nightly" ) ) ).getStatus() );
     }
 
     private static ScheduledJob job( final String name )


### PR DESCRIPTION
The `server:scheduler` management API exposed `create` (`POST /server:scheduler`) and `delete` (`DELETE /server:scheduler/{name}`) of scheduled jobs — a functionality leak. The API now serves `list` and `get` only, matching the legacy read-only `scheduler/list` REST resource it succeeds:

- Removed the `create` and `delete` routes, their request records, the calendar parsing, and the `CalendarService` reference from `SchedulerApiHandler`.
- Unrouted methods answer `405 Method Not Allowed` (covered by a test); the `verbs` vhost policy still applies to the remaining read verbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFqoY5nKdmhXqM7MAU9cqU